### PR TITLE
Reorganize extension.py into a directory to prepare for new API

### DIFF
--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -1,0 +1,20 @@
+"""
+Support for plugins that extend asdf to serialize
+additional custom types.
+"""
+from ._legacy import (
+    AsdfExtension,
+    AsdfExtensionList,
+    BuiltinExtension,
+    default_extensions,
+    get_default_resolver,
+)
+
+
+__all__ = [
+    "AsdfExtension",
+    "AsdfExtensionList",
+    "BuiltinExtension",
+    "default_extensions",
+    "get_default_resolver",
+]

--- a/asdf/extension/_legacy.py
+++ b/asdf/extension/_legacy.py
@@ -3,15 +3,12 @@ import abc
 import warnings
 from pkg_resources import iter_entry_points
 
-from . import types
-from . import resolver
-from .util import get_class_name
-from .type_index import AsdfTypeIndex
-from .version import version as asdf_version
-from .exceptions import AsdfDeprecationWarning, AsdfWarning
-
-
-__all__ = ['AsdfExtension', 'AsdfExtensionList']
+from .. import types
+from .. import resolver
+from ..util import get_class_name
+from ..type_index import AsdfTypeIndex
+from ..version import version as asdf_version
+from ..exceptions import AsdfDeprecationWarning, AsdfWarning
 
 
 ASDF_TEST_BUILD_ENV = 'ASDF_TEST_BUILD'
@@ -69,9 +66,9 @@ class AsdfExtension(metaclass=abc.ABCMeta):
         """
         pass
 
+    @abc.abstractproperty
     def url_mapping(self):
         """
-        DEPRECATED.  This property will be ignored in asdf 3.0.
         Schema content can be provided using the resource Mapping API.
 
         A list of 2-tuples or callables mapping JSON Schema URLs to
@@ -104,7 +101,7 @@ class AsdfExtension(metaclass=abc.ABCMeta):
                     '/{url_suffix}.yaml'
                    )]
         """
-        return []
+        pass
 
 
 class AsdfExtensionList:
@@ -166,6 +163,9 @@ class AsdfExtensionList:
         return self._validators
 
 
+# A kludge in asdf.util.get_class_name allows this class to retain
+# its original name, despite being moved from extension.py to
+# this file.
 class BuiltinExtension:
     """
     This is the "extension" to ASDF that includes all the built-in

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -269,6 +269,14 @@ def resolve_name(name):
     return ret
 
 
+# Kludge to cover up the fact that BuiltinExtension was moved from extension.py
+# to extension/_legacy.py.  Can be removed once BuiltinExtension is dropped
+# in asdf 3.0.
+_CLASS_NAME_OVERRIDES = {
+    "asdf.extension._legacy.BuiltinExtension": "asdf.extension.BuiltinExtension",
+}
+
+
 def get_class_name(obj, instance=True):
     """
     Given a class or instance of a class, returns a string representing the
@@ -282,9 +290,9 @@ def get_class_name(obj, instance=True):
     instance: bool
         Indicates whether given object is an instance of the class to be named
     """
-
     typ = type(obj) if instance else obj
-    return "{}.{}".format(typ.__module__, typ.__name__)
+    class_name = "{}.{}".format(typ.__module__, typ.__name__)
+    return _CLASS_NAME_OVERRIDES.get(class_name, class_name)
 
 
 def minversion(module, version, inclusive=True, version_path='__version__'):


### PR DESCRIPTION
This PR changes the `asdf.extension` module from a file to a directory, and moves the current contents of extension.py to `asdf.extension._legacy`.  All the existing public objects are imported in the new init file  so this shouldn't cause problems.