### PR TITLE
Add s390x workflow

### DIFF
--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -1,0 +1,42 @@
+name: s390x
+
+on:
+  push:
+    tags:
+      - '*'
+  schedule:
+    # Run every Monday at 6am UTC
+    - cron: '0 6 * * 1'
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-18.04
+    name: Python 3.7
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Run tests
+        id: build
+        with:
+          arch: s390x
+          distro: buster
+          shell: /bin/bash
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y git \
+                                  python3 \
+                                  python3-astropy \
+                                  python3-lz4 \
+                                  python3-numpy \
+                                  python3-venv \
+                                  python3-wheel
+          run: |
+            python3 -m venv --system-site-packages tests
+            source tests/bin/activate
+            pip3 install --upgrade pip setuptools gwcs==0.9.1 pytest==5.4.3 pytest-doctestplus==0.8.0
+            pip3 install .[all,tests]
+            python3 -m pytest --remote-data

--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -7,7 +7,6 @@ on:
   schedule:
     # Run every Monday at 6am UTC
     - cron: '0 6 * * 1'
-  pull_request:
 
 jobs:
   pytest:

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -1,6 +1,8 @@
 import os
 import io
+import getpass
 import pathlib
+import sys
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -71,6 +73,10 @@ def test_warning_deprecated_open(tmpdir):
             assert_tree_match(tree, af.tree)
 
 
+@pytest.mark.skipif(
+    not sys.platform.startswith('win') and getpass.getuser() == 'root',
+    reason="Cannot make file read-only if user is root"
+)
 def test_open_readonly(tmpdir):
 
     tmpfile = str(tmpdir.join('readonly.asdf'))


### PR DESCRIPTION
This adds a new actions workflow that runs the tests on s390x architecture.  It's scheduled to run when a new tag is created (presumably a release candidate) and Mondays at 6am UTC. 