### PR TITLE
Do not request a directory from importlib.resources.path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,7 +43,12 @@
 - Add ``edit`` subcommand to asdftool for efficient editing of
   the YAML portion of an ASDF file.  [#873]
 
-2.7.1 (unreleased)
+2.7.2 (unreleased)
+------------------
+
+- Fix bug causing test collection failures in some environments. [#889]
+
+2.7.1 (2020-08-18)
 ------------------
 
 - Fix bug preventing access to copied array data after

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -3,6 +3,7 @@ import os
 import sys
 import warnings
 from contextlib import contextmanager
+from pathlib import Path
 
 try:
     from astropy.coordinates import ICRS
@@ -41,30 +42,21 @@ except ImportError:
     INTERNET_OFF = False
 
 
-if sys.version_info >= (3, 7):
-    from importlib import resources
-else:
-    try:
-        import importlib_resources as resources
-    except ImportError:
-        resources = None
-
-
 __all__ = ['get_test_data_path', 'assert_tree_match', 'assert_roundtrip_tree',
            'yaml_to_asdf', 'get_file_sizes', 'display_warnings']
 
 
 def get_test_data_path(name, module=None):
-    if resources is None:
-        raise RuntimeError("The importlib_resources package is required to get"
-                           " test data on systems with Python < 3.7")
-
     if module is None:
         from . import data as test_data
         module = test_data
 
-    with resources.path(module, name) as path:
-        return str(path)
+    module_root = Path(module.__file__).parent
+
+    if name is None or name == "":
+        return str(module_root)
+    else:
+        return str(module_root/name)
 
 
 def assert_tree_match(old_tree, new_tree, ctx=None,


### PR DESCRIPTION
This change should fix the test failure reported in #887.  `importlib.resources.path` is clearly documented as not supporting directories:

```
package is either a name or a module object which conforms to the Package requirements. resource
is the name of the resource to open within package; it may not contain path separators and it may not
have sub-resources (i.e. it cannot be a directory).
```

In our Travis jobs `importlib.resources.path(some_module, "")` returns the path containing the module's `__init__.py`, but evidently that is not the case in all environments.

I ended up removing use of `importlib.resources` here since we're making another mistake by returning the context manager's path.  In some cases that path will point to a temporary file that is deleted on `__exit__`, so it's not appropriate to return it for use outside of the context manager.