### PR TITLE
simple version comparison for tag validation

### DIFF
--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -77,6 +77,8 @@ def _type_to_tag(type_):
 
 def _compare_tag_version(instance_tag, tagname):
     if instance_tag is not None:
+        if instance_tag.startswith("tag:yaml.org"):
+            return instance_tag == tagname
         tag_uri = tagname.rpartition("-")[0]
         tag_version = [int(v) for v in tagname.rpartition("-")[-1].split(".")]
         instance_tag_version = [int(v) for v in instance_tag.rpartition("-")[-1].split(".")]

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -75,6 +75,19 @@ def _type_to_tag(type_):
     return None
 
 
+def _compare_tag_version(instance_tag, tagname):
+    if instance_tag is not None:
+        tag_uri = tagname.rpartition("-")[0]
+        tag_version = [int(v) for v in tagname.rpartition("-")[-1].split(".")]
+        instance_tag_version = [int(v) for v in instance_tag.rpartition("-")[-1].split(".")]
+
+        version_compatible = all([v[0] == v[1] for v in zip(tag_version, instance_tag_version)])
+
+        if (not instance_tag.startswith(tag_uri)) or (not version_compatible):
+            return False
+    return True
+
+
 def validate_tag(validator, tagname, instance, schema):
 
     if hasattr(instance, '_tag'):
@@ -83,10 +96,11 @@ def validate_tag(validator, tagname, instance, schema):
         # Try tags for known Python builtins
         instance_tag = _type_to_tag(type(instance))
 
-    if instance_tag is not None and instance_tag != tagname:
-        yield ValidationError(
-            "mismatched tags, wanted '{0}', got '{1}'".format(
-                tagname, instance_tag))
+    if instance_tag is not None:
+        if not _compare_tag_version(instance_tag, tagname):
+            yield ValidationError(
+                "mismatched tags, wanted '{0}', got '{1}'".format(
+                    tagname, instance_tag))
 
 
 def validate_propertyOrder(validator, order, instance, schema):


### PR DESCRIPTION
very simple implementation for version parsing discussed in https://github.com/asdf-format/asdf-standard/issues/271
This should enable the following syntax to work:

```yaml
tag: http://stsci.edu/schemas/asdf/core/software-* # allow every version
tag: http://stsci.edu/schemas/asdf/core/software-1 # fix major version
tag: http://stsci.edu/schemas/asdf/core/software-1.2 # fix minor version
tag: http://stsci.edu/schemas/asdf/core/software-1.2.3 # fix patch version
```