### PR TITLE
Replace pyyaml with ruamel.yaml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@
 - Enable handling of subclasses of known custom types by using decorators for
   convenience. [#563]
 
+- Replace use of ``pyyaml`` with ``ruamel.yaml``. [#677]
+
 2.3.4 (unreleased)
 ------------------
 

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -19,9 +19,9 @@ __all__ = [
 ]
 
 try:
-    import yaml as _
+    import ruamel.yaml as _
 except ImportError:
-    raise ImportError("asdf requires pyyaml")
+    raise ImportError("asdf requires ruamel.yaml")
 
 try:
     import jsonschema as _

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -20,17 +20,17 @@ __all__ = [
 
 try:
     import ruamel.yaml as _
-except ImportError:
+except ImportError: # pragma: no cover
     raise ImportError("asdf requires ruamel.yaml")
 
 try:
     import jsonschema as _
-except ImportError:
+except ImportError: # pragma: no cover
     raise ImportError("asdf requires jsonschema")
 
 try:
     import numpy as _
-except ImportError:
+except ImportError: # pragma: no cover
     raise ImportError("asdf requires numpy")
 
 from .asdf import AsdfFile, open_asdf

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -14,7 +14,7 @@ from urllib import parse as urlparse
 import numpy as np
 from numpy.ma.core import masked_array
 
-import yaml
+import ruamel.yaml as yaml
 
 from . import compression as mcompression
 from .compat.numpycompat import NUMPY_LT_1_7

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -14,7 +14,7 @@ from urllib import parse as urlparse
 from jsonschema import validators as mvalidators
 from jsonschema.exceptions import ValidationError
 
-import yaml
+import ruamel.yaml as yaml
 
 from . import constants
 from . import generic_io

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_equal
 
 import jsonschema
 
-import yaml
+import ruamel.yaml as yaml
 
 import asdf
 from asdf import util

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -860,7 +860,7 @@ def test_readonly(tmpdir):
 def test_readonly_inline(tmpdir):
 
     tmpfile = str(tmpdir.join('data.asdf'))
-    tree = dict(data=np.ndarray((100)))
+    tree = dict(data=np.ones((100)))
 
     with asdf.AsdfFile(tree) as af:
         af.write_to(tmpfile, all_array_storage='inline')

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -8,7 +8,6 @@ import warnings
 
 from jsonschema import ValidationError
 
-import yaml
 import pytest
 
 import numpy as np

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import pytest
 
-import yaml
+import ruamel.yaml as yaml
 
 import asdf
 from asdf import tagged

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -5,9 +5,8 @@
 This module deals with things that change between different versions
 of the ASDF spec.
 """
+import ruamel.yaml as yaml
 from functools import total_ordering
-
-import yaml
 
 if getattr(yaml, '__with_libyaml__', None):  # pragma: no cover
     _yaml_base_loader = yaml.CSafeLoader

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -164,52 +164,6 @@ class AsdfLoader(_yaml_base_loader):
 
 
 # ----------------------------------------------------------------------
-# Handle omap (ordered mappings)
-
-YAML_OMAP_TAG = YAML_TAG_PREFIX + 'omap'
-
-
-# Add support for loading YAML !!omap objects as OrderedDicts and dumping
-# OrderedDict in the omap format as well.
-def ordereddict_constructor(loader, node):
-    try:
-        omap = loader.construct_yaml_omap(node)
-        return OrderedDict(*omap)
-    except yaml.constructor.ConstructorError:
-        return list(*loader.construct_yaml_seq(node))
-
-
-def represent_ordered_mapping(dumper, tag, data):
-    # TODO: Again, adjust for preferred flow style, and other stylistic details
-    # NOTE: For block style this uses the compact omap notation, but for flow style
-    # it does not.
-
-    # TODO: Need to see if I can figure out a mechanism so that classes that
-    # use this representer can specify which values should use flow style
-    values = []
-    node = yaml.SequenceNode(tag, values,
-                             flow_style=dumper.default_flow_style)
-    if dumper.alias_key is not None:
-        dumper.represented_objects[dumper.alias_key] = node
-    for key, value in data.items():
-        key_item = dumper.represent_data(key)
-        value_item = dumper.represent_data(value)
-        node_item = yaml.MappingNode(YAML_OMAP_TAG,
-                                     [(key_item, value_item)],
-                                     flow_style=False)
-        values.append(node_item)
-    return node
-
-
-def represent_ordereddict(dumper, data):
-    return represent_ordered_mapping(dumper, YAML_OMAP_TAG, data)
-
-
-AsdfLoader.add_constructor(YAML_OMAP_TAG, ordereddict_constructor)
-AsdfDumper.add_representer(OrderedDict, represent_ordereddict)
-
-
-# ----------------------------------------------------------------------
 # Handle numpy scalars
 
 for scalar_type in util.iter_subclasses(np.floating):

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 import numpy as np
 
-import yaml
+import ruamel.yaml as yaml
 
 from . import schema
 from . import tagged

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,7 @@ display.PYTEST_HEADER_MODULES = OrderedDict([
                                     ('asdf', 'asdf'),
                                     ('numpy', 'numpy'),
                                     ('jsonschema', 'jsonschema'),
-                                    ('pyyaml', 'yaml'),
+                                    ('ruamel.yaml', 'ruamel.yaml'),
                                     ('astropy', 'astropy')])
 
 try:

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -5,7 +5,7 @@ import os
 from importlib.util import find_spec
 from pkg_resources import parse_version
 
-import yaml
+import ruamel.yaml as yaml
 import pytest
 
 import numpy as np

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
 include_package_data = True
 install_requires =
     semantic_version>=2.3.1
-    pyyaml>=3.10
+    ruamel.yaml
     jsonschema>=2.3,<=2.6
     six>=1.9.0
     numpy>=1.8


### PR DESCRIPTION
This PR closes #391. By updating `ruamel.yaml` it appears that we can remove some older logic in `asdf` that provided handling for `omap` types. It looks like `pyyaml` handled those in an idiosyncratic way, whereas `ruamel.yaml` handles them better (see https://github.com/yaml/pyyaml/issues/78).

This PR does not address #642. The solution does not appear to be straightforward and so it will need to be fixed in a separate PR.