### PR TITLE
Versioning cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Add new resource mapping API for extending asdf with additional
   schemas. [#819, #828, #843]
 
-- Add global configuration mechanism. [#819, #839]
+- Add global configuration mechanism. [#819, #839, #844]
 
 - Drop support for automatic serialization of subclass
   attributes. [#825]

--- a/asdf/_helpers.py
+++ b/asdf/_helpers.py
@@ -1,0 +1,17 @@
+from . import versioning
+from .version import version as asdf_package_version
+
+
+def validate_version(version):
+    # Account for the possibility of AsdfVersion
+    version = str(version)
+    if version not in versioning.supported_versions:
+        raise ValueError(
+            "ASDF Standard version {} is not supported by asdf=={}.  "
+            "Available ASDF Standard versions: {}".format(
+                version,
+                asdf_package_version,
+                ", ".join(str(v) for v in versioning.supported_versions),
+            )
+        )
+    return version

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -8,12 +8,14 @@ import copy
 
 from . import entry_points
 from .resource import ResourceMappingProxy, ResourceManager
-
+from . import versioning
+from ._helpers import validate_version
 
 __all__ = ["AsdfConfig", "get_config", "config_context"]
 
 
 DEFAULT_VALIDATE_ON_READ = True
+DEFAULT_DEFAULT_VERSION = str(versioning.default_version)
 
 
 class AsdfConfig:
@@ -27,6 +29,7 @@ class AsdfConfig:
         self._resource_mappings = None
         self._resource_manager = None
         self._validate_on_read = DEFAULT_VALIDATE_ON_READ
+        self._default_version = DEFAULT_DEFAULT_VERSION
 
         self._lock = threading.RLock()
 
@@ -140,12 +143,40 @@ class AsdfConfig:
         """
         self._validate_on_read = value
 
+    @property
+    def default_version(self):
+        """
+        Get the default ASDF Standard version used for
+        new files.
+
+        Returns
+        -------
+        str
+        """
+        return self._default_version
+
+    @default_version.setter
+    def default_version(self, value):
+        """
+        Set the default ASDF Standard version used for
+        new files.
+
+        Parameters
+        ----------
+        value : str
+        """
+        self._default_version = validate_version(value)
+
     def __repr__(self):
         return (
             "<AsdfConfig\n"
             "  validate_on_read: {}\n"
+            "  default_version: {}\n"
             ">"
-        ).format(self.validate_on_read)
+        ).format(
+            self.validate_on_read,
+            self.default_version,
+        )
 
 
 class _ConfigLocal(threading.local):

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -1,0 +1,50 @@
+import pytest
+
+from asdf.asdf import AsdfFile
+from asdf import config_context
+from asdf.versioning import AsdfVersion
+
+
+def test_asdf_file_version():
+    with config_context() as config:
+        config.default_version = "1.2.0"
+
+        af = AsdfFile()
+        assert af.version == AsdfVersion("1.2.0")
+        assert af.version_string == "1.2.0"
+
+        af = AsdfFile(version="1.3.0")
+        assert af.version == AsdfVersion("1.3.0")
+        assert af.version_string == "1.3.0"
+
+        af = AsdfFile(version=AsdfVersion("1.3.0"))
+        assert af.version == AsdfVersion("1.3.0")
+        assert af.version_string == "1.3.0"
+
+        with pytest.raises(ValueError):
+            AsdfFile(version="0.5.4")
+
+        with pytest.raises(ValueError):
+            AsdfFile(version=AsdfVersion("0.5.4"))
+
+        af = AsdfFile()
+
+        af.version = "1.3.0"
+        assert af.version == AsdfVersion("1.3.0")
+        assert af.version_string == "1.3.0"
+
+        af.version = AsdfVersion("1.4.0")
+        assert af.version == AsdfVersion("1.4.0")
+        assert af.version_string == "1.4.0"
+
+        with pytest.raises(ValueError):
+            af.version = "0.5.4"
+
+        with pytest.raises(ValueError):
+            af.version = AsdfVersion("2.5.4")
+
+        af.version = "1.0.0"
+        assert af.version_map["tags"]["tag:stsci.edu:asdf/core/asdf"] == "1.0.0"
+
+        af.version = "1.2.0"
+        assert af.version_map["tags"]["tag:stsci.edu:asdf/core/asdf"] == "1.1.0"

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -1,5 +1,7 @@
 import threading
 
+import pytest
+
 import asdf
 from asdf import get_config
 from asdf import resource
@@ -75,6 +77,16 @@ def test_validate_on_read():
         assert get_config().validate_on_read is False
         config.validate_on_read = True
         assert get_config().validate_on_read is True
+
+
+def test_default_version():
+    with asdf.config_context() as config:
+        assert config.default_version == asdf.config.DEFAULT_DEFAULT_VERSION
+        assert "1.2.0" != asdf.config.DEFAULT_DEFAULT_VERSION
+        config.default_version = "1.2.0"
+        assert config.default_version == "1.2.0"
+        with pytest.raises(ValueError):
+            config.default_version = "0.1.5"
 
 
 def test_resource_mappings():
@@ -166,5 +178,7 @@ def test_resource_manager():
 def test_config_repr():
     with asdf.config_context() as config:
         config.validate_on_read = True
+        config.default_version = "1.5.0"
 
         assert "validate_on_read: True" in repr(config)
+        assert "default_version: 1.5.0" in repr(config)

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -16,8 +16,6 @@ from semantic_version import Version, SimpleSpec
 
 from . import generic_io
 from . import resolver
-from . import util
-from .version import version as asdf_version
 
 
 __all__ = ['AsdfVersion', 'AsdfSpec', 'split_tag_version', 'join_tag_version']
@@ -166,40 +164,6 @@ supported_versions = [
 ]
 
 default_version = supported_versions[-1]
-
-
-class VersionedMixin:
-    _version = default_version
-
-    @property
-    def version(self):
-        return self._version
-
-    @version.setter
-    def version(self, version):
-        if version not in supported_versions:
-            human_versions = util.human_list(
-                [str(x) for x in supported_versions])
-            raise ValueError(
-                "This version of the asdf package ({0}) only understands how "
-                "to handle versions {1} of the ASDF Standard. Got "
-                "'{2}'".format(asdf_version, human_versions, version))
-
-        self._version = version
-
-    @property
-    def version_string(self):
-        return str(self._version)
-
-    @property
-    def version_map(self):
-        try:
-            version_map = get_version_map(self.version_string)
-        except ValueError:
-            raise ValueError(
-                "Don't have information about version {0}".format(
-                    self.version_string))
-        return version_map
 
 
 # This is the ASDF Standard version at which the format of the history


### PR DESCRIPTION
- Add option to configure the default ASDF Standard version
- Move version-related properties from mixin to AsdfFile
- Update docstring on AsdfFile.write_to and AsdfFile.update to reflect true behavior of version parameter
- Add some tests