### PR TITLE
Use __qualname__ when building fully qualified class names

### DIFF
--- a/asdf/tests/test_util.py
+++ b/asdf/tests/test_util.py
@@ -1,4 +1,5 @@
 from asdf import util
+from asdf.extension import BuiltinExtension
 
 
 def test_is_primitive():
@@ -13,3 +14,19 @@ def test_not_set():
     assert util.NotSet != None
 
     assert repr(util.NotSet) == "NotSet"
+
+
+class SomeClass:
+    class SomeInnerClass:
+        pass
+
+
+def test_get_class_name():
+    assert util.get_class_name(SomeClass()) == "asdf.tests.test_util.SomeClass"
+    assert util.get_class_name(SomeClass, instance=False) == "asdf.tests.test_util.SomeClass"
+    assert util.get_class_name(SomeClass.SomeInnerClass()) == "asdf.tests.test_util.SomeClass.SomeInnerClass"
+    assert util.get_class_name(SomeClass.SomeInnerClass, instance=False) == "asdf.tests.test_util.SomeClass.SomeInnerClass"
+
+
+def test_get_class_name_override():
+    assert util.get_class_name(BuiltinExtension, instance=False) == "asdf.extension.BuiltinExtension"

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -291,7 +291,7 @@ def get_class_name(obj, instance=True):
         Indicates whether given object is an instance of the class to be named
     """
     typ = type(obj) if instance else obj
-    class_name = "{}.{}".format(typ.__module__, typ.__name__)
+    class_name = "{}.{}".format(typ.__module__, typ.__qualname__)
     return _CLASS_NAME_OVERRIDES.get(class_name, class_name)
 
 


### PR DESCRIPTION
Previously an inner class name wouldn't include the fact that it was nested in an outer class:

```python
# some_module.py
class SomeClass:
  class SomeInnerClass:
    pass
```

The name of `SomeClass` has been correct, but `SomeInnerClass` would come out as `some_module.SomeInnerClass` instead of `some_module.SomeClass.SomeInnerClass`.  This PR changes it to the latter.