### PR TITLE
Replace usage of deprecated tostring with tobytes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@
 - Prevent errors when extension metadata contains additional
   properties. [#832]
 
+- Replace use of deprecated ``numpy.ndarray.tostring`` method. [#817]
+
 2.6.0 (2020-04-22)
 ------------------
 

--- a/asdf/stream.py
+++ b/asdf/stream.py
@@ -22,7 +22,7 @@ class Stream(ndarray.NDArrayType):
          ...     ff.write_to(fd)
          ...     for i in range(200):
          ...         nbytes = fd.write(
-         ...                      np.array([i] * 1024, np.float64).tostring())
+         ...                      np.array([i] * 1024, np.float64).tobytes())
     """
     name = None
     types = []

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -96,12 +96,12 @@ def test_embed_asdf_in_fits_file(tmpdir, backwards_compat, dtype):
         assert [x.name for x in hdulist2] == ['SCI', 'DQ', 'WITH_UNDERSCORE', 'ASDF']
         assert_array_equal(hdulist2[0].data, np.arange(512, dtype=dtype))
         asdf_hdu = hdulist2['ASDF']
-        assert asdf_hdu.data.tostring().startswith(b'#ASDF')
+        assert asdf_hdu.data.tobytes().startswith(b'#ASDF')
         # When in backwards compatibility mode, the ASDF file will be contained
         # in an ImageHDU
         if backwards_compat:
             assert isinstance(asdf_hdu, fits.ImageHDU)
-            assert asdf_hdu.data.tostring().strip().endswith(b'...')
+            assert asdf_hdu.data.tobytes().strip().endswith(b'...')
         else:
             assert isinstance(asdf_hdu, fits.BinTableHDU)
 
@@ -129,7 +129,7 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir, dtype):
         assert [x.name for x in hdulist] == ['PRIMARY', '', '', 'ASDF']
         asdf_hdu = hdulist['ASDF']
         assert isinstance(asdf_hdu, fits.BinTableHDU)
-        assert asdf_hdu.data.tostring().startswith(b'#ASDF')
+        assert asdf_hdu.data.tobytes().startswith(b'#ASDF')
 
         with fits_embed.AsdfInFits.open(hdulist) as ff2:
             assert_tree_match(asdf_in_fits.tree, ff2.tree)
@@ -195,7 +195,7 @@ def test_access_hdu_data_after_write(tmpdir, dtype):
     asdf_in_fits.write_to(tempfile)
     asdf_hdu = asdf_in_fits._hdulist['ASDF']
 
-    assert asdf_hdu.data.tostring().startswith('#ASDF')
+    assert asdf_hdu.data.tobytes().startswith('#ASDF')
 
 
 @pytest.mark.parametrize('dtype', TEST_DTYPES)

--- a/asdf/tests/test_stream.py
+++ b/asdf/tests/test_stream.py
@@ -25,7 +25,7 @@ def test_stream():
     ff = asdf.AsdfFile(tree)
     ff.write_to(buff)
     for i in range(100):
-        buff.write(np.array([i] * 12, np.float64).tostring())
+        buff.write(np.array([i] * 12, np.float64).tobytes())
 
     buff.seek(0)
 
@@ -68,7 +68,7 @@ def test_stream_twice():
     ff = asdf.AsdfFile(tree)
     ff.write_to(buff)
     for i in range(100):
-        buff.write(np.array([i] * 12, np.uint8).tostring())
+        buff.write(np.array([i] * 12, np.uint8).tobytes())
 
     buff.seek(0)
 
@@ -92,7 +92,7 @@ def test_stream_with_nonstream():
     ff.set_array_storage(ff['nonstream'], 'internal')
     ff.write_to(buff)
     for i in range(100):
-        buff.write(np.array([i] * 12, np.float64).tostring())
+        buff.write(np.array([i] * 12, np.float64).tobytes())
 
     buff.seek(0)
 
@@ -121,7 +121,7 @@ def test_stream_real_file(tmpdir):
         ff.set_array_storage(ff['nonstream'], 'internal')
         ff.write_to(fd)
         for i in range(100):
-            fd.write(np.array([i] * 12, np.float64).tostring())
+            fd.write(np.array([i] * 12, np.float64).tobytes())
 
     with asdf.open(path) as ff:
         assert len(ff.blocks) == 1
@@ -144,7 +144,7 @@ def test_stream_to_stream():
     ff = asdf.AsdfFile(tree)
     ff.write_to(fd)
     for i in range(100):
-        fd.write(np.array([i] * 12, np.float64).tostring())
+        fd.write(np.array([i] * 12, np.float64).tobytes())
 
     buff.seek(0)
 
@@ -165,7 +165,7 @@ def test_array_to_stream(tmpdir):
     ff = asdf.AsdfFile(tree)
     ff.set_array_storage(tree['stream'], 'streamed')
     ff.write_to(buff)
-    buff.write(np.array([5, 6, 7, 8], np.int64).tostring())
+    buff.write(np.array([5, 6, 7, 8], np.int64).tobytes())
 
     buff.seek(0)
     ff = asdf.open(generic_io.InputStream(buff))
@@ -179,7 +179,7 @@ def test_array_to_stream(tmpdir):
         ff = asdf.AsdfFile(tree)
         ff.set_array_storage(tree['stream'], 'streamed')
         ff.write_to(fd)
-        fd.write(np.array([5, 6, 7, 8], np.int64).tostring())
+        fd.write(np.array([5, 6, 7, 8], np.int64).tobytes())
 
     with asdf.open(os.path.join(str(tmpdir), 'test.asdf')) as ff:
         assert_array_equal(ff.tree['stream'], [1, 2, 3, 4, 5, 6, 7, 8])

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -184,9 +184,9 @@ binary data.
        ff.write_to(fd)
        # Write 100 rows of data, one row at a time.  ``write``
        # expects the raw binary bytes, not an array, so we use
-       # ``tostring()``.
+       # ``tobytes()``.
        for i in range(100):
-           fd.write(np.array([i] * 128, np.float64).tostring())
+           fd.write(np.array([i] * 128, np.float64).tobytes())
 
 .. asdf:: test.asdf
 
@@ -219,7 +219,7 @@ to numpy arrays stored in ASDF:
                 # convert each row to a numpy array
                 array = np.array([int(x) for x in row], np.int64)
                 # write the array to the output file handle
-                fd.write(array.tostring())
+                fd.write(array.tobytes())
 
 Compression
 -----------

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -471,7 +471,7 @@ create an `AsdfInFits` object.
 
     with fits.open('embedded_asdf.fits') as new_hdulist:
         with open('content.asdf', 'wb') as fd:
-            fd.write(new_hdulist['ASDF'].data.tostring())
+            fd.write(new_hdulist['ASDF'].data.tobytes())
 
 The special ASDF extension in the resulting FITS file contains the following
 data.  Note that the data source of the arrays uses the ``fits:`` prefix to

--- a/docs/sphinxext/example.py
+++ b/docs/sphinxext/example.py
@@ -92,7 +92,7 @@ class AsdfDirective(Directive):
 
             with asdf.open(filename, **kwargs) as ff:
                 for i, block in enumerate(ff.blocks.internal_blocks):
-                    data = codecs.encode(block.data.tostring(), 'hex')
+                    data = codecs.encode(block.data.tobytes(), 'hex')
                     if len(data) > 40:
                         data = data[:40] + '...'.encode()
                     allocated = block._allocated


### PR DESCRIPTION
This was merged into master as part of #817, but we don't want to include that entire commit in 2.7.