### PR TITLE
Initial refactor of extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,22 @@
 - Drop support for automatic serialization of subclass
   attributes. [#825]
 
+- Fix bug that caused irrelevant extension metadata to
+  appear in the ASDF tree. [#835]
+
+- Introduce new entry point (asdf.extensions) for extensions. [#835]
+
+- Remove warning when reading a file with an older
+  version of an extension package. [#835]
+
+- Restrict the ``extensions`` parameter to ``asdf.open``
+  and ``asdf.AsdfFile`` to a list of ``asdf.AsdfExtension``.
+  Previously it accepted an instance of ``asdf.AsdfExtension``
+  or ``asdf.extension.AsdfExtensionList``. [#835]
+
+- Extend the ``asdf.AsdfExtension`` interface to support
+  versioned extensions. [#835]
+
 2.7.0 (2020-07-23)
 ------------------
 

--- a/asdf/commands/tags.py
+++ b/asdf/commands/tags.py
@@ -38,7 +38,7 @@ def _qualified_name(_class):
 def list_tags(display_classes=False, iostream=sys.stdout):
     """Function to list tags"""
     af = AsdfFile()
-    type_by_tag = af._extensions._type_index._type_by_tag
+    type_by_tag = af.type_index._type_by_tag
     tags = sorted(type_by_tag.keys())
 
     for tag in tags:

--- a/asdf/commands/tests/test_tags.py
+++ b/asdf/commands/tests/test_tags.py
@@ -16,7 +16,7 @@ def test_list_schemas():
     obs_tags = _get_tags(False)
 
     af = AsdfFile()
-    exp_tags = sorted(af._extensions._type_index._type_by_tag.keys())
+    exp_tags = sorted(af.type_index._type_by_tag.keys())
 
     for exp, obs in zip(exp_tags, obs_tags):
         assert exp == obs
@@ -25,7 +25,7 @@ def test_list_schemas_and_tags():
     tag_lines = _get_tags(True)
 
     af = AsdfFile()
-    type_by_tag = af._extensions._type_index._type_by_tag
+    type_by_tag = af.type_index._type_by_tag
     exp_tags = sorted(type_by_tag.keys())
 
     for exp_tag, line in zip(exp_tags, tag_lines):

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -3,25 +3,52 @@ import warnings
 from collections.abc import Mapping
 
 from .exceptions import AsdfWarning
+from .extension import AsdfExtension, ExtensionProxy
+from .resource import ResourceMappingProxy
 
 
 RESOURCE_MAPPINGS_GROUP = "asdf.resource_mappings"
+EXTENSIONS_GROUP = "asdf.extensions"
+LEGACY_EXTENSIONS_GROUP = "asdf_extensions"
 
 
 def get_resource_mappings():
-    return _get_entry_point_elements(RESOURCE_MAPPINGS_GROUP, Mapping)
+    return [
+        ResourceMappingProxy(mapping, package_name=package_name, package_version=package_version)
+        for mapping, package_name, package_version in _iterate_entry_point(RESOURCE_MAPPINGS_GROUP, Mapping)
+    ]
 
 
-def _get_entry_point_elements(group, element_class):
-    results = []
+def get_extensions():
+    extensions = [
+        ExtensionProxy(extension, package_name=package_name, package_version=package_version)
+        for extension, package_name, package_version in _iterate_entry_point(EXTENSIONS_GROUP, AsdfExtension)
+    ]
+
+    legacy_extensions = [
+        ExtensionProxy(extension, package_name=package_name, package_version=package_version, legacy=True)
+        for extension, package_name, package_version in _iterate_entry_point(LEGACY_EXTENSIONS_GROUP, AsdfExtension)
+    ]
+
+    return extensions + legacy_extensions
+
+
+def _iterate_entry_point(group, element_class):
     for entry_point in iter_entry_points(group=group):
         elements = entry_point.load()()
+        if isinstance(elements, element_class):
+            elements = [elements]
+        package_name = entry_point.dist.project_name
+        package_version = entry_point.dist.version
         for element in elements:
             if not isinstance(element, element_class):
                 warnings.warn(
-                    "{} is not an instance of {}.  It will be ignored.".format(element, element_class.__name__),
+                    "{!r} registered with entry point '{}' is not an instance of {}.  It will be ignored.".format(
+                        element,
+                        group,
+                        element_class.__name__
+                    ),
                     AsdfWarning
                 )
             else:
-                results.append(element)
-    return results
+                yield element, package_name, package_version

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -233,7 +233,7 @@ class AsdfInFits(asdf.AsdfFile):
     @classmethod
     def _open_impl(cls, fd, uri=None, validate_checksums=False, extensions=None,
              ignore_version_mismatch=True, ignore_unrecognized_tag=False,
-             strict_extension_check=False, _extension_metadata=None,
+             strict_extension_check=False,
              ignore_missing_extensions=False, **kwargs):
 
         close_hdulist = False
@@ -250,11 +250,9 @@ class AsdfInFits(asdf.AsdfFile):
                 msg = "Failed to parse given file '{}'. Is it FITS?"
                 raise ValueError(msg.format(uri))
 
-        self = cls(hdulist, uri=uri, extensions=extensions,
+        self = cls(hdulist, uri=uri,
                    ignore_version_mismatch=ignore_version_mismatch,
                    ignore_unrecognized_tag=ignore_unrecognized_tag)
-        if _extension_metadata is not None:
-            self._extension_metadata = _extension_metadata
 
         self._close_hdulist = close_hdulist
 
@@ -269,6 +267,7 @@ class AsdfInFits(asdf.AsdfFile):
         try:
             return cls._open_asdf(self, buff, uri=uri, mode='r',
                               validate_checksums=validate_checksums,
+                              extensions=extensions,
                               strict_extension_check=strict_extension_check,
                               ignore_missing_extensions=ignore_missing_extensions,
                               **kwargs)

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -15,6 +15,7 @@ else:
     import importlib.resources as importlib_resources
 
 import asdf
+from .util import get_class_name
 
 
 __all__ = [
@@ -23,6 +24,61 @@ __all__ = [
     "JsonschemaResourceMapping",
     "get_core_resource_mappings",
 ]
+
+
+class ResourceMappingProxy(Mapping):
+    """
+    Proxy that wraps a resource `Mapping` and carries
+    additional information on the package that provided
+    the mapping.
+    """
+    @classmethod
+    def maybe_wrap(self, delegate):
+        if isinstance(delegate, ResourceMappingProxy):
+            return delegate
+        else:
+            return ResourceMappingProxy(delegate)
+
+    def __init__(self, delegate, package_name=None, package_version=None):
+        if not isinstance(delegate, Mapping):
+            raise TypeError("Resource mapping must implement the Mapping interface")
+
+        self._delegate = delegate
+        self._package_name = package_name
+        self._package_version = package_version
+        self._class_name = get_class_name(delegate)
+
+    def __getitem__(self, uri):
+        return self._delegate.__getitem__(uri)
+
+    def __len__(self):
+        return self._delegate.__len__()
+
+    def __iter__(self):
+        return self._delegate.__iter__()
+
+    @property
+    def delegate(self):
+        return self._delegate
+
+    @property
+    def package_name(self):
+        return self._package_name
+
+    @property
+    def package_version(self):
+        return self._package_version
+
+    @property
+    def class_name(self):
+        return self._class_name
+
+    def __repr__(self):
+        return "<ResourceMappingProxy class: {} package: {}=={}>".format(
+            self.class_name,
+            self.package_name,
+            self.package_version,
+        )
 
 
 class DirectoryResourceMapping(Mapping):

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -511,7 +511,7 @@ def get_validator(schema={}, ctx=None, validators=None, url_mapping=None,
 
     if validators is None:
         validators = util.HashableDict(YAML_VALIDATORS.copy())
-        validators.update(ctx._extensions.validators)
+        validators.update(ctx._extension_list.validators)
 
     kwargs['resolver'] = _make_resolver(url_mapping)
 

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -133,8 +133,6 @@ def test_get_history_entries(tmpdir):
 def test_extension_metadata(tmpdir):
 
     ff = asdf.AsdfFile()
-    # So far only the base extension has been used
-    assert len(ff.type_index.get_extensions_used()) == 1
 
     tmpfile = str(tmpdir.join('extension.asdf'))
     ff.write_to(tmpfile)
@@ -161,33 +159,8 @@ history:
     """
 
     buff = yaml_to_asdf(yaml)
-    with pytest.warns(AsdfWarning, match="File was created with extension 'foo.bar.FooBar'"):
+    with pytest.warns(AsdfWarning, match="File was created with extension foo.bar.FooBar"):
         with asdf.open(buff):
-            pass
-
-
-def test_extension_version_warning():
-
-    yaml = """
-history:
-  extensions:
-    - !core/extension_metadata-1.0.0
-      extension_class: asdf.extension.BuiltinExtension
-      software: !core/software-1.0.0
-        name: asdf
-        version: 100.0.3
-    """
-
-    buff = yaml_to_asdf(yaml)
-    with pytest.warns(AsdfWarning, match="File was created with extension 'asdf.extension.BuiltinExtension'"):
-        with asdf.open(buff):
-            pass
-
-    buff.seek(0)
-
-    # Make sure suppressing the warning works too
-    with assert_no_warnings():
-        with asdf.open(buff, ignore_missing_extensions=True):
             pass
 
 
@@ -241,11 +214,11 @@ def test_metadata_with_custom_extension(tmpdir):
     }
 
     tmpfile = str(tmpdir.join('custom_extension.asdf'))
-    with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
+    with asdf.AsdfFile(tree, extensions=[FractionExtension()]) as ff:
         ff.write_to(tmpfile)
 
     # We expect metadata about both the Builtin extension and the custom one
-    with asdf.open(tmpfile, extensions=FractionExtension()) as af:
+    with asdf.open(tmpfile, extensions=[FractionExtension()]) as af:
         assert len(af['history']['extensions']) == 2
 
     with pytest.warns(AsdfWarning, match="was created with extension"):
@@ -256,7 +229,7 @@ def test_metadata_with_custom_extension(tmpdir):
     # no metadata about this extension should be added to the file
     tree2 = { 'x': [x for x in range(10)] }
     tmpfile2 = str(tmpdir.join('no_extension.asdf'))
-    with asdf.AsdfFile(tree2, extensions=FractionExtension()) as ff:
+    with asdf.AsdfFile(tree2, extensions=[FractionExtension()]) as ff:
         ff.write_to(tmpfile2)
 
     with asdf.open(tmpfile2) as af:
@@ -268,9 +241,9 @@ def test_metadata_with_custom_extension(tmpdir):
 
     # Make sure that this works even when constructing the tree on-the-fly
     tmpfile3 = str(tmpdir.join('custom_extension2.asdf'))
-    with asdf.AsdfFile(extensions=FractionExtension()) as ff:
+    with asdf.AsdfFile(extensions=[FractionExtension()]) as ff:
         ff.tree['fraction'] = fractions.Fraction(4, 5)
         ff.write_to(tmpfile3)
 
-    with asdf.open(tmpfile3, extensions=FractionExtension()) as af:
+    with asdf.open(tmpfile3, extensions=[FractionExtension()]) as af:
         assert len(af['history']['extensions']) == 2

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -552,7 +552,7 @@ def test_ndim_validation(tmpdir):
     buff = helpers.yaml_to_asdf(content)
 
     with pytest.raises(jsonschema.ValidationError):
-        with asdf.open(buff, extensions=CustomExtension()):
+        with asdf.open(buff, extensions=[CustomExtension()]):
             pass
 
     content = """
@@ -562,7 +562,7 @@ def test_ndim_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with asdf.open(buff, extensions=CustomExtension()):
+    with asdf.open(buff, extensions=[CustomExtension()]):
         pass
 
     content = """
@@ -573,7 +573,7 @@ def test_ndim_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with asdf.open(buff, extensions=CustomExtension()):
+    with asdf.open(buff, extensions=[CustomExtension()]):
         pass
 
     content = """
@@ -583,7 +583,7 @@ def test_ndim_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with asdf.open(buff, extensions=CustomExtension()):
+    with asdf.open(buff, extensions=[CustomExtension()]):
         pass
 
     content = """
@@ -593,7 +593,7 @@ def test_ndim_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with asdf.open(buff, extensions=CustomExtension()):
+    with asdf.open(buff, extensions=[CustomExtension()]):
         pass
 
     content = """
@@ -604,7 +604,7 @@ def test_ndim_validation(tmpdir):
     buff = helpers.yaml_to_asdf(content)
 
     with pytest.raises(jsonschema.ValidationError):
-        with asdf.open(buff, extensions=CustomExtension()):
+        with asdf.open(buff, extensions=[CustomExtension()]):
             pass
 
 
@@ -617,7 +617,7 @@ def test_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with asdf.open(buff, extensions=CustomExtension()):
+    with asdf.open(buff, extensions=[CustomExtension()]):
         pass
 
     content = """
@@ -629,7 +629,7 @@ def test_datatype_validation(tmpdir):
     buff = helpers.yaml_to_asdf(content)
 
     with pytest.raises(jsonschema.ValidationError):
-        with asdf.open(buff, extensions=CustomExtension()):
+        with asdf.open(buff, extensions=[CustomExtension()]):
             pass
 
     content = """
@@ -640,7 +640,7 @@ def test_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with asdf.open(buff, extensions=CustomExtension()):
+    with asdf.open(buff, extensions=[CustomExtension()]):
         pass
 
     content = """
@@ -652,7 +652,7 @@ def test_datatype_validation(tmpdir):
     buff = helpers.yaml_to_asdf(content)
 
     with pytest.raises(jsonschema.ValidationError):
-        with asdf.open(buff, extensions=CustomExtension()):
+        with asdf.open(buff, extensions=[CustomExtension()]):
             pass
 
     content = """
@@ -668,7 +668,7 @@ def test_datatype_validation(tmpdir):
     buff = helpers.yaml_to_asdf(content)
 
     with pytest.raises(jsonschema.ValidationError):
-        with asdf.open(buff, extensions=CustomExtension()):
+        with asdf.open(buff, extensions=[CustomExtension()]):
             pass
 
 
@@ -685,7 +685,7 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with asdf.open(buff, extensions=CustomExtension()):
+    with asdf.open(buff, extensions=[CustomExtension()]):
         pass
 
     content = """
@@ -701,7 +701,7 @@ def test_structured_datatype_validation(tmpdir):
     buff = helpers.yaml_to_asdf(content)
 
     with pytest.raises(jsonschema.ValidationError):
-        with asdf.open(buff, extensions=CustomExtension()):
+        with asdf.open(buff, extensions=[CustomExtension()]):
             pass
 
     content = """
@@ -719,7 +719,7 @@ def test_structured_datatype_validation(tmpdir):
     buff = helpers.yaml_to_asdf(content)
 
     with pytest.raises(jsonschema.ValidationError):
-        with asdf.open(buff, extensions=CustomExtension()):
+        with asdf.open(buff, extensions=[CustomExtension()]):
             pass
 
     content = """
@@ -730,7 +730,7 @@ def test_structured_datatype_validation(tmpdir):
     buff = helpers.yaml_to_asdf(content)
 
     with pytest.raises(jsonschema.ValidationError):
-        with asdf.open(buff, extensions=CustomExtension()):
+        with asdf.open(buff, extensions=[CustomExtension()]):
             pass
 
     content = """
@@ -746,7 +746,7 @@ def test_structured_datatype_validation(tmpdir):
     buff = helpers.yaml_to_asdf(content)
 
     with pytest.raises(jsonschema.ValidationError):
-        with asdf.open(buff, extensions=CustomExtension()):
+        with asdf.open(buff, extensions=[CustomExtension()]):
             pass
 
     content = """
@@ -761,7 +761,7 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with asdf.open(buff, extensions=CustomExtension()):
+    with asdf.open(buff, extensions=[CustomExtension()]):
         pass
 
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -201,7 +201,7 @@ def _assert_roundtrip_tree(tree, tmpdir, *, asdf_check_func=None,
 
     buff.seek(0)
     ff = AsdfFile(extensions=extensions, **init_options)
-    content = AsdfFile._open_impl(ff, buff, mode='r', _get_yaml_content=True)
+    content = AsdfFile._open_impl(ff, buff, mode='r', _get_yaml_content=True, extensions=extensions)
     buff.close()
     # We *never* want to get any raw python objects out
     assert b'!!python' not in content

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -17,7 +17,7 @@ from asdf import extension
 from asdf import resolver
 from asdf import schema
 from asdf import versioning
-from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
+from asdf.exceptions import AsdfDeprecationWarning
 from .helpers import (
     assert_tree_match,
     assert_roundtrip_tree,
@@ -290,39 +290,6 @@ def test_open_pathlib_path(tmpdir):
 
     with asdf.open(path) as af:
         assert (af['data'] == tree['data']).all()
-
-
-@pytest.mark.parametrize('installed,extension,warns', [
-    ('1.2.3', '2.0.0', True),
-    ('1.2.3', '2.0.dev10842', True),
-    ('2.0.0', '2.0.0', False),
-    ('2.0.1', '2.0.0', False),
-    ('2.0.1', '2.0.dev12345', False),
-])
-def test_extension_version_check(installed, extension, warns):
-
-    af = asdf.AsdfFile()
-    af._fname = 'test.asdf'
-    af._extension_metadata['foo.extension.FooExtension'] = ('foo', installed)
-
-    tree = {
-        'history': {
-            'extensions': [
-                asdf.tags.core.ExtensionMetadata(extension_class='foo.extension.FooExtension',
-                    software=asdf.tags.core.Software(name='foo', version=extension)),
-            ]
-        }
-    }
-
-    if warns:
-        with pytest.warns(AsdfWarning, match="File 'test.asdf' was created with"):
-            af._check_extensions(tree)
-
-        with pytest.raises(RuntimeError) as err:
-            af._check_extensions(tree, strict=True)
-        err.match("^File 'test.asdf' was created with")
-    else:
-        af._check_extensions(tree)
 
 
 def test_auto_inline(tmpdir):

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -3,7 +3,7 @@ import threading
 import asdf
 from asdf import get_config
 from asdf import resource
-
+from asdf.extension import BuiltinExtension
 
 def test_config_context():
     assert get_config().validate_on_read is True
@@ -112,3 +112,8 @@ def test_resource_manager():
         assert "http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager
         assert b"http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager["http://stsci.edu/schemas/asdf/core/asdf-1.1.0"]
         assert "http://somewhere.org/schemas/foo-1.0.0" not in config.resource_manager
+
+
+def test_extensions():
+    extensions = asdf.get_config().extensions
+    assert any(isinstance(e.delegate, BuiltinExtension) for e in extensions)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -399,7 +399,7 @@ def test_serialize_table(tmpdir):
 def test_extension_check():
     testfile = get_test_data_path('extension_check.fits')
 
-    with pytest.warns(AsdfWarning, match="was created with extension 'foo.bar.FooBar'"):
+    with pytest.warns(AsdfWarning, match="was created with extension foo.bar.FooBar"):
         with asdf.open(testfile):
             pass
 

--- a/asdf/tests/test_helpers.py
+++ b/asdf/tests/test_helpers.py
@@ -43,4 +43,4 @@ def test_conversion_error(tmpdir):
 
     with pytest.raises(AsdfConversionWarning):
         with pytest.warns(AsdfWarning, match="Unable to locate schema file"):
-            assert_roundtrip_tree(tree, tmpdir, extensions=FooExtension())
+            assert_roundtrip_tree(tree, tmpdir, extensions=[FooExtension()])

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -220,7 +220,7 @@ def test_flow_style():
     }
 
     buff = io.BytesIO()
-    ff = asdf.AsdfFile(tree, extensions=CustomFlowStyleExtension())
+    ff = asdf.AsdfFile(tree, extensions=[CustomFlowStyleExtension()])
     ff.write_to(buff)
 
     assert b'  a: 42\n  b: 43' in buff.getvalue()
@@ -243,7 +243,7 @@ def test_style():
     }
 
     buff = io.BytesIO()
-    ff = asdf.AsdfFile(tree, extensions=CustomStyleExtension())
+    ff = asdf.AsdfFile(tree, extensions=[CustomStyleExtension()])
     ff.write_to(buff)
 
     assert b'|-\n  short\n' in buff.getvalue()
@@ -535,7 +535,7 @@ custom: !<tag:nowhere.org:custom/foreign_tag_reference-1.0.0>
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with asdf.open(buff, extensions=ForeignTypeExtension()) as ff:
+    with asdf.open(buff, extensions=[ForeignTypeExtension()]) as ff:
         a = ff.tree['custom']['a']
         b = ff.tree['custom']['b']
         assert a['name'] == 'Something'
@@ -948,7 +948,7 @@ a: !<tag:nowhere.org:custom/doesnt_exist-1.0.0>
 
     buff = helpers.yaml_to_asdf(yaml)
     with pytest.warns(AsdfWarning, match="Unable to locate schema file"):
-        with asdf.open(buff, extensions=CustomExtension()) as af:
+        with asdf.open(buff, extensions=[CustomExtension()]) as af:
             assert str(af['a']) == 'hello'
 
 

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -155,14 +155,14 @@ b: !core/complex-1.0.0
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with asdf.open(buff, extensions=FractionExtension()) as ff:
+    with asdf.open(buff, extensions=[FractionExtension()]) as ff:
         assert ff.tree['a'] == Fraction(2, 3)
 
         buff = io.BytesIO()
         ff.write_to(buff)
 
     buff = helpers.yaml_to_asdf(yaml)
-    with asdf.open(buff, extensions=FractionCallable()) as ff:
+    with asdf.open(buff, extensions=[FractionCallable()]) as ff:
         assert ff.tree['a'] == Fraction(2, 3)
 
         buff = io.BytesIO()
@@ -217,11 +217,8 @@ a: !core/complex-42.0.0
     with open(testfile, 'wb') as handle:
         handle.write(buff.read())
 
-    expected_uri = util.filepath_to_url(str(testfile))
-
     with pytest.warns(AsdfConversionWarning, match="tag:stsci.edu:asdf/core/complex"):
         with asdf.open(testfile, ignore_version_mismatch=False) as ff:
-            assert ff._fname == expected_uri
             assert isinstance(ff.tree['a'], complex)
 
 
@@ -254,7 +251,7 @@ flow_thing:
     buff = helpers.yaml_to_asdf(yaml)
     with helpers.assert_no_warnings():
         asdf.open(buff, ignore_version_mismatch=False,
-            extensions=CustomFlowExtension())
+            extensions=[CustomFlowExtension()])
 
 
 def test_versioned_writing(monkeypatch):
@@ -451,7 +448,7 @@ flow_thing:
     d: 3.14
 """
     new_buff = helpers.yaml_to_asdf(new_yaml)
-    new_data = asdf.open(new_buff, extensions=CustomFlowExtension())
+    new_data = asdf.open(new_buff, extensions=[CustomFlowExtension()])
     assert type(new_data.tree['flow_thing']) == CustomFlow
 
     old_yaml = """
@@ -464,7 +461,7 @@ flow_thing:
     # We expect this warning since it will not be possible to convert version
     # 1.0.0 of CustomFlow to a CustomType (by design, for testing purposes).
     with pytest.warns(AsdfConversionWarning, match="Failed to convert tag:nowhere.org:custom/custom_flow-1.0.0"):
-        asdf.open(old_buff, extensions=CustomFlowExtension())
+        asdf.open(old_buff, extensions=[CustomFlowExtension()])
 
 
 def test_incompatible_version_check():
@@ -568,11 +565,11 @@ flow_thing:
     b: 3.14
 """
     new_buff = helpers.yaml_to_asdf(new_yaml)
-    new_data = asdf.open(new_buff, extensions=CustomFlowExtension())
+    new_data = asdf.open(new_buff, extensions=[CustomFlowExtension()])
     assert type(new_data.tree['flow_thing']) == CustomFlow
 
     old_buff = helpers.yaml_to_asdf(old_yaml)
-    old_data = asdf.open(old_buff, extensions=CustomFlowExtension())
+    old_data = asdf.open(old_buff, extensions=[CustomFlowExtension()])
     assert type(old_data.tree['flow_thing']) == CustomFlow
 
 def test_unsupported_version_warning():
@@ -601,7 +598,7 @@ flow_thing:
     buff = helpers.yaml_to_asdf(yaml)
 
     with pytest.warns(AsdfConversionWarning, match="Version 1.1.0 of tag:nowhere.org:custom/custom_flow is not compatible"):
-        asdf.open(buff, extensions=CustomFlowExtension())
+        asdf.open(buff, extensions=[CustomFlowExtension()])
 
 
 def test_extension_override(tmpdir):
@@ -690,11 +687,11 @@ def test_tag_without_schema(tmpdir):
     tree = dict(foo=foo)
 
     with pytest.warns(AsdfWarning, match="Unable to locate schema file"):
-        with asdf.AsdfFile(tree, extensions=FooExtension()) as af:
+        with asdf.AsdfFile(tree, extensions=[FooExtension()]) as af:
             af.write_to(tmpfile)
 
     with pytest.warns(AsdfWarning, match="Unable to locate schema file"):
-        with asdf.AsdfFile(tree, extensions=FooExtension()) as ff:
+        with asdf.AsdfFile(tree, extensions=[FooExtension()]) as ff:
             assert isinstance(ff.tree['foo'], FooType)
             assert ff.tree['foo'] == tree['foo']
 
@@ -708,8 +705,8 @@ def test_custom_reference_cycle(tmpdir):
 
     path = str(tmpdir.join("with_inverse.asdf"))
 
-    with asdf.AsdfFile(tree, extensions=FractionWithInverseExtension()) as af:
+    with asdf.AsdfFile(tree, extensions=[FractionWithInverseExtension()]) as af:
         af.write_to(path)
 
-    with asdf.open(path, extensions=FractionWithInverseExtension()) as af:
+    with asdf.open(path, extensions=[FractionWithInverseExtension()]) as af:
         assert af["fraction"].inverse.inverse is af["fraction"]

--- a/docs/asdf/extensions.rst
+++ b/docs/asdf/extensions.rst
@@ -136,7 +136,7 @@ using them:
 
     tree = {'fraction': fractions.Fraction(10, 3)}
 
-    with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
+    with asdf.AsdfFile(tree, extensions=[FractionExtension()]) as ff:
         ff.write_to("test.asdf")
 
 .. asdf:: test.asdf ignore_unrecognized_tag
@@ -228,7 +228,7 @@ chosen to use a `dict`:
 
     tree = {'fraction': fractions.Fraction(10, 3)}
 
-    with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
+    with asdf.AsdfFile(tree, extensions=[FractionExtension()]) as ff:
         ff.write_to("test.asdf")
 
 In this case, the associated schema would look like the following::
@@ -359,7 +359,7 @@ Now we can use this extension to create an ASDF file:
 
     tree = {'coordinate': coord}
 
-    with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
+    with asdf.AsdfFile(tree, extensions=[FractionExtension()]) as ff:
         ff.write_to("coord.asdf")
 
 .. asdf:: coord.asdf ignore_unrecognized_tag
@@ -440,14 +440,14 @@ After adding our type to the extension class, the tree will serialize correctly:
 
     tree = {'fraction': f1}
 
-    with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
+    with asdf.AsdfFile(tree, extensions=[FractionExtension()]) as ff:
         ff.write_to("with_inverse.asdf")
 
 But upon deserialization, we notice a problem:
 
 .. runcode::
 
-    with asdf.open("with_inverse.asdf", extensions=FractionExtension()) as ff:
+    with asdf.open("with_inverse.asdf", extensions=[FractionExtension()]) as ff:
         reconstituted_f1 = ff["fraction"]
 
     assert reconstituted_f1.inverse.inverse is asdf.treeutil.PendingValue
@@ -498,7 +498,7 @@ our ASDF file:
 
 .. runcode::
 
-    with asdf.open("with_inverse.asdf", extensions=FractionExtension()) as ff:
+    with asdf.open("with_inverse.asdf", extensions=[FractionExtension()]) as ff:
             reconstituted_f1 = ff["fraction"]
 
     assert reconstituted_f1.inverse.inverse is reconstituted_f1

--- a/docs/asdf/using_extensions.rst
+++ b/docs/asdf/using_extensions.rst
@@ -221,14 +221,14 @@ any package, we will need to pass it directly to the `AsdfFile` constructor:
 
     ...
 
-    af = asdf.AsdfFile(extensions=MyCustomExtension())
+    af = asdf.AsdfFile(extensions=[MyCustomExtension()])
     af.tree = {'thing': MyCustomType('foo') }
     # This call would cause an error if the proper extension was not
     # provided to the constructor
     af.write_to('custom.asdf')
 
 Note that the extension class must actually be instantiated when it is passed
-as the `extensions` argument.
+to the `extensions` argument.
 
 To read the file, we pass the same extension to `asdf.open`:
 
@@ -236,21 +236,19 @@ To read the file, we pass the same extension to `asdf.open`:
 
     import asdf
 
-    af = asdf.open('custom.asdf', extensions=MyCustomExtension())
+    af = asdf.open('custom.asdf', extensions=[MyCustomExtension()])
 
-If necessary, it is also possible to pass a list of extension instances to
-`asdf.open` and the `AsdfFile` constructor:
+The list may contain any number of extension instances:
 
 .. code-block:: python
 
     extensions = [MyCustomExtension(), AnotherCustomExtension()]
     af = asdf.AsdfFile(extensions=extensions)
 
-Passing either a single extension instance or a list of extension instances to
-either `asdf.open` or the `AsdfFile` constructor will not override any
-extensions that are installed in the environment. Instead, the custom types
-provided by the explicitly provided extensions will be added to the list of any
-types that are provided by installed extensions.
+Passing a list of extension instances to either `asdf.open` or the `AsdfFile`
+constructor will not override any extensions that are installed in the environment.
+Instead, the custom types provided by the explicitly provided extensions will be
+added to the list of any types that are provided by installed extensions.
 
 .. _extension_checking:
 
@@ -264,8 +262,7 @@ version of that package.
 
 When reading files with extension metadata, ASDF can check whether the required
 extensions are present before processing the file. If a required extension is
-not present, or if the wrong version of a package that provides an extension is
-installed, ASDF will issue a warning.
+not present, ASDF will issue a warning.
 
 It is possible to turn these warnings into errors by using the
 `strict_extension_check` parameter of `asdf.open`. If this parameter is set to


### PR DESCRIPTION
In an attempt to make this easier to review, I pulled out the following changes into a separate PR:

- Files are now written with only the extensions used listed in the metadata (instead of every extension used at some point in the session)
- Create wrapper for resource Mappings that carries around the package name and version of the entry point (this is just a debugging tool)
- Move code that fetches extensions from entry points to the entry_points module
- Create new extension entry point ("asdf.extensions" vs "asdf_extensions").  Extensions from the old entry point are marked "legacy" and behave differently.  At this point, the only difference is that "legacy" extensions are always enabled when reading and writing files, and new-style extensions are enabled based on the file's metadata.
- Create config property that returns the list of extensions.  AsdfFile now retrieves the extensions from the config object, which means asdf.extension.default_extensions is no longer needed.  
- Create wrapper for AsdfExtension that carries package name/version and also provides default implementations for optional methods.
- Use this wrapper as the source of extension metadata information instead of maintaining a dict on AsdfExtensionList and AsdfFile.
- Remove warning when reading a file with an older version of the package that produced it.  In a future PR we'll introduce a URI that will allow extensions themselves to be versioned, so the package version won't be relevant.
- Restrict extension lists provided by users to list of AsdfExtension.  This is how the API is documented, but currently it is possible to provide a single AsdfExtension or an AsdfExtensionList. 
- Change the AsdfFile `_extensions` attribute from AsdfExtensionList to list of AsdfExtension.  The AsdfExtensionList is now stored in `_extension_list`.  In a future PR I'll be adding a new class that collects a group of enabled extensions.
- Add `always_enabled` property to AsdfExtension that instructs the library to use the extension even when not requested by the user or the file metadata.  This is the behavior of all extensions thus far, so the property defaults to `True` for legacy extensions.
- Add `legacy_class_names` property to AsdfExtension.  These are additional class names that will allow older metadata to match to a new-style extension.
