### PR TITLE
Check resource manager before passing schema URI through resolver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ------------------
 
 - Add new Mapping API for extending asdf with additional
-  schemas. [#819]
+  schemas. [#819, #828]
 
 - Add global configuration mechanism. [#819]
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -322,17 +322,6 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
 
 @lru_cache()
 def _load_schema(url):
-    # Check if this is a URI provided by the new
-    # Mapping API:
-    resource_manager = get_config().resource_manager
-    if url in resource_manager:
-        content = resource_manager[url]
-        # The jsonschema metaschemas are JSON, but pyyaml
-        # doesn't mind:
-        result = yaml.load(content, Loader=yamlutil.AsdfLoader)
-        return result, url
-
-    # If not, fall back to fetching the schema the old way:
     with generic_io.get_file(url) as fd:
         if isinstance(url, str) and url.endswith('json'):
             json_data = fd.read().decode('utf-8')
@@ -344,6 +333,17 @@ def _load_schema(url):
 
 def _make_schema_loader(resolver):
     def load_schema(url):
+        # Check if this is a URI provided by the new
+        # Mapping API:
+        resource_manager = get_config().resource_manager
+        if url in resource_manager:
+            content = resource_manager[url]
+            # The jsonschema metaschemas are JSON, but pyyaml
+            # doesn't mind:
+            result = yaml.load(content, Loader=yamlutil.AsdfLoader)
+            return result, url
+
+        # If not, fall back to fetching the schema the old way:
         url = resolver(str(url))
         return _load_schema(url)
     return load_schema

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -473,7 +473,7 @@ def test_masked_array_stay_open_bug(tmpdir):
         with asdf.open(tmppath) as f2:
             np.sum(f2.tree['test'])
 
-    assert len(p.open_files()) == len(orig_open)
+    assert len(p.open_files()) <= len(orig_open)
 
 
 def test_masked_array_repr(tmpdir):


### PR DESCRIPTION
This PR is a minor adjustment to #819. I had intended to use schemas from the new API before resorting to the old API, but my original implementation passed the schema URI through the old resolver first, which may be converting it to a filesystem URL that the new code can't recognize. This change is simply to check the schemas from the new API first, and only pass the URI through the resolver if necessary.