### PR TITLE
Fix bug in version map caching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@
 - Stop traversing oneOf and anyOf combiners when filling
   or removing default values. [#811]
 
+- Fix bug in version map caching that caused incompatible
+  tags to be written under ASDF Standard 1.0.0. [#821]
+
 2.6.1 (unreleased)
 ------------------
 

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -57,11 +57,11 @@ def get_version_map(version):
         # Separate the core tags from the rest of the standard for convenience
         version_map['core'] = {}
         version_map['standard'] = {}
-        for name, version in version_map['tags'].items():
-            if name.startswith('tag:stsci.edu:asdf/core'):
-                version_map['core'][name] = version
+        for tag_name, tag_version in version_map['tags'].items():
+            if tag_name.startswith('tag:stsci.edu:asdf/core'):
+                version_map['core'][tag_name] = tag_version
             else:
-                version_map['standard'][name] = version
+                version_map['standard'][tag_name] = tag_version
 
         _version_map[version] = version_map
 


### PR DESCRIPTION
This resolves a bug reported by @jdavies-st where ASDF 1.0.0 files were being written with incorrect tag versions.