### PR TITLE
POC: Automatically add description from schema when available

### DIFF
--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -102,6 +102,14 @@ def validate_propertyOrder(validator, order, instance, schema):
     instance.property_order = order
 
 
+def validate_additionalProperties(validator, additionalProperties, instance, schema):
+
+    if isinstance(instance, dict):
+        instance.pop('_description', None)
+    return mvalidators.Draft4Validator.VALIDATORS['additionalProperties'](
+        validator, additionalProperties, instance, schema)
+
+
 def validate_flowStyle(validator, flow_style, instance, schema):
     """
     Sets a flag on the `tagged.TaggedList` or `tagged.TaggedDict`
@@ -152,6 +160,7 @@ YAML_VALIDATORS = util.HashableDict(
 YAML_VALIDATORS.update({
     'tag': validate_tag,
     'propertyOrder': validate_propertyOrder,
+    'additionalProperties': validate_additionalProperties,
     'flowStyle': validate_flowStyle,
     'style': validate_style,
     'type': validate_type

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -172,6 +172,7 @@ def test_table_inline(tmpdir):
         tree = yaml.load(
             re.sub(br'!core/\S+', b'', content))
 
+        del tree['table_data']['_description']
         assert tree['table_data'] == {
             'datatype': [
                 {'datatype': 'int8', 'name': 'MINE'},
@@ -228,6 +229,7 @@ def test_table(tmpdir):
         tree = yaml.load(
             re.sub(br'!core/\S+', b'', content))
 
+        del tree['table_data']['_description']
         assert tree['table_data'] == {
             'datatype': [
                 {'byteorder': 'big', 'datatype': 'int8', 'name': 'MINE'},
@@ -254,6 +256,7 @@ def test_table_nested_fields(tmpdir):
         tree = yaml.load(
             re.sub(br'!core/\S+', b'', content))
 
+        del tree['table_data']['_description']
         assert tree['table_data'] == {
             'datatype': [
                 {'datatype': 'int64', 'name': 'A', 'byteorder': 'little'},

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -303,6 +303,15 @@ class ExtensionType:
             An instance of `asdf.tagged.Tagged`.
         """
         obj = cls.to_tree(node, ctx)
+        if isinstance(obj, dict):
+            from .schema import _load_schema
+            try:
+                schema, _ = _load_schema(ctx.resolver(cls.yaml_tag))
+            except (ValueError, FileNotFoundError):
+                pass
+            else:
+                if 'description' in schema:
+                    obj['_description'] = schema['description']
         return tagged.tag_object(cls.yaml_tag, obj, ctx=ctx)
 
     @classmethod


### PR DESCRIPTION
This is a prototype of an idea that @perrygreenfield proposed for automatically adding description fields from schemas to the associated nodes of ASDF files when they are written. It should not be merged as-is, but does demonstrate proof-of-concept.

I think we might want to add a class attribute to `asdf.types.ExtensionType` that controls whether the description field should be written or not. It can be set to `False` by default but child tag implementations can override it.

This could also make it possible to populate descriptions contained in an ASDF file into the in-memory representation of the tree, where it could then be accessed by tools.