### PR TITLE
Support serialization of null values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,15 @@
 - Stop removing schema defaults for all ASDF Standard versions,
   and automatically fill defaults only for versions <= 1.5.0. [#860]
 
-2.7.1 (2020-08-18)
+- Stop removing keys with ``None`` values from the tree on write.  This
+  fixes a long-standing issue where the tree structure is not preserved
+  on write, but will break ``ExtensionType`` subclasses that depend on
+  this behavior.  Extension developers will need to modify their
+  ``to_tree`` methods to check for ``None`` before adding a key to
+  the tree (or modify the schema to permit nulls, if that is the
+  intention). [#863]
+
+2.7.1 (unreleased)
 ------------------
 
 - Fix bug preventing access to copied array data after

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -203,13 +203,30 @@ def test_walk_and_modify_remove_keys():
 
     def func(x):
         if x == 42:
-            return None
+            return treeutil.RemoveNode
         return x
 
     tree2 = treeutil.walk_and_modify(tree, func)
 
     assert 'foo' not in tree2
     assert 'bar' in tree2
+
+
+def test_walk_and_modify_retain_none():
+    tree = {
+        'foo': 42,
+        'bar': None
+    }
+
+    def func(x):
+        if x == 42:
+            return None
+        return x
+
+    tree2 = treeutil.walk_and_modify(tree, func)
+
+    assert tree2['foo'] is None
+    assert tree2['bar'] is None
 
 
 def test_copy(tmpdir):
@@ -558,3 +575,12 @@ def test_array_access_after_file_close(tmpdir):
     with asdf.open(path, lazy_load=False, copy_arrays=True) as af:
         tree = af.tree
     assert_array_equal(tree["data"], data)
+
+def test_none_values(tmpdir):
+    path = str(tmpdir.join("test.asdf"))
+
+    af = asdf.AsdfFile({"foo": None})
+    af.write_to(path)
+    with asdf.open(path) as af:
+        assert "foo" in af
+        assert af["foo"] is None

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -204,6 +204,19 @@ class _PendingValue:
 PendingValue = _PendingValue()
 
 
+class _RemoveNode:
+    """
+    Class of the RemoveNode singleton instance.  This instance is used
+    as a signal for `asdf.treeutil.walk_and_modify` to remove the
+    node received by the callback.
+    """
+    def __repr__(self):
+        return "RemoveNode"
+
+
+RemoveNode = _RemoveNode()
+
+
 def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=True, _context=None):
     """Modify a tree by walking it with a callback function.  It also has
     the effect of doing a deep copy.
@@ -221,7 +234,8 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
         - a json id (optional)
 
         It may return a different instance in order to modify the
-        tree.
+        tree.  If the singleton instance `asdf.treeutil.RemoveNode`
+        is returned, the node will be removed from the tree.
 
         The json id is the context under which any relative URLs
         should be resolved.  It may be `None` if no ids are in the file
@@ -287,7 +301,7 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
                 result[key] = PendingValue
             else:
                 value = _recurse(value, json_id)
-                if value is not None:
+                if value is not RemoveNode:
                     result[key] = value
 
         yield result
@@ -297,7 +311,7 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
             # be available.
             for key, value in pending_items.items():
                 value = _recurse(value, json_id)
-                if value is not None:
+                if value is not RemoveNode:
                     result[key] = value
                 else:
                     # The callback may have decided to delete


### PR DESCRIPTION
This PR resolves a long-standing issue where trees containing `None` values are not faithfully written to an ASDF file.  An example, using 2.7.0:

```python
In [3]: import asdf

In [6]: asdf.AsdfFile({"foo": None, "bar": 42}).write_to("test.asdf")

In [7]: cat test.asdf
#ASDF 1.0.0
#ASDF_STANDARD 1.5.0
%YAML 1.1
%TAG ! tag:stsci.edu:asdf/
--- !core/asdf-1.1.0
asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
  name: asdf, version: 2.8.0.dev49+ge6a0d37}
history:
  extensions:
  - !core/extension_metadata-1.0.0
    extension_class: asdf.extension.BuiltinExtension
    software: !core/software-1.0.0 {name: asdf, version: 2.8.0.dev49+ge6a0d37}
bar: 42
...

In [8]: af = asdf.open("test.asdf")

In [9]: "foo" in af
Out[9]: False
```

and with this branch:

```python
In [1]: import asdf

In [2]: asdf.AsdfFile({"foo": None, "bar": 42}).write_to("test.asdf")

In [3]: cat test.asdf
#ASDF 1.0.0
#ASDF_STANDARD 1.5.0
%YAML 1.1
%TAG ! tag:stsci.edu:asdf/
--- !core/asdf-1.1.0
asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
  name: asdf, version: 2.8.0.dev49+ge6a0d37}
history:
  extensions:
  - !core/extension_metadata-1.0.0
    extension_class: asdf.extension.BuiltinExtension
    software: !core/software-1.0.0 {name: asdf, version: 2.8.0.dev49+ge6a0d37}
bar: 42
foo: null
...

In [4]: af = asdf.open("test.asdf")

In [5]: "foo" in af
Out[5]: True
```

In one sense this is only a bug fix, since dropping keys with `None` values from the tree was probably an unintentional side effect.  But the fix requires a breaking change to `asdf.treeutil.walk_and_modify`, which now uses a new special object to indicate "drop this node from the tree" instead of using `None` for that purpose.  This has some consequences for existing `ExtensionType` subclasses, which may be counting on `None`s being removed before validation.

Here's an example of an `ExtensionType` subclass in astropy that will break due to this change:

https://github.com/astropy/astropy/blob/v4.1rc1/astropy/io/misc/asdf/tags/transform/tabular.py#L55

The `name` property may be `None`, but the code doesn't check that.  With this change a `None` name will result in a validation error because the schema doesn't permit null:

https://github.com/asdf-format/asdf-standard/blob/1.5.0/schemas/stsci.edu/asdf/transform/transform-1.2.0.yaml#L18

Resolves #536 