### PR TITLE
Check resource manager before passing schema URI through resolver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ------------------
 
 - Add new Mapping API for extending asdf with additional
-  schemas. [#819]
+  schemas. [#819, #828]
 
 - Add global configuration mechanism. [#819]
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -335,17 +335,6 @@ OrderedLoader.add_constructor(
 
 @lru_cache()
 def _load_schema(url):
-    # Check if this is a URI provided by the new
-    # Mapping API:
-    resource_manager = get_config().resource_manager
-    if url in resource_manager:
-        content = resource_manager[url]
-        # The jsonschema metaschemas are JSON, but pyyaml
-        # doesn't mind:
-        result = yaml.load(content, Loader=OrderedLoader)
-        return result, url
-
-    # If not, fall back to fetching the schema the old way:
     with generic_io.get_file(url) as fd:
         if isinstance(url, str) and url.endswith('json'):
             json_data = fd.read().decode('utf-8')
@@ -357,6 +346,17 @@ def _load_schema(url):
 
 def _make_schema_loader(resolver):
     def load_schema(url):
+        # Check if this is a URI provided by the new
+        # Mapping API:
+        resource_manager = get_config().resource_manager
+        if url in resource_manager:
+            content = resource_manager[url]
+            # The jsonschema metaschemas are JSON, but pyyaml
+            # doesn't mind:
+            result = yaml.load(content, Loader=OrderedLoader)
+            return result, url
+
+        # If not, fall back to fetching the schema the old way:
         url = resolver(str(url))
         return _load_schema(url)
     return load_schema


### PR DESCRIPTION
This PR is a minor adjustment to #819.  I had intended to use schemas from the new API before resorting to the old API, but my original implementation passed the schema URI through the old resolver first, which may be converting it to a filesystem URL that the new code can't recognize.  This change is simply to check the schemas from the new API first, and only pass the URI through the resolver if necessary.