### PR TITLE
Tweaks to new extension code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@
 - Drop support for Python 3.5. [#856]
 
 - Add new extension API to support versioned extensions.
-  [#850, #851, #853, #857]
+  [#850, #851, #853, #857, #874]
 
 - Permit wildcard in tag validator URIs. [#858, #865]
 

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -48,7 +48,7 @@ class AsdfConfig:
 
         Returns
         -------
-        list of collections.abc.Mapping
+        list of asdf.resource.ResourceMappingProxy
         """
         if self._resource_mappings is None:
             with self._lock:
@@ -137,11 +137,11 @@ class AsdfConfig:
     @property
     def extensions(self):
         """
-        Get the list of registered `AsdfExtension` instances.
+        Get the list of registered extensions.
 
         Returns
         -------
-        list of asdf.extension.AsdfExtension or asdf.extension.Extension
+        list of asdf.extension.ExtensionProxy
         """
         if self._extensions is None:
             with self._lock:
@@ -196,30 +196,6 @@ class AsdfConfig:
 
         with self._lock:
             self._extensions = [e for e in self.extensions if not _remove_condition(e)]
-
-    def get_extension(self, extension_uri):
-        """
-        Get an extension by URI.
-
-        Parameters
-        ----------
-        extension_uri : str
-            The URI of the extension to fetch.
-
-        Returns
-        -------
-        asdf.extension.AsdfExtension or asdf.extension.Extension
-
-        Raises
-        ------
-        KeyError
-            If no such extension exists.
-        """
-        for extension in self.extensions:
-            if extension.extension_uri == extension_uri:
-                return extension
-
-        raise KeyError("No registered extension with URI '{}'".format(extension_uri))
 
     def reset_extensions(self):
         """

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -24,7 +24,19 @@ def get_extensions():
 
 def _list_entry_points(group, proxy_class):
     results = []
-    for entry_point in iter_entry_points(group=group):
+
+    entry_points = list(iter_entry_points(group=group))
+
+    # The order of plugins may be significant, since in the case of
+    # duplicate functionality the first plugin in the list takes
+    # precedence.  It's not clear if entry points are ordered
+    # in a consistent way across systems so we explicitly sort
+    # by package name.  Plugins from this package are placed
+    # at the end so that other packages can override them.
+    asdf_entry_points = [e for e in entry_points if e.dist.project_name == "asdf"]
+    other_entry_points = sorted([e for e in entry_points if e.dist.project_name != "asdf"], key=lambda e: e.dist.project_name)
+
+    for entry_point in other_entry_points + asdf_entry_points:
         package_name = entry_point.dist.project_name
         package_version = entry_point.dist.version
 

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -293,7 +293,7 @@ class ConverterProxy(Converter):
 
         Returns
         -------
-        asdf.extension.Extension
+        asdf.extension.ExtensionProxy
         """
         return self._extension
 

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -311,10 +311,14 @@ class ExtensionProxy(Extension, AsdfExtension):
         if self.package_name is None:
             package_description = "(none)"
         else:
-            package_description = "{}=={}".format(self.package_name, self.package_version)
+            package_description = f"{self.package_name}=={self.package_version}"
 
-        return "<ExtensionProxy class: {} package: {} legacy: {}>".format(
-            self.class_name,
-            package_description,
-            self.legacy,
+        if self.extension_uri is None:
+            uri_description = "(none)"
+        else:
+            uri_description = self.extension_uri
+
+        return (
+            f"<ExtensionProxy URI: {uri_description} class: {self.class_name} "
+            f"package: {package_description} legacy: {self.legacy}>"
         )

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -52,7 +52,7 @@ class ExtensionManager:
 
         Returns
         -------
-        list of asdf.extension.Extension
+        list of asdf.extension.ExtensionProxy
         """
         return self._extensions
 

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -199,9 +199,8 @@ class AsdfInFits(asdf.AsdfFile):
         extensions : object, optional
             Additional extensions to use when reading and writing the file.
             May be any of the following: `asdf.extension.AsdfExtension`,
-            `asdf.extension.Extension`, `str` extension URI,
-            `asdf.extension.AsdfExtensionList` or a `list` of URIs and/or
-            extensions.
+            `asdf.extension.Extension`, `asdf.extension.AsdfExtensionList`
+            or a `list` extensions.
 
         ignore_version_mismatch : bool, optional
             When `True`, do not raise warnings for mismatched schema versions.

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -273,27 +273,6 @@ def test_extensions():
         assert len(config.extensions) == len(original_extensions)
 
 
-def test_get_extension():
-    class FooExtension:
-        extension_uri = "asdf://somewhere.org/extensions/foo-1.0"
-        types = []
-        tag_mapping = []
-        url_mapping = []
-
-    with asdf.config_context() as config:
-        with pytest.raises(KeyError):
-            config.get_extension(FooExtension.extension_uri)
-
-        extension = FooExtension()
-        config.add_extension(extension)
-        config.get_extension(FooExtension.extension_uri).delegate is extension
-
-        # Extensions added later take precedence:
-        duplicate_extension = FooExtension()
-        config.add_extension(extension)
-        config.get_extension(FooExtension.extension_uri).delegate is duplicate_extension
-
-
 def test_config_repr():
     with asdf.config_context() as config:
         config.validate_on_read = True


### PR DESCRIPTION
Some fixes for issues that were uncovered while testing converters in asdf-astropy:

- Sort plugins by package name + plugins from the asdf package at the end so that extension packages can override built-in plugins.
- Change `AsdfFile.extensions` property to return "user extensions" only, that is to say, extensions that were passed in to `AsdfFile.__init__` or `asdf.open`.
- Update docstrings to note where `ExtensionProxy` is returned.
- Remove some features that allowed referring to extensions by URI.  I think I went a little overboard with implementing those before we had a real use case, they can always be revived later.
- Include the extension URI in the `ExtensionProxy` repr to aid in debugging.