### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ jobs:
     - env: TOXENV=py36
       python: 3.6
 
-    # Python 3.5, stable dependencies
-    - env: TOXENV=py35
-      python: 3.5
-
     # Test ASDF file compatibility between library versions
     - env: TOXENV=compatibility
 
@@ -45,15 +41,15 @@ jobs:
     - env: TOXENV=style
 
     # Check older numpy versions
-    - env: TOXENV=py35-numpy11
-      python: 3.5
+    - env: TOXENV=py36-numpy11
+      python: 3.6
 
     - env: TOXENV=py36-numpy12
       python: 3.6
 
     # Test against oldest compatible versions of all dependencies
-    - env: TOXENV=py35-legacy
-      python: 3.5
+    - env: TOXENV=py36-legacy
+      python: 3.6
 
     # Test against development version of Astropy
     - env: TOXENV=py38-astropydev

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@
 - Include only extensions used during serialization in
   a file's metadata. [#848]
 
+- Drop support for Python 3.5. [#856]
+
 2.7.0 (2020-07-23)
 ------------------
 

--- a/docs/asdf/install.rst
+++ b/docs/asdf/install.rst
@@ -12,7 +12,7 @@ Requirements
 
 The ``asdf`` package has the following dependencies:
 
-- `python <https://www.python.org/>`__  3.5 or later
+- `python <https://www.python.org/>`__  3.6 or later
 
 - `numpy <https://www.numpy.org/>`__ 1.10 or later
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,14 +13,13 @@ github_project = asdf-format/asdf
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Development Status :: 5 - Production/Stable
 
 [options]
-python_requires= >=3.5
+python_requires= >=3.6
 setup_requires = setuptools_scm
 install_requires =
     semantic_version>=2.8

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,11 @@ deps=
     astropydev: git+git://github.com/astropy/astropy
     gwcsdev: git+git://github.com/spacetelescope/gwcs
     numpydev: git+git://github.com/numpy/numpy
-    py35,py36: importlib_resources
+    py36: importlib_resources
     # Newer versions of gwcs require astropy 4.x, which
     # isn't compatible with the older versions of numpy
     # that we test with.
-    py35,numpy12: gwcs==0.9.1
+    numpy11,numpy12,legacy: gwcs==0.9.1
     legacy: semantic_version==2.8
     legacy: pyyaml==3.10
     legacy: jsonschema==3.0.2


### PR DESCRIPTION
This PR makes Python 3.6 the minimum supported version.