### PR TITLE
Allow arrays to be written to blocks in non-contiguous order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,12 @@
 - Fix bug in version map caching that caused incompatible
   tags to be written under ASDF Standard 1.0.0. [#821]
 
+- Fix bug that corrupted ndarrays when the underlying block
+  array was converted to C order on write. [#827]
+
+# Fix bug that produced unreadable ASDF files when an
+  ndarray in the tree was both offset and broadcasted. [#827]
+
 2.6.1 (unreleased)
 ------------------
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -790,13 +790,7 @@ class Block:
 
     def __init__(self, data=None, uri=None, array_storage='internal',
                  memmap=True, lazy_load=True):
-        if isinstance(data, np.ndarray) and not data.flags.c_contiguous:
-            if data.flags.f_contiguous:
-                self._data = np.asfortranarray(data)
-            else:
-                self._data = np.ascontiguousarray(data)
-        else:
-            self._data = data
+        self._data = data
         self._uri = uri
         self._array_storage = array_storage
 
@@ -916,7 +910,7 @@ class Block:
 
     def _calculate_checksum(self, data):
         m = hashlib.new('md5')
-        m.update(self.data.flatten())
+        m.update(self.data.ravel('K'))
         return m.digest()
 
     def validate_checksum(self):

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -93,7 +93,7 @@ size : integer
 
 
 def _array_tofile_chunked(write, array, chunksize):  # pragma: no cover
-    array = array.view(np.uint8).flatten()
+    array = array.view(np.uint8)
     for i in range(0, array.nbytes, chunksize):
         write(array[i:i + chunksize].data)
 
@@ -370,7 +370,7 @@ class GenericFile(metaclass=util.InheritDocstrings):
     """
 
     def write_array(self, array):
-        _array_tofile(None, self.write, array.ravel(order='A'))
+        _array_tofile(None, self.write, array.ravel(order='K'))
 
     def seek(self, offset, whence=0):
         """
@@ -749,7 +749,7 @@ class RealFile(RandomAccessFile):
             arr.flush()
             self.fast_forward(len(arr.data))
         else:
-            _array_tofile(self._fd, self._fd.write, arr.ravel(order='A'))
+            _array_tofile(self._fd, self._fd.write, arr.ravel(order='K'))
 
     def can_memmap(self):
         return True

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -416,18 +416,18 @@ class NDArrayType(AsdfType):
 
     @classmethod
     def to_tree(cls, data, ctx):
+        if any(stride == 0 for stride in data.strides):
+            data = np.ascontiguousarray(data)
+
         base = util.get_array_base(data)
         shape = data.shape
         dtype = data.dtype
         offset = data.ctypes.data - base.ctypes.data
-        strides = None
 
-        if not data.flags.c_contiguous:
-            # We do not want to encode strides for broadcasted arrays
-            if not all(data.strides):
-                data = np.ascontiguousarray(data)
-            else:
-                strides = data.strides
+        if data.flags.c_contiguous:
+            strides = None
+        else:
+            strides = data.strides
 
         block = ctx.blocks.find_or_create_block_for_array(data, ctx)
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -818,6 +818,21 @@ def test_broadcasted_array(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+def test_broadcasted_offset_array(tmpdir):
+    base = np.arange(10)
+    offset = base[5:]
+    broadcasted = np.broadcast_to(offset, (4, 5))
+    tree = {'broadcasted': broadcasted}
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_non_contiguous_base_array(tmpdir):
+    base = np.arange(60).reshape(5, 4, 3).transpose(2, 0, 1) * 1
+    contiguous = base.transpose(1, 2, 0)
+    tree = {'contiguous': contiguous}
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
 def test_fortran_order(tmpdir):
     array = np.array([[11,12,13], [21,22,23]], order='F')
     tree = dict(data=array)


### PR DESCRIPTION
This PR allows binary blocks to be written to disk in non-contiguous order.  Previously we had allowed Fortran order but converted to C order in all other cases, and this causes problems when a view over a block is depending on the original order.

While I was investigating this one, I found another bug that produced unreadable ASDF files when an array in the tree was both offset and broadcasted.

Resolves #826 