### PR TITLE
Prevent errors when extra properties are present in extension metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@
 - Add option to disable validation of schema default values
   in the pytest plugin. [#831]
 
+- Prevent errors when extension metadata contains additional
+  properties. [#832]
+
 2.6.0 (2020-04-22)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -252,7 +252,7 @@ class AsdfFile(versioning.VersionedMixin):
             ext_meta = ExtensionMetadata(extension_class=ext_name)
             metadata = self._extension_metadata.get(ext_name)
             if metadata is not None:
-                ext_meta.software = Software(name=metadata[0], version=metadata[1])
+                ext_meta['software'] = Software(name=metadata[0], version=metadata[1])
 
             for i, entry in enumerate(self.tree['history']['extensions']):
                 # Update metadata about this extension if it already exists

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -41,25 +41,17 @@ class HistoryEntry(dict, AsdfType):
     version = '1.0.0'
 
 
-class ExtensionMetadata(AsdfType):
+class ExtensionMetadata(dict, AsdfType):
     name = 'core/extension_metadata'
     version = '1.0.0'
 
-    def __init__(self, extension_class=None, software={}):
-        self.extension_class = extension_class
-        self.software = software
+    @property
+    def extension_class(self):
+        return self['extension_class']
 
-    @classmethod
-    def from_tree(cls, node, ctx):
-        return cls(**node)
-
-    @classmethod
-    def to_tree(cls, node, ctx):
-        tree = {}
-        tree['extension_class'] = node.extension_class
-        tree['software'] = node.software
-
-        return tree
+    @property
+    def software(self):
+        return self.get('software')
 
 
 class SubclassMetadata(dict, AsdfType):

--- a/asdf/tags/core/tests/test_extension_metadata.py
+++ b/asdf/tags/core/tests/test_extension_metadata.py
@@ -1,0 +1,22 @@
+import asdf
+
+from asdf import yamlutil
+from asdf.tests import helpers
+
+def test_extra_properties():
+    yaml = """
+metadata: !core/extension_metadata-1.0.0
+  extension_class: foo.extension.FooExtension
+  software: !core/software-1.0.0
+    name: FooSoft
+    version: "1.5"
+  extension_uri: http://foo.biz/extensions/foo-1.0.0
+    """
+
+    buff = helpers.yaml_to_asdf(yaml)
+
+    with asdf.open(buff) as af:
+        af["metadata"].extension_class == "foo.extension.FooExtension"
+        af["metadata"].software["name"] == "FooSoft"
+        af["metadata"].software["version"] == "1.5"
+        af["metadata"]["extension_uri"] == "http://foo.biz/extensions/foo-1.0.0"

--- a/asdf/tags/core/tests/test_extension_metadata.py
+++ b/asdf/tags/core/tests/test_extension_metadata.py
@@ -1,6 +1,5 @@
 import asdf
 
-from asdf import yamlutil
 from asdf.tests import helpers
 
 def test_extra_properties():

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -308,8 +308,8 @@ def test_extension_version_check(installed, extension, warns):
     tree = {
         'history': {
             'extensions': [
-                asdf.tags.core.ExtensionMetadata('foo.extension.FooExtension',
-                    asdf.tags.core.Software(name='foo', version=extension)),
+                asdf.tags.core.ExtensionMetadata(extension_class='foo.extension.FooExtension',
+                    software=asdf.tags.core.Software(name='foo', version=extension)),
             ]
         }
     }


### PR DESCRIPTION
The next version of ASDF is going to add some additional properties to extension metadata, which the schema permits but would cause the library to raise an error due to the way the `ExtensionMetadata` class was initialized.  This PR changes the `ExtensionMetadata` class to a dict (like the other core objects) so that it can hold additional properties without complaint.

I'd like to get this into the 2.7 release so that files produced by 2.8 do not cause these errors.