### PR TITLE
Implement support for extension URIs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@
 
 - Drop support for Python 3.5. [#856]
 
+- Add new extension API to support versioned extensions.
+  [#850]
+
 2.7.0 (2020-07-23)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -250,6 +250,19 @@ class AsdfFile:
         self.close()
 
     def _check_extensions(self, tree, strict=False):
+        """
+        Compare the user's installed extensions to metadata in the tree
+        and warn when a) an extension is missing or b) an extension is
+        present but the file was written with a later version of the
+        extension's package.
+
+        Parameters
+        ----------
+        tree : AsdfObject
+            Fully converted tree of custom types.
+        strict : bool, optional
+            Set to `True` to convert warnings to exceptions.
+        """
         if 'history' not in tree or not isinstance(tree['history'], dict) or \
                 'extensions' not in tree['history']:
             return
@@ -305,6 +318,21 @@ class AsdfFile:
                         warnings.warn(msg, AsdfWarning)
 
     def _process_extensions(self, requested_extensions):
+        """
+        Validate a list of extensions requested by the user and
+        add missing extensions registered with the current `AsdfConfig`.
+
+        Parameters
+        ----------
+        requested_extensions : object
+            May be any of the following: `asdf.extension.AsdfExtension`, `str`
+            extension URI, `asdf.extension.AsdfExtensionList` or a `list`
+            of URIs and/or extensions.
+
+        Returns
+        -------
+        list of asdf.extension.AsdfExtension
+        """
         if requested_extensions is None:
             requested_extensions = []
         elif isinstance(requested_extensions, (AsdfExtension, ExtensionProxy, str)):
@@ -336,6 +364,15 @@ class AsdfFile:
         return extensions
 
     def _update_extension_history(self, serialization_context):
+        """
+        Update the extension metadata on this file's tree to reflect
+        extensions used during serialization.
+
+        Parameters
+        ----------
+        serialization_context : asdf.asdf.SerializationContext
+            The context that was used to serialize the tree.
+        """
         if serialization_context.version < versioning.NEW_HISTORY_FORMAT_MIN_VERSION:
             return
 

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -27,6 +27,41 @@ class ExtensionProxy(AsdfExtension):
 
         self._legacy = True
 
+        self._legacy_class_names = set()
+        for class_name in getattr(self._delegate, "legacy_class_names", []):
+            if isinstance(class_name, str):
+                self._legacy_class_names.add(class_name)
+            else:
+                raise TypeError("Extension property 'legacy_class_names' must contain str values")
+
+        if self._legacy:
+            self._legacy_class_names.add(self._class_name)
+
+    @property
+    def extension_uri(self):
+        """
+        Get the extension's identifying URI.
+
+        Returns
+        -------
+        str or None
+        """
+        return getattr(self._delegate, "extension_uri", None)
+
+    @property
+    def legacy_class_names(self):
+        """
+        Get the set of fully-qualified class names used by older
+        versions of this extension.  This allows a new-style
+        implementation of an extension to prevent warnings when a
+        legacy extension is missing.
+
+        Returns
+        -------
+        iterable of str
+        """
+        return self._legacy_class_names
+
     @property
     def types(self):
         """

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -196,10 +196,11 @@ class AsdfInFits(asdf.AsdfFile):
             If `True`, validate the blocks against their checksums.
             Requires reading the entire file, so disabled by default.
 
-        extensions : list of AsdfExtension, optional
-            A list of extensions to the ASDF to support when reading
-            and writing ASDF files.  See `asdf.types.AsdfExtension` for
-            more information.
+        extensions : object, optional
+            Additional extensions to use when reading and writing the file.
+            May be any of the following: `asdf.extension.AsdfExtension`, `str`
+            extension URI, `asdf.extension.AsdfExtensionList` or a `list`
+            of URIs and/or extensions.
 
         ignore_version_mismatch : bool, optional
             When `True`, do not raise warnings for mismatched schema versions.

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -46,6 +46,10 @@ class ExtensionMetadata(dict, AsdfType):
     version = '1.0.0'
 
     @property
+    def extension_uri(self):
+        return self.get('extension_uri')
+
+    @property
     def extension_class(self):
         return self['extension_class']
 

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -159,7 +159,7 @@ history:
     """
 
     buff = yaml_to_asdf(yaml)
-    with pytest.warns(AsdfWarning, match="File was created with extension 'foo.bar.FooBar'"):
+    with pytest.warns(AsdfWarning, match="File was created with extension class 'foo.bar.FooBar'"):
         with asdf.open(buff):
             pass
 
@@ -177,7 +177,7 @@ history:
     """
 
     buff = yaml_to_asdf(yaml)
-    with pytest.warns(AsdfWarning, match="File was created with extension 'asdf.extension.BuiltinExtension'"):
+    with pytest.warns(AsdfWarning, match="File was created with extension class 'asdf.extension.BuiltinExtension'"):
         with asdf.open(buff):
             pass
 

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -140,6 +140,15 @@ def test_resource_mappings():
         config.remove_resource_mapping(package="foo")
         assert len(config.resource_mappings) == len(default_mappings)
 
+        # Can combine the package and mapping filters when removing:
+        config.add_resource_mapping(ResourceMappingProxy(new_mapping, package_name="foo"))
+        config.remove_resource_mapping(new_mapping, package="foo")
+        assert len(config.resource_mappings) == len(default_mappings)
+
+        # But not omit both:
+        with pytest.raises(ValueError):
+            config.remove_resource_mapping()
+
         # Removing a mapping should be idempotent:
         config.add_resource_mapping(new_mapping)
         config.remove_resource_mapping(new_mapping)
@@ -187,6 +196,13 @@ def test_extensions():
             url_mapping = []
         new_extension = FooExtension()
 
+        class BarExtension:
+            extension_uri = "asdf://somewhere.org/extensions/bar-1.0"
+            types = []
+            tag_mapping = []
+            url_mapping = []
+        uri_extension = BarExtension()
+
         # Add an extension:
         config.add_extension(new_extension)
         assert len(config.extensions) == len(original_extensions) + 1
@@ -209,10 +225,26 @@ def test_extensions():
         config.remove_extension(ExtensionProxy(new_extension))
         assert len(config.extensions) == len(original_extensions)
 
+        # And also by URI:
+        config.add_extension(uri_extension)
+        config.remove_extension(uri_extension.extension_uri)
+        assert len(config.extensions) == len(original_extensions)
+
         # Remove by the name of the extension's package:
         config.add_extension(ExtensionProxy(new_extension, package_name="foo"))
-        config.add_extension(ExtensionProxy(FooExtension(), package_name="foo"))
+        config.add_extension(ExtensionProxy(uri_extension, package_name="foo"))
         config.remove_extension(package="foo")
+        assert len(config.extensions) == len(original_extensions)
+
+        # Can combine remove filters:
+        config.add_extension(ExtensionProxy(new_extension, package_name="foo"))
+        config.add_extension(ExtensionProxy(uri_extension, package_name="foo"))
+        config.remove_extension(uri_extension.extension_uri, package="foo")
+        assert len(config.extensions) == len(original_extensions) + 1
+
+        # ... but not omit both:
+        with pytest.raises(ValueError):
+            config.remove_extension()
 
         # Removing an extension should be idempotent:
         config.add_extension(new_extension)
@@ -225,6 +257,27 @@ def test_extensions():
         config.add_extension(FooExtension())
         config.reset_extensions()
         assert len(config.extensions) == len(original_extensions)
+
+
+def test_get_extension():
+    class FooExtension:
+        extension_uri = "asdf://somewhere.org/extensions/foo-1.0"
+        types = []
+        tag_mapping = []
+        url_mapping = []
+
+    with asdf.config_context() as config:
+        with pytest.raises(KeyError):
+            config.get_extension(FooExtension.extension_uri)
+
+        extension = FooExtension()
+        config.add_extension(extension)
+        config.get_extension(FooExtension.extension_uri).delegate is extension
+
+        # Extensions added later take precedence:
+        duplicate_extension = FooExtension()
+        config.add_extension(extension)
+        config.get_extension(FooExtension.extension_uri).delegate is duplicate_extension
 
 
 def test_config_repr():

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -40,6 +40,8 @@ def test_proxy_legacy():
     extension = LegacyExtension()
     proxy = ExtensionProxy(extension, package_name="foo", package_version="1.2.3")
 
+    assert proxy.extension_uri is None
+    assert proxy.legacy_class_names == {"asdf.tests.test_extension.LegacyExtension"}
     assert proxy.types == [LegacyType]
     assert proxy.tag_mapping == LegacyExtension.tag_mapping
     assert proxy.url_mapping == LegacyExtension.url_mapping

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -399,7 +399,7 @@ def test_serialize_table(tmpdir):
 def test_extension_check():
     testfile = get_test_data_path('extension_check.fits')
 
-    with pytest.warns(AsdfWarning, match="was created with extension 'foo.bar.FooBar'"):
+    with pytest.warns(AsdfWarning, match="was created with extension class 'foo.bar.FooBar'"):
         with asdf.open(testfile):
             pass
 

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -331,6 +331,10 @@ def dump_tree(tree, fd, ctx, tree_finalizer=None, _serialization_context=None):
         extension metadata on the tagged tree before it is fully
         serialized to YAML.
     """
+    # The _serialization_context parameter allows AsdfFile to track
+    # what extensions were used when converting the tree's custom
+    # types.  In 3.0, it will be passed as the `ctx` instead of the
+    # AsdfFile itself.
     tags = None
     tree_type = ctx.type_index.from_custom_type(type(tree))
     if tree_type is not None:


### PR DESCRIPTION
This PR is branched off of #849.  Here I'm adding support for extension URIs, where are defined as an attribute on the extension instance and are written to the file metadata.  Technically this is part of the new extension API, but the change fit nicely into a separate PR.

There are two new extension attributes:

- `extension_uri`: The URI of the "extension to the ASDF Standard" that the extension class implements.  Something like "asdf://somewhere.org/extensions/foo-1.0".
- `legacy_class_names`: The fully qualified names of extension classes that provided this functionality before the advent of URIs.  This allows us to switch to URIs and change the class name without incurring warnings from the library.

Additionally I changed `AsdfFile.__init__` and `asdf.open` to accept extension URIs in addition to extension instances.