### PR TITLE
Make asdf compatible with Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ python: 3.8.6
 
 jobs:
   include:
+    # Python 3.9, stable dependencies
+    - name: Python 3.9
+      env: TOXENV=py39
+      python: 3.9.0
+
     # Python 3.8, stable dependencies
     - name: Python 3.8
       env: TOXENV=py38

--- a/asdf/conftest.py
+++ b/asdf/conftest.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from .tests.httpserver import HTTPServer, RangeHTTPServer
+from asdf.tests.httpserver import HTTPServer, RangeHTTPServer
 
 
 @pytest.fixture()

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -134,7 +134,7 @@ class DirectoryResourceMapping(Mapping):
 
     Parameters
     ----------
-    root : str or importlib.resources.abc.Traversable
+    root : str or importlib.abc.Traversable
         Root directory (or directory-like Traversable) of the resource
         files.  `str` will be interpreted as a filesystem path.
     uri_prefix : str

--- a/asdf/tests/test_resource.py
+++ b/asdf/tests/test_resource.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from collections.abc import Mapping
 
 if sys.version_info < (3, 9):
-    import importlib_resources
+    import importlib_resources as importlib
 else:
-    import importlib.resources as importlib_resources
+    import importlib
 
 import pytest
 
@@ -87,7 +87,7 @@ def test_directory_resource_mapping_with_traversable():
     Confirm that DirectoryResourceMapping doesn't use pathlib.Path
     methods outside of the Traversable interface.
     """
-    class MockTraversable(importlib_resources.abc.Traversable):
+    class MockTraversable(importlib.abc.Traversable):
         def __init__(self, name, value):
             self._name = name
             self._value = value

--- a/conftest.py
+++ b/conftest.py
@@ -7,10 +7,14 @@ def _docdir(request):
     are created as part of the test get removed automatically.
     """
     # Trigger ONLY for doctestplus.
-    doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
-    if isinstance(request.node.parent, doctest_plugin._doctest_textfile_item_cls):
-        tmpdir = request.getfixturevalue('tmpdir')
-        with tmpdir.as_cwd():
+    try:
+        doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
+        if isinstance(request.node.parent, doctest_plugin._doctest_textfile_item_cls):
+            tmpdir = request.getfixturevalue('tmpdir')
+            with tmpdir.as_cwd():
+                yield
+        else:
             yield
-    else:
+    # Handle case where doctestplus is not available
+    except AttributeError:
         yield

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,4 @@
-import os
-
 import pytest
-from _pytest.doctest import DoctestItem
-
 
 @pytest.fixture(autouse=True)
 def _docdir(request):
@@ -10,19 +6,11 @@ def _docdir(request):
     Make sure that doctests run in a temporary directory so that any files that
     are created as part of the test get removed automatically.
     """
-
-    # Trigger ONLY for the doctests.
-    if isinstance(request.node, DoctestItem):
-
-        # Get the fixture dynamically by its name.
+    # Trigger ONLY for doctestplus.
+    doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
+    if isinstance(request.node.parent, doctest_plugin._doctest_textfile_item_cls):
         tmpdir = request.getfixturevalue('tmpdir')
-
-        # Chdir only for the duration of the test.
-        olddir = os.getcwd()
-        tmpdir.chdir()
-        yield
-        os.chdir(olddir)
-
+        with tmpdir.as_cwd():
+            yield
     else:
-        # For normal tests, we have to yield, since this is a yield-fixture.
         yield

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,14 +8,17 @@ author_email = help@stsci.edu
 license = BSD-3-Clause
 license_file = LICENSE.rst
 url = http://github.com/asdf-format/asdf
-edit_on_github = False
-github_project = asdf-format/asdf
+project_urls =
+    Bug Tracker = https://github.com/asdf-format/asdf/issues
+    Documentation = https://asdf.readthedocs.io/en/stable
+    Source Code = https://github.com/asdf-format/asdf
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Development Status :: 5 - Production/Stable
 
 [options]
@@ -71,7 +74,7 @@ show-response = 1
 
 [tool:pytest]
 testpaths = asdf docs asdf-standard/schemas
-minversion = 3.1
+minversion = 4.6
 norecursedirs = build docs/_build docs/sphinxext
 doctest_plus = enabled
 remote_data_strict = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ envlist= py38,style
 [testenv]
 deps=
     pytest-sugar
-    astropydev: git+git://github.com/astropy/astropy
-    gwcsdev: git+git://github.com/spacetelescope/gwcs
-    numpydev: git+git://github.com/numpy/numpy
+    astropydev: git+https://github.com/astropy/astropy
+    gwcsdev: git+https://github.com/spacetelescope/gwcs
+    numpydev: git+https://github.com/numpy/numpy
     py36: importlib_resources
     # Newer versions of gwcs require astropy 4.x, which
     # isn't compatible with the older versions of numpy


### PR DESCRIPTION
- Fix `importlib.abc.Traversable` bug
- Add Python 3.9 job to Travis CI matrix
- Update setup.cfg with `project_urls`
- Fix dev urls in `tox.ini`
- Update `_docdir` pytest autouse fixture to work with Pytest 6.0 and the latest `pytest-doctestplus`.