### PR TITLE
Resource mapping updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 2.8.0 (unreleased)
 ------------------
 
-- Add new Mapping API for extending asdf with additional
-  schemas. [#819, #828]
+- Add new resource mapping API for extending asdf with additional
+  schemas. [#819, #828, #843]
 
 - Add global configuration mechanism. [#819, #839]
 

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -1,6 +1,5 @@
 from pkg_resources import iter_entry_points
 import warnings
-from functools import partial
 
 from .exceptions import AsdfWarning
 from .resource import ResourceMappingProxy

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -1,7 +1,5 @@
 import threading
 
-import pytest
-
 import asdf
 from asdf import get_config
 from asdf import resource

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -1,8 +1,11 @@
 import threading
 
+import pytest
+
 import asdf
 from asdf import get_config
 from asdf import resource
+from asdf.resource import ResourceMappingProxy
 
 
 def test_config_context():
@@ -84,34 +87,79 @@ def test_resource_mappings():
         assert len(default_mappings) >= len(core_mappings)
 
         new_mapping = {"http://somewhere.org/schemas/foo-1.0.0": b"foo"}
-
         config.add_resource_mapping(new_mapping)
-        assert len(config.resource_mappings) == len(default_mappings) + 1
-        assert new_mapping in config.resource_mappings
 
+        assert len(config.resource_mappings) == len(default_mappings) + 1
+        assert any(m for m in config.resource_mappings if m.delegate is new_mapping)
+
+        # Adding a mapping should be idempotent:
+        config.add_resource_mapping(new_mapping)
+        # ... even if wrapped:
+        config.add_resource_mapping(ResourceMappingProxy(new_mapping))
+        assert len(config.resource_mappings) == len(default_mappings) + 1
+
+        # Adding a mapping should place it at the front of the line:
+        front_mapping = {"http://somewhere.org/schemas/baz-1.0.0": b"baz"}
+        config.add_resource_mapping(front_mapping)
+        assert len(config.resource_mappings) == len(default_mappings) + 2
+        assert config.resource_mappings[0].delegate is front_mapping
+
+        # ... even if the mapping is already in the list:
+        config.add_resource_mapping(new_mapping)
+        assert len(config.resource_mappings) == len(default_mappings) + 2
+        assert config.resource_mappings[0].delegate is new_mapping
+
+        # Reset should get rid of any additions:
+        config.reset_resources()
+        assert len(config.resource_mappings) == len(default_mappings)
+
+        # Should be able to remove a mapping:
+        config.add_resource_mapping(new_mapping)
         config.remove_resource_mapping(new_mapping)
         assert len(config.resource_mappings) == len(default_mappings)
 
+        # ... even if wrapped:
         config.add_resource_mapping(new_mapping)
-        config.reset_resources()
+        config.remove_resource_mapping(ResourceMappingProxy(new_mapping))
+        assert len(config.resource_mappings) == len(default_mappings)
+
+        # ... and also by the name of the package the mappings came from:
+        config.add_resource_mapping(ResourceMappingProxy(new_mapping, package_name="foo"))
+        config.add_resource_mapping(ResourceMappingProxy({"http://somewhere.org/schemas/bar-1.0.0": b"bar"}, package_name="foo"))
+        config.remove_resource_mapping(package="foo")
+        assert len(config.resource_mappings) == len(default_mappings)
+
+        # Removing a mapping should be idempotent:
+        config.add_resource_mapping(new_mapping)
+        config.remove_resource_mapping(new_mapping)
+        config.remove_resource_mapping(new_mapping)
         assert len(config.resource_mappings) == len(default_mappings)
 
 
 def test_resource_manager():
     with asdf.config_context() as config:
+        # Initial resource manager should contain just the entry points resources:
         assert "http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager
         assert b"http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager["http://stsci.edu/schemas/asdf/core/asdf-1.1.0"]
         assert "http://somewhere.org/schemas/foo-1.0.0" not in config.resource_manager
 
-        config.add_resource_mapping({"http://somewhere.org/schemas/foo-1.0.0": b"foo"})
-
+        # Add a mapping and confirm that the manager now contains it:
+        new_mapping = {"http://somewhere.org/schemas/foo-1.0.0": b"foo"}
+        config.add_resource_mapping(new_mapping)
         assert "http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager
         assert b"http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager["http://stsci.edu/schemas/asdf/core/asdf-1.1.0"]
         assert "http://somewhere.org/schemas/foo-1.0.0" in config.resource_manager
         assert config.resource_manager["http://somewhere.org/schemas/foo-1.0.0"] == b"foo"
 
-        config.reset_resources()
+        # Remove a mapping and confirm that the manager no longer contains it:
+        config.remove_resource_mapping(new_mapping)
+        assert "http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager
+        assert b"http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager["http://stsci.edu/schemas/asdf/core/asdf-1.1.0"]
+        assert "http://somewhere.org/schemas/foo-1.0.0" not in config.resource_manager
 
+        # Reset and confirm that the manager no longer contains the custom mapping:
+        config.add_resource_mapping(new_mapping)
+        config.reset_resources()
         assert "http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager
         assert b"http://stsci.edu/schemas/asdf/core/asdf-1.1.0" in config.resource_manager["http://stsci.edu/schemas/asdf/core/asdf-1.1.0"]
         assert "http://somewhere.org/schemas/foo-1.0.0" not in config.resource_manager

--- a/asdf/tests/test_entry_points.py
+++ b/asdf/tests/test_entry_points.py
@@ -5,40 +5,65 @@ import pytest
 
 from asdf import entry_points
 from asdf.exceptions import AsdfWarning
+from asdf.resource import ResourceMappingProxy
+from asdf.version import version as asdf_package_version
 
 
-def resource_mappings_entry_point_one():
+@pytest.fixture
+def mock_entry_points():
+    return []
+
+
+@pytest.fixture(autouse=True)
+def monkeypatch_entry_points(monkeypatch, mock_entry_points):
+    def _iter_entry_points(*, group):
+        for candidate_group, name, func_name in mock_entry_points:
+            if candidate_group == group:
+                yield EntryPoint(
+                    name, "asdf.tests.test_entry_points",
+                    attrs=(func_name,),
+                    dist=pkg_resources.get_distribution("asdf"),
+                )
+
+    monkeypatch.setattr(entry_points, "iter_entry_points", _iter_entry_points)
+
+
+def resource_mappings_entry_point_successful():
     return [
         {"http://somewhere.org/schemas/foo-1.0.0": b"foo"},
         {"http://somewhere.org/schemas/bar-1.0.0": b"bar"},
     ]
 
 
-def resource_mappings_entry_point_two():
+def resource_mappings_entry_point_failing():
+    raise Exception("NOPE")
+
+
+def resource_mappings_entry_point_bad_element():
     return [
         {"http://somewhere.org/schemas/baz-1.0.0": b"baz"},
-        {"http://somewhere.org/schemas/foz-1.0.0": b"foz"},
         object(),
+        {"http://somewhere.org/schemas/foz-1.0.0": b"foz"},
     ]
 
 
-def test_get_resource_mappings(monkeypatch):
-    def iter_entry_points(*, group):
-        if group == "asdf.resource_mappings":
-            yield EntryPoint(
-                "one", "asdf.tests.test_entry_points",
-                attrs=("resource_mappings_entry_point_one",),
-                dist=pkg_resources.get_distribution("asdf")
-            )
-            yield EntryPoint(
-                "two", "asdf.tests.test_entry_points",
-                attrs=("resource_mappings_entry_point_two",),
-                dist=pkg_resources.get_distribution("asdf")
-            )
+def test_get_resource_mappings(mock_entry_points):
+    mock_entry_points.append(("asdf.resource_mappings", "successful", "resource_mappings_entry_point_successful"))
+    mappings = entry_points.get_resource_mappings()
+    assert len(mappings) == 2
+    for m in mappings:
+        assert isinstance(m, ResourceMappingProxy)
+        assert m.package_name == "asdf"
+        assert m.package_version == asdf_package_version
 
-    monkeypatch.setattr(entry_points, "iter_entry_points", iter_entry_points)
-
-    with pytest.warns(AsdfWarning, match="is not an instance of Mapping"):
+    mock_entry_points.clear()
+    mock_entry_points.append(("asdf.resource_mappings", "failing", "resource_mappings_entry_point_failing"))
+    with pytest.warns(AsdfWarning, match="Exception: NOPE"):
         mappings = entry_points.get_resource_mappings()
+    assert len(mappings) == 0
 
-    assert len(mappings) == 4
+    mock_entry_points.clear()
+    mock_entry_points.append(("asdf.resource_mappings", "bad_element", "resource_mappings_entry_point_bad_element"))
+    with pytest.warns(AsdfWarning, match="TypeError: Resource mapping must implement the Mapping interface"):
+        mappings = entry_points.get_resource_mappings()
+    assert len(mappings) == 2

--- a/asdf/tests/test_resource.py
+++ b/asdf/tests/test_resource.py
@@ -1,5 +1,6 @@
 import io
 import sys
+from pathlib import Path
 
 if sys.version_info < (3, 9):
     import importlib_resources
@@ -63,7 +64,9 @@ def test_directory_resource_mapping(tmpdir):
     assert "http://somewhere.org/schemas/nested/bar-4.5.6" not in mapping
 
     # Check that the repr is reasonable
-    assert str(tmpdir/"schemas") in repr(mapping)
+    # Need to be careful checking the path string because
+    # pathlib normalizes Windows paths.
+    assert repr(Path(tmpdir/"schemas")) in repr(mapping)
     assert "http://somewhere.org/schemas" in repr(mapping)
     assert "recursive=True" in repr(mapping)
     assert "filename_pattern='baz-*'" in repr(mapping)

--- a/asdf/tests/test_resource.py
+++ b/asdf/tests/test_resource.py
@@ -66,7 +66,7 @@ def test_directory_resource_mapping(tmpdir):
     # Check that the repr is reasonable
     # Need to be careful checking the path string because
     # pathlib normalizes Windows paths.
-    assert repr(Path(tmpdir/"schemas")) in repr(mapping)
+    assert repr(Path(str(tmpdir/"schemas"))) in repr(mapping)
     assert "http://somewhere.org/schemas" in repr(mapping)
     assert "recursive=True" in repr(mapping)
     assert "filename_pattern='baz-*'" in repr(mapping)


### PR DESCRIPTION
Some updates to the resource mappings:
- Wrap registered mappings in a proxy class that also carries around the package that supplied the mapping.  Without this, they'll be hard to debug, since the class name of the mapping itself doesn't generally provide any useful hints.
- Make sure mappings added at runtime take precedence over automatically registered mappings.
- Add config parameter that permits removing all of a package's mappings in one call.