### PR TITLE
Asdftool edit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 - Drop support for automatic serialization of subclass
   attributes. [#825]
 
+- Support asdf:// as a URI scheme. [#854]
+
 2.7.0 (2020-07-23)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@
 - Drop support for Python 3.5. [#856]
 
 - Add new extension API to support versioned extensions.
-  [#850, #851, #853]
+  [#850, #851, #853, #857]
 
 - Permit wildcard in tag validator URIs. [#858, #865]
 

--- a/asdf/commands/__init__.py
+++ b/asdf/commands/__init__.py
@@ -10,7 +10,7 @@ from .info import info
 from .edit import edit
 
 
-__all__ = [ 'implode', 'explode', 'to_yaml', 'defragment', 'diff', 'list_tags',
+__all__ = ['implode', 'explode', 'to_yaml', 'defragment', 'diff', 'list_tags',
     'find_extensions', 'info', 'edit']
 
 

--- a/asdf/commands/__init__.py
+++ b/asdf/commands/__init__.py
@@ -7,10 +7,11 @@ from .diff import diff
 from .tags import list_tags
 from .extension import find_extensions
 from .info import info
+from .edit import edit
 
 
-__all__ = ['implode', 'explode', 'to_yaml', 'defragment', 'diff', 'list_tags',
-    'find_extensions', 'info']
+__all__ = [ 'implode', 'explode', 'to_yaml', 'defragment', 'diff', 'list_tags',
+    'find_extensions', 'info', 'edit']
 
 
 # Extracting ASDF-in-FITS files requires Astropy

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -16,7 +16,8 @@ from .. import yamlutil
 
 from .main import Command
 
-__all__ = ['edit']
+__all__ = ["edit"]
+
 
 class Edit(Command):
     @classmethod
@@ -24,48 +25,58 @@ class Edit(Command):
         """
         Set up a command line argument parser for the edit subcommand.
         """
-        desc_string = "Allows for easy editing of the YAML in an ASDF file.  " \
-                      "For edit mode, the YAML portion of an ASDF file is"  \
-                      "separated from the ASDF into a text file for easy" \
-                      "editing.  For save mode, the edited text file is written" \
-                      "to its ASDF file."
+        desc_string = (
+            "Allows for easy editing of the YAML in an ASDF file.  "
+            "For edit mode, the YAML portion of an ASDF file is"
+            "separated from the ASDF into a text file for easy"
+            "editing.  For save mode, the edited text file is written"
+            "to its ASDF file."
+        )
 
         # Set up the parser
         parser = subparsers.add_parser(
             str("edit"),
             help="Edit YAML portion of an ASDF file.",
-            description=desc_string)
+            description=desc_string,
+        )
 
         # Need an input file
         parser.add_argument(
-            '--infile', '-f',
+            "--infile",
+            "-f",
             type=str,
             required=True,
-            dest='fname',
-            help="Input file (ASDF for -e option, YAML for -s option")
+            dest="fname",
+            help="Input file (ASDF for -e option, YAML for -s option",
+        )
 
         # Need an output file
         parser.add_argument(
-            '--outfile', '-o',
+            "--outfile",
+            "-o",
             type=str,
             required=True,
-            dest='oname',
-            help="Output file (YAML for -e option, ASDF for -s option")
+            dest="oname",
+            help="Output file (YAML for -e option, ASDF for -s option",
+        )
 
         # The edit is either being performed or saved
         group = parser.add_mutually_exclusive_group(required=True)
 
         group.add_argument(
-            '-s',
-            action='store_true',
-            dest='save',
-            help="Saves a YAML text file to its ASDF file.  Requires an YAML input file and ASDF output file.")
+            "-s",
+            action="store_true",
+            dest="save",
+            help="Saves a YAML text file to an ASDF file.  Requires a "
+                 "YAML input file and ASDF output file.",
+        )
 
         group.add_argument(
-            '-e',
-            action='store_true',
-            dest='edit',
-            help="Create a YAML text file for a ASDF file.  Requires a ASDF input file.")
+            "-e",
+            action="store_true",
+            dest="edit",
+            help="Create a YAML text file for a ASDF file.  Requires a ASDF input file.",
+        )
 
         parser.set_defaults(func=cls.run)
 
@@ -89,7 +100,7 @@ def is_yaml_file(fname):
     """
 
     base, ext = os.path.splitext(fname)
-    if '.yaml' != ext:
+    if ".yaml" != ext:
         return False
     return True
 
@@ -127,7 +138,7 @@ def is_valid_asdf_path(fname):
     ----------
     fname : The character string of the input file name.
     """
-    ext = ['.asdf']
+    ext = [".asdf"]
     if is_valid_path_and_ext(fname, ext):
         return True
     print(f"Error: '{fname}' should have extension '{ext[0]}'")
@@ -142,7 +153,7 @@ def is_valid_yaml_path(fname):
     ----------
     fname : The character string of the input file name.
     """
-    ext = ['.yaml']
+    ext = [".yaml"]
     if is_valid_path_and_ext(fname, ext):
         return True
     print(f"Error: '{fname}' should have extension '{ext[0]}'")
@@ -163,16 +174,18 @@ def check_asdf_header(fd):
     The ASDF header line and the ASDF comment as bytes.
     """
 
-    header_line = fd.read_until(b'\r?\n', 2, "newline", include=True)
+    header_line = fd.read_until(b"\r?\n", 2, "newline", include=True)
     if not header_line.startswith(constants.ASDF_MAGIC):
         print("Invalid ASDF ID")
         sys.exit(1)
 
-    comment_section = fd.read_until( b'(%YAML)|(' + constants.BLOCK_MAGIC + b')',
-                                     5,
-                                     "start of content",
-                                     include=False,
-                                     exception=False)
+    comment_section = fd.read_until(
+        b"(%YAML)|(" + constants.BLOCK_MAGIC + b")",
+        5,
+        "start of content",
+        include=False,
+        exception=False,
+    )
 
     return header_line + comment_section
 
@@ -196,7 +209,7 @@ def open_and_check_asdf_header(fname):
     # Read the ASDF header and optional comments section
     header_and_comment = check_asdf_header(fd)
 
-    return fd, header_and_comment   # Return GenericFile and ASDF header bytes.
+    return fd, header_and_comment  # Return GenericFile and ASDF header bytes.
 
 
 def read_and_validate_yaml(fd, fname):
@@ -212,18 +225,20 @@ def read_and_validate_yaml(fd, fname):
     ------
     The YAML portion of an ASDF file as bytes.
     """
-    YAML_TOKEN = b'%YAML'
+    YAML_TOKEN = b"%YAML"
     token = fd.read(len(YAML_TOKEN))
     if token != YAML_TOKEN:
         print(f"Error: No YAML in '{fname}'")
         sys.exit(0)
 
     # Get YAML reader and content
-    reader = fd.reader_until(constants.YAML_END_MARKER_REGEX,
-                             7,
-                             'End of YAML marker',
-                             include=True,
-                             initial_content=token)
+    reader = fd.reader_until(
+        constants.YAML_END_MARKER_REGEX,
+        7,
+        "End of YAML marker",
+        include=True,
+        initial_content=token,
+    )
     yaml_content = reader.read()
 
     # Create a YAML tree to validate
@@ -233,9 +248,10 @@ def read_and_validate_yaml(fd, fname):
         print("Error: 'yamlutil.load_tree' failed to return a tree.")
         sys.exist(1)
 
-    schema.validate(tree, None)     # Failure raises an exception.
+    schema.validate(tree, None)  # Failure raises an exception.
 
     return yaml_content
+
 
 def edit_func(fname, oname):
     """
@@ -259,6 +275,7 @@ def edit_func(fname, oname):
 
     # Open a YAML file for the ASDF YAML.
     if not is_yaml_file(oname):
+        print("A YAML file is expected, with '.yaml' extension.")
         sys.exit(1)
 
     # Write the YAML for the original ASDF file.
@@ -267,7 +284,7 @@ def edit_func(fname, oname):
         ofd.write(yaml_text)
 
     # Output message to user.
-    delim = '*' * 70
+    delim = "*" * 70
     print(f"\n{delim}")
     print("ASDF formatting and YAML schema validated.")
     print(f"The text portion of '{fname}' is written to:")
@@ -275,15 +292,12 @@ def edit_func(fname, oname):
     print(f"The file '{oname}' can be edited using your favorite text editor.")
     print("The edited text can then be saved to the ASDF file of your choice")
     print("using 'asdftool edit -s -f <edited text file> -o <ASDF file>.")
-    print('-' * 70)
-    print("Note: This is meant to be a lightweight text editing tool of")
-    print("      ASDF .If the edited text is larger than the YAML portion")
-    print("      of the ASDF file to be written to, the edits may not be")
-    print("      able to saved.")
     print(f"{delim}\n")
 
     return
 
+
+# TODO conosidate the next two functions and change 'buffer' to 'pad'.
 def buffer_edited_text(edited_text, orig_text):
     """
     There is more text in the original ASDF file than in the edited text,
@@ -299,15 +313,12 @@ def buffer_edited_text(edited_text, orig_text):
     The buffered text and the number of spaces added as buffer.
     """
     diff = len(orig_text) - len(edited_text)
-    if diff < 1:
-        print("Error: shouldn't be here.")
-        sys.exit(1)
 
-    wdelim = b'\r\n...\r\n'
-    ldelim = b'\n...\n'
-    if edited_text[-len(wdelim) :]==wdelim:
+    wdelim = b"\r\n...\r\n"
+    ldelim = b"\n...\n"
+    if edited_text[-len(wdelim) :] == wdelim:
         delim = wdelim
-    elif edited_text[-len(ldelim) :]==ldelim:
+    elif edited_text[-len(ldelim) :] == ldelim:
         delim = ldelim
     else:
         print("Unrecognized YAML delimiter ending the YAML text.")
@@ -315,8 +326,7 @@ def buffer_edited_text(edited_text, orig_text):
         print(f"last {len(wdelim)} bytes are {edited_text[-len(wdelim):]}.")
         sys.exit(1)
 
-    # May not be correct.  If on Windows use '\r\n'.
-    buffered_text = edited_text[: -len(delim)] + b'\n' + b' '*(diff - 1) + delim
+    buffered_text = edited_text[: -len(delim)] + b"\n" + b"\0" * (diff - 1) + delim
     return buffered_text, diff - 1
 
 
@@ -333,11 +343,11 @@ def add_buffer_to_new_text(edited_text, buffer_size):
     ------
     Buffered text with the number of spaces requested as buffer.
     """
-    wdelim = b'\r\n...\r\n'
-    ldelim = b'\n...\n'
-    if edited_text[-len(wdelim) :]==wdelim:
+    wdelim = b"\r\n...\r\n"
+    ldelim = b"\n...\n"
+    if edited_text[-len(wdelim) :] == wdelim:
         delim = wdelim
-    elif edited_text[-len(ldelim) :]==ldelim:
+    elif edited_text[-len(ldelim) :] == ldelim:
         delim = ldelim
     else:
         print("Unrecognized YAML delimiter ending the YAML text.")
@@ -345,8 +355,8 @@ def add_buffer_to_new_text(edited_text, buffer_size):
         print(f"last {len(wdelim)} bytes are {edited_text[-len(wdelim):]}.")
         sys.exit(1)
 
-    buf = b' ' * buffer_size
-    buffered_text = edited_text[: -len(delim)] + b'\n' + buf + delim
+    buf = b" " * buffer_size
+    buffered_text = edited_text[: -len(delim)] + b"\n" + buf + delim
 
     return buffered_text
 
@@ -363,14 +373,16 @@ def write_block_index(fd, index):
     if len(index) < 1:
         return
 
+    # TODO - this needs to be changed to use constants.py and pyyaml
     bindex_hdr = b"#ASDF BLOCK INDEX\n%YAML 1.1\n---\n"
     fd.write(bindex_hdr)
     for idx in index:
-        ostr = f'- {idx}\n'
-        fd.write(ostr.encode('utf-8'))
-    end = b'...'
+        ostr = f"- {idx}\n"
+        fd.write(ostr.encode("utf-8"))
+    end = b"..."
     fd.write(end)
     return
+
 
 def get_next_block_header(fd):
     """
@@ -403,6 +415,7 @@ def get_next_block_header(fd):
     header = fd.read(hsz)
     return blk_header + header
 
+
 def rewrite_asdf_file(edited_text, orig_text, oname, fname):
     """
     Rewrite an ASDF file for too large edited YAML.  The edited YAML, a buffer,
@@ -419,19 +432,19 @@ def rewrite_asdf_file(edited_text, orig_text, oname, fname):
     fname : the edit YAML to write to new file.
     """
 
-    tmp_oname = oname + '.tmp'      # Save as a temp file, in case anything goes wrong.
+    tmp_oname = oname + ".tmp"  # Save as a temp file, in case anything goes wrong.
     buffer_size = 10 * 1000
     buffered_text = add_buffer_to_new_text(edited_text, buffer_size)
 
-    ifd = open(oname, "r+b")         # Open old ASDF to get binary blocks
+    ifd = open(oname, "r+b")  # Open old ASDF to get binary blocks
     ifd.seek(len(orig_text))
 
-    ofd = open(tmp_oname, "w+b")     # Open temp file to write
-    ofd.write(buffered_text)        # Write edited YAML
+    ofd = open(tmp_oname, "w+b")  # Open temp file to write
+    ofd.write(buffered_text)  # Write edited YAML
 
     current_location = len(buffered_text)
     block_index = []
-    alloc_loc = 14      # 4 bytes of block ID, 2 blocks of size, 8 blocks into header
+    alloc_loc = 14  # 4 bytes of block ID, 2 blocks of size, 8 blocks into header
     block_chunk = 2048
     while True:
         next_block = get_next_block_header(ifd)
@@ -439,7 +452,7 @@ def rewrite_asdf_file(edited_text, orig_text, oname, fname):
             break
 
         # Get block size on disk
-        alloc = struct.unpack(">Q", next_block[alloc_loc:alloc_loc+8])[0]
+        alloc = struct.unpack(">Q", next_block[alloc_loc : alloc_loc + 8])[0]
 
         # Save block location for block index
         block_index.append(current_location)
@@ -451,10 +464,9 @@ def rewrite_asdf_file(edited_text, orig_text, oname, fname):
             chunk = ifd.read(block_chunk)
             ofd.write(chunk)
             alloc -= block_chunk
-        if alloc>0:
+        if alloc > 0:
             chunk = ifd.read(alloc)
             ofd.write(chunk)
-
 
     write_block_index(ofd, block_index)
 
@@ -462,14 +474,15 @@ def rewrite_asdf_file(edited_text, orig_text, oname, fname):
     os.rename(tmp_oname, oname)
 
     # Output message to user.
-    delim = '*' * 70
+    delim = "*" * 70
     print(f"\n{delim}")
     print(f"The text in '{fname}' was too large to simply overwrite the")
     print(f"text in '{oname}'.  The file '{oname}' was rewritten to")
-    print(f"accommodate the larger text size.")
+    print("accommodate the larger text size.")
     print(f"Also, added a '\\n' and {buffer_size:,} spaces as a buffer for")
     print(f"the text in '{oname}' to allow for future edits.")
     print(f"{delim}\n")
+
 
 def save_func(fname, oname):
     """
@@ -508,7 +521,7 @@ def save_func(fname, oname):
 
     # Compare text sizes and maybe output.
     # There are three cases:
-    msg_delim = '*' * 70
+    msg_delim = "*" * 70
     if len(edited_text) == len(asdf_text):
         with open(oname, "r+b") as fd:
             fd.write(edited_text)
@@ -521,12 +534,15 @@ def save_func(fname, oname):
             fd.write(buffered_text)
         print(f"\n{msg_delim}")
         print(f"The edited text in '{fname}' was written to '{oname}'")
-        print(f"Added a  '\\n' and {diff} buffer of spaces between the YAML text and binary blocks.")
+        print(
+            f"Added a '\\n' and {diff} buffer of spaces between the YAML text and binary blocks."
+        )
         print(f"{msg_delim}\n")
     else:
         rewrite_asdf_file(edited_text, asdf_text, oname, fname)
 
     return
+
 
 def edit(args):
     """

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -35,7 +35,7 @@ class Edit(Command):
 
         # Set up the parser
         parser = subparsers.add_parser(
-            str("edit"),
+            "edit",
             help="Edit YAML portion of an ASDF file.",
             description=desc_string,
         )
@@ -59,6 +59,18 @@ class Edit(Command):
             dest="oname",
             help="Output file (YAML for -e option, ASDF for -s option",
         )
+
+        """
+        # Validate input YAML.  Optional, since this could be what's being corrected.
+        parser.add_argument(
+            "--validate",
+            "-v",
+            type=bool,
+            action="store_true",
+            dest="validate",
+            help="Validate input YAML format.",
+        )
+        """
 
         # The edit is either being performed or saved
         group = parser.add_mutually_exclusive_group(required=True)
@@ -105,7 +117,7 @@ def is_yaml_file(fname):
     """
 
     base, ext = os.path.splitext(fname)
-    if ".yaml" != ext:
+    if ".yaml" != ext and ".yml" != ext:
         return False
     return True
 
@@ -173,7 +185,7 @@ def is_valid_yaml_path(fname):
     ------
     bool
     """
-    ext = [".yaml"]
+    ext = [".yaml", ".yml"]
     if is_valid_path_and_ext(fname, ext):
         return True
     print(f"Error: '{fname}' should have extension '{ext[0]}'")
@@ -233,7 +245,7 @@ def open_and_check_asdf_header(fname):
     return fd, header_and_comment  # Return GenericFile and ASDF header bytes.
 
 
-def read_and_validate_yaml(fd, fname):
+def read_and_validate_yaml(fd, fname, validate_yaml):
     """
     Get the YAML text from an ASDF formatted file.
 
@@ -263,14 +275,15 @@ def read_and_validate_yaml(fd, fname):
     )
     yaml_content = reader.read()
 
-    # Create a YAML tree to validate
-    # The YAML text must be converted to a stream.
-    tree = yamlutil.load_tree(io.BytesIO(yaml_content))
-    if tree is None:
-        print("Error: 'yamlutil.load_tree' failed to return a tree.")
-        sys.exist(1)
+    if validate_yaml:
+        # Create a YAML tree to validate
+        # The YAML text must be converted to a stream.
+        tree = yamlutil.load_tree(io.BytesIO(yaml_content))
+        if tree is None:
+            print("Error: 'yamlutil.load_tree' failed to return a tree.")
+            sys.exist(1)
 
-    schema.validate(tree, None)  # Failure raises an exception.
+        schema.validate(tree, None)  # Failure raises an exception.
 
     return yaml_content
 
@@ -291,17 +304,16 @@ def edit_func(fname, oname):
     if not is_valid_asdf_path(fname):
         return False
 
+    if not is_yaml_file(oname):
+        print("A YAML file is expected, with '.yaml' or '.yml' extension.")
+        sys.exit(1)
+
     # Validate input file is an ASDF file.
     fd, asdf_text = open_and_check_asdf_header(fname)
 
     # Read and validate the YAML of an ASDF file.
-    yaml_text = read_and_validate_yaml(fd, fname)
+    yaml_text = read_and_validate_yaml(fd, fname, False)
     fd.close()
-
-    # Open a YAML file for the ASDF YAML.
-    if not is_yaml_file(oname):
-        print("A YAML file is expected, with '.yaml' extension.")
-        sys.exit(1)
 
     # Write the YAML for the original ASDF file.
     with open(oname, "wb") as ofd:
@@ -320,71 +332,6 @@ def edit_func(fname, oname):
     print(f"{delim}\n")
 
     return
-
-
-def get_yaml_text_and_delimiter(yaml_text):
-    """
-    Splits the YAML text into the text and the end delimiter in preparation
-    for padding.
-    """
-
-    wdelim = b"\r\n...\r\n"
-    ldelim = b"\n...\n"
-    if yaml_text[-len(wdelim) :] == wdelim:
-        delim = wdelim
-    elif yaml_text[-len(ldelim) :] == ldelim:
-        delim = ldelim
-    else:
-        print("Unrecognized YAML delimiter ending the YAML text.")
-        print(f"It should be {wdelim} or {ldelim}, but the")
-        print(f"last {len(wdelim)} bytes are {yaml_text[-len(wdelim):]}.")
-        sys.exit(1)
-
-    return yaml_text[: -len(delim)], delim
-
-
-def pad_edited_text(edited_text, orig_text):
-    """
-    There is more text in the original ASDF file than in the edited text,
-    so we will pad the edited text with spaces.
-
-    Parameters
-    ----------
-    edited_text - The text from the edited YAML file
-    orig_text - The text from the original ASDF file
-
-    Return
-    ------
-    The padded text and the number of spaces added as pad.
-    """
-    diff = len(orig_text) - len(edited_text)
-
-    edited_text, delim = get_yaml_text_and_delimiter(edited_text)
-
-    padded_text = edited_text + b"\n" + b" " * (diff - 1) + delim
-    return padded_text, diff - 1
-
-
-def add_pad_to_new_text(edited_text, pad_size):
-    """
-    Adds pad to edited text.
-
-    Parameters
-    ----------
-    edited_text - The text from the edited YAML file.
-    pad_size - The number of spaces to add as a pad.
-
-    Return
-    ------
-    Pad text with the number of spaces requested as pad.
-    """
-
-    edited_text, delim = get_yaml_text_and_delimiter(edited_text)
-
-    pad = b" " * pad_size
-    padded_text = edited_text + b"\n" + pad + delim
-
-    return padded_text
 
 
 def write_block_index(fd, index):
@@ -410,106 +357,46 @@ def write_block_index(fd, index):
     return
 
 
-def get_next_block_header(fd):
+def find_first_block(fname):
     """
-    From a file, gets the next block header.
+    Finds the location of the first binary block in an ASDF file.
+
 
     Parameters
     ----------
-    fd - The ASDF file to get the next block.
+    fname : str
+        Input ASDF file name.
 
     Return
     ------
-    If a block is found, return the bytes of the block header.
-    Otherwise return None.
+    Location, in bytes, of the first binary block.
     """
-    #     Block header structure:
-    # 4 bytes of magic number
-    # 2 bytes of header length, after the length field (min 48)
-    # 4 bytes flag
-    # 4 bytes compression
-    # 8 bytes allocated size
-    # 8 bytes used (on disk) size
-    # 8 bytes data size
-    # 16 bytes checksum
-    blk_header = fd.read(6)
-    if len(blk_header) != 6:
-        return None
-    if not blk_header.startswith(constants.BLOCK_MAGIC):
-        return None
-    hsz = struct.unpack(">H", blk_header[4:6])[0]
-    header = fd.read(hsz)
-    return blk_header + header
+    with generic_io.get_file(fname, mode="r") as fd:
+        reader = fd.reader_until(
+            constants.BLOCK_MAGIC,
+            7,
+            "First binary block",
+            include=False,
+        )
+        content_to_first_block = reader.read()
+    return len(content_to_first_block) 
+
+def write_edited_yaml_larger (oname, edited_yaml, first_block_loc):
+    print("Larger")
 
 
-def rewrite_asdf_file(edited_text, orig_text, oname, fname):
-    """
-    Rewrite an ASDF file for too large edited YAML.  The edited YAML, a pad,
-    the blocks will be rewritten.  A block index will also be rewritten.  If a
-    block index existed in the old file, it will have to be recomputed to
-    because of the larger YAML size and pad, which changes the location of
-    the binary blocks.
-
-    Parameters
-    ----------
-    edited_text : the new YAML text to write out.
-    orig_text : the original YAML text to overwrite.
-    oname : the ASDF file to overwrite.
-    fname : the edit YAML to write to new file.
-    """
-
-    tmp_oname = oname + ".tmp"  # Save as a temp file, in case anything goes wrong.
-    pad_size = 10 * 1000
-    padded_text = add_pad_to_new_text(edited_text, pad_size)
-
-    ifd = open(oname, "r+b")  # Open old ASDF to get binary blocks
-    ifd.seek(len(orig_text))
-
-    ofd = open(tmp_oname, "w+b")  # Open temp file to write
-    ofd.write(padded_text)  # Write edited YAML
-
-    current_location = len(padded_text)
-    block_index = []
-    alloc_loc = 14  # 4 bytes of block ID, 2 blocks of size, 8 blocks into header
-    block_chunk = 2048
-    while True:
-        next_block = get_next_block_header(ifd)
-        if next_block is None:
-            break
-
-        # Get block size on disk
-        alloc = struct.unpack(">Q", next_block[alloc_loc : alloc_loc + 8])[0]
-
-        # Save block location for block index
-        block_index.append(current_location)
-        current_location = current_location + len(next_block) + alloc
-
-        # Copy block
-        ofd.write(next_block)
-        while alloc >= block_chunk:
-            chunk = ifd.read(block_chunk)
-            ofd.write(chunk)
-            alloc -= block_chunk
-        if alloc > 0:
-            chunk = ifd.read(alloc)
-            ofd.write(chunk)
-    ifd.close()
-
-    write_block_index(ofd, block_index)
-    ofd.close()
-
-    # Rename temp file.
-    os.replace(tmp_oname, oname)
-
-    # Output message to user.
-    delim = "*" * 70
-    print(f"\n{delim}")
-    print(f"The text in '{fname}' was too large to simply overwrite the")
-    print(f"text in '{oname}'.  The file '{oname}' was rewritten to")
-    print("accommodate the larger text size.")
-    print(f"Also, added a '\\n' and {pad_size:,} ' ' as a pad for")
-    print(f"the text in '{oname}' to allow for future edits.")
-    print(f"{delim}\n")
+def write_edited_yaml(oname, edited_yaml, first_block_loc):
+    if len(edited_yaml) < first_block_loc:
+        pad_length = first_block_loc - len(edited_yaml)
+        padding = b'\0' * pad_length
+        with open(oname, "r+b") as fd:
+            fd.write(edited_yaml)
+            fd.write(padding)
+    elif len(edited_yaml) == first_block_loc:
+        with open(oname, "r+b") as fd:
+            fd.write(edited_yaml)
+    else:
+        write_edited_yaml_larger(oname, edited_yaml, first_block_loc)  
 
 
 def save_func(fname, oname):
@@ -525,8 +412,10 @@ def save_func(fname, oname):
 
     Parameters
     ----------
-    fname : The input YAML file.
-    oname : The output ASDF file name.
+    fname : str
+        Input YAML file name.
+    oname : str
+        The output ASDF file name.
     """
 
     if not is_valid_yaml_path(fname):
@@ -537,37 +426,25 @@ def save_func(fname, oname):
 
     # Validate input file is an ASDF formatted YAML.
     ifd, iasdf_text = open_and_check_asdf_header(fname)
-    iyaml_text = read_and_validate_yaml(ifd, fname)
+    iyaml_text = read_and_validate_yaml(ifd, fname, True)
     ifd.close()
     edited_text = iasdf_text + iyaml_text
 
-    # Get text from ASDF file.
-    ofd, oasdf_text = open_and_check_asdf_header(oname)
-    oyaml_text = read_and_validate_yaml(ofd, oname)
-    ofd.close()
-    asdf_text = oasdf_text + oyaml_text
-
-    # Compare text sizes and maybe output.
-    # There are three cases:
-    msg_delim = "*" * 70
-    if len(edited_text) == len(asdf_text):
-        with open(oname, "r+b") as fd:
-            fd.write(edited_text)
-        print(f"\n{msg_delim}")
-        print(f"The edited text in '{fname}' was written to '{oname}'")
-        print(f"{msg_delim}\n")
-    elif len(edited_text) < len(asdf_text):
-        padded_text, diff = pad_edited_text(edited_text, asdf_text)
-        with open(oname, "r+b") as fd:
-            fd.write(padded_text)
-        print(f"\n{msg_delim}")
-        print(f"The edited text in '{fname}' was written to '{oname}'")
-        print(
-            f"Added a '\\n' and {diff} pad of ' ' between the YAML text and binary blocks."
-        )
-        print(f"{msg_delim}\n")
-    else:
-        rewrite_asdf_file(edited_text, asdf_text, oname, fname)
+    # - Find location of first block.
+    loc = find_first_block(oname)
+    write_edited_yaml(oname, edited_text, loc)
+    # - Using edited_text length and first block location determine.
+    #   space availability for new YAML.
+    # - Smaller:
+    #   - Overwrite YAML in ASDF, then pad 0x00 to first b'\xd3BLK'.
+    # - Equal:
+    #   - Overwrite YAML in ASDF.  No padding.
+    # - Larger:
+    #   - Create new file.
+    #   - Write new YAML.
+    #   - Add 10,000 0x00 pad bytes between '...\r?\n' and '\xd3BLK'.
+    #   - If no streaming block found, write block index.
+    #   - If streaming block found, handle correctly.
 
     return
 

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -507,7 +507,7 @@ def rewrite_asdf_file(edited_text, orig_text, oname, fname):
     print(f"The text in '{fname}' was too large to simply overwrite the")
     print(f"text in '{oname}'.  The file '{oname}' was rewritten to")
     print("accommodate the larger text size.")
-    print(f"Also, added a '\\n' and {pad_size:,} '\\0' as a pad for")
+    print(f"Also, added a '\\n' and {pad_size:,} ' ' as a pad for")
     print(f"the text in '{oname}' to allow for future edits.")
     print(f"{delim}\n")
 
@@ -563,7 +563,7 @@ def save_func(fname, oname):
         print(f"\n{msg_delim}")
         print(f"The edited text in '{fname}' was written to '{oname}'")
         print(
-            f"Added a '\\n' and {diff} pad of '\\0' between the YAML text and binary blocks."
+            f"Added a '\\n' and {diff} pad of ' ' between the YAML text and binary blocks."
         )
         print(f"{msg_delim}\n")
     else:

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -296,6 +296,7 @@ def edit_func(fname, oname):
 
     # Read and validate the YAML of an ASDF file.
     yaml_text = read_and_validate_yaml(fd, fname)
+    fd.close()
 
     # Open a YAML file for the ASDF YAML.
     if not is_yaml_file(oname):
@@ -492,8 +493,10 @@ def rewrite_asdf_file(edited_text, orig_text, oname, fname):
         if alloc > 0:
             chunk = ifd.read(alloc)
             ofd.write(chunk)
+    ifd.close()
 
     write_block_index(ofd, block_index)
+    ofd.close()
 
     # Rename temp file.
     os.rename(tmp_oname, oname)

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -499,7 +499,7 @@ def rewrite_asdf_file(edited_text, orig_text, oname, fname):
     ofd.close()
 
     # Rename temp file.
-    os.rename(tmp_oname, oname)
+    os.replace(tmp_oname, oname)
 
     # Output message to user.
     delim = "*" * 70

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -243,7 +243,7 @@ def open_and_check_asdf_header(fname):
 
 def get_yaml_version(fd, token):
     """
-    A YAML token is found, so see if the YAML version can be parsed. 
+    A YAML token is found, so see if the YAML version can be parsed.
 
     Parameters
     ----------
@@ -265,7 +265,6 @@ def get_yaml_version(fd, token):
     sl = line.split(" ")
     if len(sl) == 2:
         yaml_version = tuple([int(x) for x in sl[1].split(".")])
-
 
 
 def read_and_validate_yaml(fd, fname, validate_yaml):
@@ -482,14 +481,14 @@ def copy_binary_blocks(ofd, ifd):
         if constants.BLOCK_FLAG_STREAMED & flags:
             while True:
                 chunk = ifd.read(chunk_sz)
-                if 0==len(chunk):
+                if 0 == len(chunk):
                     return  # End of file
                 ofd.write(chunk)
 
         alloc = struct.unpack(">Q", header[alloc_loc : alloc_loc + 8])[0]
         while alloc >= chunk_sz:
             chunk = ifd.read(chunk_sz)
-            if len(chunk)==0:
+            if len(chunk) == 0:
                 print("Error: Invalid reading of binary block {block_num}.")
                 print("       Exiting ...")
                 sys.exit(1)
@@ -518,7 +517,7 @@ def write_edited_yaml_larger(fname, oname, edited_yaml, first_block_loc):
         The edited YAML to be saved to an ASDF file.
     first_block_location : int
         The location in the ASDF file for the first binary block.
-                           
+
     """
     tmp_oname = oname + ".tmp"
 

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -63,18 +63,6 @@ class Edit(Command):
             help="Output file (YAML for -e option, ASDF for -s option)",
         )
 
-        """
-        # Validate input YAML.  Optional, since this could be what's being corrected.
-        parser.add_argument(
-            "--validate",
-            "-v",
-            type=bool,
-            action="store_true",
-            dest="validate",
-            help="Validate input YAML format.",
-        )
-        """
-
         # The edit is either being performed or saved
         group = parser.add_mutually_exclusive_group(required=True)
 
@@ -380,8 +368,9 @@ def write_block_index(fd, index):
 
     Parameters
     ----------
-    fd - The output file to write the block index.
-    index - A list of locations for each block.
+    fd : file descriptor
+    index : list
+        Integer location for each block.
     """
     global yaml_version
     if len(index) < 1:
@@ -526,9 +515,10 @@ def write_edited_yaml_larger(fname, oname, edited_yaml, first_block_loc):
     oname : str
         Input ASDF file name.
     edited_yaml : byte string
-        The edited YAML to be saved to an ASDF file
-    first_block_location : the location in the ASDF file for the first binary
-                           block
+        The edited YAML to be saved to an ASDF file.
+    first_block_location : int
+        The location in the ASDF file for the first binary block.
+                           
     """
     tmp_oname = oname + ".tmp"
 
@@ -559,8 +549,8 @@ def write_edited_yaml(fname, oname, edited_yaml, first_block_loc):
         Input ASDF file name.
     edited_yaml : byte string
         The edited YAML to be saved to an ASDF file
-    first_block_location : the location in the ASDF file for the first binary
-                           block
+    first_block_location : int
+        The location in the ASDF file for the first binary block.
     """
     if len(edited_yaml) < first_block_loc:
         # The YAML in the ASDF can simply be overwritten

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -1,0 +1,545 @@
+"""
+Contains commands for lightweight text editing of an ASDF file.
+Future work: Make this interactive editing.
+"""
+
+import io
+import os
+import struct
+import sys
+
+import asdf.constants as constants
+
+from .. import generic_io
+from .. import schema
+from .. import yamlutil
+
+from .main import Command
+
+__all__ = ['edit']
+
+class Edit(Command):
+    @classmethod
+    def setup_arguments(cls, subparsers):
+        """
+        Set up a command line argument parser for the edit subcommand.
+        """
+        desc_string = "Allows for easy editing of the YAML in an ASDF file.  " \
+                      "For edit mode, the YAML portion of an ASDF file is"  \
+                      "separated from the ASDF into a text file for easy" \
+                      "editing.  For save mode, the edited text file is written" \
+                      "to its ASDF file."
+
+        # Set up the parser
+        parser = subparsers.add_parser(
+            str("edit"),
+            help="Edit YAML portion of an ASDF file.",
+            description=desc_string)
+
+        # Need an input file
+        parser.add_argument(
+            '--infile', '-f',
+            type=str,
+            required=True,
+            dest='fname',
+            help="Input file (ASDF for -e option, YAML for -s option")
+
+        # Need an output file
+        parser.add_argument(
+            '--outfile', '-o',
+            type=str,
+            required=True,
+            dest='oname',
+            help="Output file (YAML for -e option, ASDF for -s option")
+
+        # The edit is either being performed or saved
+        group = parser.add_mutually_exclusive_group(required=True)
+
+        group.add_argument(
+            '-s',
+            action='store_true',
+            dest='save',
+            help="Saves a YAML text file to its ASDF file.  Requires an YAML input file and ASDF output file.")
+
+        group.add_argument(
+            '-e',
+            action='store_true',
+            dest='edit',
+            help="Create a YAML text file for a ASDF file.  Requires a ASDF input file.")
+
+        parser.set_defaults(func=cls.run)
+
+        return parser
+
+    @classmethod
+    def run(cls, args):
+        """
+        Execute the edit subcommand.
+        """
+        return edit(args)
+
+
+def is_yaml_file(fname):
+    """
+    Determines if a file is a YAML file based only on the file extension.
+
+    Parameters
+    ----------
+    fname : The character string of the input file name.
+    """
+
+    base, ext = os.path.splitext(fname)
+    if '.yaml' != ext:
+        return False
+    return True
+
+
+def is_valid_path_and_ext(fname, wanted_ext=None):
+    """
+    Validates the path exists and the extension is one wanted.
+
+    Parameters
+    ----------
+    fname : The character string of the input file name.
+    wanted_ext : List of extensions to check.
+    """
+    if not os.path.exists(fname):
+        print(f"Error: No file '{fname}' exists.")
+        return False
+
+    # Simply validates the path existence
+    if wanted_ext is None:
+        return True
+
+    # Make sure the extension is one desired.
+    base, ext = os.path.splitext(fname)
+    if ext not in wanted_ext:
+        return False
+
+    return True
+
+
+def is_valid_asdf_path(fname):
+    """
+    Validates fname path exists and has extension '.asdf'.
+
+    Parameters
+    ----------
+    fname : The character string of the input file name.
+    """
+    ext = ['.asdf']
+    if is_valid_path_and_ext(fname, ext):
+        return True
+    print(f"Error: '{fname}' should have extension '{ext[0]}'")
+    return False
+
+
+def is_valid_yaml_path(fname):
+    """
+    Validates fname path exists and has extension '.yaml'.
+
+    Parameters
+    ----------
+    fname : The character string of the input file name.
+    """
+    ext = ['.yaml']
+    if is_valid_path_and_ext(fname, ext):
+        return True
+    print(f"Error: '{fname}' should have extension '{ext[0]}'")
+    return False
+
+
+def check_asdf_header(fd):
+    """
+    Makes sure the header line is the expected one, as well
+    as getting the optional comment line.
+
+    Parameters
+    ----------
+    fd : GenericFile
+
+    Return
+    ------
+    The ASDF header line and the ASDF comment as bytes.
+    """
+
+    header_line = fd.read_until(b'\r?\n', 2, "newline", include=True)
+    if not header_line.startswith(constants.ASDF_MAGIC):
+        print("Invalid ASDF ID")
+        sys.exit(1)
+
+    comment_section = fd.read_until( b'(%YAML)|(' + constants.BLOCK_MAGIC + b')',
+                                     5,
+                                     "start of content",
+                                     include=False,
+                                     exception=False)
+
+    return header_line + comment_section
+
+
+def open_and_check_asdf_header(fname):
+    """
+    Open and validate the ASDF file, as well as read in all the YAML
+    that will be outputted to a YAML file.
+
+    Parameters
+    ----------
+    fname : The character string of the input file name.
+
+    Return
+    ------
+    File descriptor for ASDF file and the ASDF header and ASDF comments as bytes.
+    """
+    fullpath = os.path.abspath(fname)
+    fd = generic_io.get_file(fullpath, mode="r")
+
+    # Read the ASDF header and optional comments section
+    header_and_comment = check_asdf_header(fd)
+
+    return fd, header_and_comment   # Return GenericFile and ASDF header bytes.
+
+
+def read_and_validate_yaml(fd, fname):
+    """
+    Get the YAML text from an ASDF formatted file.
+
+    Parameters
+    ----------
+    fname : The character string of the input file name.
+    fd : GenericFile for fname.
+
+    Return
+    ------
+    The YAML portion of an ASDF file as bytes.
+    """
+    YAML_TOKEN = b'%YAML'
+    token = fd.read(len(YAML_TOKEN))
+    if token != YAML_TOKEN:
+        print(f"Error: No YAML in '{fname}'")
+        sys.exit(0)
+
+    # Get YAML reader and content
+    reader = fd.reader_until(constants.YAML_END_MARKER_REGEX,
+                             7,
+                             'End of YAML marker',
+                             include=True,
+                             initial_content=token)
+    yaml_content = reader.read()
+
+    # Create a YAML tree to validate
+    # The YAML text must be converted to a stream.
+    tree = yamlutil.load_tree(io.BytesIO(yaml_content))
+    if tree is None:
+        print("Error: 'yamlutil.load_tree' failed to return a tree.")
+        sys.exist(1)
+
+    schema.validate(tree, None)     # Failure raises an exception.
+
+    return yaml_content
+
+def edit_func(fname, oname):
+    """
+    Creates a YAML file from an ASDF file.  The YAML file will contain only the
+    YAML from the ASDF file.  The YAML text will be written to a YAML text file
+    in the same, so from 'example.asdf' the file 'example.yaml' will be created.
+
+    Parameters
+    ----------
+    fname : The character string of the input ASDF file name.
+    oname : The character string of the output YAML file name.
+    """
+    if not is_valid_asdf_path(fname):
+        return False
+
+    # Validate input file is an ASDF file.
+    fd, asdf_text = open_and_check_asdf_header(fname)
+
+    # Read and validate the YAML of an ASDF file.
+    yaml_text = read_and_validate_yaml(fd, fname)
+
+    # Open a YAML file for the ASDF YAML.
+    if not is_yaml_file(oname):
+        sys.exit(1)
+
+    # Write the YAML for the original ASDF file.
+    with open(oname, "wb") as ofd:
+        ofd.write(asdf_text)
+        ofd.write(yaml_text)
+
+    # Output message to user.
+    delim = '*' * 70
+    print(f"\n{delim}")
+    print("ASDF formatting and YAML schema validated.")
+    print(f"The text portion of '{fname}' is written to:")
+    print(f"    '{oname}'")
+    print(f"The file '{oname}' can be edited using your favorite text editor.")
+    print("The edited text can then be saved to the ASDF file of your choice")
+    print("using 'asdftool edit -s -f <edited text file> -o <ASDF file>.")
+    print('-' * 70)
+    print("Note: This is meant to be a lightweight text editing tool of")
+    print("      ASDF .If the edited text is larger than the YAML portion")
+    print("      of the ASDF file to be written to, the edits may not be")
+    print("      able to saved.")
+    print(f"{delim}\n")
+
+    return
+
+def buffer_edited_text(edited_text, orig_text):
+    """
+    There is more text in the original ASDF file than in the edited text,
+    so we will buffer the edited text with spaces.
+
+    Parameters
+    ----------
+    edited_text - The text from the edited YAML file
+    orig_text - The text from the original ASDF file
+
+    Return
+    ------
+    The buffered text and the number of spaces added as buffer.
+    """
+    diff = len(orig_text) - len(edited_text)
+    if diff < 1:
+        print("Error: shouldn't be here.")
+        sys.exit(1)
+
+    wdelim = b'\r\n...\r\n'
+    ldelim = b'\n...\n'
+    if edited_text[-len(wdelim) :]==wdelim:
+        delim = wdelim
+    elif edited_text[-len(ldelim) :]==ldelim:
+        delim = ldelim
+    else:
+        print("Unrecognized YAML delimiter ending the YAML text.")
+        print(f"It should be {wdelim} or {ldelim}, but the")
+        print(f"last {len(wdelim)} bytes are {edited_text[-len(wdelim):]}.")
+        sys.exit(1)
+
+    # May not be correct.  If on Windows use '\r\n'.
+    buffered_text = edited_text[: -len(delim)] + b'\n' + b' '*(diff - 1) + delim
+    return buffered_text, diff - 1
+
+
+def add_buffer_to_new_text(edited_text, buffer_size):
+    """
+    Adds buffer to edited text.
+
+    Parameters
+    ----------
+    edited_text - The text from the edited YAML file.
+    buffer_size - The number of spaces to add as a buffer.
+
+    Return
+    ------
+    Buffered text with the number of spaces requested as buffer.
+    """
+    wdelim = b'\r\n...\r\n'
+    ldelim = b'\n...\n'
+    if edited_text[-len(wdelim) :]==wdelim:
+        delim = wdelim
+    elif edited_text[-len(ldelim) :]==ldelim:
+        delim = ldelim
+    else:
+        print("Unrecognized YAML delimiter ending the YAML text.")
+        print(f"It should be {wdelim} or {ldelim}, but the")
+        print(f"last {len(wdelim)} bytes are {edited_text[-len(wdelim):]}.")
+        sys.exit(1)
+
+    buf = b' ' * buffer_size
+    buffered_text = edited_text[: -len(delim)] + b'\n' + buf + delim
+
+    return buffered_text
+
+
+def write_block_index(fd, index):
+    """
+    Write the block index to an ASDF file.
+
+    Parameters
+    ----------
+    fd - The output file to write the block index.
+    index - A list of locations for each block.
+    """
+    if len(index) < 1:
+        return
+
+    bindex_hdr = b"#ASDF BLOCK INDEX\n%YAML 1.1\n---\n"
+    fd.write(bindex_hdr)
+    for idx in index:
+        ostr = f'- {idx}\n'
+        fd.write(ostr.encode('utf-8'))
+    end = b'...'
+    fd.write(end)
+    return
+
+def get_next_block_header(fd):
+    """
+    From a file, gets the next block header.
+
+    Parameters
+    ----------
+    fd - The ASDF file to get the next block.
+
+    Return
+    ------
+    If a block is found, return the bytes of the block header.
+    Otherwise return None.
+    """
+    #     Block header structure:
+    # 4 bytes of magic number
+    # 2 bytes of header length, after the length field (min 48)
+    # 4 bytes flag
+    # 4 bytes compression
+    # 8 bytes allocated size
+    # 8 bytes used (on disk) size
+    # 8 bytes data size
+    # 16 bytes checksum
+    blk_header = fd.read(6)
+    if len(blk_header) != 6:
+        return None
+    if not blk_header.startswith(constants.BLOCK_MAGIC):
+        return None
+    hsz = struct.unpack(">H", blk_header[4:6])[0]
+    header = fd.read(hsz)
+    return blk_header + header
+
+def rewrite_asdf_file(edited_text, orig_text, oname, fname):
+    """
+    Rewrite an ASDF file for too large edited YAML.  The edited YAML, a buffer,
+    the blocks will be rewritten.  A block index will also be rewritten.  If a
+    block index existed in the old file, it will have to be recomputed to
+    because of the larger YAML size and buffer, which changes the location of
+    the binary blocks.
+
+    Parameters
+    ----------
+    edited_text : the new YAML text to write out.
+    orig_text : the original YAML text to overwrite.
+    oname : the ASDF file to overwrite.
+    fname : the edit YAML to write to new file.
+    """
+
+    tmp_oname = oname + '.tmp'      # Save as a temp file, in case anything goes wrong.
+    buffer_size = 10 * 1000
+    buffered_text = add_buffer_to_new_text(edited_text, buffer_size)
+
+    ifd = open(oname, "r+b")         # Open old ASDF to get binary blocks
+    ifd.seek(len(orig_text))
+
+    ofd = open(tmp_oname, "w+b")     # Open temp file to write
+    ofd.write(buffered_text)        # Write edited YAML
+
+    current_location = len(buffered_text)
+    block_index = []
+    alloc_loc = 14      # 4 bytes of block ID, 2 blocks of size, 8 blocks into header
+    block_chunk = 2048
+    while True:
+        next_block = get_next_block_header(ifd)
+        if next_block is None:
+            break
+
+        # Get block size on disk
+        alloc = struct.unpack(">Q", next_block[alloc_loc:alloc_loc+8])[0]
+
+        # Save block location for block index
+        block_index.append(current_location)
+        current_location = current_location + len(next_block) + alloc
+
+        # Copy block
+        ofd.write(next_block)
+        while alloc >= block_chunk:
+            chunk = ifd.read(block_chunk)
+            ofd.write(chunk)
+            alloc -= block_chunk
+        if alloc>0:
+            chunk = ifd.read(alloc)
+            ofd.write(chunk)
+
+
+    write_block_index(ofd, block_index)
+
+    # Rename temp file.
+    os.rename(tmp_oname, oname)
+
+    # Output message to user.
+    delim = '*' * 70
+    print(f"\n{delim}")
+    print(f"The text in '{fname}' was too large to simply overwrite the")
+    print(f"text in '{oname}'.  The file '{oname}' was rewritten to")
+    print(f"accommodate the larger text size.")
+    print(f"Also, added a '\\n' and {buffer_size:,} spaces as a buffer for")
+    print(f"the text in '{oname}' to allow for future edits.")
+    print(f"{delim}\n")
+
+def save_func(fname, oname):
+    """
+    Checks to makes sure a corresponding ASDF file exists.  This is done by
+        seeing if a file of the same name with '.asdf' as an extension exists.
+    Checks to makes sure fname is a valid YAML file.
+    If the YAML text is smaller than the YAML text in the ASDF file
+        overwrite the YAML in the ASDF file.
+    If the YAML text is smaller than the YAML text in the ASDF file
+        If the file is small, then rewrite file.
+        If the file is large, ask if rewrite is desired.
+
+    Parameters
+    ----------
+    fname : The input YAML file.
+    oname : The output ASDF file name.
+    """
+
+    if not is_valid_yaml_path(fname):
+        return False
+
+    if not is_valid_asdf_path(oname):
+        return False
+
+    # Validate input file is an ASDF formatted YAML.
+    ifd, iasdf_text = open_and_check_asdf_header(fname)
+    iyaml_text = read_and_validate_yaml(ifd, fname)
+    ifd.close()
+    edited_text = iasdf_text + iyaml_text
+
+    # Get text from ASDF file.
+    ofd, oasdf_text = open_and_check_asdf_header(oname)
+    oyaml_text = read_and_validate_yaml(ofd, oname)
+    ofd.close()
+    asdf_text = oasdf_text + oyaml_text
+
+    # Compare text sizes and maybe output.
+    # There are three cases:
+    msg_delim = '*' * 70
+    if len(edited_text) == len(asdf_text):
+        with open(oname, "r+b") as fd:
+            fd.write(edited_text)
+        print(f"\n{msg_delim}")
+        print(f"The edited text in '{fname}' was written to '{oname}'")
+        print(f"{msg_delim}\n")
+    elif len(edited_text) < len(asdf_text):
+        buffered_text, diff = buffer_edited_text(edited_text, asdf_text)
+        with open(oname, "r+b") as fd:
+            fd.write(buffered_text)
+        print(f"\n{msg_delim}")
+        print(f"The edited text in '{fname}' was written to '{oname}'")
+        print(f"Added a  '\\n' and {diff} buffer of spaces between the YAML text and binary blocks.")
+        print(f"{msg_delim}\n")
+    else:
+        rewrite_asdf_file(edited_text, asdf_text, oname, fname)
+
+    return
+
+def edit(args):
+    """
+    Implode a given ASDF file, which may reference external data, back
+    into a single ASDF file.
+
+    Parameters
+    ----------
+    args : The command line arguments.
+    """
+    if args.edit:
+        return edit_func(args.fname, args.oname)
+    elif args.save:
+        return save_func(args.fname, args.oname)
+    else:
+        return print("Invalid arguments")

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -34,11 +34,11 @@ def _create_edited_yaml(base_yaml, edited_yaml, pattern, replacement):
             fd.write(new_content)
 
 
-def _initialize_test(tmpdir, version, test_name):
-    asdf_base = os.path.join(tmpdir, f"{test_name}_base.asdf")
-    yaml_base = os.path.join(tmpdir, f"{test_name}_base.yaml")
-    asdf_edit = os.path.join(tmpdir, f"{test_name}_edit.asdf")
-    yaml_edit = os.path.join(tmpdir, f"{test_name}_edit.yaml")
+def _initialize_test(tmpdir, version):
+    asdf_base = os.path.join(tmpdir, f"base.asdf")
+    yaml_base = os.path.join(tmpdir, f"base.yaml")
+    asdf_edit = os.path.join(tmpdir, f"edit.asdf")
+    yaml_edit = os.path.join(tmpdir, f"edit.yaml")
 
     _create_base_asdf(version, asdf_base)
     _create_base_asdf(version, asdf_edit)
@@ -52,7 +52,7 @@ def _initialize_test(tmpdir, version, test_name):
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_smaller(tmpdir, version):
     asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
-        tmpdir, version, "smaller"
+        tmpdir, version
     )
 
     _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 2")
@@ -68,7 +68,7 @@ def test_edit_smaller(tmpdir, version):
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_equal(tmpdir, version):
     asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
-        tmpdir, version, "equal"
+        tmpdir, version
     )
 
     _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 41")
@@ -81,10 +81,11 @@ def test_edit_equal(tmpdir, version):
         assert af.tree["foo"] == 41
 
 
+"""
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_larger(tmpdir, version):
     asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
-        tmpdir, version, "larger"
+        tmpdir, version
     )
 
     _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 42\nbar: 13")
@@ -95,3 +96,6 @@ def test_edit_larger(tmpdir, version):
 
     with asdf.open(asdf_edit) as af:
         assert "bar" in af.tree
+
+#TODO - Test stream
+"""

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -23,8 +23,8 @@ def _create_base_asdf(version, oname):
         "sequence": seq,
     }
 
-    af = asdf.AsdfFile(tree, version=version)
-    af.write_to(oname)
+    with asdf.AsdfFile(tree, version=version) as af:
+        af.write_to(oname)
 
 
 def _create_edited_yaml(base_yaml, edited_yaml, pattern, replacement):
@@ -52,7 +52,9 @@ def _initialize_test(tmpdir, version, test_name):
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_smaller(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version, "smaller")
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
+        tmpdir, version, "smaller"
+    )
 
     _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 2")
 
@@ -66,7 +68,9 @@ def test_edit_smaller(tmpdir, version):
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_equal(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version, "equal")
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
+        tmpdir, version, "equal"
+    )
 
     _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 41")
 
@@ -80,7 +84,9 @@ def test_edit_equal(tmpdir, version):
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_larger(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version, "larger")
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
+        tmpdir, version, "larger"
+    )
 
     _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 42\nbar: 13")
 

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -49,15 +49,11 @@ def _create_edited_yaml(base_yaml, edited_yaml, pattern, replacement):
 
 
 def _initialize_test(tmpdir, version, create_asdf):
-    asdf_base = os.path.join(tmpdir, f"base.asdf")
-    yaml_base = os.path.join(tmpdir, f"base.yaml")
-    asdf_edit = os.path.join(tmpdir, f"edit.asdf")
-    yaml_edit = os.path.join(tmpdir, f"edit.yaml")
+    asdf_base = os.path.join(tmpdir, "base.asdf")
+    yaml_base = os.path.join(tmpdir, "base.yaml")
+    asdf_edit = os.path.join(tmpdir, "edit.asdf")
+    yaml_edit = os.path.join(tmpdir, "edit.yaml")
 
-    """
-    _create_base_asdf(version, asdf_base)
-    _create_base_asdf(version, asdf_edit)
-    """
     create_asdf(version, asdf_base)
     create_asdf(version, asdf_edit)
 

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -27,7 +27,7 @@ def _create_base_asdf(version, oname):
 
 
 def _create_edited_yaml(base_yaml, edited_yaml, pattern, replacement):
-    with open(base_yaml,"rb") as fd:
+    with open(base_yaml, "rb") as fd:
         content = fd.read()
         new_content = re.sub(pattern, replacement, content)
         with open(edited_yaml, "wb") as fd:

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 
 import numpy as np
@@ -10,30 +11,7 @@ from asdf.commands import main
 from ...tests.helpers import get_file_sizes, assert_tree_match
 
 
-
-"""
-Three tests are defined.  
-
-1. Run the command 'asdftool edit -e' to create a YAML file, simulating
-   the steps a user would make to start editing an ASDF file.
-2. Run the command 'asdftool edit -s' to save YAML edits such that the
-   edited YAML will have the same or fewer characters as the original
-   ASDF file, so will be overwritten in place with the space character
-   used as any buffer, to consume all the memory on disk the YAML takes
-   up in the ASDF file.
-2. Run the command 'asdftool edit -s' to save YAML edits such that the
-   edited YAML will have the more characters than the original ASDF file.
-   This triggers a rewrite of the file, since there isn't enough 'room' 
-   on disk to accomadate the edited YAML.  The resultant YAML will be 
-   rewritten with a buffer (using the space character as buffer) to 
-   accomodate future edits.  If a block index existed in the original ASDF
-   file, it will need to be recomputed and if one didn't exist, it will be
-   added to the resultant ASDF file.  
-"""
-
-
-
-def create_base_asdf(tmpdir, version):
+def _create_base_asdf(version, oname):
     """
     In the test temp directory, create a base ASDF file to edit
     and test against.
@@ -47,184 +25,71 @@ def create_base_asdf(tmpdir, version):
         "sequence": seq,
     }
 
-    fname = "test_edit_base.asdf"
-    oname = os.path.join(tmpdir, fname)
-    if os.path.exists(oname):
-        os.remove(oname)
-    af = asdf.AsdfFile(tree,version=version)
+    af = asdf.AsdfFile(tree, version=version)
     af.write_to(oname)
 
-    return oname
+
+def _create_edited_yaml(base_yaml, edited_yaml, pattern, replacement):
+    with open(base_yaml) as fd:
+        content = fd.read()
+        new_content = re.sub(pattern, replacement, content)
+        with open(edited_yaml, "w") as fd:
+            fd.write(new_content)
 
 
-def create_edit_equal(base_yaml):
-    """
-    The YAML from the base ASDF file will have a 'foo' value of 42.  Create
-    an edited YAML file with this value being 41.  This will create an edited
-    YAML file with the same number of characters in the YAML section as was in
-    the original ASDF file.
-    """
-    with open(base_yaml, "r") as fd:
-        lines = fd.readlines()
+def _initialize_test(tmpdir, version):
+    asdf_base = os.path.join(tmpdir, "base.asdf")
+    yaml_base = os.path.join(tmpdir, "base.yaml")
+    asdf_edit = os.path.join(tmpdir, "edit.asdf")
+    yaml_edit = os.path.join(tmpdir, "edit.yaml")
 
-    base, ext = os.path.splitext(base_yaml)
-    oname = f"{base}_edit_equal.yaml"
-    if os.path.exists(oname):
-        os.remove(oname)
-    with open(oname, "w") as fd:
-        for l in lines:
-            if "foo" in l:
-                print("foo: 41", file=fd)  #  Change a value
-            else:
-                fd.write(l)
+    _create_base_asdf(version,asdf_base)
+    shutil.copyfile(asdf_base, asdf_edit)
 
-    return oname
-
-
-def create_edit_smaller(base_yaml):
-    """
-    The YAML from the base ASDF file will have a 'foo' value of 42.  Create
-    an edited YAML file with this value being 41.  This will create an edited
-    YAML file with the same number of characters in the YAML section as was in
-    the original ASDF file.
-    """
-    with open(base_yaml, "r") as fd:
-        lines = fd.readlines()
-
-    base, ext = os.path.splitext(base_yaml)
-    oname = f"{base}_edit_smaller.yaml"
-    if os.path.exists(oname):
-        os.remove(oname)
-    with open(oname, "w") as fd:
-        for l in lines:
-            if "foo" in l:
-                print("foo: 2", file=fd)  #  Change a value
-            else:
-                fd.write(l)
-
-    return oname
-
-
-def create_edit_larger(base_yaml):
-    """
-    The YAML from the base ASDF file will have a 'foo' value.  After this
-    line, add another line.  This will create an edited YAML file that will
-    have more characters than the YAML portion of the original ASDF file.
-    """
-    with open(base_yaml, "r") as fd:
-        lines = fd.readlines()
-
-    base, ext = os.path.splitext(base_yaml)
-    oname = f"{base}_edit_larger.yaml"
-    if os.path.exists(oname):
-        os.remove(oname)
-    with open(oname, "w") as fd:
-        for l in lines:
-            fd.write(l)
-            if "foo" in l:
-                print("bar: 13", file=fd)  # Add a line
-
-    return oname
-
-
-def copy_base_asdf_equal(base_asdf):
-    """
-    Create an ASDF file from the base ASDF file to test the editing of the
-    YAML portion with equal number of YAML characters.
-    """
-    base, ext = os.path.splitext(base_asdf)
-    oname = f"{base}_equal.asdf"
-    if os.path.exists(oname):
-        os.remove(oname)
-    shutil.copyfile(base_asdf, oname)
-
-    return oname
-
-
-def copy_base_asdf_smaller(base_asdf):
-    """
-    Create an ASDF file from the base ASDF file to test the editing of the
-    YAML portion with equal number of YAML characters.
-    """
-    base, ext = os.path.splitext(base_asdf)
-    oname = f"{base}_smaller.asdf"
-    if os.path.exists(oname):
-        os.remove(oname)
-    shutil.copyfile(base_asdf, oname)
-
-    return oname
-
-
-def copy_base_asdf_larger(base_asdf):
-    """
-    Create an ASDF file from the base ASDF file to test the editing of the
-    YAML portion with a larger number of YAML characters.
-    """
-    base, ext = os.path.splitext(base_asdf)
-    oname = f"{base}_larger.asdf"
-    if os.path.exists(oname):
-        os.remove(oname)
-    shutil.copyfile(base_asdf, oname)
-
-    return oname
-
-
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edits(tmpdir,version):
-    #        Test:
-    # Create base ASDF file for testing
-    asdf_base = create_base_asdf(tmpdir, version)
-
-    # Create base YAML file from base ASDF file
-    base, ext = os.path.splitext(asdf_base)
-    yaml_base = f"{base}.yaml"
-    # Run: asdftool edit -e -f {asdf_base} -o {yaml_base}
     args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{yaml_base}"]
     main.main_from_args(args)
 
-    # Test smaller
-    # Create ASDF file to edit with larger sized YAML
-    asdf_smaller = copy_base_asdf_smaller(asdf_base)
+    return asdf_base, yaml_base, asdf_edit, yaml_edit
 
-    # Create edited YAML file with larger number of characters
-    yaml_smaller = create_edit_smaller(yaml_base)
 
-    # Run: asdftool edit -s -f {yaml_larger} -o {asdf_larger}
-    args = ["edit", "-s", "-f", f"{yaml_smaller}", "-o", f"{asdf_smaller}"]
-    main.main_from_args(args)
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_smaller(tmpdir, version):
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version)
 
-    af_smaller = asdf.open(asdf_smaller)
-    assert af_smaller.tree["foo"] == 2
-    assert os.path.getsize(asdf_smaller) == os.path.getsize(asdf_base)
+    _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 2")
 
-    # Test equal
-    # Create ASDF file to edit with equal sized YAML
-    asdf_equal = copy_base_asdf_equal(asdf_base)
+    args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
+    ret = main.main_from_args(args)
+    assert 0==ret
 
-    # Create edited YAML file with equal number of characters
-    yaml_equal = create_edit_equal(yaml_base)
+    with asdf.open(asdf_edit) as af:
+        assert af.tree["foo"] == 2
+        assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
-    # Save edits to ASDF files
-    # Run: asdftool edit -s -f {yaml_equal} -o {asdf_equal}
-    args = ["edit", "-s", "-f", f"{yaml_equal}", "-o", f"{asdf_equal}"]
-    print(f"args = {args}")
-    main.main_from_args(args)
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_equal(tmpdir, version):
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version)
 
-    af_equal = asdf.open(asdf_equal)
-    assert af_equal.tree["foo"] == 41
-    assert os.path.getsize(asdf_equal) == os.path.getsize(asdf_base)
+    _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 41")
 
-    # Test larger
-    # Create ASDF file to edit with larger sized YAML
-    asdf_larger = copy_base_asdf_larger(asdf_base)
+    args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
+    ret = main.main_from_args(args)
+    assert 0==ret
 
-    # Create edited YAML file with larger number of characters
-    yaml_larger = create_edit_larger(yaml_base)
+    with asdf.open(asdf_edit) as af:
+        assert af.tree["foo"] == 41
+        assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
-    # Run: asdftool edit -s -f {yaml_larger} -o {asdf_larger}
-    args = ["edit", "-s", "-f", f"{yaml_larger}", "-o", f"{asdf_larger}"]
-    main.main_from_args(args)
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_larger(tmpdir, version):
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version)
 
-    af_larger = asdf.open(asdf_larger)
-    assert "bar" in af_larger.tree
-    assert os.path.getsize(asdf_larger) - os.path.getsize(asdf_base) > 10000
+    _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 41\nbar: 13")
+
+    args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
+    ret = main.main_from_args(args)
+    assert 0==ret
+
+    with asdf.open(asdf_edit) as af:
+        assert "bar" in af.tree
+        assert os.path.getsize(asdf_edit) - os.path.getsize(asdf_base) > 10000

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -27,10 +27,10 @@ def _create_base_asdf(version, oname):
 
 
 def _create_edited_yaml(base_yaml, edited_yaml, pattern, replacement):
-    with open(base_yaml) as fd:
+    with open(base_yaml,"rb") as fd:
         content = fd.read()
         new_content = re.sub(pattern, replacement, content)
-        with open(edited_yaml, "w") as fd:
+        with open(edited_yaml, "wb") as fd:
             fd.write(new_content)
 
 
@@ -55,7 +55,7 @@ def test_edit_smaller(tmpdir, version):
         tmpdir, version, "smaller"
     )
 
-    _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 2")
+    _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 2")
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
     main.main_from_args(args)
@@ -71,7 +71,7 @@ def test_edit_equal(tmpdir, version):
         tmpdir, version, "equal"
     )
 
-    _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 41")
+    _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 41")
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
     main.main_from_args(args)
@@ -87,7 +87,7 @@ def test_edit_larger(tmpdir, version):
         tmpdir, version, "larger"
     )
 
-    _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 42\nbar: 13")
+    _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 42\nbar: 13")
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
     main.main_from_args(args)

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -35,11 +35,11 @@ def _create_edited_yaml(base_yaml, edited_yaml, pattern, replacement):
             fd.write(new_content)
 
 
-def _initialize_test(tmpdir, version):
-    asdf_base = os.path.join(tmpdir, "base.asdf")
-    yaml_base = os.path.join(tmpdir, "base.yaml")
-    asdf_edit = os.path.join(tmpdir, "edit.asdf")
-    yaml_edit = os.path.join(tmpdir, "edit.yaml")
+def _initialize_test(tmpdir, version, test_name):
+    asdf_base = os.path.join(tmpdir, f"{test_name}_base.asdf")
+    yaml_base = os.path.join(tmpdir, f"{test_name}_base.yaml")
+    asdf_edit = os.path.join(tmpdir, f"{test_name}_edit.asdf")
+    yaml_edit = os.path.join(tmpdir, f"{test_name}_edit.yaml")
 
     _create_base_asdf(version, asdf_base)
     shutil.copyfile(asdf_base, asdf_edit)
@@ -52,12 +52,12 @@ def _initialize_test(tmpdir, version):
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_smaller(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version)
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version, "smaller")
 
     _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 2")
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
-    ret = main.main_from_args(args)
+    main.main_from_args(args)
     assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
     with asdf.open(asdf_edit) as af:
@@ -66,12 +66,12 @@ def test_edit_smaller(tmpdir, version):
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_equal(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version)
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version, "equal")
 
     _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 41")
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
-    ret = main.main_from_args(args)
+    main.main_from_args(args)
     assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
     with asdf.open(asdf_edit) as af:
@@ -80,12 +80,12 @@ def test_edit_equal(tmpdir, version):
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_larger(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version)
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version, "larger")
 
     _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 42\nbar: 13")
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
-    ret = main.main_from_args(args)
+    main.main_from_args(args)
     assert os.path.getsize(asdf_edit) - os.path.getsize(asdf_base) > 10000
 
     with asdf.open(asdf_edit) as af:

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -173,7 +173,6 @@ def copy_base_asdf_larger(base_asdf):
 def test_edits(tmpdir,version):
     #        Test:
     # Create base ASDF file for testing
-    tmpdir = "/Users/kmacdonald/tmp"
     asdf_base = create_base_asdf(tmpdir, version)
 
     # Create base YAML file from base ASDF file

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -1,6 +1,5 @@
 import os
 import re
-import shutil
 
 import numpy as np
 import pytest
@@ -42,7 +41,7 @@ def _initialize_test(tmpdir, version, test_name):
     yaml_edit = os.path.join(tmpdir, f"{test_name}_edit.yaml")
 
     _create_base_asdf(version, asdf_base)
-    shutil.copyfile(asdf_base, asdf_edit)
+    _create_base_asdf(version, asdf_edit)
 
     args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{yaml_base}"]
     main.main_from_args(args)

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -27,13 +27,23 @@ def _create_base_asdf(version, oname):
     In the test temp directory, create a base ASDF file to edit
     and test against.
     """
-    seq = np.arange(100)
+    seq = np.arange(713)
 
     # Store the data in an arbitrarily nested dictionary
     tree = {
         "foo": 42,
         "name": "Monty",
         "sequence": seq,
+    }
+
+    with asdf.AsdfFile(tree, version=version) as af:
+        af.write_to(oname)
+
+
+def _create_base_asdf_no_blocks(version, oname):
+    tree = {
+        "foo": 42,
+        "name": "Monty",
     }
 
     with asdf.AsdfFile(tree, version=version) as af:
@@ -61,6 +71,86 @@ def _initialize_test(tmpdir, version, create_asdf):
     main.main_from_args(args)
 
     return asdf_base, yaml_base, asdf_edit, yaml_edit
+
+
+# --------------- Tests ---------------
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_tack_s_bad_args_bad_f(tmpdir, version):
+    asdf_base = os.path.join(tmpdir, "base.asdf")
+
+    args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{asdf_base}"]
+    with pytest.raises(SystemExit) as e:
+        main.main(args)
+    assert e.value.code == 1
+
+
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_tack_s_bad_args_bad_o(tmpdir, version):
+    yaml_base = os.path.join(tmpdir, "base.yaml")
+
+    args = ["edit", "-e", "-f", f"{yaml_base}", "-o", f"{yaml_base}"]
+    with pytest.raises(SystemExit) as e:
+        main.main(args)
+    assert e.value.code == 1
+
+
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_tack_e_bad_args_bad_o(tmpdir, version):
+    asdf_base = os.path.join(tmpdir, "base.asdf")
+
+    args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{asdf_base}"]
+    with pytest.raises(SystemExit) as e:
+        main.main(args)
+    assert e.value.code == 1
+
+
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_tack_e_bad_args_bad_f(tmpdir, version):
+    yaml_base = os.path.join(tmpdir, "base.yaml")
+
+    args = ["edit", "-e", "-f", f"{yaml_base}", "-o", f"{yaml_base}"]
+    with pytest.raises(SystemExit) as e:
+        main.main(args)
+    assert e.value.code == 1
+
+
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_bad_args(tmpdir, version):
+    asdf_base = os.path.join(tmpdir, "base.asdf")
+
+    args = ["edit", "-e", "-f", f"{asdf_base}"]
+    with pytest.raises(SystemExit) as e:
+        main.main(args)
+    assert e.value.code == 2
+
+
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_save_to_no_binary(tmpdir, version):
+    asdf_base = os.path.join(tmpdir, "base.asdf")
+    yaml_base = os.path.join(tmpdir, "base.yaml")
+    yaml_edit = os.path.join(tmpdir, "edit.yaml")
+
+    _create_base_asdf_no_blocks(version, asdf_base)
+    _create_base_asdf_no_blocks(version, yaml_base)
+
+    _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 2")
+
+    args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_base}"]
+    with pytest.raises(SystemExit) as e:
+        main.main(args)
+    assert e.value.code == 1
+
+
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edit_no_binary(tmpdir, version):
+    asdf_base = os.path.join(tmpdir, "base.asdf")
+    yaml_base = os.path.join(tmpdir, "base.yaml")
+    _create_base_asdf_no_blocks(version, asdf_base)
+
+    args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{yaml_base}"]
+    with pytest.raises(SystemExit) as e:
+        main.main(args)
+    assert e.value.code == 1
 
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -2,11 +2,13 @@ import os
 import shutil
 
 import numpy as np
+import pytest
 
 import asdf
 from asdf import AsdfFile
 from asdf.commands import main
 from ...tests.helpers import get_file_sizes, assert_tree_match
+
 
 
 """
@@ -30,7 +32,8 @@ Three tests are defined.
 """
 
 
-def create_base_asdf(tmpdir):
+
+def create_base_asdf(tmpdir, version):
     """
     In the test temp directory, create a base ASDF file to edit
     and test against.
@@ -48,7 +51,7 @@ def create_base_asdf(tmpdir):
     oname = os.path.join(tmpdir, fname)
     if os.path.exists(oname):
         os.remove(oname)
-    af = asdf.AsdfFile(tree)
+    af = asdf.AsdfFile(tree,version=version)
     af.write_to(oname)
 
     return oname
@@ -166,11 +169,12 @@ def copy_base_asdf_larger(base_asdf):
     return oname
 
 
-def test_edits(tmpdir):
+@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
+def test_edits(tmpdir,version):
     #        Test:
     # Create base ASDF file for testing
     tmpdir = "/Users/kmacdonald/tmp"
-    asdf_base = create_base_asdf(tmpdir)
+    asdf_base = create_base_asdf(tmpdir, version)
 
     # Create base YAML file from base ASDF file
     base, ext = os.path.splitext(asdf_base)

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -61,10 +61,10 @@ def test_edit_smaller(tmpdir, version):
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
     ret = main.main_from_args(args)
     assert 0==ret
+    assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
     with asdf.open(asdf_edit) as af:
         assert af.tree["foo"] == 2
-        assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_equal(tmpdir, version):
@@ -75,21 +75,21 @@ def test_edit_equal(tmpdir, version):
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
     ret = main.main_from_args(args)
     assert 0==ret
+    assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
     with asdf.open(asdf_edit) as af:
         assert af.tree["foo"] == 41
-        assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_larger(tmpdir, version):
     asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version)
 
-    _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 41\nbar: 13")
+    _create_edited_yaml(yaml_base, yaml_edit, "foo: 42", "foo: 42\nbar: 13")
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
     ret = main.main_from_args(args)
     assert 0==ret
+    assert os.path.getsize(asdf_edit) - os.path.getsize(asdf_base) > 10000
 
     with asdf.open(asdf_edit) as af:
         assert "bar" in af.tree
-        assert os.path.getsize(asdf_edit) - os.path.getsize(asdf_base) > 10000

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -51,9 +51,7 @@ def _initialize_test(tmpdir, version):
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_smaller(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
-        tmpdir, version
-    )
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version)
 
     _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 2")
 
@@ -67,9 +65,7 @@ def test_edit_smaller(tmpdir, version):
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_equal(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
-        tmpdir, version
-    )
+    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(tmpdir, version)
 
     _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 41")
 

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -109,6 +109,7 @@ def test_edit_larger(tmpdir, version):
 
     with asdf.open(asdf_edit) as af:
         assert "bar" in af.tree
+        assert af.tree["bar"] == 13
 
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
@@ -125,3 +126,4 @@ def test_edit_larger_stream(tmpdir, version):
 
     with asdf.open(asdf_edit) as af:
         assert "bar" in af.tree
+        assert af.tree["bar"] == 13

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -6,9 +6,7 @@ import numpy as np
 import pytest
 
 import asdf
-from asdf import AsdfFile
 from asdf.commands import main
-from ...tests.helpers import get_file_sizes, assert_tree_match
 
 
 def _create_base_asdf(version, oname):
@@ -43,7 +41,7 @@ def _initialize_test(tmpdir, version):
     asdf_edit = os.path.join(tmpdir, "edit.asdf")
     yaml_edit = os.path.join(tmpdir, "edit.yaml")
 
-    _create_base_asdf(version,asdf_base)
+    _create_base_asdf(version, asdf_base)
     shutil.copyfile(asdf_base, asdf_edit)
 
     args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{yaml_base}"]
@@ -60,11 +58,11 @@ def test_edit_smaller(tmpdir, version):
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
     ret = main.main_from_args(args)
-    assert 0==ret
     assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
     with asdf.open(asdf_edit) as af:
         assert af.tree["foo"] == 2
+
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_equal(tmpdir, version):
@@ -74,11 +72,11 @@ def test_edit_equal(tmpdir, version):
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
     ret = main.main_from_args(args)
-    assert 0==ret
     assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
 
     with asdf.open(asdf_edit) as af:
         assert af.tree["foo"] == 41
+
 
 @pytest.mark.parametrize("version", asdf.versioning.supported_versions)
 def test_edit_larger(tmpdir, version):
@@ -88,7 +86,6 @@ def test_edit_larger(tmpdir, version):
 
     args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
     ret = main.main_from_args(args)
-    assert 0==ret
     assert os.path.getsize(asdf_edit) - os.path.getsize(asdf_base) > 10000
 
     with asdf.open(asdf_edit) as af:

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -1,0 +1,178 @@
+import os
+import shutil
+
+import numpy as np
+
+import asdf
+from asdf import AsdfFile
+from asdf.commands import main
+from ...tests.helpers import get_file_sizes, assert_tree_match
+
+
+"""
+Three tests are defined.  
+
+1. Run the command 'asdftool edit -e' to create a YAML file, simulating
+   the steps a user would make to start editing an ASDF file.
+2. Run the command 'asdftool edit -s' to save YAML edits such that the
+   edited YAML will have the same or fewer characters as the original
+   ASDF file, so will be overwritten in place with the space character
+   used as any buffer, to consume all the memory on disk the YAML takes
+   up in the ASDF file.
+2. Run the command 'asdftool edit -s' to save YAML edits such that the
+   edited YAML will have the more characters than the original ASDF file.
+   This triggers a rewrite of the file, since there isn't enough 'room' 
+   on disk to accomadate the edited YAML.  The resultant YAML will be 
+   rewritten with a buffer (using the space character as buffer) to 
+   accomodate future edits.  If a block index existed in the original ASDF
+   file, it will need to be recomputed and if one didn't exist, it will be
+   added to the resultant ASDF file.  
+"""
+
+
+def create_base_asdf(tmpdir):
+    """
+    In the test temp directory, create a base ASDF file to edit
+    and test against.
+    """
+    seq = np.arange(100)
+
+    # Store the data in an arbitrarily nested dictionary
+    tree = {
+        "foo": 42,
+        "name": "Monty",
+        "sequence": seq,
+    }
+
+    fname = "test_edit_base.asdf"
+    oname = os.path.join(tmpdir, fname)
+    if os.path.exists(oname):
+        os.remove(oname)
+    af = asdf.AsdfFile(tree)
+    af.write_to(oname)
+
+    return oname
+
+
+def create_edit_equal(base_yaml):
+    """
+    The YAML from the base ASDF file will have a 'foo' value of 42.  Create
+    an edited YAML file with this value being 41.  This will create an edited
+    YAML file with the same number of characters in the YAML section as was in
+    the original ASDF file.
+    """
+    with open(base_yaml, "r") as fd:
+        lines = fd.readlines()
+
+    base, ext = os.path.splitext(base_yaml)
+    oname = f"{base}_edit_equal.yaml"
+    if os.path.exists(oname):
+        os.remove(oname)
+    with open(oname, "w") as fd:
+        for l in lines:
+            if "foo" in l:
+                print("foo: 41", file=fd)  #  Change a value
+            else:
+                fd.write(l)
+
+    return oname
+
+
+added_line = "bar: 13"
+
+
+def create_edit_larger(base_yaml):
+    """
+    The YAML from the base ASDF file will have a 'foo' value.  After this
+    line, add another line.  This will create an edited YAML file that will
+    have more characters than the YAML portion of the original ASDF file.
+    """
+    with open(base_yaml, "r") as fd:
+        lines = fd.readlines()
+
+    base, ext = os.path.splitext(base_yaml)
+    oname = f"{base}_edit_larger.yaml"
+    if os.path.exists(oname):
+        os.remove(oname)
+    with open(oname, "w") as fd:
+        for l in lines:
+            fd.write(l)
+            if "foo" in l:
+                print(f"{added_line}", file=fd)  # Add a line
+
+    return oname
+
+
+def copy_base_asdf_equal(base_asdf):
+    """
+    Create an ASDF file from the base ASDF file to test the editing of the
+    YAML portion with equal number of YAML characters.
+    """
+    base, ext = os.path.splitext(base_asdf)
+    oname = f"{base}_equal.asdf"
+    if os.path.exists(oname):
+        os.remove(oname)
+    shutil.copyfile(base_asdf, oname)
+
+    return oname
+
+
+def copy_base_asdf_larger(base_asdf):
+    """
+    Create an ASDF file from the base ASDF file to test the editing of the
+    YAML portion with a larger number of YAML characters.
+    """
+    base, ext = os.path.splitext(base_asdf)
+    oname = f"{base}_larger.asdf"
+    if os.path.exists(oname):
+        os.remove(oname)
+    shutil.copyfile(base_asdf, oname)
+
+    return oname
+
+
+def test_edits(tmpdir):
+    #        Test:
+    # Create base ASDF file for testing
+    tmpdir = "/Users/kmacdonald/tmp"
+    asdf_base = create_base_asdf(tmpdir)
+
+    # Create base YAML file from base ASDF file
+    base, ext = os.path.splitext(asdf_base)
+    yaml_base = f"{base}.yaml"
+    # Run: asdftool edit -e -f {asdf_base} -o {yaml_base}
+    args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{yaml_base}"]
+    main.main_from_args(args)
+
+
+    # Create ASDF file to edit with equal sized YAML
+    asdf_equal = copy_base_asdf_equal(asdf_base)
+
+    # Create edited YAML file with equal number of characters
+    yaml_equal = create_edit_equal(yaml_base)
+
+    # Save edits to ASDF files
+    # Run: asdftool edit -s -f {yaml_equal} -o {asdf_equal}
+    args = ["edit", "-s", "-f", f"{yaml_equal}", "-o", f"{asdf_equal}"]
+    print(f"args = {args}")
+    main.main_from_args(args)
+
+    af_equal = asdf.open(asdf_equal)
+    assert af_equal.tree["foo"] == 41
+    assert os.path.getsize(asdf_equal) == os.path.getsize(asdf_base) 
+
+
+
+    # Create ASDF file to edit with larger sized YAML
+    asdf_larger = copy_base_asdf_larger(asdf_base)
+
+    # Create edited YAML file with larger number of characters
+    yaml_larger = create_edit_larger(yaml_base)
+
+    # Run: asdftool edit -s -f {yaml_larger} -o {asdf_larger}
+    args = ["edit", "-s", "-f", f"{yaml_larger}", "-o", f"{asdf_larger}"]
+    main.main_from_args(args)
+
+    af_larger = asdf.open(asdf_larger)
+    assert "bar" in af_larger.tree
+    assert os.path.getsize(asdf_larger) - os.path.getsize(asdf_base) > 10000


### PR DESCRIPTION
I have added an 'edit' subcommand to the asdftool.  It separates the ASDF markings and YAML text into a separate file to be edited, using
```
asdftool -e -f <ASDF file> -o <YAML file name>
```
Once editing the YAML is complete, use 
```
asdftool -s -f <edited YAML file> -o <ASDF to save YAML to>
```
There may be a gotcha when saving the edited YAML back to ASDF file.  If the edited YAML contains for characters than the number of characters before the binary blocks in the ASDF file, an error message is returned.