### PR TITLE
Make config module public and add missing test coverage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Add new Mapping API for extending asdf with additional
   schemas. [#819, #828]
 
-- Add global configuration mechanism. [#819]
+- Add global configuration mechanism. [#819, #839]
 
 - Drop support for automatic serialization of subclass
   attributes. [#825]

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -24,6 +24,6 @@ from . import commands
 from .tags.core import IntegerType
 from .tags.core.external_reference import ExternalArrayReference
 from ._convenience import info
-from ._config import get_config, config_context
+from .config import get_config, config_context
 
 from jsonschema import ValidationError

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -9,7 +9,7 @@ from pkg_resources import parse_version
 import numpy as np
 from jsonschema import ValidationError
 
-from ._config import get_config
+from .config import get_config
 from . import block
 from . import constants
 from . import generic_io

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -10,6 +10,9 @@ from . import entry_points
 from .resource import ResourceManager
 
 
+__all__ = ["AsdfConfig", "get_config", "config_context"]
+
+
 DEFAULT_VALIDATE_ON_READ = True
 
 
@@ -152,11 +155,11 @@ _local = _ConfigLocal()
 def get_config():
     """
     Get the current config, which may have been altered by
-    one or more surrounding calls to `config_context`.
+    one or more surrounding calls to `asdf.config_context`.
 
     Returns
     -------
-    AsdfConfig
+    asdf.config.AsdfConfig
     """
     if len(_local.config_stack) == 0:
         return _global_config
@@ -168,7 +171,7 @@ def get_config():
 def config_context():
     """
     Context manager that temporarily overrides asdf configuration.
-    The context yields an `AsdfConfig` instance that can be modified
+    The context yields an `asdf.config.AsdfConfig` instance that can be modified
     without affecting code outside of the context.
     """
     if len(_local.config_stack) == 0:

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -23,19 +23,10 @@ class AsdfConfig:
     `asdf.config_context` module methods.
     """
 
-    def __init__(
-        self,
-        resource_mappings=None,
-        resource_manager=None,
-        validate_on_read=None,
-    ):
-        self._resource_mappings = resource_mappings
-        self._resource_manager = resource_manager
-
-        if validate_on_read is None:
-            self._validate_on_read = DEFAULT_VALIDATE_ON_READ
-        else:
-            self._validate_on_read = validate_on_read
+    def __init__(self):
+        self._resource_mappings = None
+        self._resource_manager = None
+        self._validate_on_read = DEFAULT_VALIDATE_ON_READ
 
         self._lock = threading.RLock()
 
@@ -136,10 +127,9 @@ class AsdfConfig:
 
     def __repr__(self):
         return (
-            "AsdfConfig(\n"
-            "  resource_mappings=[...],\n"
-            "  validate_on_read={!r},\n"
-            ")"
+            "<AsdfConfig\n"
+            "  validate_on_read: {}\n"
+            ">"
         ).format(self.validate_on_read)
 
 

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -43,7 +43,7 @@ class DirectoryResourceMapping(Mapping):
         If `True`, recurse into subdirectories.  Defaults to `False`.
     filename_pattern : str, optional
         Glob pattern that identifies relevant filenames.
-        Defaults to "*.yaml".
+        Defaults to `"*.yaml"`.
     stem_filename : bool, optional
         If `True`, remove the filename's extension when
         constructing its URI.

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -13,7 +13,7 @@ from jsonschema.exceptions import ValidationError
 import yaml
 import numpy as np
 
-from ._config import get_config
+from .config import get_config
 from . import constants
 from . import generic_io
 from . import reference

--- a/asdf/tests/conftest.py
+++ b/asdf/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 from . import create_small_tree, create_large_tree
 
-from asdf import _config
+from asdf import config
 
 
 @pytest.fixture
@@ -21,5 +21,5 @@ def large_tree():
 @pytest.fixture(autouse=True)
 def restore_default_config():
     yield
-    _config._global_config = _config.AsdfConfig()
-    _config._local = _config._ConfigLocal()
+    config._global_config = config.AsdfConfig()
+    config._local = config._ConfigLocal()

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -84,13 +84,16 @@ def test_resource_mappings():
         assert len(default_mappings) >= len(core_mappings)
 
         new_mapping = {"http://somewhere.org/schemas/foo-1.0.0": b"foo"}
-        config.add_resource_mapping(new_mapping)
 
+        config.add_resource_mapping(new_mapping)
         assert len(config.resource_mappings) == len(default_mappings) + 1
         assert new_mapping in config.resource_mappings
 
-        config.reset_resources()
+        config.remove_resource_mapping(new_mapping)
+        assert len(config.resource_mappings) == len(default_mappings)
 
+        config.add_resource_mapping(new_mapping)
+        config.reset_resources()
         assert len(config.resource_mappings) == len(default_mappings)
 
 
@@ -112,3 +115,10 @@ def test_resource_manager():
         assert "http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager
         assert b"http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager["http://stsci.edu/schemas/asdf/core/asdf-1.1.0"]
         assert "http://somewhere.org/schemas/foo-1.0.0" not in config.resource_manager
+
+
+def test_config_repr():
+    with asdf.config_context() as config:
+        config.validate_on_read = True
+
+        assert "validate_on_read: True" in repr(config)

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -69,7 +69,7 @@ def test_global_config():
 
 def test_validate_on_read():
     with asdf.config_context() as config:
-        assert config.validate_on_read == asdf._config.DEFAULT_VALIDATE_ON_READ
+        assert config.validate_on_read == asdf.config.DEFAULT_VALIDATE_ON_READ
         config.validate_on_read = False
         assert get_config().validate_on_read is False
         config.validate_on_read = True

--- a/docs/asdf/developer_api.rst
+++ b/docs/asdf/developer_api.rst
@@ -1,5 +1,5 @@
 *************
-Developer API 
+Developer API
 *************
 
 The classes and functions documented here will be of use to developers who wish
@@ -8,6 +8,8 @@ to create their own custom ASDF types and extensions.
 .. automodapi:: asdf.types
 
 .. automodapi:: asdf.extension
+
+.. automodapi:: asdf.resource
 
 .. automodapi:: asdf.yamlutil
 

--- a/docs/asdf/user_api.rst
+++ b/docs/asdf/user_api.rst
@@ -8,3 +8,5 @@ User API
     :skip: ValidationError
 
 .. automodapi:: asdf.search
+
+.. automodapi:: asdf.config


### PR DESCRIPTION
Since `AsdfConfig` is returned by `asdf.get_config`, it should be considered a part of the public API and included in the documentation.  This PR changes `asdf._config` --> `asdf.config`, updates the docs, and adds some missing test coverage.