### PR TITLE
Rename used extensions attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@
 - Support asdf:// as a URI scheme. [#854, #855]
 
 - Include only extensions used during serialization in
-  a file's metadata. [#848]
+  a file's metadata. [#848, #864]
 
 - Drop support for Python 3.5. [#856]
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -403,7 +403,7 @@ class AsdfFile:
         elif 'extensions' not in self.tree['history']:
             self.tree['history']['extensions'] = []
 
-        for extension in serialization_context.extensions_used:
+        for extension in serialization_context._extensions_used:
             ext_name = extension.class_name
             ext_meta = ExtensionMetadata(extension_class=ext_name)
             if extension.package_name is not None:
@@ -1732,7 +1732,7 @@ class SerializationContext:
     def __init__(self, version):
         self._version = validate_version(version)
 
-        self._extensions_used = set()
+        self.__extensions_used = set()
 
     @property
     def version(self):
@@ -1745,7 +1745,7 @@ class SerializationContext:
         """
         return self._version
 
-    def mark_extension_used(self, extension):
+    def _mark_extension_used(self, extension):
         """
         Note that an extension was used when reading or writing the file.
 
@@ -1753,10 +1753,10 @@ class SerializationContext:
         ----------
         extension : asdf.extension.AsdfExtension
         """
-        self._extensions_used.add(ExtensionProxy.maybe_wrap(extension))
+        self.__extensions_used.add(ExtensionProxy.maybe_wrap(extension))
 
     @property
-    def extensions_used(self):
+    def _extensions_used(self):
         """
         Get the set of extensions that were used when reading or writing the file.
 
@@ -1764,4 +1764,4 @@ class SerializationContext:
         -------
         set of asdf.extension.AsdfExtension
         """
-        return self._extensions_used
+        return self.__extensions_used

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -213,18 +213,18 @@ def test_open_asdf_extensions(tmpdir):
 def test_serialization_context():
     context = SerializationContext("1.4.0")
     assert context.version == "1.4.0"
-    assert context.extensions_used == set()
+    assert context._extensions_used == set()
 
     extension = get_config().extensions[0]
-    context.mark_extension_used(extension)
-    assert context.extensions_used == {extension}
-    context.mark_extension_used(extension)
-    assert context.extensions_used == {extension}
-    context.mark_extension_used(extension.delegate)
-    assert context.extensions_used == {extension}
+    context._mark_extension_used(extension)
+    assert context._extensions_used == {extension}
+    context._mark_extension_used(extension)
+    assert context._extensions_used == {extension}
+    context._mark_extension_used(extension.delegate)
+    assert context._extensions_used == {extension}
 
     with pytest.raises(TypeError):
-        context.mark_extension_used(object())
+        context._mark_extension_used(object())
 
     with pytest.raises(ValueError):
         SerializationContext("0.5.4")

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -135,7 +135,7 @@ class _AsdfWriteTypeIndex:
         extension = self._extension_by_cls[custom_type]
         self._extensions_used.add(extension)
         if serialization_context is not None:
-            serialization_context.mark_extension_used(extension)
+            serialization_context._mark_extension_used(extension)
 
     def _process_dynamic_subclass(self, custom_type, serialization_context):
         for key, val in self._types_with_dynamic_subclasses.items():
@@ -296,7 +296,7 @@ class AsdfTypeIndex:
         tag = self.fix_yaml_tag(ctx, tag)
         asdftype = self._type_by_tag.get(tag)
         if asdftype is not None and _serialization_context is not None:
-            _serialization_context.mark_extension_used(self._extension_by_type[asdftype])
+            _serialization_context._mark_extension_used(self._extension_by_type[asdftype])
         return asdftype
 
     @lru_cache(5)


### PR DESCRIPTION
I think we should give these a leading underscore, since I can't see them being useful to extension developers and we may want to change the implementation after the old extension API is removed.