### PR TITLE
Increase size of tag pattern cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@
 - Add new extension API to support versioned extensions.
   [#850, #851]
 
-- Permit wildcard in tag validator URIs. [#858]
+- Permit wildcard in tag validator URIs. [#858, #865]
 
 2.7.0 (2020-07-23)
 ------------------

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -483,7 +483,7 @@ def uri_match(pattern, uri):
         return pattern == uri
 
 
-@lru_cache(128)
+@lru_cache(1024)
 def _compile_uri_match_pattern(pattern):
     # Escape the pattern in case it contains regex special characters
     # ('.' in particular is common in URIs) and then replace the


### PR DESCRIPTION
With the new API using tag patterns in the converters, this cache should be larger.  I checked the size of some relevant compiled regexes and `sys.getsizeof` reported < 1024 bytes for all, so at most this will require 1 MiB which seems reasonable. 