### PR TITLE
Add new resource Mapping API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 os: linux
+dist: xenial
 language: python
 python: 3.8
-# Use Travis' container-based architecture
-sudo: false
 
-matrix:
+jobs:
   include:
     # Python 3.8, stable dependencies
     - env: TOXENV=py38
@@ -78,16 +77,15 @@ matrix:
     - env:
         - TOXENV=py38
         - PATH=/usr/local/opt/python@3.8/bin:$PATH
-        # As of 2020-01-24, homebrew on Travis requires an update
-        # to make Python 3.8 available.
-        # - HOMEBREW_NO_AUTO_UPDATE=1
-        - HOMEBREW_NO_INSTALL_CLEANUP=1
       os: osx
+      osx_image: xcode12
       language: shell
-      before_install:
-        - brew unlink python@2
-        - brew install python@3.8
-      install: pip3 install tox
+      addons:
+        homebrew:
+          packages:
+            - python@3.8
+      install:
+        - pip3 install tox
 
     # Test on Windows
     - env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.8.0 (unreleased)
+------------------
+
+- Add new Mapping API for extending asdf with additional
+  schemas. [#819]
+
+- Add global configuration mechanism. [#819]
+
 2.7.0 (unreleased)
 ------------------
 

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -12,7 +12,7 @@ from ._internal_init import __version__, __githash__, test
 __all__ = [
     'AsdfFile', 'CustomType', 'AsdfExtension', 'Stream', 'open', 'test',
     'commands', 'IntegerType', 'ExternalArrayReference', 'info', '__version__',
-    '__githash__', 'ValidationError'
+    '__githash__', 'ValidationError', 'get_config', 'config_context',
 ]
 
 
@@ -24,6 +24,7 @@ from . import commands
 from .tags.core import IntegerType
 from .tags.core.external_reference import ExternalArrayReference
 from ._convenience import info
+from ._config import get_config, config_context
 
 from jsonschema import ValidationError
 

--- a/asdf/_config.py
+++ b/asdf/_config.py
@@ -1,0 +1,185 @@
+"""
+Methods for getting and setting asdf global configuration
+options.
+"""
+import threading
+from contextlib import contextmanager
+import copy
+
+from . import entry_points
+from .resource import ResourceManager
+
+
+DEFAULT_VALIDATE_ON_READ = True
+
+
+class AsdfConfig:
+    """
+    Container for ASDF configuration options.  Users are not intended to
+    construct this object directly; instead, use the `asdf.get_config` and
+    `asdf.config_context` module methods.
+    """
+
+    def __init__(
+        self,
+        resource_mappings=None,
+        resource_manager=None,
+        validate_on_read=None,
+    ):
+        self._resource_mappings = resource_mappings
+        self._resource_manager = resource_manager
+
+        if validate_on_read is None:
+            self._validate_on_read = DEFAULT_VALIDATE_ON_READ
+        else:
+            self._validate_on_read = validate_on_read
+
+        self._lock = threading.RLock()
+
+    @property
+    def resource_mappings(self):
+        """
+        Get the list of enabled resource Mapping instances.  Unless
+        overridden by user configuration, this includes every Mapping
+        registered with an entry point.
+
+        Returns
+        -------
+        list of collections.abc.Mapping
+        """
+        if self._resource_mappings is None:
+            with self._lock:
+                if self._resource_mappings is None:
+                    self._resource_mappings = entry_points.get_resource_mappings()
+        return self._resource_mappings
+
+    def add_resource_mapping(self, mapping):
+        """
+        Register a new resource Mapping.
+
+        Parameters
+        ----------
+        mapping : collections.abc.Mapping
+            map of `str` resource URI to `bytes` content
+        """
+        with self._lock:
+            resource_mappings = self.resource_mappings.copy()
+            resource_mappings.append(mapping)
+            self._resource_mappings = resource_mappings
+            self._resource_manager = None
+
+    def remove_resource_mapping(self, mapping):
+        """
+        Remove a registered resource mapping.
+
+        Parameters
+        ----------
+        mapping : collections.abc.Mapping
+        """
+        with self._lock:
+            resource_mappings = [m for m in self.resource_mappings if m is not mapping]
+            self._resource_mappings = resource_mappings
+            self._resource_manager = None
+
+    def reset_resources(self):
+        """
+        Reset registered resource mappings to the default list
+        provided as entry points.
+        """
+        with self._lock:
+            self._resource_mappings = None
+            self._resource_manager = None
+
+    @property
+    def resource_manager(self):
+        """
+        Get the `ResourceManager` instance.  Includes resources from
+        registered resource Mappings and any Mappings added at runtime.
+
+        Returns
+        -------
+        asdf.resource.ResourceManager
+        """
+        if self._resource_manager is None:
+            with self._lock:
+                if self._resource_manager is None:
+                    self._resource_manager = ResourceManager(self.resource_mappings)
+        return self._resource_manager
+
+    @property
+    def validate_on_read(self):
+        """
+        Get configuration that controls schema validation of
+        ASDF files on read.
+
+        Returns
+        -------
+        bool
+        """
+        return self._validate_on_read
+
+    @validate_on_read.setter
+    def validate_on_read(self, value):
+        """
+        Set the configuration that controls schema validation of
+        ASDF files on read.  If `True`, newly opened files will
+        be validated.
+
+        Parameters
+        ----------
+        value : bool
+        """
+        self._validate_on_read = value
+
+    def __repr__(self):
+        return (
+            "AsdfConfig(\n"
+            "  resource_mappings=[...],\n"
+            "  validate_on_read={!r},\n"
+            ")"
+        ).format(self.validate_on_read)
+
+
+class _ConfigLocal(threading.local):
+    def __init__(self):
+        self.config_stack = []
+
+
+_global_config = AsdfConfig()
+_local = _ConfigLocal()
+
+
+def get_config():
+    """
+    Get the current config, which may have been altered by
+    one or more surrounding calls to `config_context`.
+
+    Returns
+    -------
+    AsdfConfig
+    """
+    if len(_local.config_stack) == 0:
+        return _global_config
+    else:
+        return _local.config_stack[-1]
+
+
+@contextmanager
+def config_context():
+    """
+    Context manager that temporarily overrides asdf configuration.
+    The context yields an `AsdfConfig` instance that can be modified
+    without affecting code outside of the context.
+    """
+    if len(_local.config_stack) == 0:
+        base_config = _global_config
+    else:
+        base_config = _local.config_stack[-1]
+
+    config = copy.copy(base_config)
+    _local.config_stack.append(config)
+
+    try:
+        yield config
+    finally:
+        _local.config_stack.pop()

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -9,6 +9,7 @@ from pkg_resources import parse_version
 import numpy as np
 from jsonschema import ValidationError
 
+from ._config import get_config
 from . import block
 from . import constants
 from . import generic_io
@@ -612,13 +613,23 @@ class AsdfFile(versioning.VersionedMixin):
                    _force_raw_types=False,
                    strict_extension_check=False,
                    ignore_missing_extensions=False,
-                   validate_on_read=True):
+                   **kwargs):
         """Attempt to populate AsdfFile data from file-like object"""
 
         if strict_extension_check and ignore_missing_extensions:
             raise ValueError(
                 "'strict_extension_check' and 'ignore_missing_extensions' are "
                 "incompatible options")
+
+        if "validate_on_read" in kwargs:
+            warnings.warn(
+                "The 'validate_on_read' argument is deprecated, set "
+                "asdf.get_config().validate_on_read instead.",
+                AsdfDeprecationWarning
+            )
+            validate_on_read = kwargs["validate_on_read"]
+        else:
+            validate_on_read = get_config().validate_on_read
 
         self._mode = mode
 
@@ -704,7 +715,7 @@ class AsdfFile(versioning.VersionedMixin):
                    _force_raw_types=False,
                    strict_extension_check=False,
                    ignore_missing_extensions=False,
-                   validate_on_read=True):
+                   **kwargs):
         """Attempt to open file-like object as either AsdfFile or AsdfInFits"""
         if not is_asdf_file(fd):
             try:
@@ -720,7 +731,7 @@ class AsdfFile(versioning.VersionedMixin):
                             ignore_missing_extensions=ignore_missing_extensions,
                             ignore_unrecognized_tag=self._ignore_unrecognized_tag,
                             _extension_metadata=self._extension_metadata,
-                            validate_on_read=validate_on_read)
+                            **kwargs)
             except ValueError:
                 raise ValueError(
                     "Input object does not appear to be an ASDF file or a FITS with " +
@@ -737,7 +748,7 @@ class AsdfFile(versioning.VersionedMixin):
                 _force_raw_types=_force_raw_types,
                 strict_extension_check=strict_extension_check,
                 ignore_missing_extensions=ignore_missing_extensions,
-                validate_on_read=validate_on_read)
+                **kwargs)
 
     @classmethod
     def open(cls, fd, uri=None, mode='r',
@@ -1379,8 +1390,8 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False,
               ignore_version_mismatch=True, ignore_unrecognized_tag=False,
               _force_raw_types=False, copy_arrays=False, lazy_load=True,
               custom_schema=None, strict_extension_check=False,
-              ignore_missing_extensions=False, validate_on_read=True,
-              _compat=False):
+              ignore_missing_extensions=False, _compat=False,
+              **kwargs):
     """
     Open an existing ASDF file.
 
@@ -1450,8 +1461,9 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False,
         to `False`.
 
     validate_on_read : bool, optional
-        When `True`, validate the newly opened file against tag and custom
-        schemas.  Recommended unless the file is already known to be valid.
+        DEPRECATED. When `True`, validate the newly opened file against tag
+        and custom schemas.  Recommended unless the file is already known
+        to be valid.
 
     Returns
     -------
@@ -1480,7 +1492,7 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False,
         _force_raw_types=_force_raw_types,
         strict_extension_check=strict_extension_check,
         ignore_missing_extensions=ignore_missing_extensions,
-        validate_on_read=validate_on_read)
+        **kwargs)
 
 
 def is_asdf_file(fd):

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -1,0 +1,27 @@
+from pkg_resources import iter_entry_points
+import warnings
+from collections.abc import Mapping
+
+from .exceptions import AsdfWarning
+
+
+RESOURCE_MAPPINGS_GROUP = "asdf.resource_mappings"
+
+
+def get_resource_mappings():
+    return _get_entry_point_elements(RESOURCE_MAPPINGS_GROUP, Mapping)
+
+
+def _get_entry_point_elements(group, element_class):
+    results = []
+    for entry_point in iter_entry_points(group=group):
+        elements = entry_point.load()()
+        for element in elements:
+            if not isinstance(element, element_class):
+                warnings.warn(
+                    "{} is not an instance of {}.  It will be ignored.".format(element, element_class.__name__),
+                    AsdfWarning
+                )
+            else:
+                results.append(element)
+    return results

--- a/asdf/extension.py
+++ b/asdf/extension.py
@@ -25,8 +25,7 @@ class AsdfExtension(metaclass=abc.ABCMeta):
     def __subclasshook__(cls, C):
         if cls is AsdfExtension:
             return (hasattr(C, 'types') and
-                    hasattr(C, 'tag_mapping') and
-                    hasattr(C, 'url_mapping'))
+                    hasattr(C, 'tag_mapping'))
         return NotImplemented
 
     @abc.abstractproperty
@@ -70,9 +69,11 @@ class AsdfExtension(metaclass=abc.ABCMeta):
         """
         pass
 
-    @abc.abstractproperty
     def url_mapping(self):
         """
+        DEPRECATED.  This property will be ignored in asdf 3.0.
+        Schema content can be provided using the resource Mapping API.
+
         A list of 2-tuples or callables mapping JSON Schema URLs to
         other URLs.  This is useful if the JSON Schemas are not
         actually fetchable at their corresponding URLs but are on the
@@ -103,7 +104,7 @@ class AsdfExtension(metaclass=abc.ABCMeta):
                     '/{url_suffix}.yaml'
                    )]
         """
-        pass
+        return []
 
 
 class AsdfExtensionList:
@@ -121,7 +122,9 @@ class AsdfExtensionList:
                     "Extension must implement asdf.types.AsdfExtension "
                     "interface")
             tag_mapping.extend(extension.tag_mapping)
-            url_mapping.extend(extension.url_mapping)
+            # New-style extensions will not include a url_mapping attribute.
+            if hasattr(extension, "url_mapping"):
+                url_mapping.extend(extension.url_mapping)
             for typ in extension.types:
                 self._type_index.add_type(typ, extension)
                 validators.update(typ.validators)

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -177,7 +177,7 @@ class AsdfInFits(asdf.AsdfFile):
     def open(cls, fd, uri=None, validate_checksums=False, extensions=None,
              ignore_version_mismatch=True, ignore_unrecognized_tag=False,
              strict_extension_check=False, ignore_missing_extensions=False,
-             validate_on_read=True):
+             **kwargs):
         """Creates a new AsdfInFits object based on given input data
 
         Parameters
@@ -217,8 +217,9 @@ class AsdfInFits(asdf.AsdfFile):
             to `False`.
 
         validate_on_read : bool, optional
-            When `True`, validate the newly opened file against tag and custom
-            schemas.  Recommended unless the file is already known to be valid.
+            DEPRECATED. When `True`, validate the newly opened file against tag
+            and custom schemas.  Recommended unless the file is already known
+            to be valid.
         """
         return cls._open_impl(fd, uri=uri,
                        validate_checksums=validate_checksums,
@@ -227,13 +228,13 @@ class AsdfInFits(asdf.AsdfFile):
                        ignore_unrecognized_tag=ignore_unrecognized_tag,
                        strict_extension_check=strict_extension_check,
                        ignore_missing_extensions=ignore_missing_extensions,
-                       validate_on_read=validate_on_read)
+                       **kwargs)
 
     @classmethod
     def _open_impl(cls, fd, uri=None, validate_checksums=False, extensions=None,
              ignore_version_mismatch=True, ignore_unrecognized_tag=False,
              strict_extension_check=False, _extension_metadata=None,
-             ignore_missing_extensions=False, validate_on_read=True):
+             ignore_missing_extensions=False, **kwargs):
 
         close_hdulist = False
         if isinstance(fd, fits.hdu.hdulist.HDUList):
@@ -270,7 +271,7 @@ class AsdfInFits(asdf.AsdfFile):
                               validate_checksums=validate_checksums,
                               strict_extension_check=strict_extension_check,
                               ignore_missing_extensions=ignore_missing_extensions,
-                              validate_on_read=validate_on_read)
+                              **kwargs)
         except RuntimeError:
             self.close()
             raise

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -1,0 +1,180 @@
+"""
+Support for plugins that provide access to resources such
+as schemas.
+"""
+from collections.abc import Mapping
+from pathlib import Path
+import fnmatch
+import os
+import pkgutil
+import sys
+
+if sys.version_info < (3, 9):
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
+
+import asdf
+
+
+__all__ = ["TraversableResourceMapping", "ResourceManager"]
+
+
+class TraversableResourceMapping(Mapping):
+    """
+    Resource mapping that reads resource content
+    from a root directory.
+
+    Parameters
+    ----------
+    root : str or importlib.resources.abc.Traversable
+        Root directory of the resource files.  `str` will
+        be interpreted as a filesystem path.
+    uri_prefix : str
+        Prefix used to construct URIs from file paths.  The
+        prefix will be prepended to paths relative to the root
+        directory.
+    recursive : bool, optional
+        If `True`, recurse into subdirectories.  Defaults to `False`.
+    filename_pattern : str, optional
+        Glob pattern that identifies relevant filenames.
+        Defaults to "*.yaml".
+    stem_filename : bool, optional
+        If `True`, remove the filename's extension when
+        constructing its URI.
+    """
+    def __init__(self, root, uri_prefix, recursive=False, filename_pattern="*.yaml", stem_filename=True):
+        self._uri_to_traversable = {}
+        self._recursive = recursive
+        self._filename_pattern = filename_pattern
+        self._stem_filename = stem_filename
+
+        if isinstance(root, str):
+            self._root = Path(root)
+        else:
+            self._root = root
+
+        if uri_prefix.endswith("/"):
+            self._uri_prefix = uri_prefix[:-1]
+        else:
+            self._uri_prefix = uri_prefix
+
+        for traversable, path in self._iterate_files(self._root, []):
+            self._uri_to_traversable[self._make_uri(traversable, path)] = traversable
+
+    def _iterate_files(self, traversable, path):
+        for obj in traversable.iterdir():
+            if obj.is_file() and fnmatch.fnmatch(obj.name, self._filename_pattern):
+                yield obj, path
+            elif obj.is_dir() and self._recursive:
+                yield from self._iterate_files(obj, path + [obj.name])
+
+    def _make_uri(self, traversable, path):
+        if self._stem_filename:
+            filename = os.path.splitext(traversable.name)[0]
+        else:
+            filename = traversable.name
+
+        return "/".join([self._uri_prefix] + path + [filename])
+
+    def __getitem__(self, uri):
+        return self._uri_to_traversable[uri].read_bytes()
+
+    def __len__(self):
+        return len(self._uri_to_traversable)
+
+    def __iter__(self):
+        yield from self._uri_to_traversable
+
+    def __repr__(self):
+        return "{}({!r}, {!r}, recursive={!r}, filename_pattern={!r}, stem_filename={!r})".format(
+            self.__class__.__name__,
+            self._root,
+            self._uri_prefix,
+            self._recursive,
+            self._filename_pattern,
+            self._stem_filename,
+        )
+
+
+class ResourceManager(Mapping):
+    """
+    Wraps multiple resource mappings into a single interface
+    with some friendlier error handling.
+
+    Parameters
+    ----------
+    resource_mappings : list of collections.abc.Mapping
+        Underlying resource mappings.  In the case of
+        a duplicate URI, the latest mapping in the list
+        will override.
+    """
+    def __init__(self, resource_mappings):
+        self._resource_mappings = resource_mappings
+
+        self._mappings_by_uri = {}
+        for mapping in resource_mappings:
+            for uri in mapping:
+                self._mappings_by_uri[uri] = mapping
+
+    def __getitem__(self, uri):
+        if uri not in self._mappings_by_uri:
+            raise KeyError("Resource unavailable for URI: {}".format(uri))
+
+        content = self._mappings_by_uri[uri][uri]
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+
+        return content
+
+    def __len__(self):
+        return len(self._mappings_by_uri)
+
+    def __iter__(self):
+        yield from self._mappings_by_uri
+
+    def __contains__(self, uri):
+        return uri in self._mappings_by_uri
+
+
+_JSONSCHEMA_URI_TO_FILENAME = {
+    "http://json-schema.org/draft-04/schema": "draft4.json",
+}
+
+
+class JsonschemaResourceMapping(Mapping):
+    """
+    Resource mapping that fetches metaschemas from
+    the jsonschema package.
+    """
+    def __getitem__(self, uri):
+        filename = _JSONSCHEMA_URI_TO_FILENAME[uri]
+        return pkgutil.get_data("jsonschema", "schemas/{}".format(filename))
+
+    def __len__(self):
+        return len(_JSONSCHEMA_URI_TO_FILENAME)
+
+    def __iter__(self):
+        yield from _JSONSCHEMA_URI_TO_FILENAME
+
+    def __repr__(self):
+        return "JsonschemaResourceMapping()"
+
+
+def get_core_resource_mappings():
+    """
+    Get the resource mapping instances for the core schemas.
+    This method is registered with the asdf.resource_mappings entry point.
+    """
+    core_schemas_root = importlib_resources.files(asdf)/"schemas"/"stsci.edu"
+    if not core_schemas_root.is_dir():
+        # In an editable install, the schemas can be found in the
+        # asdf-standard submodule.
+        core_schemas_root = Path(__file__).parent.parent/"asdf-standard"/"schemas"/"stsci.edu"
+        if not core_schemas_root.is_dir():
+            raise RuntimeError("Unable to locate core schemas")
+
+    return [
+        TraversableResourceMapping(core_schemas_root, "http://stsci.edu/schemas", recursive=True),
+        JsonschemaResourceMapping(),
+    ]

--- a/asdf/tests/conftest.py
+++ b/asdf/tests/conftest.py
@@ -1,6 +1,11 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
 import pytest
 
 from . import create_small_tree, create_large_tree
+
+from asdf import _config
 
 
 @pytest.fixture
@@ -11,3 +16,10 @@ def small_tree():
 @pytest.fixture
 def large_tree():
     return create_large_tree()
+
+
+@pytest.fixture(autouse=True)
+def restore_default_config():
+    yield
+    _config._global_config = _config.AsdfConfig()
+    _config._local = _config._ConfigLocal()

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -11,6 +11,7 @@ import pytest
 from jsonschema.exceptions import ValidationError
 
 import asdf
+from asdf import get_config
 from asdf import treeutil
 from asdf import extension
 from asdf import resolver
@@ -95,12 +96,14 @@ invalid_software: !core/software-1.0.0
     buff = yaml_to_asdf(content)
 
     with pytest.raises(ValidationError):
-        with asdf.open(buff, validate_on_read=True):
+        get_config().validate_on_read = True
+        with asdf.open(buff):
             pass
 
     buff.seek(0)
 
-    with asdf.open(buff, validate_on_read=False) as af:
+    get_config().validate_on_read = False
+    with asdf.open(buff) as af:
         assert af["invalid_software"]["name"] == "Minesweeper"
         assert af["invalid_software"]["version"] == 3
 

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -1,0 +1,98 @@
+import threading
+
+import asdf
+from asdf import get_config
+from asdf import resource
+
+
+def test_config_context():
+    assert get_config().validate_on_read is True
+
+    with asdf.config_context() as config:
+        config.validate_on_read = False
+        assert get_config().validate_on_read is False
+
+    assert get_config().validate_on_read is True
+
+
+def test_config_context_nested():
+    assert get_config().validate_on_read is True
+
+    with asdf.config_context() as config1:
+        config1.validate_on_read = False
+        with asdf.config_context() as config2:
+            config2.validate_on_read = True
+            with asdf.config_context() as config3:
+                config3.validate_on_read = False
+                assert get_config().validate_on_read is False
+
+    assert get_config().validate_on_read is True
+
+
+def test_config_context_threaded():
+    assert get_config().validate_on_read is True
+
+    thread_value = None
+    def worker():
+        nonlocal thread_value
+        thread_value = get_config().validate_on_read
+        with asdf.config_context() as config:
+            config.validate_on_read = False
+            pass
+
+    with asdf.config_context() as config:
+        config.validate_on_read = False
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+    assert thread_value is True
+    assert get_config().validate_on_read is True
+
+
+def test_validate_on_read():
+    config = get_config()
+    assert config.validate_on_read == asdf._config.DEFAULT_VALIDATE_ON_READ
+    config.validate_on_read = False
+    assert get_config().validate_on_read is False
+    config.validate_on_read = True
+    assert get_config().validate_on_read is True
+
+
+def test_resource_mappings():
+    config = get_config()
+    core_mappings = resource.get_core_resource_mappings()
+
+    default_mappings = config.resource_mappings
+    assert len(default_mappings) >= len(core_mappings)
+
+    new_mapping = {"http://somewhere.org/schemas/foo-1.0.0": b"foo"}
+    config.add_resource_mapping(new_mapping)
+
+    assert len(config.resource_mappings) == len(default_mappings) + 1
+    assert new_mapping in config.resource_mappings
+
+    config.reset_resources()
+
+    assert len(config.resource_mappings) == len(default_mappings)
+
+
+def test_resource_manager():
+    config = get_config()
+
+    assert "http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager
+    assert b"http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager["http://stsci.edu/schemas/asdf/core/asdf-1.1.0"]
+    assert "http://somewhere.org/schemas/foo-1.0.0" not in config.resource_manager
+
+    config.add_resource_mapping({"http://somewhere.org/schemas/foo-1.0.0": b"foo"})
+
+    assert "http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager
+    assert b"http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager["http://stsci.edu/schemas/asdf/core/asdf-1.1.0"]
+    assert "http://somewhere.org/schemas/foo-1.0.0" in config.resource_manager
+    assert config.resource_manager["http://somewhere.org/schemas/foo-1.0.0"] == b"foo"
+
+    config.reset_resources()
+
+    assert "http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager
+    assert b"http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager["http://stsci.edu/schemas/asdf/core/asdf-1.1.0"]
+    assert "http://somewhere.org/schemas/foo-1.0.0" not in config.resource_manager

--- a/asdf/tests/test_entry_points.py
+++ b/asdf/tests/test_entry_points.py
@@ -1,0 +1,44 @@
+from pkg_resources import EntryPoint
+import pkg_resources
+
+import pytest
+
+from asdf import entry_points
+from asdf.exceptions import AsdfWarning
+
+
+def resource_mappings_entry_point_one():
+    return [
+        {"http://somewhere.org/schemas/foo-1.0.0": b"foo"},
+        {"http://somewhere.org/schemas/bar-1.0.0": b"bar"},
+    ]
+
+
+def resource_mappings_entry_point_two():
+    return [
+        {"http://somewhere.org/schemas/baz-1.0.0": b"baz"},
+        {"http://somewhere.org/schemas/foz-1.0.0": b"foz"},
+        object(),
+    ]
+
+
+def test_get_resource_mappings(monkeypatch):
+    def iter_entry_points(*, group):
+        if group == "asdf.resource_mappings":
+            yield EntryPoint(
+                "one", "asdf.tests.test_entry_points",
+                attrs=("resource_mappings_entry_point_one",),
+                dist=pkg_resources.get_distribution("asdf")
+            )
+            yield EntryPoint(
+                "two", "asdf.tests.test_entry_points",
+                attrs=("resource_mappings_entry_point_two",),
+                dist=pkg_resources.get_distribution("asdf")
+            )
+
+    monkeypatch.setattr(entry_points, "iter_entry_points", iter_entry_points)
+
+    with pytest.warns(AsdfWarning, match="is not an instance of Mapping"):
+        mappings = entry_points.get_resource_mappings()
+
+    assert len(mappings) == 4

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -12,6 +12,7 @@ from astropy.table import Table
 from jsonschema.exceptions import ValidationError
 
 import asdf
+from asdf import get_config
 from asdf import fits_embed
 from asdf import open as asdf_open
 from asdf.exceptions import AsdfWarning, AsdfConversionWarning
@@ -319,10 +320,12 @@ invalid_software: !core/software-1.0.0
 
     for open_method in [asdf.open, fits_embed.AsdfInFits.open]:
         with pytest.raises(ValidationError):
-            with open_method(tmpfile, validate_on_read=True):
+            get_config().validate_on_read = True
+            with open_method(tmpfile):
                 pass
 
-        with open_method(tmpfile, validate_on_read=False) as af:
+        get_config().validate_on_read = False
+        with open_method(tmpfile) as af:
             assert af["invalid_software"]["name"] == "Minesweeper"
             assert af["invalid_software"]["version"] == 3
 

--- a/asdf/tests/test_resource.py
+++ b/asdf/tests/test_resource.py
@@ -1,9 +1,17 @@
+import io
+import sys
+
+if sys.version_info < (3, 9):
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
+
 import pytest
 
 from asdf import resource
 
 
-def test_traversable_resource_mapping(tmpdir):
+def test_directory_resource_mapping(tmpdir):
     tmpdir.mkdir("schemas")
     (tmpdir/"schemas").mkdir("nested")
     with (tmpdir/"schemas"/"foo-1.2.3.yaml").open("w") as f:
@@ -13,7 +21,7 @@ def test_traversable_resource_mapping(tmpdir):
     with (tmpdir/"schemas"/"baz-7.8.9").open("w") as f:
         f.write("id: http://somewhere.org/schemas/baz-7.8.9\n")
 
-    mapping = resource.TraversableResourceMapping(str(tmpdir/"schemas"), "http://somewhere.org/schemas")
+    mapping = resource.DirectoryResourceMapping(str(tmpdir/"schemas"), "http://somewhere.org/schemas")
     assert len(mapping) == 1
     assert set(mapping) == {"http://somewhere.org/schemas/foo-1.2.3"}
     assert "http://somewhere.org/schemas/foo-1.2.3" in mapping
@@ -23,7 +31,7 @@ def test_traversable_resource_mapping(tmpdir):
     assert "http://somewhere.org/schemas/foo-1.2.3.yaml" not in mapping
     assert "http://somewhere.org/schemas/nested/bar-4.5.6" not in mapping
 
-    mapping = resource.TraversableResourceMapping(str(tmpdir/"schemas"), "http://somewhere.org/schemas", recursive=True)
+    mapping = resource.DirectoryResourceMapping(str(tmpdir/"schemas"), "http://somewhere.org/schemas", recursive=True)
     assert len(mapping) == 2
     assert set(mapping) == {"http://somewhere.org/schemas/foo-1.2.3", "http://somewhere.org/schemas/nested/bar-4.5.6"}
     assert "http://somewhere.org/schemas/foo-1.2.3" in mapping
@@ -33,7 +41,7 @@ def test_traversable_resource_mapping(tmpdir):
     assert "http://somewhere.org/schemas/nested/bar-4.5.6" in mapping
     assert b"http://somewhere.org/schemas/nested/bar-4.5.6" in mapping["http://somewhere.org/schemas/nested/bar-4.5.6"]
 
-    mapping = resource.TraversableResourceMapping(
+    mapping = resource.DirectoryResourceMapping(
         str(tmpdir/"schemas"),
         "http://somewhere.org/schemas",
         recursive=True,
@@ -46,6 +54,112 @@ def test_traversable_resource_mapping(tmpdir):
     assert "http://somewhere.org/schemas/baz-7.8.9" in mapping
     assert b"http://somewhere.org/schemas/baz-7.8.9" in mapping["http://somewhere.org/schemas/baz-7.8.9"]
     assert "http://somewhere.org/schemas/nested/bar-4.5.6" not in mapping
+
+    # Make sure trailing slash is handled correctly
+    mapping = resource.DirectoryResourceMapping(str(tmpdir/"schemas"), "http://somewhere.org/schemas/")
+    assert len(mapping) == 1
+    assert set(mapping) == {"http://somewhere.org/schemas/foo-1.2.3"}
+    assert "http://somewhere.org/schemas/foo-1.2.3" in mapping
+    assert b"http://somewhere.org/schemas/foo-1.2.3" in mapping["http://somewhere.org/schemas/foo-1.2.3"]
+
+
+def test_directory_resource_mapping_with_traversable():
+    """
+    Confirm that DirectoryResourceMapping doesn't use pathlib.Path
+    methods outside of the Traversable interface.
+    """
+    class MockTraversable(importlib_resources.abc.Traversable):
+        def __init__(self, name, value):
+            self._name = name
+            self._value = value
+
+        def iterdir(self):
+            if isinstance(self._value, dict):
+                for key, child in self._value.items():
+                    yield MockTraversable(key, child)
+
+        def read_bytes(self):
+            if not isinstance(self._value, bytes):
+                raise RuntimeError("Not a file")
+            return self._value
+
+        def read_text(self, encoding="utf-8"):
+            return self.read_bytes().decode(encoding)
+
+        def is_dir(self):
+            return isinstance(self._value, dict)
+
+        def is_file(self):
+            return self._value is not None and not isinstance(self._value, dict)
+
+        def joinpath(self, child):
+            if isinstance(self._value, dict):
+                child_value = self._value.get(child)
+            else:
+                child_value = None
+
+            return MockTraversable(child, child_value)
+
+        def __truediv__(self, child):
+            return self.joinpath(child)
+
+        def open(self, mode="r", *args, **kwargs):
+            if not self.is_file():
+                raise RuntimeError("Not a file")
+
+            if mode == "r":
+                return io.TextIOWrapper(io.BytesIO(self._value), *args, **kwargs)
+            elif mode == "rb":
+                return io.BytesIO(self._value)
+            else:
+                raise "Not a valid mode"
+
+        @property
+        def name(self):
+            return self._name
+
+    root = MockTraversable("/path/to/some/root", {
+        "foo-1.0.0.yaml": b"foo",
+        "bar-1.0.0.yaml": b"bar",
+        "baz-1.0.0": b"baz",
+        "nested": {
+            "foz-1.0.0.yaml": b"foz"
+        }
+    })
+
+    mapping = resource.DirectoryResourceMapping(root, "http://somewhere.org/schemas")
+    assert len(mapping) == 2
+    assert set(mapping) == {"http://somewhere.org/schemas/foo-1.0.0", "http://somewhere.org/schemas/bar-1.0.0"}
+    assert "http://somewhere.org/schemas/foo-1.0.0" in mapping
+    assert mapping["http://somewhere.org/schemas/foo-1.0.0"] == b"foo"
+    assert "http://somewhere.org/schemas/bar-1.0.0" in mapping
+    assert mapping["http://somewhere.org/schemas/bar-1.0.0"] == b"bar"
+    assert "http://somewhere.org/schemas/baz-1.0.0" not in mapping
+    assert "http://somewhere.org/schemas/nested/foz-1.0.0" not in mapping
+
+    mapping = resource.DirectoryResourceMapping(root, "http://somewhere.org/schemas", recursive=True)
+    assert len(mapping) == 3
+    assert set(mapping) == {
+        "http://somewhere.org/schemas/foo-1.0.0",
+        "http://somewhere.org/schemas/bar-1.0.0",
+        "http://somewhere.org/schemas/nested/foz-1.0.0"
+    }
+    assert "http://somewhere.org/schemas/foo-1.0.0" in mapping
+    assert mapping["http://somewhere.org/schemas/foo-1.0.0"] == b"foo"
+    assert "http://somewhere.org/schemas/bar-1.0.0" in mapping
+    assert mapping["http://somewhere.org/schemas/bar-1.0.0"] == b"bar"
+    assert "http://somewhere.org/schemas/baz-1.0.0" not in mapping
+    assert "http://somewhere.org/schemas/nested/foz-1.0.0" in mapping
+    assert mapping["http://somewhere.org/schemas/nested/foz-1.0.0"] == b"foz"
+
+    mapping = resource.DirectoryResourceMapping(root, "http://somewhere.org/schemas", filename_pattern="baz-*", stem_filename=False)
+    assert len(mapping) == 1
+    assert set(mapping) == {"http://somewhere.org/schemas/baz-1.0.0"}
+    assert "http://somewhere.org/schemas/foo-1.0.0" not in mapping
+    assert "http://somewhere.org/schemas/bar-1.0.0" not in mapping
+    assert "http://somewhere.org/schemas/baz-1.0.0" in mapping
+    assert mapping["http://somewhere.org/schemas/baz-1.0.0"] == b"baz"
+    assert "http://somewhere.org/schemas/nested/foz-1.0.0" not in mapping
 
 
 def test_resource_manager():

--- a/asdf/tests/test_resource.py
+++ b/asdf/tests/test_resource.py
@@ -1,0 +1,102 @@
+import pytest
+
+from asdf import resource
+
+
+def test_traversable_resource_mapping(tmpdir):
+    tmpdir.mkdir("schemas")
+    (tmpdir/"schemas").mkdir("nested")
+    with (tmpdir/"schemas"/"foo-1.2.3.yaml").open("w") as f:
+        f.write("id: http://somewhere.org/schemas/foo-1.2.3\n")
+    with (tmpdir/"schemas"/"nested"/"bar-4.5.6.yaml").open("w") as f:
+        f.write("id: http://somewhere.org/schemas/nested/bar-4.5.6\n")
+    with (tmpdir/"schemas"/"baz-7.8.9").open("w") as f:
+        f.write("id: http://somewhere.org/schemas/baz-7.8.9\n")
+
+    mapping = resource.TraversableResourceMapping(str(tmpdir/"schemas"), "http://somewhere.org/schemas")
+    assert len(mapping) == 1
+    assert set(mapping) == {"http://somewhere.org/schemas/foo-1.2.3"}
+    assert "http://somewhere.org/schemas/foo-1.2.3" in mapping
+    assert b"http://somewhere.org/schemas/foo-1.2.3" in mapping["http://somewhere.org/schemas/foo-1.2.3"]
+    assert "http://somewhere.org/schemas/baz-7.8.9" not in mapping
+    assert "http://somewhere.org/schemas/baz-7.8" not in mapping
+    assert "http://somewhere.org/schemas/foo-1.2.3.yaml" not in mapping
+    assert "http://somewhere.org/schemas/nested/bar-4.5.6" not in mapping
+
+    mapping = resource.TraversableResourceMapping(str(tmpdir/"schemas"), "http://somewhere.org/schemas", recursive=True)
+    assert len(mapping) == 2
+    assert set(mapping) == {"http://somewhere.org/schemas/foo-1.2.3", "http://somewhere.org/schemas/nested/bar-4.5.6"}
+    assert "http://somewhere.org/schemas/foo-1.2.3" in mapping
+    assert b"http://somewhere.org/schemas/foo-1.2.3" in mapping["http://somewhere.org/schemas/foo-1.2.3"]
+    assert "http://somewhere.org/schemas/baz-7.8.9" not in mapping
+    assert "http://somewhere.org/schemas/baz-7.8" not in mapping
+    assert "http://somewhere.org/schemas/nested/bar-4.5.6" in mapping
+    assert b"http://somewhere.org/schemas/nested/bar-4.5.6" in mapping["http://somewhere.org/schemas/nested/bar-4.5.6"]
+
+    mapping = resource.TraversableResourceMapping(
+        str(tmpdir/"schemas"),
+        "http://somewhere.org/schemas",
+        recursive=True,
+        filename_pattern="baz-*",
+        stem_filename=False
+    )
+    assert len(mapping) == 1
+    assert set(mapping) == {"http://somewhere.org/schemas/baz-7.8.9"}
+    assert "http://somewhere.org/schemas/foo-1.2.3" not in mapping
+    assert "http://somewhere.org/schemas/baz-7.8.9" in mapping
+    assert b"http://somewhere.org/schemas/baz-7.8.9" in mapping["http://somewhere.org/schemas/baz-7.8.9"]
+    assert "http://somewhere.org/schemas/nested/bar-4.5.6" not in mapping
+
+
+def test_resource_manager():
+    mapping1 = {
+        "http://somewhere.org/schemas/foo-1.0.0": b"foo",
+        "http://somewhere.org/schemas/bar-1.0.0": b"bar",
+    }
+    mapping2 = {
+        "http://somewhere.org/schemas/foo-1.0.0": b"foo override",
+        "http://somewhere.org/schemas/baz-1.0.0": b"baz",
+        "http://somewhere.org/schemas/foz-1.0.0": "foz",
+    }
+    manager = resource.ResourceManager([mapping1, mapping2])
+
+    assert len(manager) == 4
+    assert set(manager) == {
+        "http://somewhere.org/schemas/foo-1.0.0",
+        "http://somewhere.org/schemas/bar-1.0.0",
+        "http://somewhere.org/schemas/baz-1.0.0",
+        "http://somewhere.org/schemas/foz-1.0.0",
+    }
+    assert "http://somewhere.org/schemas/foo-1.0.0" in manager
+    assert manager["http://somewhere.org/schemas/foo-1.0.0"] == b"foo override"
+    assert "http://somewhere.org/schemas/bar-1.0.0" in manager
+    assert manager["http://somewhere.org/schemas/bar-1.0.0"] == b"bar"
+    assert "http://somewhere.org/schemas/baz-1.0.0" in manager
+    assert manager["http://somewhere.org/schemas/baz-1.0.0"] == b"baz"
+    assert "http://somewhere.org/schemas/foz-1.0.0" in manager
+    assert manager["http://somewhere.org/schemas/foz-1.0.0"] == b"foz"
+
+    with pytest.raises(KeyError, match="http://somewhere.org/schemas/missing-1.0.0"):
+        manager["http://somewhere.org/schemas/missing-1.0.0"]
+
+
+def test_jsonschema_resource_mapping():
+    mapping = resource.JsonschemaResourceMapping()
+    assert len(mapping) == 1
+    assert set(mapping) == {"http://json-schema.org/draft-04/schema"}
+    assert "http://json-schema.org/draft-04/schema" in mapping
+    assert b"http://json-schema.org/draft-04/schema" in mapping["http://json-schema.org/draft-04/schema"]
+
+
+@pytest.mark.parametrize("uri", [
+    "http://json-schema.org/draft-04/schema",
+    "http://stsci.edu/schemas/yaml-schema/draft-01",
+    "http://stsci.edu/schemas/asdf/core/asdf-1.1.0",
+])
+def test_get_core_resource_mappings(uri):
+    mappings = resource.get_core_resource_mappings()
+
+    mapping = next(m for m in mappings if uri in m)
+    assert mapping is not None
+
+    assert uri.encode("utf-8") in mapping[uri]

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_array_equal
 import pytest
 
 import asdf
+from asdf import get_config
 from asdf import extension
 from asdf import resolver
 from asdf import schema
@@ -181,6 +182,24 @@ def test_asdf_file_resolver_hashing():
 
     assert hash(a1.resolver) == hash(a2.resolver)
     assert a1.resolver == a2.resolver
+
+
+def test_load_schema_from_resource_mapping():
+    content = """
+id: http://somewhere.org/schemas/razmataz-1.0.0
+type: object
+properties:
+  foo:
+    type: string
+  bar:
+    type: boolean
+""".encode("utf-8")
+
+    get_config().add_resource_mapping({"http://somewhere.org/schemas/razmataz-1.0.0": content})
+
+    s = schema.load_schema("http://somewhere.org/schemas/razmataz-1.0.0")
+
+    assert s["id"] == "http://somewhere.org/schemas/razmataz-1.0.0"
 
 
 def test_flow_style():

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     pyyaml>=3.10
     jsonschema>=3.0.2,<4
     numpy>=1.10
+    importlib_resources>=3;python_version<"3.9"
 
 [options.extras_require]
 all =
@@ -54,6 +55,8 @@ asdf_extensions =
     builtin = asdf.extension:BuiltinExtension
 pytest11 =
     asdf_schema_tester = pytest_asdf.plugin
+asdf.resource_mappings =
+    asdf = asdf.resource:get_core_resource_mappings
 
 [build_sphinx]
 source-dir = docs


### PR DESCRIPTION
This PR introduces a new API for extending asdf with additional schemas.  The entry point accepts any `collections.abc.Mapping`, where the key is the schema URI `str` and the value is the content as `bytes`.

Included is a `Mapping` implementation that makes it easy to serve up schemas from a directory or package.  For asdf_transform_schemas, it'll look something like this:

```python
from pathlib import Path

from asdf.resource import DirectoryResourceMapping

def entry_point():
  schemas_root = Path(__file__).parent/"schemas". 
  return [
    DirectoryResourceMapping(schemas_root, "http://asdf-format.org/schemas/transform")
  ]
```

But any `Mapping` will work, so users can also add a schema from the console using a `dict`:
```python
import asdf

schema = """
type: object
properties:
  bar:
    type: integer
"""

asdf.get_config().add_resource_mapping({"http://somewhere.org/schemas/foo-1.0.0": schema})
```