### PR TITLE
Stop removing defaults and fill defaults only for legacy versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@
   the standard limits mapping keys to string, integer, or
   boolean. [#866]
 
+- Stop removing schema defaults for all ASDF Standard versions,
+  and automatically fill defaults only for versions <= 1.5.0. [#860]
+
 2.7.0 (2020-07-23)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -509,7 +509,7 @@ class AsdfFile:
         """
         return generic_io.resolve_uri(self.uri, uri)
 
-    def open_external(self, uri, do_not_fill_defaults=False):
+    def open_external(self, uri, **kwargs):
         """
         Open an external ASDF file, from the given (possibly relative)
         URI.  There is a cache (internal to this ASDF file) that ensures
@@ -520,9 +520,6 @@ class AsdfFile:
         uri : str
             An absolute or relative URI to resolve against the URI of
             this ASDF file.
-
-        do_not_fill_defaults : bool, optional
-            When `True`, do not fill in missing default values.
 
         Returns
         -------
@@ -542,7 +539,7 @@ class AsdfFile:
         if asdffile is None:
             asdffile = open_asdf(
                 resolved_uri,
-                mode='r', do_not_fill_defaults=do_not_fill_defaults)
+                mode='r', **kwargs)
             self._external_asdf_by_uri[resolved_uri] = asdffile
         return asdffile
 
@@ -765,7 +762,6 @@ class AsdfFile:
     def _open_asdf(cls, self, fd, uri=None, mode='r',
                    validate_checksums=False,
                    extensions=None,
-                   do_not_fill_defaults=False,
                    _get_yaml_content=False,
                    _force_raw_types=False,
                    strict_extension_check=False,
@@ -787,6 +783,16 @@ class AsdfFile:
             validate_on_read = kwargs["validate_on_read"]
         else:
             validate_on_read = get_config().validate_on_read
+
+        if "do_not_fill_defaults" in kwargs:
+            warnings.warn(
+                "The 'do_not_fill_defaults' argument is deprecated, set "
+                "asdf.get_config().legacy_fill_schema_defaults instead.",
+                AsdfDeprecationWarning
+            )
+            legacy_fill_schema_defaults = not kwargs["do_not_fill_defaults"]
+        else:
+            legacy_fill_schema_defaults = get_config().legacy_fill_schema_defaults
 
         self._mode = mode
 
@@ -850,7 +856,8 @@ class AsdfFile:
             self._blocks.read_block_index(fd, self)
 
         tree = reference.find_references(tree, self)
-        if not do_not_fill_defaults:
+
+        if self.version <= versioning.FILL_DEFAULTS_MAX_VERSION and legacy_fill_schema_defaults:
             schema.fill_defaults(tree, self, reading=True)
 
         if validate_on_read:
@@ -874,7 +881,6 @@ class AsdfFile:
     def _open_impl(cls, self, fd, uri=None, mode='r',
                    validate_checksums=False,
                    extensions=None,
-                   do_not_fill_defaults=False,
                    _get_yaml_content=False,
                    _force_raw_types=False,
                    strict_extension_check=False,
@@ -907,7 +913,6 @@ class AsdfFile:
         return cls._open_asdf(self, fd, uri=uri, mode=mode,
                 validate_checksums=validate_checksums,
                 extensions=extensions,
-                do_not_fill_defaults=do_not_fill_defaults,
                 _get_yaml_content=_get_yaml_content,
                 _force_raw_types=_force_raw_types,
                 strict_extension_check=strict_extension_check,
@@ -918,7 +923,6 @@ class AsdfFile:
     def open(cls, fd, uri=None, mode='r',
              validate_checksums=False,
              extensions=None,
-             do_not_fill_defaults=False,
              ignore_version_mismatch=True,
              ignore_unrecognized_tag=False,
              _force_raw_types=False,
@@ -926,7 +930,8 @@ class AsdfFile:
              lazy_load=True,
              custom_schema=None,
              strict_extension_check=False,
-             ignore_missing_extensions=False):
+             ignore_missing_extensions=False,
+             **kwargs):
         """
         Open an existing ASDF file.
 
@@ -943,7 +948,6 @@ class AsdfFile:
             fd, uri=uri, mode=mode,
             validate_checksums=validate_checksums,
             extensions=extensions,
-            do_not_fill_defaults=do_not_fill_defaults,
             ignore_version_mismatch=ignore_version_mismatch,
             ignore_unrecognized_tag=ignore_unrecognized_tag,
             _force_raw_types=_force_raw_types,
@@ -951,7 +955,8 @@ class AsdfFile:
             custom_schema=custom_schema,
             strict_extension_check=strict_extension_check,
             ignore_missing_extensions=ignore_missing_extensions,
-            _compat=True)
+            _compat=True,
+            **kwargs)
 
     def _write_tree(self, tree, fd, pad_blocks):
         fd.write(constants.ASDF_MAGIC)
@@ -1279,7 +1284,7 @@ class AsdfFile:
         # Set directly to self._tree, since it doesn't need to be re-validated.
         self._tree = reference.find_references(self._tree, self)
 
-    def resolve_references(self, do_not_fill_defaults=False):
+    def resolve_references(self, **kwargs):
         """
         Finds all external "JSON References" in the tree, loads the
         external content, and places it directly in the tree.  Saving
@@ -1575,8 +1580,7 @@ def _check_and_set_mode(fileobj, asdf_mode):
     return asdf_mode
 
 
-def open_asdf(fd, uri=None, mode=None, validate_checksums=False,
-              extensions=None, do_not_fill_defaults=False,
+def open_asdf(fd, uri=None, mode=None, validate_checksums=False, extensions=None,
               ignore_version_mismatch=True, ignore_unrecognized_tag=False,
               _force_raw_types=False, copy_arrays=False, lazy_load=True,
               custom_schema=None, strict_extension_check=False,
@@ -1608,9 +1612,6 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False,
         May be any of the following: `asdf.extension.AsdfExtension`, `str`
         extension URI, `asdf.extension.AsdfExtensionList` or a `list`
         of URIs and/or extensions.
-
-    do_not_fill_defaults : bool, optional
-        When `True`, do not fill in missing default values.
 
     ignore_version_mismatch : bool, optional
         When `True`, do not raise warnings for mismatched schema versions.
@@ -1681,7 +1682,6 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False,
         fd, uri=uri, mode=mode,
         validate_checksums=validate_checksums,
         extensions=extensions,
-        do_not_fill_defaults=do_not_fill_defaults,
         _force_raw_types=_force_raw_types,
         strict_extension_check=strict_extension_check,
         ignore_missing_extensions=ignore_missing_extensions,

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -666,8 +666,7 @@ class BlockManager:
             raise ValueError("Block '{0}' not found.".format(source))
 
         elif isinstance(source, str):
-            asdffile = self._asdffile().open_external(
-                source, do_not_fill_defaults=True)
+            asdffile = self._asdffile().open_external(source)
             block = asdffile.blocks._internal_blocks[0]
             self.set_array_storage(block, 'external')
 

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -19,6 +19,7 @@ __all__ = ["AsdfConfig", "get_config", "config_context"]
 
 DEFAULT_VALIDATE_ON_READ = True
 DEFAULT_DEFAULT_VERSION = str(versioning.default_version)
+DEFAULT_LEGACY_FILL_SCHEMA_DEFAULTS = True
 
 
 class AsdfConfig:
@@ -34,6 +35,7 @@ class AsdfConfig:
         self._extensions = None
         self._validate_on_read = DEFAULT_VALIDATE_ON_READ
         self._default_version = DEFAULT_DEFAULT_VERSION
+        self._legacy_fill_schema_defaults = DEFAULT_LEGACY_FILL_SCHEMA_DEFAULTS
 
         self._lock = threading.RLock()
 
@@ -275,15 +277,45 @@ class AsdfConfig:
         """
         self._default_version = validate_version(value)
 
+    @property
+    def legacy_fill_schema_defaults(self):
+        """
+        Get the configuration that controls filling defaults
+        from schemas for older ASDF Standard versions.  If
+        `True`, missing default values will be filled from the
+        schema when reading files from ASDF Standard <= 1.5.0.
+        Later versions of the standard do not support removing
+        or filling schema defaults.
+
+        Returns
+        -------
+        bool
+        """
+        return self._legacy_fill_schema_defaults
+
+    @legacy_fill_schema_defaults.setter
+    def legacy_fill_schema_defaults(self, value):
+        """
+        Set the flag that controls filling defaults from
+        schemas for older ASDF Standard versions.
+
+        Parameters
+        ----------
+        value : bool
+        """
+        self._legacy_fill_schema_defaults = value
+
     def __repr__(self):
         return (
             "<AsdfConfig\n"
             "  validate_on_read: {}\n"
             "  default_version: {}\n"
+            "  legacy_fill_schema_defaults: {}\n"
             ">"
         ).format(
             self.validate_on_read,
             self.default_version,
+            self.legacy_fill_schema_defaults,
         )
 
 

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -58,14 +58,13 @@ class Reference(AsdfType):
         self._base_uri = base_uri
         self._target = target
 
-    def _get_target(self, do_not_fill_defaults=False):
+    def _get_target(self, **kwargs):
         if self._target is None:
             base_uri = self._base_uri
             if base_uri is None:
                 base_uri = self._asdffile().uri
             uri = generic_io.resolve_uri(base_uri, self._uri)
-            asdffile = self._asdffile().open_external(
-                uri, do_not_fill_defaults=do_not_fill_defaults)
+            asdffile = self._asdffile().open_external(uri, **kwargs)
             parts = patched_urllib_parse.urlparse(self._uri)
             fragment = parts.fragment
             self._target = resolve_fragment(asdffile.tree, fragment)
@@ -107,8 +106,8 @@ class Reference(AsdfType):
     def __array__(self):
         return np.asarray(self._get_target())
 
-    def __call__(self, do_not_fill_defaults=False):
-        return self._get_target(do_not_fill_defaults=do_not_fill_defaults)
+    def __call__(self, **kwargs):
+        return self._get_target(**kwargs)
 
     def __contains__(self, item):
         return item in self._get_target()
@@ -140,14 +139,14 @@ def find_references(tree, ctx):
         tree, do_find, ignore_implicit_conversion=ctx._ignore_implicit_conversion)
 
 
-def resolve_references(tree, ctx, do_not_fill_defaults=False):
+def resolve_references(tree, ctx, **kwargs):
     """
     Resolve all of the references in the tree, by loading the external
     data and inserting it directly into the tree.
     """
     def do_resolve(tree):
         if isinstance(tree, Reference):
-            return tree(do_not_fill_defaults=do_not_fill_defaults)
+            return tree(**kwargs)
         return tree
 
     tree = find_references(tree, ctx)

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -90,6 +90,15 @@ def test_default_version():
             config.default_version = "0.1.5"
 
 
+def test_legacy_fill_schema_defaults():
+    with asdf.config_context() as config:
+        assert config.legacy_fill_schema_defaults == asdf.config.DEFAULT_LEGACY_FILL_SCHEMA_DEFAULTS
+        config.legacy_fill_schema_defaults = False
+        assert get_config().legacy_fill_schema_defaults is False
+        config.legacy_fill_schema_defaults = True
+        assert get_config().legacy_fill_schema_defaults is True
+
+
 def test_resource_mappings():
     with asdf.config_context() as config:
         core_mappings = resource.get_core_resource_mappings()
@@ -289,6 +298,8 @@ def test_config_repr():
     with asdf.config_context() as config:
         config.validate_on_read = True
         config.default_version = "1.5.0"
+        config.legacy_fill_schema_defaults = False
 
         assert "validate_on_read: True" in repr(config)
         assert "default_version: 1.5.0" in repr(config)
+        assert "legacy_fill_schema_defaults: False" in repr(config)

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -175,3 +175,8 @@ NEW_HISTORY_FORMAT_MIN_VERSION = AsdfVersion("1.2.0")
 # This is the ASDF Standard version at which we begin restricting
 # mapping keys to string, integer, and boolean only.
 RESTRICTED_KEYS_MIN_VERSION = AsdfVersion("1.6.0")
+
+
+# This library never removed defaults for ASDF Standard versions
+# later than 1.5.0, so filling them isn't necessary.
+FILL_DEFAULTS_MAX_VERSION = AsdfVersion("1.5.0")

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -351,7 +351,6 @@ def dump_tree(tree, fd, ctx, tree_finalizer=None, _serialization_context=None):
     if tree_finalizer is not None:
         tree_finalizer(tree)
     schema.validate(tree, ctx)
-    schema.remove_defaults(tree, ctx)
 
     yaml_version = tuple(
         int(x) for x in ctx.version_map['YAML_VERSION'].split('.'))


### PR DESCRIPTION
This PR includes the following changes:

- Stop removing schema defaults for all ASDF Standard versions
- Stop filling defaults for ASDF Standard versions > 1.5.0 (this will only affect the forthcoming 1.6.0 standard)
- Deprecate the `do_not_fill_defaults` argument wherever it may be found
- Add the `legacy_fill_schema_defaults` global config option to control filling defaults for older ASDF Standard versions