### PR TITLE
Wait to assign extensions until version is known

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -688,6 +688,7 @@ class AsdfFile:
     @classmethod
     def _open_asdf(cls, self, fd, uri=None, mode='r',
                    validate_checksums=False,
+                   extensions=None,
                    do_not_fill_defaults=False,
                    _get_yaml_content=False,
                    _force_raw_types=False,
@@ -729,6 +730,12 @@ class AsdfFile:
         version = cls._find_asdf_version_in_comments(self._comments)
         if version is not None:
             self.version = version
+
+        # Now that version is set for good, we can add any additional
+        # extensions, which may have narrow ASDF Standard version
+        # requirements.
+        if extensions:
+            self.extensions = extensions
 
         yaml_token = fd.read(4)
         has_blocks = False
@@ -790,6 +797,7 @@ class AsdfFile:
     @classmethod
     def _open_impl(cls, self, fd, uri=None, mode='r',
                    validate_checksums=False,
+                   extensions=None,
                    do_not_fill_defaults=False,
                    _get_yaml_content=False,
                    _force_raw_types=False,
@@ -805,8 +813,8 @@ class AsdfFile:
                 from . import fits_embed
                 return fits_embed.AsdfInFits._open_impl(fd, uri=uri,
                             validate_checksums=validate_checksums,
+                            extensions=extensions,
                             ignore_version_mismatch=self._ignore_version_mismatch,
-                            extensions=self._extensions,
                             strict_extension_check=strict_extension_check,
                             ignore_missing_extensions=ignore_missing_extensions,
                             ignore_unrecognized_tag=self._ignore_unrecognized_tag,
@@ -822,6 +830,7 @@ class AsdfFile:
                     "installed") from None
         return cls._open_asdf(self, fd, uri=uri, mode=mode,
                 validate_checksums=validate_checksums,
+                extensions=extensions,
                 do_not_fill_defaults=do_not_fill_defaults,
                 _get_yaml_content=_get_yaml_content,
                 _force_raw_types=_force_raw_types,
@@ -1583,7 +1592,7 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False,
         mode = _check_and_set_mode(fd, mode)
         readonly = (mode == 'r' and not copy_arrays)
 
-    instance = AsdfFile(extensions=extensions,
+    instance = AsdfFile(
                    ignore_version_mismatch=ignore_version_mismatch,
                    ignore_unrecognized_tag=ignore_unrecognized_tag,
                    copy_arrays=copy_arrays, lazy_load=lazy_load,
@@ -1592,6 +1601,7 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False,
     return AsdfFile._open_impl(instance,
         fd, uri=uri, mode=mode,
         validate_checksums=validate_checksums,
+        extensions=extensions,
         do_not_fill_defaults=do_not_fill_defaults,
         _force_raw_types=_force_raw_types,
         strict_extension_check=strict_extension_check,

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -250,7 +250,7 @@ class AsdfInFits(asdf.AsdfFile):
                 msg = "Failed to parse given file '{}'. Is it FITS?"
                 raise ValueError(msg.format(uri))
 
-        self = cls(hdulist, uri=uri, extensions=extensions,
+        self = cls(hdulist, uri=uri,
                    ignore_version_mismatch=ignore_version_mismatch,
                    ignore_unrecognized_tag=ignore_unrecognized_tag)
 
@@ -267,6 +267,7 @@ class AsdfInFits(asdf.AsdfFile):
         try:
             return cls._open_asdf(self, buff, uri=uri, mode='r',
                               validate_checksums=validate_checksums,
+                              extensions=extensions,
                               strict_extension_check=strict_extension_check,
                               ignore_missing_extensions=ignore_missing_extensions,
                               **kwargs)


### PR DESCRIPTION
This PR continues from #848 and changes `asdf.open` to wait to assign extensions to the `AsdfFile` instance until the version is known.  In the future, extensions will have ASDF Standard version requirements, and assigning them early will result in unnecessary warnings.

This change won't be needed until the new extension API comes, but it's a nicely self-contained bit of work so I thought I'd separate it to make review easier.