### PR TITLE
Add a collection-like object of ExternalArrayReference objects

### DIFF
--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -39,7 +39,7 @@ from .extension import AsdfExtension
 from .stream import Stream
 from . import commands
 from .tags.core import IntegerType
-from .tags.core.external_reference import ExternalArrayReference
+from .tags.core.external_reference import ExternalArrayReference, ExternalArrayReferenceCollection
 
 from jsonschema import ValidationError
 

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -75,3 +75,114 @@ class ExternalArrayReference(AsdfType):
     @classmethod
     def from_tree(cls, tree, ctx):
         return cls(tree['fileuri'], tree['target'], tree['datatype'], tree['shape'])
+
+
+
+class ExternalArrayReferenceCollection(AsdfType):
+    """
+    A homogeneous collection of `asdf.ExternalArrayReference` like objects.
+
+    This class differs from a list of `asdf.ExternalArrayReference` objects
+    because all of the references have the same shape, dtype and target. This
+    allows for much more yaml and schema efficient storage in the asdf tree.
+
+    Parameters
+    ----------
+
+    fileuris: `list` or `tuple`
+        An interable of paths to be referenced. Can be nested arbitarily deep.
+
+    target: `object`
+        Some internal target to the data in the files. Examples may include a HDU
+        index, a HDF path or an asdf fragment.
+
+    dtype: `str`
+        The (numpy) dtype of the contained arrays.
+
+    shape: `tuple`
+        The shape of the arrays to be loaded.
+    """
+    name = "core/externalarrayreference"
+    version = (1, 0, 0)
+
+    @classmethod
+    def _validate_homogenaity(cls, shape, target, dtype, ear):
+        """
+        Ensure that if constructing from `asdf.ExternalArrayReference` objects
+        all of them have the same shape, dtype and target.
+        """
+        if isinstance(ears, (list, tuple)):
+            return list(map(partial(cls._validate_homogenaity, shape, target, dtype), ear))
+
+        if not isinstance(ear, ExternalArrayReference):
+            raise TypeError("Every element of must be an instance of ExternalArrayReference.")
+        if ear.dtype != dtype:
+            raise ValueError(f"The Reference {ear} does not have the same dtype as the first reference.")
+        if ear.shape != shape:
+            raise ValueError(f"The Reference {ear} does not have the same shape as the first reference.")
+        if ear.target != target:
+            raise ValueError(f"The Reference {ear} does not have the same target as the first reference.")
+        return ear.fileuri
+
+    @classmethod
+    def from_external_array_references(cls, ears):
+        """
+        Construct a collection from a (nested) iterable of
+        `asdf.ExternalArrayReference` objects.
+        """
+        shape = ears[0].shape
+        dtype = ears[0].dtype
+        target = ears[0].target
+
+        for i, ele in enumerate(ears):
+            uris = cls._validate_homogenaity(shape, target, dtype, ears)
+
+        return cls(uris, target, dtype, shape)
+
+    def __init__(self, fileuris, target, dtype, shape):
+        self.shape = tuple(shape)
+        self.dtype = dtype
+        self.target = target
+        self.fileuris = fileuris
+
+    def _to_ears(self, urilist):
+        if isinstance(urilist, (list, tuple)):
+            return list(map(self._to_ears, urilist))
+        return ExternalArrayReference(urilist, self.target, self.dtype, self.shape)
+
+    @property
+    def external_array_references(self):
+        """
+        Represent this collection as a list of `asdf.ExternalArrayReference` objects.
+        """
+        return self._to_ears(self.fileuris)
+
+    def __getitem__(self, item):
+        uris = self.fileuris[item]
+        if isinstance(uris, str):
+            uris = [uris]
+        return type(self)(uris, self.target, self.dtype, self.shape)
+
+    def __len__(self):
+        return len(self.fileuris)
+
+    def __eq__(self, other):
+        uri = self.fileuris == other.fileuris
+        target = self.target == other.target
+        dtype = self.dtype == other.dtype
+        shape = self.shape == other.shape
+
+        return all((uri, target, dtype, shape))
+
+    @classmethod
+    def to_tree(self, data, ctx):
+        node = {}
+        node['fileuris'] = data.fileuris
+        node['target'] = data.target
+        node['datatype'] = data.dtype
+        node['shape'] = data.shape
+        return node
+
+    @classmethod
+    def from_tree(cls, tree, ctx):
+        return cls(tree['fileuris'], tree['target'], tree['datatype'], tree['shape'])

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from ...types import AsdfType
 
 
@@ -111,7 +113,7 @@ class ExternalArrayReferenceCollection(AsdfType):
         Ensure that if constructing from `asdf.ExternalArrayReference` objects
         all of them have the same shape, dtype and target.
         """
-        if isinstance(ears, (list, tuple)):
+        if isinstance(ear, (list, tuple)):
             return list(map(partial(cls._validate_homogenaity, shape, target, dtype), ear))
 
         if not isinstance(ear, ExternalArrayReference):
@@ -125,7 +127,7 @@ class ExternalArrayReferenceCollection(AsdfType):
         return ear.fileuri
 
     @classmethod
-    def from_external_array_references(cls, ears):
+    def from_external_array_references(cls, ears, **kwargs):
         """
         Construct a collection from a (nested) iterable of
         `asdf.ExternalArrayReference` objects.
@@ -135,7 +137,7 @@ class ExternalArrayReferenceCollection(AsdfType):
         target = ears[0].target
 
         for i, ele in enumerate(ears):
-            uris = cls._validate_homogenaity(shape, target, dtype, ears)
+            uris = cls._validate_homogenaity(shape, target, dtype, ears, **kwargs)
 
         return cls(uris, target, dtype, shape)
 
@@ -175,7 +177,7 @@ class ExternalArrayReferenceCollection(AsdfType):
         return all((uri, target, dtype, shape))
 
     @classmethod
-    def to_tree(self, data, ctx):
+    def to_tree(cls, data, ctx):
         node = {}
         node['fileuris'] = data.fileuris
         node['target'] = data.target

--- a/asdf/tags/core/tests/test_external_reference.py
+++ b/asdf/tags/core/tests/test_external_reference.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
+import pytest
 
-from asdf.tags.core.external_reference import ExternalArrayReference
+from asdf.tags.core.external_reference import ExternalArrayReference, ExternalArrayReferenceCollection
 from asdf.tests import helpers
 
 
@@ -12,3 +13,36 @@ def test_roundtrip_external_array(tmpdir):
     tree = {'nothere': ref}
 
     helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+@pytest.fixture
+def earcollection():
+    return ExternalArrayReferenceCollection(["./nonexistant.fits",
+                                             "./nonexistant-1.fits"],
+                                             1,
+                                             "np.float64",
+                                             (100, 100))
+
+
+def test_roundtrip_external_array_collection(tmpdir, earcollection):
+    tree = {'nothere': earcollection}
+
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_collection_to_references(tmpdir, earcollection):
+    ears = earcollection.external_array_references
+    assert len(earcollection) == len(ears) == 2
+
+    for ear in ears:
+      assert isinstance(ear, ExternalArrayReference)
+      assert ear.target == earcollection.target
+      assert ear.dtype == earcollection.dtype
+      assert ear.shape == earcollection.shape
+
+
+def test_collection_getitem(tmpdir, earcollection):
+    assert isinstance(earcollection[0], ExternalArrayReferenceCollection)
+    assert isinstance(earcollection[1], ExternalArrayReferenceCollection)
+    assert len(earcollection[0]) == len(earcollection[1]) == 1
+    assert earcollection[0:2] == earcollection


### PR DESCRIPTION
This is mainly motivated by the fact that I have a large number of `ExternalArrayReference` objects in my trees and because each one is a separate schema they all have to be validated. Not to mention that it takes up a lot of lines of yaml. I am hoping this will massively improve my load performance. 