### PR TITLE
Fix errors and warnings with numpy 1.20

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,8 @@
 
 - Fix bug causing test collection failures in some environments. [#889]
 
+- Fix bug when decompressing arrays with numpy 1.20.  [#901]
+
 2.7.1 (2020-08-18)
 ------------------
 

--- a/asdf/commands/tests/test_defragment.py
+++ b/asdf/commands/tests/test_defragment.py
@@ -10,7 +10,7 @@ from asdf.tests.helpers import get_file_sizes, assert_tree_match
 
 
 def _test_defragment(tmpdir, codec):
-    x = np.arange(0, 1000, dtype=np.float)
+    x = np.arange(0, 1000, dtype=float)
 
     tree = {
         'science_data': x,

--- a/asdf/commands/tests/test_exploded.py
+++ b/asdf/commands/tests/test_exploded.py
@@ -9,7 +9,7 @@ from ...tests.helpers import get_file_sizes, assert_tree_match
 
 
 def test_explode_then_implode(tmpdir):
-    x = np.arange(0, 10, dtype=np.float)
+    x = np.arange(0, 10, dtype=float)
 
     tree = {
         'science_data': x,

--- a/asdf/commands/tests/test_to_yaml.py
+++ b/asdf/commands/tests/test_to_yaml.py
@@ -9,7 +9,7 @@ from ...tests.helpers import get_file_sizes, assert_tree_match
 
 
 def test_to_yaml(tmpdir):
-    x = np.arange(0, 10, dtype=np.float)
+    x = np.arange(0, 10, dtype=float)
 
     tree = {
         'science_data': x,

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -200,7 +200,11 @@ def decompress(fd, used_size, data_size, compression):
             raise ValueError("Decompressed data too long")
         elif i + len(decoded) < data_size:
             raise ValueError("Decompressed data too short")
-        buffer[i:i+len(decoded)] = decoded
+        # Previous versions of numpy permitted assignment of an
+        # empty bytes object to an empty array range, but starting
+        # with numpy 1.20 this raises an error.
+        elif len(decoded) > 0:
+            buffer[i:i+len(decoded)] = decoded
 
     return buffer
 

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -133,8 +133,8 @@ class AsdfInFits(asdf.AsdfFile):
         from astropy.io import fits
 
         hdulist = fits.HDUList()
-        hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='SCI'))
-        hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='DQ'))
+        hdulist.append(fits.ImageHDU(np.arange(512, dtype=float), name='SCI'))
+        hdulist.append(fits.ImageHDU(np.arange(512, dtype=float), name='DQ'))
 
         tree = {
             'model': {

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -57,7 +57,7 @@ class CustomExtension:
 
 
 def test_sharing(tmpdir):
-    x = np.arange(0, 10, dtype=np.float)
+    x = np.arange(0, 10, dtype=float)
     tree = {
         'science_data': x,
         'subset': x[3:-3],
@@ -133,7 +133,7 @@ def test_all_dtypes(tmpdir):
 
 
 def test_dont_load_data():
-    x = np.arange(0, 10, dtype=np.float)
+    x = np.arange(0, 10, dtype=float)
     tree = {
         'science_data': x,
         'subset': x[3:-3],
@@ -266,7 +266,7 @@ def test_table_nested_fields(tmpdir):
 
 
 def test_inline():
-    x = np.arange(0, 10, dtype=np.float)
+    x = np.arange(0, 10, dtype=float)
     tree = {
         'science_data': x,
         'subset': x[3:-3],
@@ -298,7 +298,7 @@ def test_inline_bare():
 
 
 def test_mask_roundtrip(tmpdir):
-    x = np.arange(0, 10, dtype=np.float)
+    x = np.arange(0, 10, dtype=float)
     m = ma.array(x, mask=x > 5)
     tree = {
         'masked_array': m,
@@ -318,7 +318,7 @@ def test_mask_roundtrip(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf)
 
 def test_len_roundtrip(tmpdir):
-    sequence = np.arange(0, 10, dtype=np.int)
+    sequence = np.arange(0, 10, dtype=int)
     tree = {
         'sequence': sequence
         }

--- a/asdf/tests/__init__.py
+++ b/asdf/tests/__init__.py
@@ -25,7 +25,7 @@ class CustomTestType(CustomType):
 
 
 def create_small_tree():
-    x = np.arange(0, 10, dtype=np.float)
+    x = np.arange(0, 10, dtype=float)
     tree = {
         'science_data': x,
         'subset': x[3:-3],

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -434,9 +434,9 @@ def test_dangling_file_handle(tmpdir):
 
     # Create FITS file to use for test
     hdulist = fits.HDUList()
-    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
-    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
-    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=float)))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=float)))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=float)))
     hdulist.writeto(fits_filename)
     hdulist.close()
 

--- a/asdf/tests/test_reference.py
+++ b/asdf/tests/test_reference.py
@@ -17,13 +17,13 @@ from .helpers import assert_tree_match
 def test_external_reference(tmpdir):
     exttree = {
         'cool_stuff': {
-            'a': np.array([0, 1, 2], np.float),
-            'b': np.array([3, 4, 5], np.float)
+            'a': np.array([0, 1, 2], float),
+            'b': np.array([3, 4, 5], float)
             },
         'list_of_stuff': [
             'foobar',
             42,
-            np.array([7, 8, 9], np.float)
+            np.array([7, 8, 9], float)
             ]
         }
     external_path = os.path.join(str(tmpdir), 'external.asdf')
@@ -168,7 +168,7 @@ def test_external_reference_invalid_fragment(tmpdir):
         'list_of_stuff': [
             'foobar',
             42,
-            np.array([7, 8, 9], np.float)
+            np.array([7, 8, 9], float)
             ]
         }
     external_path = os.path.join(str(tmpdir), 'external.asdf')
@@ -203,8 +203,8 @@ def test_make_reference(tmpdir):
         # Include some ~ and / in the name to make sure that escaping
         # is working correctly
         'f~o~o/': {
-            'a': np.array([0, 1, 2], np.float),
-            'b': np.array([3, 4, 5], np.float)
+            'a': np.array([0, 1, 2], float),
+            'b': np.array([3, 4, 5], float)
             }
         }
     external_path = os.path.join(str(tmpdir), 'external.asdf')

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -434,8 +434,8 @@ respectively.
     from astropy.io import fits
 
     hdulist = fits.HDUList()
-    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='SCI'))
-    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='DQ'))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=float), name='SCI'))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=float), name='DQ'))
 
 Next we make a tree structure out of the data in the FITS file.  Importantly,
 we use the *same* array references in the FITS `~astropy.io.fits.HDUList` and


### PR DESCRIPTION
This fixes an issue with numpy 1.20 due to code in compression.py assigning an empty bytes object to an empty ndarray range.  I also changed instances of np.int and np.float to int and float, respectively, since the numpy aliases have been marked as deprecated in 1.20.