### PR TITLE
Include only extensions used in metadata + introduce SerializationContext

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,10 @@
 - Drop support for automatic serialization of subclass
   attributes. [#825]
 
-- Support asdf:// as a URI scheme. [#854. #855]
+- Support asdf:// as a URI scheme. [#854, #855]
+
+- Include only extensions used during serialization in
+  a file's metadata. [#848]
 
 2.7.0 (2020-07-23)
 ------------------

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from asdf.asdf import AsdfFile, open_asdf
+from asdf.asdf import AsdfFile, open_asdf, SerializationContext
 from asdf import config_context, get_config
 from asdf.versioning import AsdfVersion
 from asdf.extension import ExtensionProxy, AsdfExtensionList
@@ -100,3 +100,23 @@ def test_open_asdf_extensions(tmpdir):
         with pytest.raises(TypeError):
             with open_asdf(path, extensions=arg) as af:
                 pass
+
+
+def test_serialization_context():
+    context = SerializationContext("1.4.0")
+    assert context.version == "1.4.0"
+    assert context.extensions_used == set()
+
+    extension = get_config().extensions[0]
+    context.mark_extension_used(extension)
+    assert context.extensions_used == {extension}
+    context.mark_extension_used(extension)
+    assert context.extensions_used == {extension}
+    context.mark_extension_used(extension.delegate)
+    assert context.extensions_used == {extension}
+
+    with pytest.raises(TypeError):
+        context.mark_extension_used(object())
+
+    with pytest.raises(ValueError):
+        SerializationContext("0.5.4")


### PR DESCRIPTION
This PR continues from #847 and fixes the issue where extensions not used during serialization were written to the file metadata.  The fix necessitated adding a hook to `yamlutil.dump_tree` to modify the tagged tree after it had been converted, since only then do we know what extensions were used.

My long-term goal for the new `SerializationContext` class is for us to pass that object around instead of the `AsdfFile` itself.  Currently when `AsdfFile.write_to` is called, it modifies the `AsdfFile` instance in order to write with the specified parameters.  Some of these modifications are permanent, which breaks the contract of `write_to` (it's documented as an "export" type of operation that doesn't change the `AsdfFile`), and some are merely awkward, like these:

```python
    def _post_write(self, fd):
        if len(self._tree):
            self.run_hook('post_write')

        # TODO: there has got to be a better way to do this...
        if hasattr(self, '_all_array_storage'):
            del self._all_array_storage
        if hasattr(self, '_all_array_compression'):
            del self._all_array_compression
        if hasattr(self, '_auto_inline'):
            del self._auto_inline
```

The new `Converter` API will receive an instance of `SerializationContext` in its `ctx` argument instead of `AsdfFile`, and in 3.0 all `ctx` arguments will contain `SerializationContext`.