### PR TITLE
Add asdf_standard_requirement property to AsdfExtension interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@
   or ``asdf.extension.AsdfExtensionList``. [#835]
 
 - Extend the ``asdf.AsdfExtension`` interface to support
-  versioned extensions. [#835]
+  versioned extensions. [#835, #836]
 
 2.7.0 (2020-07-23)
 ------------------

--- a/asdf/_config.py
+++ b/asdf/_config.py
@@ -128,6 +128,22 @@ class AsdfConfig:
                     self._extensions = entry_points.get_extensions()
         return self._extensions
 
+    def get_extensions(self, version):
+        """
+        Get a list of installed `AsdfExtension` instances that
+        support the specified ASDF Standard version.
+
+        Parameters
+        ----------
+        version : str
+            ASDF Standard version.
+
+        Returns
+        -------
+        list of asdf.AsdfExtension
+        """
+        return [e for e in self.extensions if version in e.asdf_standard_requirement]
+
     @property
     def validate_on_read(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     jsonschema>=3.0.2,<4
     numpy>=1.10
     importlib_resources>=3;python_version<"3.9"
+    packaging>=16.0
 
 [options.extras_require]
 all =


### PR DESCRIPTION
This PR adds an `asdf_standard_requirement` property to `AsdfExtension` that will allow an extension to specify the ASDF Standard version(s) that it supports.  This will be needed for the transform extensions, some of which pair with one ASDF Standard version only.

Opened against #835's branch for now, I'll switch this to master once that one's been merged.