### PR TITLE
Add ASDF Standard 1.6.0 and implement restriction of mapping key types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@
 
 - Permit wildcard in tag validator URIs. [#858]
 
+- Implement support for ASDF Standard 1.6.0.  This version of
+  the standard limits mapping keys to string, integer, or
+  boolean. [#866]
+
 2.7.0 (2020-07-23)
 ------------------
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -7,7 +7,6 @@ from numpy import ma
 from jsonschema import ValidationError
 
 from ...types import AsdfType
-from ... import schema
 from ... import util
 
 
@@ -203,8 +202,6 @@ def numpy_array_to_list(array):
             return x
 
     result = ascii_to_unicode(tolist(array))
-
-    schema.validate_large_literals(result)
 
     return result
 

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -161,11 +161,17 @@ supported_versions = [
     AsdfVersion('1.3.0'),
     AsdfVersion('1.4.0'),
     AsdfVersion('1.5.0'),
+    AsdfVersion('1.6.0'),
 ]
 
-default_version = supported_versions[-1]
+default_version = AsdfVersion('1.5.0')
 
 
 # This is the ASDF Standard version at which the format of the history
 # field changed to include extension metadata.
 NEW_HISTORY_FORMAT_MIN_VERSION = AsdfVersion("1.2.0")
+
+
+# This is the ASDF Standard version at which we begin restricting
+# mapping keys to string, integer, and boolean only.
+RESTRICTED_KEYS_MIN_VERSION = AsdfVersion("1.6.0")


### PR DESCRIPTION
This updates the asdf-standard submodule to include the latest draft of the ASDF Standard 1.6.0 version map, and implements the restriction on mapping key types that will be part of that version.  Starting with 1.6.0, mapping keys will be limited to string, integer, or boolean type.