### PR TITLE
Add Extension and Converter ABCs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@
 - Drop support for Python 3.5. [#856]
 
 - Add new extension API to support versioned extensions.
-  [#850, #851]
+  [#850, #851, #853]
 
 - Permit wildcard in tag validator URIs. [#858, #865]
 

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -139,7 +139,7 @@ class AsdfConfig:
 
         Returns
         -------
-        list of asdf.extension.AsdfExtension
+        list of asdf.extension.AsdfExtension or asdf.extension.Extension
         """
         if self._extensions is None:
             with self._lock:
@@ -154,7 +154,7 @@ class AsdfConfig:
 
         Parameters
         ----------
-        extension : asdf.extension.AsdfExtension
+        extension : asdf.extension.AsdfExtension or asdf.extension.Extension
         """
         with self._lock:
             extension = ExtensionProxy.maybe_wrap(extension)
@@ -166,8 +166,8 @@ class AsdfConfig:
 
         Parameters
         ----------
-        extension : asdf.extension.AsdfExtension or str, optional
-            An extension instance or URI or URI pattern to remove.
+        extension : asdf.extension.AsdfExtension or asdf.extension.Extension or str, optional
+            An extension instance or URI pattern to remove.
         package : str, optional
             Remove only extensions provided by this package.  If the `extension`
             argument is omitted, then all extensions from this package will
@@ -206,7 +206,7 @@ class AsdfConfig:
 
         Returns
         -------
-        asdf.extension.AsdfExtension
+        asdf.extension.AsdfExtension or asdf.extension.Extension
 
         Raises
         ------

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -7,6 +7,7 @@ from .extension import ExtensionProxy
 
 
 RESOURCE_MAPPINGS_GROUP = "asdf.resource_mappings"
+EXTENSIONS_GROUP = "asdf.extensions"
 LEGACY_EXTENSIONS_GROUP = "asdf_extensions"
 
 
@@ -15,9 +16,10 @@ def get_resource_mappings():
 
 
 def get_extensions():
+    extensions = _list_entry_points(EXTENSIONS_GROUP, ExtensionProxy)
     legacy_extensions = _list_entry_points(LEGACY_EXTENSIONS_GROUP, ExtensionProxy)
 
-    return legacy_extensions
+    return extensions + legacy_extensions
 
 
 def _list_entry_points(group, proxy_class):

--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -2,7 +2,10 @@
 Support for plugins that extend asdf to serialize
 additional custom types.
 """
-from ._extension import ExtensionProxy
+from ._extension import Extension, ExtensionProxy
+from ._manager import ExtensionManager, get_cached_extension_manager
+from ._tag import TagDefinition
+from ._converter import Converter, ConverterProxy
 from ._legacy import (
     AsdfExtension,
     AsdfExtensionList,
@@ -15,7 +18,13 @@ from ._legacy import (
 
 __all__ = [
     # New API
+    "Extension",
     "ExtensionProxy",
+    "ExtensionManager",
+    "get_cached_extension_manager",
+    "TagDefinition",
+    "Converter",
+    "ConverterProxy",
     # Legacy API
     "AsdfExtension",
     "AsdfExtensionList",

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -1,0 +1,357 @@
+"""
+Support for Converter, the new API for serializing custom
+types.  Will eventually replace the `asdf.types` module.
+"""
+import abc
+
+from ..util import get_class_name, uri_match
+
+
+class Converter(abc.ABC):
+    """
+    Abstract base class for plugins that convert nodes from the
+    parsed YAML tree into custom objects, and vice versa.
+
+    Implementing classes must provide the `tags` and `types`
+    properties and `to_yaml_tree` and `from_yaml_tree` methods.
+    The `select_tag` method is optional.
+    """
+    @classmethod
+    def __subclasshook__(cls, C):
+        if cls is Converter:
+            return (hasattr(C, "tags") and
+                    hasattr(C, "types") and
+                    hasattr(C, "to_yaml_tree") and
+                    hasattr(C, "from_yaml_tree"))
+        return NotImplemented # pragma: no cover
+
+    @abc.abstractproperty
+    def tags(self):
+        """
+        Get the YAML tags that this converter is capable of
+        handling.  URI patterns are permitted, see
+        `asdf.util.uri_match` for details.
+
+        Returns
+        -------
+        iterable of str
+            Tag URIs or URI patterns.
+        """
+        pass # pragma: no cover
+
+    @abc.abstractproperty
+    def types(self):
+        """
+        Get the Python types that this converter is capable of
+        handling.
+
+        Returns
+        -------
+        iterable of str or type
+            If str, the fully qualified class name of the type.
+        """
+        pass # pragma: no cover
+
+    def select_tag(self, obj, tags, ctx):
+        """
+        Select the tag to use when converting an object to YAML.
+        Typically only one tag will be active in a given context, but
+        converters that map one type to many tags must provide logic
+        to choose the appropriate tag.
+
+        Parameters
+        ----------
+        obj : object
+            Instance of the custom type being converted.  Guaranteed
+            to be an instance of one of the types listed in the
+            `types` property.
+        tags : list of str
+            List of active tags to choose from.  Guaranteed to match
+            one of the tag patterns listed in the 'tags' property.
+        ctx : asdf.asdf.SerializationContext
+            Context of the current serialization request.
+
+        Returns
+        -------
+        str
+            The selected tag.  Should be one of the tags passed
+            to this method in the `tags` parameter.
+        """
+        return tags[0]
+
+    @abc.abstractmethod
+    def to_yaml_tree(self, obj, tag, ctx):
+        """
+        Convert an object into a node suitable for YAML serialization.
+        This method is not responsible for writing actual YAML; rather, it
+        converts an instance of a custom type to a built-in Python object type
+        (such as dict, list, str, or number), which can then be automatically
+        serialized to YAML as needed.
+
+        For container types returned by this method (dict or list),
+        the children of the container need not themselves be converted.
+        Any list elements or dict values will be converted by subsequent
+        calls to to_yaml_tree implementations.
+
+        The returned node must be an instance of `dict`, `list`, or `str`.
+        Children may be any type supported by an available Converter.
+
+        Parameters
+        ----------
+        obj : object
+            Instance of a custom type to be serialized.  Guaranteed to
+            be an instance of one of the types listed in the `types`
+            property.
+        tag : str
+            The tag identifying the YAML type that `obj` should be
+            converted into.  Selected by a call to this converter's
+            select_tag method.
+        ctx : asdf.asdf.SerializationContext
+            The context of the current serialization request.
+
+        Returns
+        -------
+        dict or list or str
+            The YAML node representation of the object.
+        """
+        pass # pragma: no cover
+
+    @abc.abstractmethod
+    def from_yaml_tree(self, node, tag, ctx):
+        """
+        Convert a YAML node into an instance of a custom type.
+
+        For container types received by this method (dict or list),
+        the children of the container will have already been converted
+        by prior calls to from_yaml_tree implementations.
+
+        Note on circular references: trees that reference themselves
+        among their descendants must be handled with care.  Most
+        implementations need not concern themselves with this case, but
+        if the custom type supports circular references, then the
+        implementation of this method will need to return a generator.
+        Consult the documentation for more details.
+
+        Parameters
+        ----------
+        tree : dict or list or str
+            The YAML node to convert.
+        tag : str
+            The YAML tag of the object being converted.
+        ctx : asdf.asdf.SerializationContext
+            The context of the current deserialization request.
+
+        Returns
+        -------
+        object
+            An instance of one of the types listed in the `types` property,
+            or a generator that yields such an instance.
+        """
+        pass # pragma: no cover
+
+
+class ConverterProxy(Converter):
+    """
+    Proxy that wraps a `Converter` and provides default
+    implementations of optional methods.
+    """
+    def __init__(self, delegate, extension):
+        if not isinstance(delegate, Converter):
+            raise TypeError("Converter must implement the asdf.extension.Converter interface")
+
+        self._delegate = delegate
+        self._extension = extension
+        self._class_name = get_class_name(delegate)
+
+        # Sort these out up-front so that errors are raised when the extension is loaded
+        # and not in the middle of the user's session.  The extension will fail to load
+        # and a warning will be emitted, but it won't crash the program.
+
+        relevant_tags = set()
+        for tag in delegate.tags:
+            if isinstance(tag, str):
+                relevant_tags.update(t.tag_uri for t in extension.tags if uri_match(tag, t.tag_uri))
+            else:
+                raise TypeError("Converter property 'tags' must contain str values")
+
+        if len(relevant_tags) > 1 and not hasattr(delegate, "select_tag"):
+            raise RuntimeError(
+                "Converter handles multiple tags for this extension, "
+                "but does not implement a select_tag method."
+            )
+
+        self._tags = sorted(relevant_tags)
+
+        self._types = []
+        for typ in delegate.types:
+            if isinstance(typ, (str, type)):
+                self._types.append(typ)
+            else:
+                raise TypeError("Converter property 'types' must contain str or type values")
+
+    @property
+    def tags(self):
+        """
+        Get the list of tag URIs that this converter is capable of
+        handling.
+
+        Returns
+        -------
+        list of str
+        """
+        return self._tags
+
+    @property
+    def types(self):
+        """
+        Get the Python types that this converter is capable of
+        handling.
+
+        Returns
+        -------
+        list of type or str
+        """
+        return self._types
+
+    def select_tag(self, obj, ctx):
+        """
+        Select the tag to use when converting an object to YAML.
+
+        Parameters
+        ----------
+        obj : object
+            Instance of the custom type being converted.
+        ctx : asdf.asdf.SerializationContext
+            Serialization parameters.
+
+        Returns
+        -------
+        str
+            Selected tag.
+        """
+        method = getattr(self._delegate, "select_tag", None)
+        if method is None:
+            return self._tags[0]
+        else:
+            return method(obj, self._tags, ctx)
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        """
+        Convert an object into a node suitable for YAML serialization.
+
+        Parameters
+        ----------
+        obj : object
+            Instance of a custom type to be serialized.
+        tag : str
+            The tag identifying the YAML type that `obj` should be
+            converted into.
+        ctx : asdf.asdf.SerializationContext
+            Serialization parameters.
+
+        Returns
+        -------
+        object
+            The YAML node representation of the object.
+        """
+        return self._delegate.to_yaml_tree(obj, tag, ctx)
+
+    def from_yaml_tree(self, node, tag, ctx):
+        """
+        Convert a YAML node into an instance of a custom type.
+
+        Parameters
+        ----------
+        tree : dict or list or str
+            The YAML node to convert.
+        tag : str
+            The YAML tag of the object being converted.
+        ctx : asdf.asdf.SerializationContext
+            Serialization parameters.
+
+        Returns
+        -------
+        object
+        """
+        return self._delegate.from_yaml_tree(node, tag, ctx)
+
+    @property
+    def delegate(self):
+        """
+        Get the wrapped converter instance.
+
+        Returns
+        -------
+        asdf.extension.Converter
+        """
+        return self._delegate
+
+    @property
+    def extension(self):
+        """
+        Get the extension that provided this converter.
+
+        Returns
+        -------
+        asdf.extension.Extension
+        """
+        return self._extension
+
+    @property
+    def package_name(self):
+        """
+        Get the name of the Python package of this converter's
+        extension.  This may not be the same package that implements
+        the converter's class.
+
+        Returns
+        -------
+        str or None
+            Package name, or `None` if the extension was added at runtime.
+        """
+        return self.extension.package_name
+
+    @property
+    def package_version(self):
+        """
+        Get the version of the Python package of this converter's
+        extension.  This may not be the same package that implements
+        the converter's class.
+
+        Returns
+        -------
+        str or None
+            Package version, or `None` if the extension was added at runtime.
+        """
+        return self.extension.package_version
+
+    @property
+    def class_name(self):
+        """
+        Get the fully qualified class name of this converter.
+
+        Returns
+        -------
+        str
+        """
+        return self._class_name
+
+    def __eq__(self, other):
+        if isinstance(other, ConverterProxy):
+            return other.delegate is self.delegate and other.extension is self.extension
+        else:
+            return False
+
+    def __hash__(self):
+        return hash((id(self.delegate), id(self.extension)))
+
+    def __repr__(self):
+        if self.package_name is None:
+            package_description = "(none)"
+        else:
+            package_description = "{}=={}".format(self.package_name, self.package_version)
+
+        return "<ConverterProxy class: {} package: {}>".format(
+            self.class_name,
+            package_description,
+        )

--- a/asdf/extension/_legacy.py
+++ b/asdf/extension/_legacy.py
@@ -8,12 +8,10 @@ from ..type_index import AsdfTypeIndex
 from ..exceptions import AsdfDeprecationWarning
 
 
-ASDF_TEST_BUILD_ENV = 'ASDF_TEST_BUILD'
-
-
 class AsdfExtension(metaclass=abc.ABCMeta):
     """
-    Abstract base class defining an extension to ASDF.
+    Abstract base class defining a (legacy) extension to ASDF.
+    New code should use `asdf.extension.Extension` instead.
     """
     @classmethod
     def __subclasshook__(cls, C):

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -1,0 +1,210 @@
+from functools import lru_cache
+
+from ._extension import ExtensionProxy
+from ..util import get_class_name
+
+
+class ExtensionManager:
+    """
+    Wraps a list of extensions and indexes their converters
+    by tag and by Python type.
+
+    Parameters
+    ----------
+    extensions : iterable of asdf.extension.Extension
+        List of enabled extensions to manage.  Extensions placed earlier
+        in the list take precedence.
+    """
+    def __init__(self, extensions):
+        self._extensions = [ExtensionProxy.maybe_wrap(e) for e in extensions]
+
+        self._tag_defs_by_tag = {}
+        self._converters_by_tag = {}
+        # This dict has both str and type keys:
+        self._converters_by_type = {}
+
+        for extension in self._extensions:
+            for tag_def in extension.tags:
+                if tag_def.tag_uri not in self._tag_defs_by_tag:
+                    self._tag_defs_by_tag[tag_def.tag_uri] = tag_def
+            for converter in extension.converters:
+                # If a converter's tags do not actually overlap with
+                # the extension tag list, then there's no reason to
+                # use it.
+                if len(converter.tags) > 0:
+                    for tag in converter.tags:
+                        if tag not in self._converters_by_tag:
+                            self._converters_by_tag[tag] = converter
+                    for typ in converter.types:
+                        if isinstance(typ, str):
+                            if typ not in self._converters_by_type:
+                                self._converters_by_type[typ] = converter
+                        else:
+                            type_class_name = get_class_name(typ, instance=False)
+                            if typ not in self._converters_by_type and type_class_name not in self._converters_by_type:
+                                self._converters_by_type[typ] = converter
+                                self._converters_by_type[type_class_name] = converter
+
+    @property
+    def extensions(self):
+        """
+        Get the list of extensions.
+
+        Returns
+        -------
+        list of asdf.extension.Extension
+        """
+        return self._extensions
+
+    def handles_tag(self, tag):
+        """
+        Return `True` if the specified tag is handled by a
+        converter.
+
+        Parameters
+        ----------
+        tag : str
+            Tag URI.
+
+        Returns
+        -------
+        bool
+        """
+        return tag in self._converters_by_tag
+
+    def handles_type(self, typ):
+        """
+        Returns `True` if the specified Python type is handled
+        by a converter.
+
+        Parameters
+        ----------
+        typ : type
+
+        Returns
+        -------
+        bool
+        """
+        return (
+            typ in self._converters_by_type
+            or get_class_name(typ, instance=False) in self._converters_by_type
+        )
+
+    def get_tag_definition(self, tag):
+        """
+        Get the tag definition for the specified tag.
+
+        Parameters
+        ----------
+        tag : str
+            Tag URI.
+
+        Returns
+        -------
+        asdf.extension.TagDefinition
+
+        Raises
+        ------
+        KeyError
+            Unrecognized tag URI.
+        """
+        try:
+            return self._tag_defs_by_tag[tag]
+        except KeyError:
+            raise KeyError(
+                "No support available for YAML tag '{}'.  "
+                "You may need to install a missing extension.".format(
+                    tag
+                )
+            ) from None
+
+    def get_converter_for_tag(self, tag):
+        """
+        Get the converter for the specified tag.
+
+        Parameters
+        ----------
+        tag : str
+            Tag URI.
+
+        Returns
+        -------
+        asdf.extension.Converter
+
+        Raises
+        ------
+        KeyError
+            Unrecognized tag URI.
+        """
+        try:
+            return self._converters_by_tag[tag]
+        except KeyError:
+            raise KeyError(
+                "No support available for YAML tag '{}'.  "
+                "You may need to install a missing extension.".format(
+                    tag
+                )
+            ) from None
+
+    def get_converter_for_type(self, typ):
+        """
+        Get the converter for the specified Python type.
+
+        Parameters
+        ----------
+        typ : type
+
+        Returns
+        -------
+        asdf.extension.Converter
+
+        Raises
+        ------
+        KeyError
+            Unrecognized type.
+        """
+        try:
+            return self._converters_by_type[typ]
+        except KeyError:
+            class_name = get_class_name(typ, instance=False)
+            try:
+                return self._converters_by_type[class_name]
+            except KeyError:
+                raise KeyError(
+                    "No support available for Python type '{}'.  "
+                    "You may need to install or enable an extension.".format(
+                        get_class_name(typ, instance=False)
+                    )
+                ) from None
+
+
+def get_cached_extension_manager(extensions):
+    """
+    Get a previously created ExtensionManager for the specified
+    extensions, or create and cache one if necessary.  Building
+    the manager is expensive, so it helps performance to reuse
+    it when possible.
+
+    Parameters
+    ----------
+    extensions : list of asdf.extension.AsdfExtension or asdf.extension.Extension
+
+    Returns
+    -------
+    asdf.extension.ExtensionManager
+    """
+    from ._extension import ExtensionProxy
+    # The tuple makes the extensions hashable so that we
+    # can pass them to the lru_cache method.  The ExtensionProxy
+    # overrides __hash__ to return the hashed object id of the wrapped
+    # extension, so this will method will only return the same
+    # ExtensionManager if the list contains identical extension
+    # instances in identical order.
+    extensions = tuple(ExtensionProxy.maybe_wrap(e) for e in extensions)
+
+    return _get_cached_extension_manager(extensions)
+
+
+@lru_cache()
+def _get_cached_extension_manager(extensions):
+    return ExtensionManager(extensions)

--- a/asdf/extension/_tag.py
+++ b/asdf/extension/_tag.py
@@ -1,0 +1,72 @@
+class TagDefinition:
+    """
+    Container for properties of a custom YAML tag.
+
+    Parameters
+    ----------
+    tag_uri : str
+        Tag URI.
+    schema_uri : str, optional
+        URI of the schema that should be used to validate objects
+        with this tag.
+    title : str, optional
+        Short description of the tag.
+    description : str, optional
+        Long description of the tag.
+    """
+    def __init__(self, tag_uri, *, schema_uri=None, title=None, description=None):
+        if "*" in tag_uri:
+            raise ValueError("URI patterns are not permitted in TagDefinition")
+
+        self._tag_uri = tag_uri
+        self._schema_uri = schema_uri
+        self._title = title
+        self._description = description
+
+    @property
+    def tag_uri(self):
+        """
+        Get the tag URI.
+
+        Returns
+        -------
+        str
+        """
+        return self._tag_uri
+
+    @property
+    def schema_uri(self):
+        """
+        Get the URI of the schema that should be used to validate
+        objects wtih this tag.
+
+        Returns
+        -------
+        str or None
+        """
+        return self._schema_uri
+
+    @property
+    def title(self):
+        """
+        Get the short description of the tag.
+
+        Returns
+        -------
+        str or None
+        """
+        return self._title
+
+    @property
+    def description(self):
+        """
+        Get the long description of the tag.
+
+        Returns
+        -------
+        str or None
+        """
+        return self._description
+
+    def __repr__(self):
+        return ("<TagDefinition URI: {}>".format(self.tag_uri))

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -198,9 +198,10 @@ class AsdfInFits(asdf.AsdfFile):
 
         extensions : object, optional
             Additional extensions to use when reading and writing the file.
-            May be any of the following: `asdf.extension.AsdfExtension`, `str`
-            extension URI, `asdf.extension.AsdfExtensionList` or a `list`
-            of URIs and/or extensions.
+            May be any of the following: `asdf.extension.AsdfExtension`,
+            `asdf.extension.Extension`, `str` extension URI,
+            `asdf.extension.AsdfExtensionList` or a `list` of URIs and/or
+            extensions.
 
         ignore_version_mismatch : bool, optional
             When `True`, do not raise warnings for mismatched schema versions.

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -303,18 +303,26 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
                 if _schema is None:
                     tag = getattr(instance, '_tag', None)
                     if tag is not None:
-                        schema_path = self.ctx.resolver(tag)
-                        if schema_path != tag:
+                        if self.serialization_context.extension_manager.handles_tag(tag):
+                            tag_def = self.serialization_context.extension_manager.get_tag_definition(tag)
+                            schema_uri = tag_def.schema_uri
+                        else:
+                            schema_uri = self.ctx.tag_mapping(tag)
+                            if schema_uri == tag:
+                                schema_uri = None
+
+                        if schema_uri is not None:
                             try:
-                                s = _load_schema_cached(schema_path, self.ctx.resolver, False, False)
+                                s = _load_schema_cached(schema_uri, self.ctx.resolver, False, False)
                             except FileNotFoundError:
                                 msg = "Unable to locate schema file for '{}': '{}'"
-                                warnings.warn(msg.format(tag, schema_path), AsdfWarning)
+                                warnings.warn(msg.format(tag, schema_uri), AsdfWarning)
                                 s = {}
                             if s:
-                                with self.resolver.in_scope(schema_path):
+                                with self.resolver.in_scope(schema_uri):
                                     for x in super(ASDFValidator, self).iter_errors(instance, s):
                                         yield x
+
 
                     if isinstance(instance, dict):
                         for val in instance.values():
@@ -492,7 +500,8 @@ def _load_schema_cached(url, resolver, resolve_references, resolve_local_refs):
 
 
 def get_validator(schema={}, ctx=None, validators=None, url_mapping=None,
-                  *args, _visit_repeat_nodes=False, **kwargs):
+                  *args, _visit_repeat_nodes=False, _serialization_context=None,
+                  **kwargs):
     """
     Get a JSON schema validator object for the given schema.
 
@@ -530,6 +539,9 @@ def get_validator(schema={}, ctx=None, validators=None, url_mapping=None,
         from .asdf import AsdfFile
         ctx = AsdfFile()
 
+    if _serialization_context is None:
+        _serialization_context = ctx._create_serialization_context()
+
     if validators is None:
         validators = util.HashableDict(YAML_VALIDATORS.copy())
         validators.update(ctx.extension_list.validators)
@@ -544,6 +556,7 @@ def get_validator(schema={}, ctx=None, validators=None, url_mapping=None,
     cls = _create_validator(validators=validators, visit_repeat_nodes=_visit_repeat_nodes)
     validator = cls(schema, *args, **kwargs)
     validator.ctx = ctx
+    validator.serialization_context = _serialization_context
     return validator
 
 

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -4,7 +4,7 @@ from asdf.asdf import AsdfFile, open_asdf, SerializationContext
 from asdf import config_context, get_config
 from asdf.versioning import AsdfVersion
 from asdf.exceptions import AsdfWarning
-from asdf.extension import ExtensionProxy, AsdfExtensionList
+from asdf.extension import ExtensionProxy, AsdfExtensionList, ExtensionManager
 from asdf.tests.helpers import yaml_to_asdf, assert_no_warnings
 
 
@@ -211,8 +211,10 @@ def test_open_asdf_extensions(tmpdir):
 
 
 def test_serialization_context():
-    context = SerializationContext("1.4.0")
+    extension_manager = ExtensionManager([])
+    context = SerializationContext("1.4.0", extension_manager)
     assert context.version == "1.4.0"
+    assert context.extension_manager is extension_manager
     assert context._extensions_used == set()
 
     extension = get_config().extensions[0]
@@ -227,7 +229,7 @@ def test_serialization_context():
         context._mark_extension_used(object())
 
     with pytest.raises(ValueError):
-        SerializationContext("0.5.4")
+        SerializationContext("0.5.4", extension_manager)
 
 
 def test_reading_extension_metadata():

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -2,9 +2,16 @@ import pytest
 from packaging.specifiers import SpecifierSet
 
 from asdf.extension import (
-    BuiltinExtension,
+    Extension,
     ExtensionProxy,
-    get_cached_asdf_extension_list,
+    ExtensionManager,
+    get_cached_extension_manager,
+    TagDefinition,
+    Converter,
+    ConverterProxy,
+    AsdfExtension,
+    BuiltinExtension,
+    get_cached_asdf_extension_list
 )
 from asdf.types import CustomType
 
@@ -28,8 +35,93 @@ class LegacyExtension:
     url_mapping = [("http://somewhere.org/", "http://somewhere.org/{url_suffix}.yaml")]
 
 
-def test_proxy_maybe_wrap():
-    extension = LegacyExtension()
+class MinimumExtension:
+    extension_uri = "asdf://somewhere.org/extensions/minimum-1.0"
+
+
+class MinimumExtensionSubclassed(Extension):
+    extension_uri = "asdf://somewhere.org/extensions/minimum-1.0"
+
+
+class FullExtension:
+    extension_uri = "asdf://somewhere.org/extensions/full-1.0"
+
+    def __init__(
+        self,
+        converters=None,
+        asdf_standard_requirement=None,
+        tags=None,
+        legacy_class_names=None,
+    ):
+        self._converters = [] if converters is None else converters
+        self._asdf_standard_requirement = asdf_standard_requirement
+        self._tags = tags
+        self._legacy_class_names = [] if legacy_class_names is None else legacy_class_names
+
+    @property
+    def converters(self):
+        return self._converters
+
+    @property
+    def asdf_standard_requirement(self):
+        return self._asdf_standard_requirement
+
+    @property
+    def tags(self):
+        return self._tags
+
+    @property
+    def legacy_class_names(self):
+        return self._legacy_class_names
+
+
+class MinimumConverter:
+    def __init__(self, tags=None, types=None):
+        if tags is None:
+            self._tags = []
+        else:
+            self._tags = tags
+
+        if types is None:
+            self._types = []
+        else:
+            self._types = types
+
+    @property
+    def tags(self):
+        return self._tags
+
+    @property
+    def types(self):
+        return self._types
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return "to_yaml_tree result"
+
+    def from_yaml_tree(self, obj, tag, ctx):
+        return "from_yaml_tree result"
+
+
+class FullConverter(MinimumConverter):
+    def select_tag(self, obj, tags, ctx):
+        return "select_tag result"
+
+
+# Some dummy types for testing converters:
+class FooType:
+    pass
+
+
+class BarType:
+    pass
+
+
+class BazType:
+    pass
+
+
+def test_extension_proxy_maybe_wrap():
+    extension = MinimumExtension()
     proxy = ExtensionProxy.maybe_wrap(extension)
     assert proxy.delegate is extension
     assert ExtensionProxy.maybe_wrap(proxy) is proxy
@@ -38,13 +130,151 @@ def test_proxy_maybe_wrap():
         ExtensionProxy.maybe_wrap(object())
 
 
-def test_proxy_legacy():
+def test_extension_proxy():
+    # Test with minimum properties:
+    extension = MinimumExtension()
+    proxy = ExtensionProxy(extension)
+
+    assert isinstance(proxy, Extension)
+    assert isinstance(proxy, AsdfExtension)
+
+    assert proxy.extension_uri == "asdf://somewhere.org/extensions/minimum-1.0"
+    assert proxy.legacy_class_names == set()
+    assert proxy.asdf_standard_requirement == SpecifierSet()
+    assert proxy.converters == []
+    assert proxy.tags == []
+    assert proxy.types == []
+    assert proxy.tag_mapping == []
+    assert proxy.url_mapping == []
+    assert proxy.delegate is extension
+    assert proxy.legacy is False
+    assert proxy.package_name is None
+    assert proxy.package_version is None
+    assert proxy.class_name == "asdf.tests.test_extension.MinimumExtension"
+
+    # The subclassed version should have the same defaults:
+    extension = MinimumExtensionSubclassed()
+    subclassed_proxy = ExtensionProxy(extension)
+    assert subclassed_proxy.extension_uri == proxy.extension_uri
+    assert subclassed_proxy.legacy_class_names == proxy.legacy_class_names
+    assert subclassed_proxy.asdf_standard_requirement == proxy.asdf_standard_requirement
+    assert subclassed_proxy.converters == proxy.converters
+    assert subclassed_proxy.tags == proxy.tags
+    assert subclassed_proxy.types == proxy.types
+    assert subclassed_proxy.tag_mapping == proxy.tag_mapping
+    assert subclassed_proxy.url_mapping == proxy.url_mapping
+    assert subclassed_proxy.delegate is extension
+    assert subclassed_proxy.legacy == proxy.legacy
+    assert subclassed_proxy.package_name == proxy.package_name
+    assert subclassed_proxy.package_version == proxy.package_name
+    assert subclassed_proxy.class_name == "asdf.tests.test_extension.MinimumExtensionSubclassed"
+
+    # Test with all properties present:
+    converters = [
+        MinimumConverter(
+            tags=["asdf://somewhere.org/extensions/full/tags/foo-*"],
+            types=[]
+        )
+    ]
+    extension = FullExtension(
+        converters=converters,
+        asdf_standard_requirement=">=1.4.0",
+        tags=["asdf://somewhere.org/extensions/full/tags/foo-1.0"],
+        legacy_class_names=["foo.extensions.SomeOldExtensionClass"]
+    )
+    proxy = ExtensionProxy(extension, package_name="foo", package_version="1.2.3")
+
+    assert proxy.extension_uri == "asdf://somewhere.org/extensions/full-1.0"
+    assert proxy.legacy_class_names == {"foo.extensions.SomeOldExtensionClass"}
+    assert proxy.asdf_standard_requirement == SpecifierSet(">=1.4.0")
+    assert proxy.converters == [ConverterProxy(c, proxy) for c in converters]
+    assert len(proxy.tags) == 1
+    assert proxy.tags[0].tag_uri == "asdf://somewhere.org/extensions/full/tags/foo-1.0"
+    assert proxy.types == []
+    assert proxy.tag_mapping == []
+    assert proxy.url_mapping == []
+    assert proxy.delegate is extension
+    assert proxy.legacy is False
+    assert proxy.package_name == "foo"
+    assert proxy.package_version == "1.2.3"
+    assert proxy.class_name == "asdf.tests.test_extension.FullExtension"
+
+    # Should fail when the input is not one of the two extension interfaces:
+    with pytest.raises(TypeError):
+        ExtensionProxy(object)
+
+    # Should fail with a bad converter:
+    with pytest.raises(TypeError):
+        ExtensionProxy(FullExtension(converters=[object()]))
+
+    # Unparseable ASDF Standard requirement:
+    with pytest.raises(ValueError):
+        ExtensionProxy(FullExtension(asdf_standard_requirement="asdf-standard >= 1.4.0"))
+
+    # Unrecognized ASDF Standard requirement type:
+    with pytest.raises(TypeError):
+        ExtensionProxy(FullExtension(asdf_standard_requirement=object()))
+
+    # Bad tag:
+    with pytest.raises(TypeError):
+        ExtensionProxy(FullExtension(tags=[object()]))
+
+    # Bad legacy class names:
+    with pytest.raises(TypeError):
+        ExtensionProxy(FullExtension(legacy_class_names=[object]))
+
+
+def test_extension_proxy_tags():
+    """
+    The tags behavior is a tad complex, so they get their own test.
+    """
+    foo_tag_uri = "asdf://somewhere.org/extensions/full/tags/foo-1.0"
+    foo_tag_def = TagDefinition(
+        foo_tag_uri,
+        schema_uri="asdf://somewhere.org/extensions/full/schemas/foo-1.0",
+        title="Some tag title",
+        description="Some tag description"
+    )
+
+    bar_tag_uri = "asdf://somewhere.org/extensions/full/tags/bar-1.0"
+    bar_tag_def = TagDefinition(
+        bar_tag_uri,
+        schema_uri="asdf://somewhere.org/extensions/full/schemas/bar-1.0",
+        title="Some other tag title",
+        description="Some other tag description"
+    )
+
+    # The converter should return only the tags
+    # supported by the extension.
+    converter = FullConverter(tags=["**"])
+    extension = FullExtension(tags=[foo_tag_def], converters=[converter])
+    proxy = ExtensionProxy(extension)
+    assert proxy.converters[0].tags == [foo_tag_uri]
+
+    # The converter should not return tags that
+    # its patterns do not match.
+    converter = FullConverter(tags=["**/foo-1.0"])
+    extension = FullExtension(tags=[foo_tag_def, bar_tag_def], converters=[converter])
+    proxy = ExtensionProxy(extension)
+    assert proxy.converters[0].tags == [foo_tag_uri]
+
+    # The process should still work if the extension property
+    # contains str instead of TagDescription.
+    converter = FullConverter(tags=["**/foo-1.0"])
+    extension = FullExtension(tags=[foo_tag_uri, bar_tag_uri], converters=[converter])
+    proxy = ExtensionProxy(extension)
+    assert proxy.converters[0].tags == [foo_tag_uri]
+
+
+def test_extension_proxy_legacy():
     extension = LegacyExtension()
     proxy = ExtensionProxy(extension, package_name="foo", package_version="1.2.3")
 
     assert proxy.extension_uri is None
     assert proxy.legacy_class_names == {"asdf.tests.test_extension.LegacyExtension"}
     assert proxy.asdf_standard_requirement == SpecifierSet()
+    assert proxy.converters == []
+    assert proxy.tags == []
     assert proxy.types == [LegacyType]
     assert proxy.tag_mapping == LegacyExtension.tag_mapping
     assert proxy.url_mapping == LegacyExtension.url_mapping
@@ -55,8 +285,8 @@ def test_proxy_legacy():
     assert proxy.class_name == "asdf.tests.test_extension.LegacyExtension"
 
 
-def test_proxy_hash_and_eq():
-    extension = LegacyExtension()
+def test_extension_proxy_hash_and_eq():
+    extension = MinimumExtension()
     proxy1 = ExtensionProxy(extension)
     proxy2 = ExtensionProxy(extension, package_name="foo", package_version="1.2.3")
 
@@ -66,16 +296,238 @@ def test_proxy_hash_and_eq():
     assert proxy2 != extension
 
 
-def test_proxy_repr():
+def test_extension_proxy_repr():
+    proxy = ExtensionProxy(MinimumExtension(), package_name="foo", package_version="1.2.3")
+    assert "class: asdf.tests.test_extension.MinimumExtension" in repr(proxy)
+    assert "package: foo==1.2.3" in repr(proxy)
+    assert "legacy: False" in repr(proxy)
+
+    proxy = ExtensionProxy(MinimumExtension())
+    assert "class: asdf.tests.test_extension.MinimumExtension" in repr(proxy)
+    assert "package: (none)" in repr(proxy)
+    assert "legacy: False" in repr(proxy)
+
     proxy = ExtensionProxy(LegacyExtension(), package_name="foo", package_version="1.2.3")
     assert "class: asdf.tests.test_extension.LegacyExtension" in repr(proxy)
     assert "package: foo==1.2.3" in repr(proxy)
     assert "legacy: True" in repr(proxy)
 
-    proxy = ExtensionProxy(LegacyExtension())
-    assert "class: asdf.tests.test_extension.LegacyExtension" in repr(proxy)
+
+def test_extension_manager():
+    converter1 = FullConverter(
+        tags=[
+            "asdf://somewhere.org/extensions/full/tags/foo-*",
+            "asdf://somewhere.org/extensions/full/tags/bar-*",
+        ],
+        types=[
+            FooType,
+            "asdf.tests.test_extension.BarType",
+        ],
+    )
+    converter2 = FullConverter(
+        tags=[
+            "asdf://somewhere.org/extensions/full/tags/baz-*",
+        ],
+        types=[
+            BazType
+        ],
+    )
+    converter3= FullConverter(
+        tags=[
+            "asdf://somewhere.org/extensions/full/tags/foo-*",
+        ],
+        types=[
+            FooType,
+            BarType,
+        ],
+    )
+    extension1 = FullExtension(
+        converters=[converter1, converter2],
+        tags=[
+            "asdf://somewhere.org/extensions/full/tags/foo-1.0",
+            "asdf://somewhere.org/extensions/full/tags/baz-1.0",
+        ]
+    )
+    extension2 = FullExtension(
+        converters=[converter3],
+        tags = [
+            "asdf://somewhere.org/extensions/full/tags/foo-1.0",
+        ]
+    )
+
+    manager = ExtensionManager([extension1, extension2])
+
+    assert manager.extensions == [ExtensionProxy(extension1), ExtensionProxy(extension2)]
+
+    assert manager.handles_tag("asdf://somewhere.org/extensions/full/tags/foo-1.0") is True
+    assert manager.handles_tag("asdf://somewhere.org/extensions/full/tags/bar-1.0") is False
+    assert manager.handles_tag("asdf://somewhere.org/extensions/full/tags/baz-1.0") is True
+
+    assert manager.handles_type(FooType) is True
+    # This should return True even though BarType was listed
+    # as string class name:
+    assert manager.handles_type(BarType) is True
+    assert manager.handles_type(BazType) is True
+
+    assert manager.get_tag_definition("asdf://somewhere.org/extensions/full/tags/foo-1.0").tag_uri == "asdf://somewhere.org/extensions/full/tags/foo-1.0"
+    assert manager.get_tag_definition("asdf://somewhere.org/extensions/full/tags/baz-1.0").tag_uri == "asdf://somewhere.org/extensions/full/tags/baz-1.0"
+    with pytest.raises(KeyError):
+        manager.get_tag_definition("asdf://somewhere.org/extensions/full/tags/bar-1.0")
+
+    assert manager.get_converter_for_tag("asdf://somewhere.org/extensions/full/tags/foo-1.0").delegate is converter1
+    assert manager.get_converter_for_tag("asdf://somewhere.org/extensions/full/tags/baz-1.0").delegate is converter2
+    with pytest.raises(KeyError):
+        manager.get_converter_for_tag("asdf://somewhere.org/extensions/full/tags/bar-1.0")
+
+    assert manager.get_converter_for_type(FooType).delegate is converter1
+    assert manager.get_converter_for_type(BarType).delegate is converter1
+    assert manager.get_converter_for_type(BazType).delegate is converter2
+    with pytest.raises(KeyError):
+        manager.get_converter_for_type(object)
+
+
+def test_get_cached_extension_manager():
+    extension = MinimumExtension()
+    extension_manager = get_cached_extension_manager([extension])
+    assert get_cached_extension_manager([extension]) is extension_manager
+    assert get_cached_extension_manager([MinimumExtension()]) is not extension_manager
+
+
+def test_tag_definition():
+    tag_def = TagDefinition(
+        "asdf://somewhere.org/extensions/foo/tags/foo-1.0",
+        schema_uri="asdf://somewhere.org/extensions/foo/schemas/foo-1.0",
+        title="Some title",
+        description="Some description",
+    )
+
+    assert tag_def.tag_uri == "asdf://somewhere.org/extensions/foo/tags/foo-1.0"
+    assert tag_def.schema_uri == "asdf://somewhere.org/extensions/foo/schemas/foo-1.0"
+    assert tag_def.title == "Some title"
+    assert tag_def.description == "Some description"
+
+    assert "URI: asdf://somewhere.org/extensions/foo/tags/foo-1.0" in repr(tag_def)
+
+    with pytest.raises(ValueError):
+        TagDefinition("asdf://somewhere.org/extensions/foo/tags/foo-*")
+
+
+def test_converter():
+    class ConverterNoSubclass:
+        tags = []
+        types = []
+
+        def to_yaml_tree(self, *args):
+            pass
+
+        def from_yaml_tree(self, *args):
+            pass
+
+    assert issubclass(ConverterNoSubclass, Converter)
+
+    class ConverterWithSubclass(Converter):
+        tags = []
+        types = []
+
+        def to_yaml_tree(self, *args):
+            pass
+
+        def from_yaml_tree(self, *args):
+            pass
+
+    # Confirm the behavior of the default select_tag implementation
+    assert ConverterWithSubclass().select_tag(object(), ["tag1", "tag2"], object()) == "tag1"
+
+
+def test_converter_proxy():
+    # Test the minimum set of converter methods:
+    extension = ExtensionProxy(MinimumExtension())
+    converter = MinimumConverter()
+    proxy = ConverterProxy(converter, extension)
+
+    assert isinstance(proxy, Converter)
+
+    assert proxy.tags == []
+    assert proxy.types == []
+    assert proxy.to_yaml_tree(None, None, None) == "to_yaml_tree result"
+    assert proxy.from_yaml_tree(None, None, None) == "from_yaml_tree result"
+    assert proxy.tags == []
+    assert proxy.delegate is converter
+    assert proxy.extension == extension
+    assert proxy.package_name is None
+    assert proxy.package_version is None
+    assert proxy.class_name == "asdf.tests.test_extension.MinimumConverter"
+
+    # Check the __eq__ and __hash__ behavior:
+    assert proxy == ConverterProxy(converter, extension)
+    assert proxy != ConverterProxy(MinimumConverter(), extension)
+    assert proxy != ConverterProxy(converter, MinimumExtension())
+    assert proxy in {ConverterProxy(converter, extension)}
+    assert proxy not in {
+        ConverterProxy(MinimumConverter(), extension),
+        ConverterProxy(converter, MinimumExtension())
+    }
+
+    # Check the __repr__:
+    assert "class: asdf.tests.test_extension.MinimumConverter" in repr(proxy)
     assert "package: (none)" in repr(proxy)
-    assert "legacy: True" in repr(proxy)
+
+    # Test the full set of converter methods:
+    converter = FullConverter(
+        tags=[
+            "asdf://somewhere.org/extensions/test/tags/foo-*",
+            "asdf://somewhere.org/extensions/test/tags/bar-*",
+        ],
+        types=[FooType, BarType]
+    )
+
+    extension = FullExtension(
+        tags=[
+            TagDefinition(
+                "asdf://somewhere.org/extensions/test/tags/foo-1.0",
+                schema_uri="asdf://somewhere.org/extensions/test/schemas/foo-1.0",
+                title="Foo tag title",
+                description="Foo tag description"
+            ),
+            TagDefinition(
+                "asdf://somewhere.org/extensions/test/tags/bar-1.0",
+                schema_uri="asdf://somewhere.org/extensions/test/schemas/bar-1.0",
+                title="Bar tag title",
+                description="Bar tag description"
+            ),
+        ]
+    )
+
+    extension_proxy = ExtensionProxy(extension, package_name="foo", package_version="1.2.3")
+    proxy = ConverterProxy(converter, extension_proxy)
+    assert len(proxy.tags) == 2
+    assert "asdf://somewhere.org/extensions/test/tags/foo-1.0" in proxy.tags
+    assert "asdf://somewhere.org/extensions/test/tags/bar-1.0" in proxy.tags
+    assert proxy.types == [FooType, BarType]
+    assert proxy.to_yaml_tree(None, None, None) == "to_yaml_tree result"
+    assert proxy.from_yaml_tree(None, None, None) == "from_yaml_tree result"
+    assert proxy.select_tag(None, None) == "select_tag result"
+    assert proxy.delegate is converter
+    assert proxy.extension == extension_proxy
+    assert proxy.package_name == "foo"
+    assert proxy.package_version == "1.2.3"
+    assert proxy.class_name == "asdf.tests.test_extension.FullConverter"
+
+    # Check the __repr__ since it will contain package info now:
+    assert "class: asdf.tests.test_extension.FullConverter" in repr(proxy)
+    assert "package: foo==1.2.3" in repr(proxy)
+
+    # Should error because object() does fulfill the Converter interface:
+    with pytest.raises(TypeError):
+        ConverterProxy(object(), extension)
+
+    # Should fail because tags must be str:
+    with pytest.raises(TypeError):
+        ConverterProxy(MinimumConverter(tags=[object()]), extension)
+
+    # Should fail because types must instances of type:
+    with pytest.raises(TypeError):
+        ConverterProxy(MinimumConverter(types=[object()]), extension)
 
 
 def test_get_cached_asdf_extension_list():

--- a/asdf/tests/test_integration.py
+++ b/asdf/tests/test_integration.py
@@ -1,0 +1,70 @@
+"""
+Integration tests for the new plugin APIs.
+"""
+import pytest
+
+import asdf
+from asdf.extension import TagDefinition
+
+
+FOO_SCHEMA_URI = "asdf://somewhere.org/extensions/foo/schemas/foo-1.0"
+FOO_SCHEMA = """
+id: {}
+type: object
+properties:
+  value:
+    type: string
+required: ["value"]
+""".format(FOO_SCHEMA_URI)
+
+
+class Foo:
+    def __init__(self, value):
+        self._value = value
+
+    @property
+    def value(self):
+        return self._value
+
+
+class FooConverter:
+    types = [Foo]
+    tags = ["asdf://somewhere.org/extensions/foo/tags/foo-*"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return {
+            "value": obj.value
+        }
+
+    def from_yaml_tree(self, obj, tag, ctx):
+        return Foo(obj["value"])
+
+
+class FooExtension:
+    extension_uri = "asdf://somewhere.org/extensions/foo-1.0"
+    converters = [FooConverter()]
+    tags = [
+        TagDefinition(
+            "asdf://somewhere.org/extensions/foo/tags/foo-1.0",
+            schema_uri=FOO_SCHEMA_URI,
+        )
+    ]
+
+
+def test_serialize_custom_type(tmpdir):
+    with asdf.config_context() as config:
+        config.add_resource_mapping({FOO_SCHEMA_URI: FOO_SCHEMA})
+        config.add_extension(FooExtension())
+
+        path = str(tmpdir/"test.asdf")
+
+        af = asdf.AsdfFile()
+        af["foo"] = Foo("bar")
+        af.write_to(path)
+
+        with asdf.open(path) as af2:
+            assert af2["foo"].value == "bar"
+
+        with pytest.raises(asdf.ValidationError):
+            af["foo"] = Foo(12)
+            af.write_to(path)

--- a/asdf/tests/test_resource.py
+++ b/asdf/tests/test_resource.py
@@ -1,6 +1,7 @@
 import io
 import sys
 from pathlib import Path
+from collections.abc import Mapping
 
 if sys.version_info < (3, 9):
     import importlib_resources
@@ -29,6 +30,7 @@ def test_directory_resource_mapping(tmpdir):
         f.write("id: http://somewhere.org/schemas/baz-7.8.9\n")
 
     mapping = DirectoryResourceMapping(str(tmpdir/"schemas"), "http://somewhere.org/schemas")
+    assert isinstance(mapping, Mapping)
     assert len(mapping) == 1
     assert set(mapping) == {"http://somewhere.org/schemas/foo-1.2.3"}
     assert "http://somewhere.org/schemas/foo-1.2.3" in mapping
@@ -191,6 +193,8 @@ def test_resource_manager():
     }
     manager = ResourceManager([mapping1, mapping2])
 
+    assert isinstance(manager, Mapping)
+
     assert len(manager) == 4
     assert set(manager) == {
         "http://somewhere.org/schemas/foo-1.0.0",
@@ -216,6 +220,8 @@ def test_resource_manager():
 
 def test_jsonschema_resource_mapping():
     mapping = JsonschemaResourceMapping()
+    assert isinstance(mapping, Mapping)
+
     assert len(mapping) == 1
     assert set(mapping) == {"http://json-schema.org/draft-04/schema"}
     assert "http://json-schema.org/draft-04/schema" in mapping
@@ -236,6 +242,10 @@ def test_get_core_resource_mappings(uri):
     assert mapping is not None
 
     assert uri.encode("utf-8") in mapping[uri]
+
+
+def test_proxy_is_mapping():
+    assert isinstance(ResourceMappingProxy({}), Mapping)
 
 
 def test_proxy_maybe_wrap():


### PR DESCRIPTION
Here at last are the new `Extension` and `Converter` APIs!  Some features aren't yet implemented (and may not be until the 2.9 release), but I think the interfaces have everything we need to support the asdf-astropy package.  Here's what a converter might look like for the identity transform:

```python
class IdentityConverter(TransformConverter):
    tags = [
      "asdf://asdf-format.org/extensions/transform/tags/identity-*",
      "tag:stsci.edu:asdf/transform/identity-*",
    ]
    types = ["astropy.modeling.mappings.Identity"]
    
    def from_yaml_tree_transform(self, node, tag, ctx):
        from astropy.modeling.models import Identity
        return Identity(node.get("n_dims", 1))

    def to_yaml_tree_transform(self, model, tag, ctx):
	node = {}
        if model.n_inputs != 1:
	    node["n_dims"] = model.n_inputs
	return node
```

I'd like to specify types as strings as much as possible, since this allows the converter to be loaded without importing anything from astropy.  This should make the asdf experience much snappier when opening the first file.