### PR TITLE
Literal bit limit changed from 52 bits to 64 bits

### DIFF
--- a/asdf/constants.py
+++ b/asdf/constants.py
@@ -25,3 +25,8 @@ BLOCK_FLAG_STREAMED = 0x1
 
 # All arrays shorter than this default to inline storage.
 DEFAULT_AUTO_INLINE = 100
+
+# ASDF max number size
+MAX_BITS = 63
+MAX_NUMBER = (1<<MAX_BITS) - 1
+MIN_NUMBER = -((1<<MAX_BITS) - 2)

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -630,7 +630,6 @@ def validate(instance, ctx=None, schema={}, validators=None, reading=False,
                               *args, **kwargs)
     validator.validate(instance, _schema=(schema or None))
 
-    # additional_validators = [_validate_large_literals]
     additional_validators = []
     if ctx.version >= versioning.RESTRICTED_KEYS_MIN_VERSION:
         additional_validators.append(_validate_mapping_keys)

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -567,39 +567,6 @@ def get_validator(schema={}, ctx=None, validators=None, url_mapping=None,
     return validator
 
 
-def _validate_large_literals(instance, reading):
-    """
-    Validate that the tree has no large numeric literals.
-    """
-    def _validate(value):
-        bits = 63
-        max_integer_limit = (1 << bits) - 1
-        min_integer_limit = -((1 << bits) - 2)
-
-        if value <= max_integer_limit and value >= min_integer_limit:
-            return
-
-        if reading:
-            warnings.warn(
-                f"Invalid integer literal value {value} detected while reading file. "
-                "The value has been read safely, but the file should be "
-                "fixed.",
-                AsdfWarning
-            )
-        else:
-            raise ValidationError(
-                f"Integer value {value} is too large to safely represent as a "
-                "literal in ASDF"
-            )
-
-    if isinstance(instance, Integral):
-        _validate(instance)
-    elif isinstance(instance, Mapping):
-        for key in instance:
-            if isinstance(key, Integral):
-                _validate(key)
-
-
 def _validate_mapping_keys(instance, reading):
     """
     Validate that mappings do not contain illegal key types

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -573,7 +573,10 @@ def _validate_large_literals(instance, reading):
     """
     def _validate(value):
         # We can count on 52 bits of precision
-        if value <= ((1 << 51) - 1) and value >= -((1 << 51) - 2):
+        bits = 63
+        max_integer_limit = (1 << bits) - 1
+        min_integer_limit = -((1 << bits) - 2)
+        if value <= max_integer_limit and value >= min_integer_limit:
             return
 
         if reading:

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -572,10 +572,10 @@ def _validate_large_literals(instance, reading):
     Validate that the tree has no large numeric literals.
     """
     def _validate(value):
-        # We can count on 52 bits of precision
         bits = 63
         max_integer_limit = (1 << bits) - 1
         min_integer_limit = -((1 << bits) - 2)
+
         if value <= max_integer_limit and value >= min_integer_limit:
             return
 
@@ -663,7 +663,8 @@ def validate(instance, ctx=None, schema={}, validators=None, reading=False,
                               *args, **kwargs)
     validator.validate(instance, _schema=(schema or None))
 
-    additional_validators = [_validate_large_literals]
+    # additional_validators = [_validate_large_literals]
+    additional_validators = []
     if ctx.version >= versioning.RESTRICTED_KEYS_MIN_VERSION:
         additional_validators.append(_validate_mapping_keys)
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -572,11 +572,7 @@ def _validate_large_literals(instance, reading):
     Validate that the tree has no large numeric literals.
     """
     def _validate(value):
-        # We can count on 52 bits of precision
-        bits = 63
-        max_large_literal = (1<<bits) - 1
-        min_large_literal = -((1<<bits) - 2)
-        if value <= max_large_literal and value >= min_large_literal:
+        if value <= constants.MAX_NUMBER and value >= constants.MIN_NUMBER:
             return
 
         if reading:
@@ -663,7 +659,6 @@ def validate(instance, ctx=None, schema={}, validators=None, reading=False,
                               *args, **kwargs)
     validator.validate(instance, _schema=(schema or None))
 
-    # additional_validators = []
     additional_validators = [_validate_large_literals]
     if ctx.version >= versioning.RESTRICTED_KEYS_MIN_VERSION:
         additional_validators.append(_validate_mapping_keys)

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -10,7 +10,7 @@ class IntegerType(AsdfType):
     Enables the storage of arbitrarily large integer values
 
     The ASDF Standard mandates that integer literals in the tree can be no
-    larger than 52 bits. Use of this class enables the storage of arbitrarily
+    larger than 64 bits. Use of this class enables the storage of arbitrarily
     large integer values.
 
     When reading files that contain arbitrarily large integers, the values that

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -406,13 +406,11 @@ def test_auto_inline_large_value(val):
 
     tree = {"array": val}
     with pytest.raises(ValidationError):
-        af = asdf.AsdfFile(tree)
-        af.close()
+        asdf.AsdfFile(tree)
 
     tree = {val: "foo"}
     with pytest.raises(ValidationError):
-        af = asdf.AsdfFile(tree)
-        af.close()
+        asdf.AsdfFile(tree)
 
 
 def test_auto_inline_string_array(tmpdir):

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -401,24 +401,6 @@ def test_auto_inline_masked_array(tmpdir):
         assert len(list(af.blocks.internal_blocks)) == 2
 
 
-def test_auto_inline_large_value(tmpdir):
-    outfile = str(tmpdir.join('test.asdf'))
-    arr = np.array([2**52 + 1] + [k for k in range(constants.DEFAULT_AUTO_INLINE)])
-    tree = {"array": arr}
-
-    with asdf.AsdfFile(tree) as af:
-        af.write_to(outfile)
-        assert len(list(af.blocks.inline_blocks)) == 0
-        assert len(list(af.blocks.internal_blocks)) == 1
-
-        with pytest.raises(ValidationError):
-            af.write_to(outfile, auto_inline=150)
-
-        af.write_to(outfile, auto_inline=5)
-        assert len(list(af.blocks.inline_blocks)) == 0
-        assert len(list(af.blocks.internal_blocks)) == 1
-
-
 def test_auto_inline_string_array(tmpdir):
     outfile = str(tmpdir.join('test.asdf'))
     arr = np.array(["peach", "plum", "apricot", "nectarine", "cherry", "pluot"])

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -11,6 +11,7 @@ import pytest
 from jsonschema.exceptions import ValidationError
 
 import asdf
+from asdf import constants
 from asdf import get_config, config_context
 from asdf import treeutil
 from asdf import extension
@@ -26,7 +27,6 @@ from .helpers import (
     assert_no_warnings,
 )
 
-from .. import constants
 
 
 def test_get_data_from_closed_file(tmpdir):
@@ -405,7 +405,7 @@ def test_auto_inline_large_value(tmpdir):
     outfile = str(tmpdir.join('test.asdf'))
 
     # Check for large positive numbers
-    val = 2**64
+    val = constants.MAX_NUMBER+1
 
     tree = {"array": val}
     with pytest.raises(ValidationError):
@@ -418,7 +418,7 @@ def test_auto_inline_large_value(tmpdir):
             pass
 
     # Check for large negative numbers
-    val = -((1<<63) - 1)
+    val = constants.MIN_NUMBER-1
 
     tree = {"array": val}
     with pytest.raises(ValidationError):

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -401,6 +401,21 @@ def test_auto_inline_masked_array(tmpdir):
         assert len(list(af.blocks.internal_blocks)) == 2
 
 
+def test_auto_inline_large_value(tmpdir):
+    outfile = str(tmpdir.join('test.asdf'))
+    val = 2**64
+
+    tree = {"array": val}
+    with pytest.raises(ValidationError):
+        with asdf.AsdfFile(tree) as af:
+            pass
+
+    tree = {val: "foo"}
+    with pytest.raises(ValidationError):
+        with asdf.AsdfFile(tree) as af:
+            pass
+
+
 def test_auto_inline_string_array(tmpdir):
     outfile = str(tmpdir.join('test.asdf'))
     arr = np.array(["peach", "plum", "apricot", "nectarine", "cherry", "pluot"])

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -403,7 +403,22 @@ def test_auto_inline_masked_array(tmpdir):
 
 def test_auto_inline_large_value(tmpdir):
     outfile = str(tmpdir.join('test.asdf'))
+
+    # Check for large positive numbers
     val = 2**64
+
+    tree = {"array": val}
+    with pytest.raises(ValidationError):
+        with asdf.AsdfFile(tree) as af:
+            pass
+
+    tree = {val: "foo"}
+    with pytest.raises(ValidationError):
+        with asdf.AsdfFile(tree) as af:
+            pass
+
+    # Check for large negative numbers
+    val = -((1<<63) - 1)
 
     tree = {"array": val}
     with pytest.raises(ValidationError):

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -401,18 +401,6 @@ def test_auto_inline_masked_array(tmpdir):
         assert len(list(af.blocks.internal_blocks)) == 2
 
 
-@pytest.mark.parametrize("val", [constants.MAX_NUMBER+1, constants.MIN_NUMBER-1])
-def test_auto_inline_large_value(val):
-
-    tree = {"array": val}
-    with pytest.raises(ValidationError):
-        asdf.AsdfFile(tree)
-
-    tree = {val: "foo"}
-    with pytest.raises(ValidationError):
-        asdf.AsdfFile(tree)
-
-
 def test_auto_inline_string_array(tmpdir):
     outfile = str(tmpdir.join('test.asdf'))
     arr = np.array(["peach", "plum", "apricot", "nectarine", "cherry", "pluot"])

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -401,34 +401,18 @@ def test_auto_inline_masked_array(tmpdir):
         assert len(list(af.blocks.internal_blocks)) == 2
 
 
-def test_auto_inline_large_value(tmpdir):
-    outfile = str(tmpdir.join('test.asdf'))
-
-    # Check for large positive numbers
-    val = constants.MAX_NUMBER+1
+@pytest.mark.parametrize("val", [constants.MAX_NUMBER+1, constants.MIN_NUMBER-1])
+def test_auto_inline_large_value(val):
 
     tree = {"array": val}
     with pytest.raises(ValidationError):
-        with asdf.AsdfFile(tree) as af:
-            pass
+        af = asdf.AsdfFile(tree)
+        af.close()
 
     tree = {val: "foo"}
     with pytest.raises(ValidationError):
-        with asdf.AsdfFile(tree) as af:
-            pass
-
-    # Check for large negative numbers
-    val = constants.MIN_NUMBER-1
-
-    tree = {"array": val}
-    with pytest.raises(ValidationError):
-        with asdf.AsdfFile(tree) as af:
-            pass
-
-    tree = {val: "foo"}
-    with pytest.raises(ValidationError):
-        with asdf.AsdfFile(tree) as af:
-            pass
+        af = asdf.AsdfFile(tree)
+        af.close()
 
 
 def test_auto_inline_string_array(tmpdir):

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -617,6 +617,25 @@ def test_schema_resolved_via_entry_points():
     assert tag in repr(s)
 
 
+def test_read_large_literal():
+    value = 1 << 64
+    yaml = f"integer: {value}"
+
+    buff = helpers.yaml_to_asdf(yaml)
+
+    with pytest.warns(AsdfWarning, match="Invalid integer literal value"):
+        with asdf.open(buff) as af:
+            assert af['integer'] == value
+
+    yaml = f"{value}: foo"
+
+    buff = helpers.yaml_to_asdf(yaml)
+
+    with pytest.warns(AsdfWarning, match="Invalid integer literal value"):
+        with asdf.open(buff) as af:
+            assert af[value] == "foo"
+
+
 @pytest.mark.parametrize(
     "version,keys",
     [

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -644,14 +644,8 @@ def test_max_min_literals(num):
         asdf.AsdfFile(tree)
 
 
-@pytest.mark.parametrize("num, ttype", [
-    (constants.MAX_NUMBER+1, "val"),
-    (constants.MAX_NUMBER+1, "list"),
-    (constants.MAX_NUMBER+1, "key"),
-    (constants.MIN_NUMBER-1, "val"),
-    (constants.MIN_NUMBER-1, "list"),
-    (constants.MIN_NUMBER-1, "key")
-])
+@pytest.mark.parametrize("num", [constants.MAX_NUMBER+1, constants.MIN_NUMBER-1])
+@pytest.mark.parametrize("ttype", ["val", "list", "key"])
 def test_max_min_literals_write(num, ttype, tmpdir):
     outfile = tmpdir / "test.asdf"
     af = asdf.AsdfFile()

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_array_equal
 import pytest
 
 import asdf
+from asdf import constants
 from asdf import get_config, config_context
 from asdf import extension
 from asdf import resolver
@@ -17,6 +18,7 @@ from asdf import yamlutil
 from asdf import tagged
 from asdf.tests import helpers, CustomExtension
 from asdf.exceptions import AsdfWarning, AsdfConversionWarning, AsdfDeprecationWarning
+
 
 
 class TagReferenceType(types.CustomType):
@@ -617,35 +619,34 @@ def test_schema_resolved_via_entry_points():
     assert tag in repr(s)
 
 
-# @pytest.mark.parametrize('use_numpy', [False, True])
-def test_large_literals():
 
-    largeval = 1 << 64
+@pytest.mark.parametrize("num", [constants.MAX_NUMBER+1, constants.MIN_NUMBER-1])
+def test_max_min_literals(num):
 
     tree = {
-        'large_int': largeval,
+        'test_int': num,
     }
 
     with pytest.raises(ValidationError):
         asdf.AsdfFile(tree)
 
     tree = {
-        'large_list': [largeval],
+        'test_list': [num],
     }
 
     with pytest.raises(ValidationError):
         asdf.AsdfFile(tree)
 
     tree = {
-        largeval: 'large_key',
+        num: 'test_key',
     }
 
     with pytest.raises(ValidationError):
         asdf.AsdfFile(tree)
 
 
-def test_read_large_literal():
-    value = 1 << 64
+@pytest.mark.parametrize("value", [constants.MAX_NUMBER+1, constants.MIN_NUMBER-1])
+def test_read_large_literal(value):
     yaml = f"integer: {value}"
 
     buff = helpers.yaml_to_asdf(yaml)

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -617,68 +617,6 @@ def test_schema_resolved_via_entry_points():
     assert tag in repr(s)
 
 
-@pytest.mark.parametrize('use_numpy', [False, True])
-def test_large_literals(use_numpy):
-
-    largeval = 1 << 53
-    if use_numpy:
-        largeval = np.uint64(largeval)
-
-    tree = {
-        'large_int': largeval,
-    }
-
-    with pytest.raises(ValidationError):
-        asdf.AsdfFile(tree)
-
-    tree = {
-        'large_list': [largeval],
-    }
-
-    with pytest.raises(ValidationError):
-        asdf.AsdfFile(tree)
-
-    tree = {
-        largeval: 'large_key',
-    }
-
-    with pytest.raises(ValidationError):
-        asdf.AsdfFile(tree)
-
-    tree = {
-        'large_array': np.array([largeval], np.uint64)
-    }
-
-    ff = asdf.AsdfFile(tree)
-    buff = io.BytesIO()
-    ff.write_to(buff, auto_inline=None)
-
-    ff.set_array_storage(ff.tree['large_array'], 'inline')
-    buff = io.BytesIO()
-    with pytest.raises(ValidationError):
-        ff.write_to(buff)
-        print(buff.getvalue())
-
-
-def test_read_large_literal():
-    value = 1 << 64
-    yaml = f"integer: {value}"
-
-    buff = helpers.yaml_to_asdf(yaml)
-
-    with pytest.warns(AsdfWarning, match="Invalid integer literal value"):
-        with asdf.open(buff) as af:
-            assert af['integer'] == value
-
-    yaml = f"{value}: foo"
-
-    buff = helpers.yaml_to_asdf(yaml)
-
-    with pytest.warns(AsdfWarning, match="Invalid integer literal value"):
-        with asdf.open(buff) as af:
-            assert af[value] == "foo"
-
-
 @pytest.mark.parametrize(
     "version,keys",
     [

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -617,6 +617,33 @@ def test_schema_resolved_via_entry_points():
     assert tag in repr(s)
 
 
+# @pytest.mark.parametrize('use_numpy', [False, True])
+def test_large_literals():
+
+    largeval = 1 << 64
+
+    tree = {
+        'large_int': largeval,
+    }
+
+    with pytest.raises(ValidationError):
+        asdf.AsdfFile(tree)
+
+    tree = {
+        'large_list': [largeval],
+    }
+
+    with pytest.raises(ValidationError):
+        asdf.AsdfFile(tree)
+
+    tree = {
+        largeval: 'large_key',
+    }
+
+    with pytest.raises(ValidationError):
+        asdf.AsdfFile(tree)
+
+
 def test_read_large_literal():
     value = 1 << 64
     yaml = f"integer: {value}"

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -619,7 +619,6 @@ def test_schema_resolved_via_entry_points():
     assert tag in repr(s)
 
 
-
 @pytest.mark.parametrize("num", [constants.MAX_NUMBER+1, constants.MIN_NUMBER-1])
 def test_max_min_literals(num):
 
@@ -644,8 +643,31 @@ def test_max_min_literals(num):
     with pytest.raises(ValidationError):
         asdf.AsdfFile(tree)
 
-# TODO mirror the above, but create an empty ASDF, add the tree, then write
-#      to get an error on asdf.write_to
+
+@pytest.mark.parametrize("num, ttype", [
+    (constants.MAX_NUMBER+1, "val"),
+    (constants.MAX_NUMBER+1, "list"),
+    (constants.MAX_NUMBER+1, "key"),
+    (constants.MIN_NUMBER-1, "val"),
+    (constants.MIN_NUMBER-1, "list"),
+    (constants.MIN_NUMBER-1, "key")
+])
+def test_max_min_literals_write(num, ttype, tmpdir):
+    outfile = tmpdir / "test.asdf"
+    af = asdf.AsdfFile()
+
+    # Validation doesn't occur here, so no warning/error will be raised.
+    if ttype == "val":
+        af.tree['test_int'] = num
+    elif ttype == "list":
+        af.tree['test_int'] = [num]
+    else:
+        af.tree[num] = 'test_key'
+
+    # Validation will occur on write, though, so detect it.
+    with pytest.raises(ValidationError):
+        af.write_to(outfile)
+    af.close()
 
 
 @pytest.mark.parametrize("value", [constants.MAX_NUMBER+1, constants.MIN_NUMBER-1])

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -644,6 +644,9 @@ def test_max_min_literals(num):
     with pytest.raises(ValidationError):
         asdf.AsdfFile(tree)
 
+# TODO mirror the above, but create an empty ASDF, add the tree, then write
+#      to get an error on asdf.write_to
+
 
 @pytest.mark.parametrize("value", [constants.MAX_NUMBER+1, constants.MIN_NUMBER-1])
 def test_read_large_literal(value):


### PR DESCRIPTION
Removal of the 52 bit limit for numbers in an ndarray (originally imposed for anticipated use with javascript), which allows usage for larger numbers.  The `ndarray` is still limited by 64 bits by the `dtype`.  In addition to removing this validation check, the `pytest` tests used to test the original limit have been removed as well.

Resolves #891