### PR TITLE
Allow installed extensions to be configured with AsdfConfig

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Add new resource mapping API for extending asdf with additional
   schemas. [#819, #828, #843, #846]
 
-- Add global configuration mechanism. [#819, #839, #844]
+- Add global configuration mechanism. [#819, #839, #844, #847]
 
 - Drop support for automatic serialization of subclass
   attributes. [#825]

--- a/asdf/commands/tags.py
+++ b/asdf/commands/tags.py
@@ -38,7 +38,7 @@ def _qualified_name(_class):
 def list_tags(display_classes=False, iostream=sys.stdout):
     """Function to list tags"""
     af = AsdfFile()
-    type_by_tag = af._extensions._type_index._type_by_tag
+    type_by_tag = af.type_index._type_by_tag
     tags = sorted(type_by_tag.keys())
 
     for tag in tags:

--- a/asdf/commands/tests/test_tags.py
+++ b/asdf/commands/tests/test_tags.py
@@ -16,7 +16,7 @@ def test_list_schemas():
     obs_tags = _get_tags(False)
 
     af = AsdfFile()
-    exp_tags = sorted(af._extensions._type_index._type_by_tag.keys())
+    exp_tags = sorted(af.type_index._type_by_tag.keys())
 
     for exp, obs in zip(exp_tags, obs_tags):
         assert exp == obs
@@ -25,7 +25,7 @@ def test_list_schemas_and_tags():
     tag_lines = _get_tags(True)
 
     af = AsdfFile()
-    type_by_tag = af._extensions._type_index._type_by_tag
+    type_by_tag = af.type_index._type_by_tag
     exp_tags = sorted(type_by_tag.keys())
 
     for exp_tag, line in zip(exp_tags, tag_lines):

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -3,13 +3,21 @@ import warnings
 
 from .exceptions import AsdfWarning
 from .resource import ResourceMappingProxy
+from .extension import ExtensionProxy
 
 
 RESOURCE_MAPPINGS_GROUP = "asdf.resource_mappings"
+LEGACY_EXTENSIONS_GROUP = "asdf_extensions"
 
 
 def get_resource_mappings():
     return _list_entry_points(RESOURCE_MAPPINGS_GROUP, ResourceMappingProxy)
+
+
+def get_extensions():
+    legacy_extensions = _list_entry_points(LEGACY_EXTENSIONS_GROUP, ExtensionProxy)
+
+    return legacy_extensions
 
 
 def _list_entry_points(group, proxy_class):

--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -2,6 +2,7 @@
 Support for plugins that extend asdf to serialize
 additional custom types.
 """
+from ._extension import ExtensionProxy
 from ._legacy import (
     AsdfExtension,
     AsdfExtensionList,
@@ -12,6 +13,9 @@ from ._legacy import (
 
 
 __all__ = [
+    # New API
+    "ExtensionProxy",
+    # Legacy API
     "AsdfExtension",
     "AsdfExtensionList",
     "BuiltinExtension",

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -1,0 +1,140 @@
+from ..util import get_class_name
+from ._legacy import AsdfExtension
+
+
+class ExtensionProxy(AsdfExtension):
+    """
+    Proxy that wraps an extension, provides default implementations
+    of optional methods, and carries additional information on the
+    package that provided the extension.
+    """
+    @classmethod
+    def maybe_wrap(self, delegate):
+        if isinstance(delegate, ExtensionProxy):
+            return delegate
+        else:
+            return ExtensionProxy(delegate)
+
+    def __init__(self, delegate, package_name=None, package_version=None):
+        if not isinstance(delegate, AsdfExtension):
+            raise TypeError("Extension must implement the AsdfExtension interface")
+
+        self._delegate = delegate
+        self._package_name = package_name
+        self._package_version = package_version
+
+        self._class_name = get_class_name(delegate)
+
+        self._legacy = True
+
+    @property
+    def types(self):
+        """
+        Get the legacy extension's ExtensionType subclasses.
+
+        Returns
+        -------
+        iterable of asdf.type.ExtensionType
+        """
+        return getattr(self._delegate, "types", [])
+
+    @property
+    def tag_mapping(self):
+        """
+        Get the legacy extension's tag-to-schema-URI mapping.
+
+        Returns
+        -------
+        iterable of tuple or callable
+        """
+        return getattr(self._delegate, "tag_mapping", [])
+
+    @property
+    def url_mapping(self):
+        """
+        Get the legacy extension's schema-URI-to-URL mapping.
+
+        Returns
+        -------
+        iterable of tuple or callable
+        """
+        return getattr(self._delegate, "url_mapping", [])
+
+    @property
+    def delegate(self):
+        """
+        Get the wrapped extension instance.
+
+        Returns
+        -------
+        asdf.extension.AsdfExtension
+        """
+        return self._delegate
+
+    @property
+    def package_name(self):
+        """
+        Get the name of the Python package that provided this extension.
+
+        Returns
+        -------
+        str or None
+            `None` if the extension was added at runtime.
+        """
+        return self._package_name
+
+    @property
+    def package_version(self):
+        """
+        Get the version of the Python package that provided the extension
+
+        Returns
+        -------
+        str or None
+            `None` if the extension was added at runtime.
+        """
+        return self._package_version
+
+    @property
+    def class_name(self):
+        """
+        Get the fully qualified class name of the extension.
+
+        Returns
+        -------
+        str
+        """
+        return self._class_name
+
+    @property
+    def legacy(self):
+        """
+        Get the extension's legacy flag.  Subclasses of `asdf.extension.AsdfExtension`
+        are marked `True`.
+
+        Returns
+        -------
+        bool
+        """
+        return self._legacy
+
+    def __eq__(self, other):
+        if isinstance(other, ExtensionProxy):
+            return other.delegate is self.delegate
+        else:
+            return False
+
+    def __hash__(self):
+        return hash(id(self.delegate))
+
+    def __repr__(self):
+        if self.package_name is None:
+            package_description = "(none)"
+        else:
+            package_description = "{}=={}".format(self.package_name, self.package_version)
+
+        return "<ExtensionProxy class: {} package: {} legacy: {}>".format(
+            self.class_name,
+            package_description,
+            self.legacy,
+        )

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -233,7 +233,7 @@ class AsdfInFits(asdf.AsdfFile):
     @classmethod
     def _open_impl(cls, fd, uri=None, validate_checksums=False, extensions=None,
              ignore_version_mismatch=True, ignore_unrecognized_tag=False,
-             strict_extension_check=False, _extension_metadata=None,
+             strict_extension_check=False,
              ignore_missing_extensions=False, **kwargs):
 
         close_hdulist = False
@@ -253,8 +253,6 @@ class AsdfInFits(asdf.AsdfFile):
         self = cls(hdulist, uri=uri, extensions=extensions,
                    ignore_version_mismatch=ignore_version_mismatch,
                    ignore_unrecognized_tag=ignore_unrecognized_tag)
-        if _extension_metadata is not None:
-            self._extension_metadata = _extension_metadata
 
         self._close_hdulist = close_hdulist
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -511,7 +511,7 @@ def get_validator(schema={}, ctx=None, validators=None, url_mapping=None,
 
     if validators is None:
         validators = util.HashableDict(YAML_VALIDATORS.copy())
-        validators.update(ctx._extensions.validators)
+        validators.update(ctx.extension_list.validators)
 
     kwargs['resolver'] = _make_resolver(url_mapping)
 

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -133,8 +133,8 @@ def test_get_history_entries(tmpdir):
 def test_extension_metadata(tmpdir):
 
     ff = asdf.AsdfFile()
-    # So far only the base extension has been used
-    assert len(ff.type_index.get_extensions_used()) == 1
+    # No extensions used yet:
+    assert len(ff.type_index.get_extensions_used()) == 0
 
     tmpfile = str(tmpdir.join('extension.asdf'))
     ff.write_to(tmpfile)

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -1,8 +1,9 @@
 import pytest
 
-from asdf.asdf import AsdfFile
-from asdf import config_context
+from asdf.asdf import AsdfFile, open_asdf
+from asdf import config_context, get_config
 from asdf.versioning import AsdfVersion
+from asdf.extension import ExtensionProxy, AsdfExtensionList
 
 
 def test_asdf_file_version():
@@ -48,3 +49,54 @@ def test_asdf_file_version():
 
         af.version = "1.2.0"
         assert af.version_map["tags"]["tag:stsci.edu:asdf/core/asdf"] == "1.1.0"
+
+
+def test_asdf_file_extensions():
+    af = AsdfFile()
+    assert af.extensions == get_config().extensions
+
+    class FooExtension:
+        types = []
+        tag_mapping = []
+        url_mapping = []
+    extension = FooExtension()
+
+    for arg in ([extension], extension, AsdfExtensionList([extension])):
+        af = AsdfFile(extensions=arg)
+        assert af.extensions[0] == ExtensionProxy(extension)
+        assert af.extensions[1:] == get_config().extensions
+
+        af = AsdfFile()
+        af.extensions = arg
+        assert af.extensions[0] == ExtensionProxy(extension)
+        assert af.extensions[1:] == get_config().extensions
+
+    for arg in (object(), [object()]):
+        with pytest.raises(TypeError):
+            AsdfFile(extensions=arg)
+
+
+def test_open_asdf_extensions(tmpdir):
+    class FooExtension:
+        types = []
+        tag_mapping = []
+        url_mapping = []
+    extension = FooExtension()
+
+    path = str(tmpdir/"test.asdf")
+
+    with AsdfFile() as af:
+        af.write_to(path)
+
+    with open_asdf(path) as af:
+        assert af.extensions == get_config().extensions
+
+    for arg in ([extension], extension, AsdfExtensionList([extension])):
+        with open_asdf(path, extensions=arg) as af:
+            assert af.extensions[0] == ExtensionProxy(extension)
+            assert af.extensions[1:] == get_config().extensions
+
+    for arg in (object(), [object()]):
+        with pytest.raises(TypeError):
+            with open_asdf(path, extensions=arg) as af:
+                pass

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -1,7 +1,69 @@
-from asdf.extension import BuiltinExtension
+import pytest
+
+from asdf.extension import BuiltinExtension, ExtensionProxy
+from asdf.types import CustomType
 
 from asdf.tests.helpers import assert_extension_correctness
 
 def test_builtin_extension():
     extension = BuiltinExtension()
     assert_extension_correctness(extension)
+
+
+class LegacyType(dict, CustomType):
+    organization = "somewhere.org"
+    name = "test"
+    version = "1.0.0"
+
+
+class LegacyExtension:
+    types = [LegacyType]
+    tag_mapping = [("tag:somewhere.org/", "http://somewhere.org/{tag_suffix}")]
+    url_mapping = [("http://somewhere.org/", "http://somewhere.org/{url_suffix}.yaml")]
+
+
+def test_proxy_maybe_wrap():
+    extension = LegacyExtension()
+    proxy = ExtensionProxy.maybe_wrap(extension)
+    assert proxy.delegate is extension
+    assert ExtensionProxy.maybe_wrap(proxy) is proxy
+
+    with pytest.raises(TypeError):
+        ExtensionProxy.maybe_wrap(object())
+
+
+def test_proxy_legacy():
+    extension = LegacyExtension()
+    proxy = ExtensionProxy(extension, package_name="foo", package_version="1.2.3")
+
+    assert proxy.types == [LegacyType]
+    assert proxy.tag_mapping == LegacyExtension.tag_mapping
+    assert proxy.url_mapping == LegacyExtension.url_mapping
+    assert proxy.delegate is extension
+    assert proxy.legacy is True
+    assert proxy.package_name == "foo"
+    assert proxy.package_version == "1.2.3"
+    assert proxy.class_name == "asdf.tests.test_extension.LegacyExtension"
+
+
+def test_proxy_hash_and_eq():
+    extension = LegacyExtension()
+    proxy1 = ExtensionProxy(extension)
+    proxy2 = ExtensionProxy(extension, package_name="foo", package_version="1.2.3")
+
+    assert proxy1 == proxy2
+    assert hash(proxy1) == hash(proxy2)
+    assert proxy1 != extension
+    assert proxy2 != extension
+
+
+def test_proxy_repr():
+    proxy = ExtensionProxy(LegacyExtension(), package_name="foo", package_version="1.2.3")
+    assert "class: asdf.tests.test_extension.LegacyExtension" in repr(proxy)
+    assert "package: foo==1.2.3" in repr(proxy)
+    assert "legacy: True" in repr(proxy)
+
+    proxy = ExtensionProxy(LegacyExtension())
+    assert "class: asdf.tests.test_extension.LegacyExtension" in repr(proxy)
+    assert "package: (none)" in repr(proxy)
+    assert "legacy: True" in repr(proxy)

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -608,9 +608,6 @@ def test_extension_override(tmpdir):
 
     gwcs = pytest.importorskip('gwcs', '0.12.0')
 
-    from asdf.extension import default_extensions
-    default_extensions.reset()
-
     version = str(versioning.default_version)
     tmpfile = str(tmpdir.join('override.asdf'))
 
@@ -628,9 +625,6 @@ def test_extension_override_subclass(tmpdir):
 
     gwcs = pytest.importorskip('gwcs', '0.12.0')
     pytest.importorskip('astropy', '4.0.0')
-
-    from asdf.extension import default_extensions
-    default_extensions.reset()
 
     version = str(versioning.default_version)
     tmpfile = str(tmpdir.join('override.asdf'))


### PR DESCRIPTION
This PR refactors the existing extension code to make the new API easier to implement.  Changes include:
- Move extension loading from `_DefaultExtensions` to the new `asdf.entry_points` module
- Move list of registered extensions from `_DefaultExtensions` to `AsdfConfig`
- Remove most of the code from `_DefaultExtensions` so that it becomes a thin interface around `AsdfConfig`
- Add methods for adding and removing registered extensions at runtime
- Add wrapper that allows extensions to carry around their own metadata
