### PR TITLE
Support for ASDF Standard requirements on extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@
 - Drop support for Python 3.5. [#856]
 
 - Add new extension API to support versioned extensions.
-  [#850]
+  [#850, #851]
 
 2.7.0 (2020-07-23)
 ------------------

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -1,3 +1,5 @@
+from packaging.specifiers import SpecifierSet
+
 from ..util import get_class_name
 from ._legacy import AsdfExtension
 
@@ -34,6 +36,14 @@ class ExtensionProxy(AsdfExtension):
             else:
                 raise TypeError("Extension property 'legacy_class_names' must contain str values")
 
+        value = getattr(self._delegate, "asdf_standard_requirement", None)
+        if isinstance(value, str):
+            self._asdf_standard_requirement = SpecifierSet(value)
+        elif value is None:
+            self._asdf_standard_requirement = SpecifierSet()
+        else:
+            raise TypeError("Extension property 'asdf_standard_requirement' must be str or None")
+
         if self._legacy:
             self._legacy_class_names.add(self._class_name)
 
@@ -61,6 +71,17 @@ class ExtensionProxy(AsdfExtension):
         iterable of str
         """
         return self._legacy_class_names
+
+    @property
+    def asdf_standard_requirement(self):
+        """
+        Get the extension's ASDF Standard requirement.
+
+        Returns
+        -------
+        packaging.specifiers.SpecifierSet
+        """
+        return self._asdf_standard_requirement
 
     @property
     def types(self):

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -1,4 +1,5 @@
 import pytest
+from packaging.specifiers import SpecifierSet
 
 from asdf.extension import (
     BuiltinExtension,
@@ -8,6 +9,7 @@ from asdf.extension import (
 from asdf.types import CustomType
 
 from asdf.tests.helpers import assert_extension_correctness
+
 
 def test_builtin_extension():
     extension = BuiltinExtension()
@@ -42,6 +44,7 @@ def test_proxy_legacy():
 
     assert proxy.extension_uri is None
     assert proxy.legacy_class_names == {"asdf.tests.test_extension.LegacyExtension"}
+    assert proxy.asdf_standard_requirement == SpecifierSet()
     assert proxy.types == [LegacyType]
     assert proxy.tag_mapping == LegacyExtension.tag_mapping
     assert proxy.url_mapping == LegacyExtension.url_mapping

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     jsonschema>=3.0.2,<4
     numpy>=1.10
     importlib_resources>=3;python_version<"3.9"
+    packaging>=16.0
 
 [options.extras_require]
 all =


### PR DESCRIPTION
This PR is branched off of #850.  It adds support for specifying an ASDF Standard version requirement as an attribute on the extension class.  We'll need this for the older transform extensions, each of which corresponds to a specific ASDF Standard version.  It'll also be handy when we implement the core extension (currently `asdf.extension.BuiltinExtension`) using the new API.