### PR TITLE
Update CHANGES.rst for 2.7.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,21 @@
 2.7.0 (unreleased)
 ------------------
 
+- Fix bug preventing diff of files containing ndarray-1.0.0
+  objects in simplified form. [#786]
+
+- Fix bug causing duplicate elements to appear when calling
+  ``copy.deepcopy`` on a ``TaggedList``. [#788]
+
+- Improve validator performance by skipping unnecessary step of
+  copying schema objects. [#784]
+
+- Fix bug with ``auto_inline`` option where inline blocks
+  are not converted to internal when they exceed the threshold. [#802]
+
+- Fix misinterpretation of byte order of blocks stored
+  in FITS files. [#810]
+
 - Improve read performance by skipping unnecessary rebuild
   of tagged tree. [#787]
 
@@ -44,24 +59,6 @@
 
 - Fix bug preventing validation of default values in
   ``schema.check_schema``. [#785]
-
-2.6.1 (unreleased)
-------------------
-
-- Fix bug preventing diff of files containing ndarray-1.0.0
-  objects in simplified form. [#786]
-
-- Fix bug causing duplicate elements to appear when calling
-  ``copy.deepcopy`` on a ``TaggedList``. [#788]
-
-- Improve validator performance by skipping unnecessary step of
-  copying schema objects. [#784]
-
-- Fix bug with ``auto_inline`` option where inline blocks
-  are not converted to internal when they exceed the threshold. [#802]
-
-- Fix misinterpretation of byte order of blocks stored
-  in FITS files. [#810]
 
 2.6.0 (2020-04-22)
 ------------------


### PR DESCRIPTION
This just removes the 2.6.1 section of the changelog and moves its entries to the top of the 2.7.0 section.