### PR TITLE
Fix oversights in support for asdf:// URI scheme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@
 - Drop support for automatic serialization of subclass
   attributes. [#825]
 
-- Support asdf:// as a URI scheme. [#854]
+- Support asdf:// as a URI scheme. [#854. #855]
 
 2.7.0 (2020-07-23)
 ------------------

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -6,7 +6,6 @@ import re
 import struct
 import weakref
 from collections import namedtuple
-from urllib import parse as urlparse
 
 import numpy as np
 
@@ -19,6 +18,8 @@ from . import generic_io
 from . import treeutil
 from . import util
 from . import yamlutil
+
+from .util import patched_urllib_parse
 
 
 class BlockManager:
@@ -546,13 +547,13 @@ class BlockManager:
         """
         if uri is None:
             uri = ''
-        parts = list(urlparse.urlparse(uri))
+        parts = list(patched_urllib_parse.urlparse(uri))
         path = parts[2]
         dirname, filename = os.path.split(path)
         filename = self.get_external_filename(filename, index)
         path = os.path.join(dirname, filename)
         parts[2] = path
-        return urlparse.urlunparse(parts)
+        return patched_urllib_parse.urlunparse(parts)
 
     def _find_used_blocks(self, tree, ctx):
         reserved_blocks = set()
@@ -706,7 +707,7 @@ class BlockManager:
                         "Can't write external blocks, since URI of main file is "
                         "unknown.")
 
-                parts = list(urlparse.urlparse(self._asdffile().uri))
+                parts = list(patched_urllib_parse.urlparse(self._asdffile().uri))
                 path = parts[2]
                 filename = os.path.basename(path)
                 return self.get_external_filename(filename, i)

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -10,12 +10,13 @@ import weakref
 
 import numpy as np
 
-from urllib import parse as urlparse
-
 from .types import AsdfType
 from . import generic_io
 from . import treeutil
 from . import util
+
+from .util import patched_urllib_parse
+
 
 __all__ = [
     'resolve_fragment', 'Reference', 'find_references', 'resolve_references',
@@ -27,7 +28,7 @@ def resolve_fragment(tree, pointer):
     Resolve a JSON Pointer within the tree.
     """
     pointer = pointer.lstrip(u"/")
-    parts = urlparse.unquote(pointer).split(u"/") if pointer else []
+    parts = patched_urllib_parse.unquote(pointer).split(u"/") if pointer else []
 
     for part in parts:
         part = part.replace(u"~1", u"/").replace(u"~0", u"~")
@@ -65,7 +66,7 @@ class Reference(AsdfType):
             uri = generic_io.resolve_uri(base_uri, self._uri)
             asdffile = self._asdffile().open_external(
                 uri, do_not_fill_defaults=do_not_fill_defaults)
-            parts = urlparse.urlparse(self._uri)
+            parts = patched_urllib_parse.urlparse(self._uri)
             fragment = parts.fragment
             self._target = resolve_fragment(asdffile.tree, fragment)
         return self._target


### PR DESCRIPTION
It turns out my test didn't catch all the issues that come up during actual validation.  I updated the test, made some fixes, and also made sure that the patched `urilib.parse` is used everywhere.