### PR TITLE
Fix performance regression due to rebuilding type index

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -22,7 +22,12 @@ from . import versioning
 from . import yamlutil
 from . import _display as display
 from .exceptions import AsdfDeprecationWarning, AsdfWarning, AsdfConversionWarning
-from .extension import AsdfExtensionList, AsdfExtension, ExtensionProxy
+from .extension import (
+    AsdfExtensionList,
+    AsdfExtension,
+    ExtensionProxy,
+    get_cached_asdf_extension_list,
+)
 from .util import NotSet
 from .search import AsdfSearchResult
 from ._helpers import validate_version
@@ -232,7 +237,7 @@ class AsdfFile:
         asdf.extension.AsdfExtensionList
         """
         if self._extension_list is None:
-            self._extension_list = AsdfExtensionList(self.extensions)
+            self._extension_list = get_cached_asdf_extension_list(self.extensions)
         return self._extension_list
 
     def __enter__(self):

--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -9,6 +9,7 @@ from ._legacy import (
     BuiltinExtension,
     default_extensions,
     get_default_resolver,
+    get_cached_asdf_extension_list,
 )
 
 
@@ -21,4 +22,5 @@ __all__ = [
     "BuiltinExtension",
     "default_extensions",
     "get_default_resolver",
+    "get_cached_asdf_extension_list",
 ]

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -133,8 +133,6 @@ def test_get_history_entries(tmpdir):
 def test_extension_metadata(tmpdir):
 
     ff = asdf.AsdfFile()
-    # No extensions used yet:
-    assert len(ff.type_index.get_extensions_used()) == 0
 
     tmpfile = str(tmpdir.join('extension.asdf'))
     ff.write_to(tmpfile)

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -1,6 +1,10 @@
 import pytest
 
-from asdf.extension import BuiltinExtension, ExtensionProxy
+from asdf.extension import (
+    BuiltinExtension,
+    ExtensionProxy,
+    get_cached_asdf_extension_list,
+)
 from asdf.types import CustomType
 
 from asdf.tests.helpers import assert_extension_correctness
@@ -67,3 +71,10 @@ def test_proxy_repr():
     assert "class: asdf.tests.test_extension.LegacyExtension" in repr(proxy)
     assert "package: (none)" in repr(proxy)
     assert "legacy: True" in repr(proxy)
+
+
+def test_get_cached_asdf_extension_list():
+    extension = LegacyExtension()
+    extension_list = get_cached_asdf_extension_list([extension])
+    assert get_cached_asdf_extension_list([extension]) is extension_list
+    assert get_cached_asdf_extension_list([LegacyExtension()]) is not extension_list


### PR DESCRIPTION
This (partially) fixes a performance regression due to #847.  I noticed that the tests were running ~ 15% slower on the latest master, and it turns out my changes are causing the `TypeIndex` object for the default set of extensions to be rebuilt when previously it was reused from the `asdf.extension.default_extensions` object.

The change here doesn't actually improve the tests much, since an autouse fixture resets the config every time and forces cache misses.  But here's a test program that demonstrates the difference:

```python
from time import time
from asdf import AsdfFile

started_at = time()
for _ in range(10000):
    AsdfFile().extension_list
print(time() - started_at)
```

Trials on 2.7.0:
```
0.6928091049194336
0.694317102432251
0.6906321048736572
```

Trials on master:
```
10.935057163238525
11.144551992416382
11.305798768997192
```

Trials on this branch:
```
1.1489489078521729
1.0827388763427734
1.1393661499023438
```

(I had to adapt the program a little to run on 2.7.0, since the `extension_list` property didn't exist at that point)

So there's still more work to do but this takes care of the lion's share of the problem.