### PR TITLE
Adjust CI workflow filters

### DIFF
--- a/.github/workflows/asdf_ci.yml
+++ b/.github/workflows/asdf_ci.yml
@@ -2,9 +2,13 @@ name: ASDF CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - stable
+      - '*.x'
+    tags:
+      - '*'
   pull_request:
-    branches: [ master ]
 
 jobs:
   tox:
@@ -44,7 +48,7 @@ jobs:
             python-version: 3.9
             toxenv: py39
 
-          - name: Compatibility 
+          - name: Compatibility
             os: ubuntu-latest
             python-version: 3.9
             toxenv: compatibility


### PR DESCRIPTION
I noticed that the tests aren't running on the 2.7.x branch, so I added that to the list.  I also added all tags and all PR bases.