### PR TITLE
Add bandit to CI jobs and fix or # nosec failed lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ jobs:
     # Do a code style check
     - env: TOXENV=style
 
+    # Bandit security audit:
+    - env: TOXENV=bandit
+
     # Check older numpy versions
     - env: TOXENV=py36-numpy11
       python: 3.6

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -478,7 +478,9 @@ class BlockManager:
 
         yaml_content = content[content.find(b'\n') + 1:]
 
-        offsets = yaml.load(yaml_content,
+        # The following call to yaml.load is safe because we're
+        # using pyyaml's SafeLoader.
+        offsets = yaml.load(yaml_content, # nosec
                             Loader=yamlutil._yaml_base_loader)
 
         # Make sure the indices look sane
@@ -909,7 +911,9 @@ class Block:
             self._checksum = checksum
 
     def _calculate_checksum(self, data):
-        m = hashlib.new('md5')
+        # The following line is safe because we're only using
+        # the MD5 as a checksum.
+        m = hashlib.new('md5') # nosec
         m.update(self.data.ravel('K'))
         return m.digest()
 
@@ -1115,7 +1119,9 @@ class Block:
             allocated_size = self.allocated
             used_size = self._size
         self.input_compression = self.output_compression
-        assert allocated_size >= used_size
+
+        if allocated_size < used_size:
+            raise RuntimeError(f"Block used size {used_size} larger than allocated size {allocated_size}")
 
         if self.checksum is not None:
             checksum = self.checksum
@@ -1153,7 +1159,8 @@ class Block:
                         used_size=self._size)
                     fd.seek(end)
             else:
-                assert used_size == data_size
+                if used_size != data_size:
+                    raise RuntimeError(f"Block used size {used_size} is not equal to the data size {data_size}")
                 fd.write_array(self._data)
 
     @property

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -100,7 +100,8 @@ class PrintTree:
         return print_list
 
     def __setitem__(self, node_list, visit):
-        assert isinstance(node_list, list)
+        if not isinstance(node_list, list):
+            raise TypeError("node_list parameter must be an instance of list")
         current = self.__tree
         for node in ['tree'] + node_list:
             if not node in current['children']:

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -57,9 +57,11 @@ class Resolver:
     def add_mapping(self, mappings, prefix=''):
         # Deprecating this because Resolver is used as part of a dictionary key
         # and so shouldn't be mutable.
-        assert prefix == self._prefix
-
         warnings.warn("The 'add_mapping' method is deprecated.", AsdfDeprecationWarning)
+
+        if prefix != self._prefix:
+            raise ValueError(f"Prefix '{prefix}' does not match the Resolver prefix '{self._prefix}'")
+
         self._mappings = self._mappings + self._validate_mappings(mappings)
 
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -350,7 +350,9 @@ def _load_schema(url):
             json_data = fd.read().decode('utf-8')
             result = json.loads(json_data, object_pairs_hook=OrderedDict)
         else:
-            result = yaml.load(fd, Loader=yamlutil.AsdfLoader)
+            # The following call to yaml.load is safe because we're
+            # using a loader that inherits from pyyaml's SafeLoader.
+            result = yaml.load(fd, Loader=yamlutil.AsdfLoader) # nosec
     return result, fd.uri
 
 
@@ -362,8 +364,10 @@ def _make_schema_loader(resolver):
         if url in resource_manager:
             content = resource_manager[url]
             # The jsonschema metaschemas are JSON, but pyyaml
-            # doesn't mind:
-            result = yaml.load(content, Loader=yamlutil.AsdfLoader)
+            # doesn't mind.
+            # The following call to yaml.load is safe because we're
+            # using a loader that inherits from pyyaml's SafeLoader.
+            result = yaml.load(content, Loader=yamlutil.AsdfLoader) # nosec
             return result, url
 
         # If not, fall back to fetching the schema the old way:

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -48,7 +48,8 @@ class IntegerType(AsdfType):
     _value_cache = dict()
 
     def __init__(self, value, storage_type='internal'):
-        assert storage_type in ['internal', 'inline'], "Invalid storage type given"
+        if storage_type not in ['internal', 'inline']:
+            raise ValueError(f"storage_type '{storage_type}' is not a recognized storage type")
         self._value = value
         self._sign = '-' if value < 0 else '+'
         self._storage = storage_type

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -465,7 +465,9 @@ class NDArrayType(AsdfType):
     def _assert_equality(cls, old, new, func):
         if old.dtype.fields:
             if not new.dtype.fields:
-                assert False, "arrays not equal"
+                # This line is safe because this is actually a piece of test
+                # code, even though it lives in this file:
+                assert False, "arrays not equal" # nosec
             for a, b in zip(old, new):
                 cls._assert_equality(a, b, func)
         else:
@@ -478,7 +480,9 @@ class NDArrayType(AsdfType):
                     new = new.astype('U')
                 old = old.tolist()
                 new = new.tolist()
-                assert old == new
+                # This line is safe because this is actually a piece of test
+                # code, even though it lives in this file:
+                assert old == new # nosec
             else:
                 func(old, new)
 

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -46,7 +46,9 @@ def get_version_map(version):
             '{url_suffix}', 'asdf/version_map-{0}'.format(version))
         try:
             with generic_io.get_file(version_map_path, 'r') as fd:
-                version_map = yaml.load(
+                # The following call to yaml.load is safe because we're
+                # using a loader that inherits from pyyaml's SafeLoader.
+                version_map = yaml.load( # nosec
                     fd, Loader=_yaml_base_loader)
         except Exception:
             raise ValueError(

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -355,7 +355,9 @@ def load_tree(stream):
     stream : readable file-like object
         Stream containing the raw YAML content.
     """
-    return yaml.load(stream, Loader=AsdfLoader)
+    # The following call to yaml.load is safe because we're
+    # using a loader that inherits from pyyaml's SafeLoader.
+    return yaml.load(stream, Loader=AsdfLoader) # nosec
 
 
 def dump_tree(tree, fd, ctx, tree_finalizer=None, _serialization_context=None):

--- a/tox.ini
+++ b/tox.ini
@@ -109,4 +109,4 @@ basepython= python3.8
 deps=
     bandit
 commands=
-    bandit -lll -r -x asdf/tests,asdf/commands/tests,asdf/tags/core/tests,asdf/extern asdf
+    bandit -r -x asdf/tests,asdf/commands/tests,asdf/tags/core/tests,asdf/extern asdf

--- a/tox.ini
+++ b/tox.ini
@@ -103,3 +103,10 @@ deps=
 extras= all,tests
 commands=
     pytest compatibility_tests/ --remote-data
+
+[testenv:bandit]
+basepython= python3.8
+deps=
+    bandit
+commands=
+    bandit -lll -r -x asdf/tests,asdf/commands/tests,asdf/tags/core/tests,asdf/extern asdf


### PR DESCRIPTION
This PR adds bandit to to the Travis jobs and fixes or marks `# nosec` failing lines in the non-test (and non-extern) code.