### PR TITLE
Fix validation of default values in schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,8 +39,11 @@
 - Fix bug that corrupted ndarrays when the underlying block
   array was converted to C order on write. [#827]
 
-# Fix bug that produced unreadable ASDF files when an
+- Fix bug that produced unreadable ASDF files when an
   ndarray in the tree was both offset and broadcasted. [#827]
+
+- Fix bug preventing validation of default values in
+  ``schema.check_schema``. [#785]
 
 2.6.1 (unreleased)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,8 +82,18 @@ filterwarnings =
 text_file_format = rst
 # Account for both the astropy test runner case and the native pytest case
 asdf_schema_root = asdf-standard/schemas asdf/schemas
-asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
-asdf_schema_skip_examples = domain-1.0.0 frame-1.0.0 frame-1.1.0
+asdf_schema_skip_names =
+    asdf-schema-1.0.0
+    draft-01
+    celestial_frame-1.0.0
+    celestial_frame-1.1.0
+    frame-1.1.0
+    spectral_frame-1.1.0
+    step-1.1.0
+    step-1.2.0
+    wcs-1.1.0
+    wcs-1.2.0
+asdf_schema_skip_examples = domain-1.0.0 frame-1.0.0
 # Enable the schema tests by default
 asdf_schema_tests_enabled = true
 asdf_schema_ignore_unrecognized_tag = true


### PR DESCRIPTION
This PR addresses a bug in `check_schema` that has been preventing us from thoroughly validating default values in schemas.  Happily, the only schemas which seem to be invalid are the old wcs schemas, which are deprecated anyway.  The specific issue is in frame-1.1.0:

```
      obsgeoloc:
        description: |
          3-vector giving the position of the observer relative to the
          center-of-mass of the Earth, oriented the same as
          BCRS/ICRS. Defaults to `[0, 0, 0]`, meaning "true" GCRS.  Used
          when `reference_frame` is `GCRS` or `precessed_geocentric`.
        type: array
        items:
          $ref: ../unit/quantity-1.1.0
        minItems: 3
        maxItems: 3
        default:
          - { value: [0], unit: m }
          - { value: [0], unit: m }
          - { value: [0], unit: m }
```

The elements of the default array aren't valid because they aren't tagged, instead they're generic objects that merely resemble quantity-1.1.0 in structure.  The default should look something like this:

```
        default:
          - !<tag:stsci.edu:asdf/unit/quantity-1.1.0>
            value: !<tag:stsci.edu:asdf/core/ndarray-1.0.0> [0]
            unit: !<tag:stsci.edu:asdf/unit/unit-1.0.0> m
          - !<tag:stsci.edu:asdf/unit/quantity-1.1.0>
            value: !<tag:stsci.edu:asdf/core/ndarray-1.0.0> [0]
            unit: !<tag:stsci.edu:asdf/unit/unit-1.0.0> m
          - !<tag:stsci.edu:asdf/unit/quantity-1.1.0>
            value: !<tag:stsci.edu:asdf/core/ndarray-1.0.0> [0]
            unit: !<tag:stsci.edu:asdf/unit/unit-1.0.0> m
```

I've excluded anything that uses frame-1.1.0 from the schema tests.