### PR TITLE
Fix buffer assignment in compression.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@
 
 - Fix bug causing test collection failures in some environments. [#889]
 
-- Fix bug when decompressing arrays with numpy 1.20.  [#901]
+- Fix bug when decompressing arrays with numpy 1.20.  [#901, #909]
 
 2.7.1 (2020-08-18)
 ------------------

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -198,9 +198,11 @@ def decompress(fd, used_size, data_size, compression):
         decoded = decoder.flush()
         if i + len(decoded) > data_size:
             raise ValueError("Decompressed data too long")
-        elif i + len(decoded) < data_size:
-            raise ValueError("Decompressed data too short")
         buffer.data[i:i+len(decoded)] = decoded
+        i += len(decoded)
+
+    if i < data_size:
+        raise ValueError("Decompressed data too short")
 
     return buffer
 

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -200,11 +200,7 @@ def decompress(fd, used_size, data_size, compression):
             raise ValueError("Decompressed data too long")
         elif i + len(decoded) < data_size:
             raise ValueError("Decompressed data too short")
-        # Previous versions of numpy permitted assignment of an
-        # empty bytes object to an empty array range, but starting
-        # with numpy 1.20 this raises an error.
-        elif len(decoded) > 0:
-            buffer[i:i+len(decoded)] = decoded
+        buffer.data[i:i+len(decoded)] = decoded
 
     return buffer
 


### PR DESCRIPTION
I missed that we were setting `buffer[...]` here and not `buffer.data[...]`!  That's the real source of the problem.  This is the difference between them:

```python
In [10]: buffer = np.zeros((10,), np.uint8)
    ...: buffer.data[0:5] = b'12345'
    ...: buffer
Out[10]: array([49, 50, 51, 52, 53,  0,  0,  0,  0,  0], dtype=uint8)

In [11]: buffer = np.zeros((10,), np.uint8)
    ...: buffer[0:5] = b'12345'
    ...: buffer
Out[11]: array([57, 57, 57, 57, 57,  0,  0,  0,  0,  0], dtype=uint8)
```

(where 57 is 12345 % 2**8)