### PR TITLE
Make validation of schema default configurable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,9 @@
 - Fix bug preventing validation of default values in
   ``schema.check_schema``. [#785]
 
+- Add option to disable validation of schema default values
+  in the pytest plugin. [#831]
+
 2.6.0 (2020-04-22)
 ------------------
 

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -13,6 +13,7 @@ from asdf import schema
 from asdf import types
 from asdf import util
 from asdf import yamlutil
+from asdf import tagged
 from asdf.tests import helpers, CustomExtension
 from asdf.exceptions import AsdfWarning, AsdfConversionWarning
 
@@ -360,6 +361,30 @@ def test_default_check_in_schema():
         schema.check_schema(s)
 
     schema.check_schema(s, validate_default=False)
+
+
+def test_check_complex_default():
+    default_software = tagged.TaggedDict(
+        {"name": "asdf", "version": "2.7.0"},
+        "tag:stsci.edu/asdf/core/software-1.0.0"
+    )
+
+    s = {
+        'type': 'object',
+        'properties': {
+            'a': {
+                'type': 'object',
+                'tag': 'tag:stsci.edu/asdf/core/software-1.0.0',
+                'default': default_software
+            }
+        }
+    }
+
+    schema.check_schema(s)
+
+    s['properties']['a']['tag'] = 'tag:stsci.edu/asdf/core/ndarray-1.0.0'
+    with pytest.raises(ValidationError):
+        schema.check_schema(s)
 
 
 def test_fill_and_remove_defaults():

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -359,6 +359,8 @@ def test_default_check_in_schema():
     with pytest.raises(ValidationError):
         schema.check_schema(s)
 
+    schema.check_schema(s, validate_default=False)
+
 
 def test_fill_and_remove_defaults():
     class DefaultType(dict, types.CustomType):

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -26,6 +26,12 @@ def pytest_addoption(parser):
         default=False,
     )
     parser.addini(
+        "asdf_schema_validate_default",
+        "Set to true to enable validation of the schema 'default' property",
+        type="bool",
+        default=True,
+    )
+    parser.addini(
         "asdf_schema_ignore_unrecognized_tag",
         "Set to true to disable warnings when tag serializers are missing",
         type="bool",
@@ -43,7 +49,7 @@ def pytest_addoption(parser):
 
 class AsdfSchemaFile(pytest.File):
     @classmethod
-    def from_parent(cls, parent, *, fspath, skip_examples=False,
+    def from_parent(cls, parent, *, fspath, skip_examples=False, validate_default=True,
         ignore_unrecognized_tag=False, ignore_version_mismatch=False, **kwargs):
         if hasattr(super(), "from_parent"):
             result = super().from_parent(parent, fspath=fspath, **kwargs)
@@ -51,12 +57,13 @@ class AsdfSchemaFile(pytest.File):
             result = AsdfSchemaFile(fspath, parent, **kwargs)
 
         result.skip_examples = skip_examples
+        result.validate_default = validate_default
         result.ignore_unrecognized_tag = ignore_unrecognized_tag
         result.ignore_version_mismatch = ignore_version_mismatch
         return result
 
     def collect(self):
-        yield AsdfSchemaItem.from_parent(self, self.fspath)
+        yield AsdfSchemaItem.from_parent(self, self.fspath, validate_default=self.validate_default)
         if not self.skip_examples:
             for example in self.find_examples_in_schema():
                 yield AsdfSchemaExampleItem.from_parent(
@@ -84,13 +91,14 @@ class AsdfSchemaFile(pytest.File):
 
 class AsdfSchemaItem(pytest.Item):
     @classmethod
-    def from_parent(cls, parent, schema_path, **kwargs):
+    def from_parent(cls, parent, schema_path, validate_default=True, **kwargs):
         if hasattr(super(), "from_parent"):
             result = super().from_parent(parent, name=str(schema_path), **kwargs)
         else:
             result = AsdfSchemaItem(str(schema_path), parent, **kwargs)
 
         result.schema_path = schema_path
+        result.validate_default = validate_default
         return result
 
     def runtest(self):
@@ -101,7 +109,7 @@ class AsdfSchemaItem(pytest.Item):
         schema_tree = schema.load_schema(
             self.schema_path, resolver=default_extensions.resolver,
             resolve_references=True)
-        schema.check_schema(schema_tree)
+        schema.check_schema(schema_tree, validate_default=self.validate_default)
 
 
 ASTROPY_4_0_TAGS = {
@@ -228,6 +236,7 @@ def pytest_collect_file(path, parent):
 
     skip_names = parent.config.getini('asdf_schema_skip_names')
     skip_examples = parent.config.getini('asdf_schema_skip_examples')
+    validate_default = parent.config.getini('asdf_schema_validate_default')
     ignore_unrecognized_tag = parent.config.getini('asdf_schema_ignore_unrecognized_tag')
     ignore_version_mismatch = parent.config.getini('asdf_schema_ignore_version_mismatch')
 
@@ -243,6 +252,7 @@ def pytest_collect_file(path, parent):
                 parent,
                 fspath=path,
                 skip_examples=(path.purebasename in skip_examples),
+                validate_default=validate_default,
                 ignore_unrecognized_tag=ignore_unrecognized_tag,
                 ignore_version_mismatch=ignore_version_mismatch,
             )


### PR DESCRIPTION
A [recent bug fix](https://github.com/asdf-format/asdf/pull/785) made this check more strict, which is causing tests in jwst to fail.  This PR adds an option to disable validation of the schema `default` property for projects that want to use a descriptive `default` value instead of providing a literal default.