### PR TITLE
Restrict pytest to versions < 6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,9 @@ docs =
     matplotlib
     docutils
 tests =
-    pytest
+    # As of 2020-07-28, pytest-doctestplus is not compatible
+    # with pytest 6.0.0.
+    pytest<6
     astropy
     gwcs
     pytest-doctestplus


### PR DESCRIPTION
pytest 6 was released today and seems to be incompatible with pytest-doctestplus.

Example build failure: https://travis-ci.com/github/asdf-format/asdf/jobs/365887046

Related pytest-doctestplus issue here: https://github.com/astropy/pytest-doctestplus/issues/118