### PR TITLE
Fix bug preventing access to arrays after file is closed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,12 @@
 - Stop removing schema defaults for all ASDF Standard versions,
   and automatically fill defaults only for versions <= 1.5.0. [#860]
 
+2.7.1 (unreleased)
+------------------
+
+- Fix bug preventing access to copied array data after
+  ``AsdfFile`` is closed. [#869]
+
 2.7.0 (2020-07-23)
 ------------------
 


### PR DESCRIPTION
This fixes a bug reported in #867 where copied arrays were unavailable after the `AsdfFile` was closed.  This feature was broken by https://github.com/asdf-format/asdf/pull/716, which forced all arrays to be regenerated if the underlying file was closed.  The solution is to regenerate memory-mapped arrays only.

Resolves #867 