### PR TITLE
Automatically launch editor when user invokes asdftool edit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@
   than defaulting to storing all arrays internally. [#882]
 
 - Add ``edit`` subcommand to asdftool for efficient editing of
-  the YAML portion of an ASDF file.  [#873]
+  the YAML portion of an ASDF file.  [#873, #922]
 
 2.7.2 (2020-01-15)
 ------------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -755,11 +755,15 @@ class AsdfFile:
         return version
 
     @classmethod
-    def _parse_comment_section(cls, content):
+    def _read_comment_section(cls, fd):
         """
-        Parses the comment section, between the header line and the
+        Reads the comment section, between the header line and the
         Tree or first block.
         """
+        content = fd.read_until(
+            b'(%YAML)|(' + constants.BLOCK_MAGIC + b')', 5,
+            "start of content", include=False, exception=False)
+
         comments = []
 
         lines = content.splitlines()
@@ -830,10 +834,7 @@ class AsdfFile:
         self._file_format_version = cls._parse_header_line(header_line)
         self.version = self._file_format_version
 
-        comment_section = fd.read_until(
-            b'(%YAML)|(' + constants.BLOCK_MAGIC + b')', 5,
-            "start of content", include=False, exception=False)
-        self._comments = cls._parse_comment_section(comment_section)
+        self._comments = cls._read_comment_section(fd)
 
         version = cls._find_asdf_version_in_comments(self._comments)
         if version is not None:

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -1,23 +1,32 @@
 """
 Contains commands for lightweight text editing of an ASDF file.
-Future work: Make this interactive editing.
 """
 
 import io
 import os
-import struct
+import shutil
+import subprocess
 import sys
+import tempfile
 import yaml
 
-import asdf.constants as constants
-
+from .. import constants
 from .. import generic_io
 from .. import schema
-from .. import yamlutil
+from .. import util
 
+from ..asdf import is_asdf_file, open_asdf, AsdfFile
+from ..block import BlockManager
 from .main import Command
 
+
 __all__ = ["edit"]
+
+
+if sys.platform.startswith("win"):
+    DEFAULT_EDITOR = "notepad"
+else:
+    DEFAULT_EDITOR = "vi"
 
 
 class Edit(Command):
@@ -26,57 +35,16 @@ class Edit(Command):
         """
         Set up a command line argument parser for the edit subcommand.
         """
-        desc_string = (
-            "Allows for easy editing of the YAML in an ASDF file.  "
-            "For edit mode, the YAML portion of an ASDF file is "
-            "separated from the ASDF into a text file for easy "
-            "editing.  For save mode, the edited text file is written "
-            "to its ASDF file."
-        )
-
         # Set up the parser
         parser = subparsers.add_parser(
             "edit",
-            help="Edit YAML portion of an ASDF file.",
-            description=desc_string,
+            description="Edit the YAML portion of an ASDF file in-place.",
         )
 
         # Need an input file
         parser.add_argument(
-            "--infile",
-            "-f",
-            type=str,
-            required=True,
-            dest="fname",
-            help="Input file (ASDF for -e option, YAML for -s option)",
-        )
-
-        # Need an output file
-        parser.add_argument(
-            "--outfile",
-            "-o",
-            type=str,
-            required=True,
-            dest="oname",
-            help="Output file (YAML for -e option, ASDF for -s option)",
-        )
-
-        # The edit is either being performed or saved
-        group = parser.add_mutually_exclusive_group(required=True)
-
-        group.add_argument(
-            "-s",
-            action="store_true",
-            dest="save",
-            help="Saves a YAML text file to an ASDF file.  Requires a "
-            "YAML input file and ASDF output file.",
-        )
-
-        group.add_argument(
-            "-e",
-            action="store_true",
-            dest="edit",
-            help="Create a YAML text file for a ASDF file.  Requires a ASDF input file.",
+            "filename",
+            help="Path to an ASDF file.",
         )
 
         parser.set_defaults(func=cls.run)
@@ -88,611 +56,270 @@ class Edit(Command):
         """
         Execute the edit subcommand.
         """
-        return edit(args)
+        return edit(args.filename)
 
 
-def is_yaml_file(fname):
+def read_yaml(fd):
     """
-    Determines if a file is a YAML file based only on the file extension.
-
-    Parameters
-    ----------
-    fname : str
-        Input file name.
-
-    Return
-    ------
-    bool
-    """
-
-    base, ext = os.path.splitext(fname)
-    if ".yaml" != ext and ".yml" != ext:
-        return False
-    return True
-
-
-def is_valid_path_and_ext(fname, wanted_ext=None):
-    """
-    Validates the path exists and the extension is one wanted.
-
-    Parameters
-    ----------
-    fname : str
-        Input file name.
-    wanted_ext : List of str, optional
-        Extensions to check
-
-    Return
-    ------
-    bool
-    """
-    if not os.path.exists(fname):
-        print(f"Error: No file '{fname}' exists.")
-        return False
-
-    # Simply validates the path existence
-    if wanted_ext is None:
-        return True
-
-    # Make sure the extension is one desired.
-    base, ext = os.path.splitext(fname)
-    if ext not in wanted_ext:
-        return False
-
-    return True
-
-
-def is_valid_asdf_path(fname):
-    """
-    Validates fname path exists and has extension '.asdf'.
-
-    Parameters
-    ----------
-    fname : str
-        ASDF file name
-
-    Return
-    ------
-    bool
-    """
-    ext = [".asdf"]
-    if is_valid_path_and_ext(fname, ext):
-        return True
-    print(f"Error: '{fname}' should have extension '{ext[0]}'")
-    return False
-
-
-def is_valid_yaml_path(fname):
-    """
-    Validates fname path exists and has extension '.yaml'.
-
-    Parameters
-    ----------
-    fname : str
-        ASDF file name
-
-    Return
-    ------
-    bool
-    """
-    ext = [".yaml", ".yml"]
-    if is_valid_path_and_ext(fname, ext):
-        return True
-    print(f"Error: '{fname}' should have extension '{ext[0]}'")
-    return False
-
-
-def check_asdf_header(fd):
-    """
-    Makes sure the header line is the expected one, as well
-    as getting the optional comment line.
+    Read the YAML portion of an open ASDF file's content.
 
     Parameters
     ----------
     fd : GenericFile
 
-    Return
-    ------
+    Returns
+    -------
     bytes
-        The ASDF header line and the ASDF comment.
+        YAML content
+    int
+        total number of bytes available for YAML area
+    bool
+        True if the file contains binary blocks
     """
-
-    header_line = fd.read_until(b"\r?\n", 2, "newline", include=True)
-    if not header_line.startswith(constants.ASDF_MAGIC):
-        print("Invalid ASDF ID")
-        sys.exit(1)
-
-    comment_section = fd.read_until(
-        b"(%YAML)|(" + constants.BLOCK_MAGIC + b")",
-        5,
-        "start of content",
-        include=False,
-        exception=False,
-    )
-
-    return header_line + comment_section
-
-
-def open_and_check_asdf_header(fname):
-    """
-    Open and validate the ASDF file, as well as read in all the YAML
-    that will be outputted to a YAML file.
-
-    Parameters
-    ----------
-    fname : str
-        Input file name
-
-    Return
-    ------
-    GenericFile
-        File descriptor for ASDF file.
-    bytes
-        ASDF header and ASDF comments.
-    """
-    fullpath = os.path.abspath(fname)
-    fd = generic_io.get_file(fullpath, mode="r")
-
-    # Read the ASDF header and optional comments section
-    header_and_comment = check_asdf_header(fd)
-
-    return fd, header_and_comment  # Return GenericFile and ASDF header bytes.
-
-
-def get_yaml_version(fd, token):
-    """
-    A YAML token is found, so see if the YAML version can be parsed.
-
-    Parameters
-    ----------
-    fd : GenericFile
-    token : bytes
-        The YAML token
-
-    Return
-    ------
-    yaml_version: tuple
-    """
-    offset = fd.tell()
-    while True:
-        c = fd.read(1)
-        token += c
-        if b"\n" == c:
-            break
-    fd.seek(offset)
-
-    # Expects a string looking like '%YAML X.X'
-    yaml_version = None
-    line = token.decode("utf-8").strip()
-    sl = line.split(" ")
-    if len(sl) == 2:
-        yaml_version = tuple([int(x) for x in sl[1].split(".")])
-
-    return yaml_version
-
-
-def binary_block_exists(fd):
-    """
-    Checks to see if there is a binary block.
-
-    Parameters
-    ----------
-    fd : GenericFile
-    """
-    offset = fd.tell()
-
-    # Find location of the first binary block after the end of the YAML.
-    reader = fd.reader_until(
-        constants.BLOCK_MAGIC,
-        7,
-        "First binary block",
-        include=False,
-    )
-    try:
-        reader.read()  # Read to the beginning of the first binary block.
-        fd.seek(offset)
-        return True
-    except ValueError:
-        fd.seek(offset)
-        return False
-
-
-def read_and_validate_yaml(fd, fname, validate_yaml):
-    """
-    Get the YAML text from an ASDF formatted file.
-
-    Parameters
-    ----------
-    fname : str
-        Input file name
-    fd : GenericFile
-        for fname.
-    validate_yaml: bool
-
-    Return
-    ------
-    bytes
-        The YAML portion of an ASDF file.
-    yaml_version: tuple or None
-    """
-    YAML_TOKEN = b"%YAML"
-    token = fd.read(len(YAML_TOKEN))
-    if token != YAML_TOKEN:
-        print(f"Error: No YAML in '{fname}'")
-        sys.exit(1)
-
-    yaml_version = None
-    if validate_yaml:
-        yaml_version = get_yaml_version(fd, token)
-
-    # Get YAML reader and content
+    # All ASDF files produced by this library, even the binary files
+    # of an exploded ASDF file, include a YAML header, so we'll just
+    # let this raise an error if the end marker can't be found.
+    # Revisit this if someone starts producing files without a
+    # YAML section, which the standard permits but is not possible
+    # with current software.
     reader = fd.reader_until(
         constants.YAML_END_MARKER_REGEX,
         7,
         "End of YAML marker",
         include=True,
-        initial_content=token,
     )
-    yaml_content = reader.read()
+    content = reader.read()
 
-    # YAML validation implies we are reading from a normal YAML file, so
-    # should not have any binary blocks.
-    if not validate_yaml and not binary_block_exists(fd):
-        delim = "!" * 70
-        print(delim)
-        print(f"No binary blocks exist in {fname}.  This ASDF file can")
-        print("directly edited in any text file.  Or the file is poorly")
-        print("formatted and cannot be corrected with this tool.")
-        print(delim)
-        sys.exit(1)
-
-    if validate_yaml:
-        # Create a YAML tree to validate
-        # The YAML text must be converted to a stream.
-        tree = yamlutil.load_tree(io.BytesIO(yaml_content))
-        if tree is None:
-            print("Error: 'yamlutil.load_tree' failed to return a tree.")
-            sys.exist(1)
-
-        schema.validate(tree)  # Failure raises an exception.
-
-    return yaml_content, yaml_version
-
-
-def edit_func(fname, oname):
-    """
-    Creates a YAML file from an ASDF file.  The YAML file will contain only the
-    YAML from the ASDF file.  The YAML text will be written to a YAML text file
-    in the same, so from 'example.asdf' the file 'example.yaml' will be created.
-
-    Parameters
-    ----------
-    fname : str
-        Input ASDF file name
-    oname : str
-        Output YAML file name.
-    """
-    if not is_valid_asdf_path(fname):
-        return 1
-
-    if not is_yaml_file(oname):
-        print("A YAML file is expected, with '.yaml' or '.yml' extension.")
-        return 1
-
-    # Validate input file is an ASDF file.
-    fd, asdf_text = open_and_check_asdf_header(fname)
-
-    # Read and validate the YAML of an ASDF file.
-    yaml_text, _ = read_and_validate_yaml(fd, fname, False)
-    fd.close()
-
-    # Write the YAML for the original ASDF file.
-    with open(oname, "wb") as ofd:
-        ofd.write(asdf_text)
-        ofd.write(yaml_text)
-
-    # Output message to user.
-    delim = "*" * 70
-    print(f"\n{delim}")
-    print(f"The text portion of '{fname}' is written to:")
-    print(f"    '{oname}'")
-    print(f"The file '{oname}' can be edited using your favorite text editor.")
-    print("The edited text can then be saved to the ASDF file of your choice")
-    print("using 'asdftool edit -s -f <edited text file> -o <ASDF file>.")
-    print(f"{delim}\n")
-
-    return
-
-
-def write_block_index(fd, index, yaml_version):
-    """
-    Write the block index to an ASDF file.
-
-    Parameters
-    ----------
-    fd : file descriptor
-    index : list
-        Integer location for each block.
-    yaml_version: tuple
-    """
-    if len(index) < 1:
-        return
-
-    fd.write(constants.INDEX_HEADER)
-    fd.write(b"\n")
-
-    # If no YAML version found in edited YAML force it to 1.1
-    if yaml_version is None:
-        yaml_version = tuple([1, 1])
-    yaml.dump(
-        index,
-        Dumper=yamlutil._yaml_base_dumper,
-        stream=fd,
-        explicit_start=True,
-        explicit_end=True,
-        version=yaml_version,
-        allow_unicode=True,
-        encoding="utf-8",
+    reader = fd.reader_until(
+        constants.BLOCK_MAGIC,
+        len(constants.BLOCK_MAGIC),
+        include=False,
+        exception=False,
     )
+    buffer = reader.read()
+
+    contains_blocks = fd._peek(len(constants.BLOCK_MAGIC)) == constants.BLOCK_MAGIC
+
+    return content, len(content) + len(buffer), contains_blocks
 
 
-def find_first_block(fname):
+def write_edited_yaml_larger(path, new_content, version):
     """
-    Finds the location of the first binary block in an ASDF file.
+    Rewrite an ASDF file, replacing the YAML portion with the
+    specified YAML content and updating the block index if present.
+    The file is assumed to contain binary blocks.
 
     Parameters
     ----------
-    fname : str
-        Input ASDF file name.
-
-    Return
-    ------
-    int
-        Location, in bytes, of the first binary block.
+    path : str
+        Path to ASDF file
+    content : bytes
+        Updated YAML content
     """
-    with generic_io.get_file(fname, mode="r") as fd:
-        # Read past possible BLOCK_MAGIC being in YAML
-        reader = fd.reader_until(
-            constants.YAML_END_MARKER_REGEX,
-            7,
-            "End of YAML marker",
-            include=True,
-        )
-        reader.read()  # Read to the end of the YAML delimiter.
+    prefix = os.path.splitext(os.path.basename(path))[0] + "-"
+    # Since the original file may be large, create the temporary
+    # file in the same directory to avoid filling up the system
+    # temporary area.
+    with tempfile.NamedTemporaryFile(dir=os.path.dirname(path), prefix=prefix, suffix=".asdf") as temp_file:
+        with generic_io.get_file(temp_file, mode="w") as fd:
+            fd.write(new_content)
+            # Allocate additional space for future YAML updates:
+            pad_length = util.calculate_padding(len(new_content), True, fd.block_size)
+            fd.fast_forward(pad_length)
 
-        # Find location of the first binary block after the end of the YAML.
-        reader = fd.reader_until(
-            constants.BLOCK_MAGIC,
-            7,
-            "First binary block",
-            include=False,
-        )
-        try:
-            reader.read()  # Read to the beginning of the first binary block.
-        except ValueError:
-            delim = "!" * 50
-            print(delim)
-            print(f"No binary blocks are found in {fname}.")
-            print("The file should be directly edited in a standard text editor")
-            print("without use of this tool.")
-            print(delim)
-            sys.exit(1)
-        binary_block_location = fd.tell()
-    return binary_block_location
+            with generic_io.get_file(path) as original_fd:
+                # Consume the file up to the first block, which must exist
+                # as a precondition to using this method.
+                original_fd.seek_until(
+                    constants.BLOCK_MAGIC,
+                    len(constants.BLOCK_MAGIC),
+                )
+                ctx = AsdfFile(version=version)
+                blocks = BlockManager(ctx)
+                blocks.read_internal_blocks(original_fd, past_magic=True, validate_checksums=False)
+                blocks.write_internal_blocks_serial(fd)
+                blocks.write_block_index(fd, ctx)
+
+        # Swap in the new version of the file atomically:
+        shutil.copy(temp_file.name, path)
 
 
-def get_next_binary_block_header(fd):
+def write_edited_yaml(path, new_content, available_bytes):
     """
-    Gets the next binary block token and length field, as well as the header.
+    Overwrite the YAML portion of an ASDF tree with the specified
+    YAML content.  The content must fit in the space available.
 
     Parameters
     ----------
-    fd: file descriptor
-        Input ASDF file.
-
-    Return
-    ------
-    bytes
-        Binary block header
+    path : str
+        Path to ASDF file
+    yaml_content : bytes
+        Updated YAML content
+    available_bytes : int
+        Number of bytes available for YAML
     """
-    min_header_sz = 48
-    token_length = fd.read(6)
-    if not token_length.startswith(constants.BLOCK_MAGIC):
-        fd.seek(-6, os.SEEK_CUR)
-        return None
+    # generic_io mode "rw" opens the file as "r+b":
+    with generic_io.get_file(path, mode="rw") as fd:
+        fd.write(new_content)
 
-    hlen = struct.unpack(">H", token_length[4:])[0]
-    if hlen < min_header_sz:
-        print(f"Error: Invalid binary block length ({hlen}).")
-        print(f"       Header length must be a minimum of {min_header_sz}.")
-        sys.exit(1)
-
-    header = fd.read(hlen)
-    if len(header) != hlen:
-        print(f"Error: Expected to read {hlen} bytes of binary block")
-        print(f"       header, but read only {len(header)}.")
-        sys.exit(1)
-
-    return token_length + header
+        pad_length = available_bytes - len(new_content)
+        if pad_length > 0:
+            fd.write(b"\0" * pad_length)
 
 
-def copy_binary_blocks(ofd, ifd, yaml_version):
+def edit(path):
     """
-    Copies the binary blocks from the input ASDF to the output ASDF.
+    Copy the YAML portion of an ASDF file to a temporary file, present
+    the file to the user for editing, then update the original file
+    with the modified YAML.
 
     Parameters
     ----------
-    ofd: file descriptor
-        Output ASDF file.
-    ifd: file descriptor
-        Input ASDF file.
-    yaml_version: tuple
+    path : str
+        Path to ASDF file
     """
-    block_index = []  # A new block index needs to be computed.
-    alloc_loc = 14
-    chunk_sz = 1024
+    # Extract the YAML portion of the original file:
+    with generic_io.get_file(path, mode="r") as fd:
+        if not is_asdf_file(path):
+            print(f"Error: '{path}' is not an ASDF file.")
+            return 1
 
-    block_num = 0
-    while True:
-        header = get_next_binary_block_header(ifd)
-        if header is None:
+        original_content, available_bytes, contains_blocks = read_yaml(fd)
+
+    original_version = parse_version(original_content)
+
+    prefix = os.path.splitext(os.path.basename(path))[0] + "-"
+    with tempfile.NamedTemporaryFile(prefix=prefix, suffix=".yaml") as temp_file:
+        # Write the YAML to a temporary path:
+        temp_file.write(original_content)
+        temp_file.flush()
+
+        # Loop so that the user can correct errors in the edited file:
+        while True:
+            open_editor(temp_file.name)
+
+            temp_file.seek(0)
+            new_content = temp_file.read()
+
+            if new_content == original_content:
+                print("No changes made to file")
+                return 0
+
+            new_version = parse_version(new_content)
+            if new_version != original_version:
+                print("Error: cannot modify ASDF Standard version using this tool.")
+                choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
+                if choice == "a":
+                    return 1
+                else:
+                    continue
+
+            try:
+                # Blocks are not read during validation, so this will not raise
+                # an error even though we're only opening the YAML portion of
+                # the file.
+                with open_asdf(io.BytesIO(new_content), _force_raw_types=True):
+                    pass
+            except yaml.YAMLError as e:
+                print("Error: failed to parse updated YAML:")
+                print_exception(e)
+                choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
+                if choice == "a":
+                    return 1
+                else:
+                    continue
+            except schema.ValidationError as e:
+                print("Warning: updated ASDF tree failed validation:")
+                print_exception(e)
+                choice = request_input("(c)ontinue editing, (f)orce update, or (a)bort? ", ["c", "f", "a"])
+                if choice == "a":
+                    return 1
+                elif choice == "c":
+                    continue
+            except Exception as e:
+                print("Error: failed to read updated file as ASDF:")
+                print_exception(e)
+                choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
+                if choice == "a":
+                    return 1
+                else:
+                    continue
+
+            # We've either opened the file without error, or
+            # the user has agreed to ignore validation errors.
+            # Break out of the loop so that we can update the
+            # original file.
             break
-        block_index.append(ofd.tell())
 
-        ofd.write(header)
-
-        flags = struct.unpack(">I", header[6:10])[0]
-        if constants.BLOCK_FLAG_STREAMED & flags:
-            while True:
-                chunk = ifd.read(chunk_sz)
-                if 0 == len(chunk):
-                    return  # End of file
-                ofd.write(chunk)
-
-        alloc = struct.unpack(">Q", header[alloc_loc : alloc_loc + 8])[0]
-        while alloc >= chunk_sz:
-            chunk = ifd.read(chunk_sz)
-            if len(chunk) == 0:
-                print("Error: Invalid reading of binary block {block_num}.")
-                print("       Exiting ...")
-                sys.exit(1)
-            ofd.write(chunk)
-            alloc -= chunk_sz
-
-        if alloc > 0:
-            chunk = ifd.read(alloc)
-            ofd.write(chunk)
-        block_num += 1
-
-    if len(block_index) > 0:
-        write_block_index(ofd, block_index, yaml_version)
-
-
-def write_edited_yaml_larger(fname, oname, edited_yaml, first_block_loc, yaml_version):
-    """
-    The edited YAML is too large to simply overwrite the exiting YAML in an
-    ASDF file, so the ASDF file needs to be rewritten.
-
-    Parameters
-    ----------
-    oname : str
-        Input ASDF file name.
-    edited_yaml : byte string
-        The edited YAML to be saved to an ASDF file.
-    first_block_location : int
-        The location in the ASDF file for the first binary block.
-    yaml_version: tuple
-    """
-    tmp_oname = oname + ".tmp"
-
-    ifd = open(oname, "rb")
-    ifd.seek(first_block_loc)
-
-    ofd = open(tmp_oname, "wb")
-    ofd.write(edited_yaml)
-
-    pad_length = 10000
-    padding = b"\0" * pad_length
-    ofd.write(padding)
-
-    copy_binary_blocks(ofd, ifd, yaml_version)
-
-    ifd.close()
-    ofd.close()
-    os.replace(tmp_oname, oname)
-
-
-def write_edited_yaml(fname, oname, edited_yaml, first_block_loc, yaml_version):
-    """
-    Write the edited YAML is to an existing ASDF file.
-
-    Parameters
-    ----------
-    oname : str
-        Input ASDF file name.
-    edited_yaml : byte string
-        The edited YAML to be saved to an ASDF file
-    first_block_location : int
-        The location in the ASDF file for the first binary block.
-    yaml_version: tuple
-    """
-    padded = False
-    if len(edited_yaml) < first_block_loc:
-        # The YAML in the ASDF can simply be overwritten
-        pad_length = first_block_loc - len(edited_yaml)
-        padding = b"\0" * pad_length
-        with open(oname, "r+b") as fd:
-            fd.write(edited_yaml)
-            fd.write(padding)
-    elif len(edited_yaml) == first_block_loc:
-        # The YAML in the ASDF can simply be overwritten
-        with open(oname, "r+b") as fd:
-            fd.write(edited_yaml)
+    if len(new_content) <= available_bytes:
+        # File has sufficient space allocated in the YAML area.
+        write_edited_yaml(path, new_content, available_bytes)
+    elif not contains_blocks:
+        # File does not have sufficient space, but there are
+        # no binary blocks, so we can just expand the file.
+        write_edited_yaml(path, new_content, len(new_content))
     else:
-        padded = True
-        write_edited_yaml_larger(
-            fname, oname, edited_yaml, first_block_loc, yaml_version
-        )
-
-    delim = "*" * 70
-    print(f"\n{delim}")
-    print("The edited YAML was validated and written to:")
-    print(f"    '{oname}'")
-    if padded:
-        print("The edited YAML was too large to simply overwrite in place, so the")
-        print("ASDF file was rewritten with 10,000 characters of padding added.")
-    else:
-        print("The YAML in the ASDF file was overwritten in place.")
-    print(f"{delim}\n")
+        # File does not have sufficient space, and binary blocks
+        # are present.
+        print("Warning: updated YAML larger than allocated space.  File must be rewritten.")
+        choice = request_input("(c)ontinue or (a)bort? ", ["c", "a"])
+        if choice == "a":
+            return 1
+        else:
+            write_edited_yaml_larger(path, new_content, new_version)
 
 
-def save_func(fname, oname):
+def parse_version(content):
     """
-    Checks to makes sure a corresponding ASDF file exists.  This is done by
-        seeing if a file of the same name with '.asdf' as an extension exists.
-    Checks to makes sure fname is a valid YAML file.
-    If the YAML text is smaller than the YAML text in the ASDF file
-        overwrite the YAML in the ASDF file.
-    If the YAML text is smaller than the YAML text in the ASDF file
-        If the file is small, then rewrite file.
-        If the file is large, ask if rewrite is desired.
+    Extract the ASDF Standard version from YAML content.
 
     Parameters
     ----------
-    fname : str
-        Input YAML file name.
-    oname : str
-        The output ASDF file name.
+    content : bytes
+
+    Returns
+    -------
+    asdf.versioning.AsdfVersion
+        ASDF Standard version
     """
-
-    if not is_valid_yaml_path(fname):
-        return 1
-
-    if not is_valid_asdf_path(oname):
-        return 1
-
-    # Validate input file is an ASDF formatted YAML.
-    ifd, iasdf_text = open_and_check_asdf_header(fname)
-    iyaml_text, yaml_version = read_and_validate_yaml(ifd, fname, True)
-    ifd.close()
-    edited_text = iasdf_text + iyaml_text
-
-    loc = find_first_block(oname)
-    write_edited_yaml(fname, oname, edited_text, loc, yaml_version)
+    comments = AsdfFile._read_comment_section(generic_io.get_file(io.BytesIO(content)))
+    return AsdfFile._find_asdf_version_in_comments(comments)
 
 
-def edit(args):
+def print_exception(e):
     """
-    Implode a given ASDF file, which may reference external data, back
-    into a single ASDF file.
+    Print an exception, indented 4 spaces and elided if too many lines.
+    """
+    lines = str(e).split("\n")
+    if len(lines) > 20:
+        lines = lines[0:20] + ["..."]
+    for line in lines:
+        print(f"    {line}")
+
+
+def request_input(message, choices):
+    """
+    Request user input.
 
     Parameters
     ----------
-    args : The command line arguments.
+    message : str
+        Message to display
+    choices : list of str
+        List of recognized inputs
     """
-    if args.edit:
-        return edit_func(args.fname, args.oname)
-    elif args.save:
-        return save_func(args.fname, args.oname)
-    else:
-        return print("Invalid arguments")
+    while True:
+        choice = input(message).strip().lower()
+
+        if choice in choices:
+            return choice
+        else:
+            print(f"Invalid choice: {choice}")
+
+
+def open_editor(path):
+    """
+    Launch an editor process with the file at path opened.
+    """
+    editor = os.environ.get("EDITOR", DEFAULT_EDITOR)
+    subprocess.run(f"{editor} {path}", check=True, shell=True)

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -139,8 +139,9 @@ def write_edited_yaml_larger(path, new_content, version):
                     len(constants.BLOCK_MAGIC),
                 )
                 ctx = AsdfFile(version=version)
-                blocks = BlockManager(ctx)
+                blocks = BlockManager(ctx, copy_arrays=False, lazy_load=False)
                 blocks.read_internal_blocks(original_fd, past_magic=True, validate_checksums=False)
+                blocks.finish_reading_internal_blocks()
                 blocks.write_internal_blocks_serial(fd)
                 blocks.write_block_index(fd, ctx)
 

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -144,6 +144,7 @@ def write_edited_yaml_larger(path, new_content, version):
                 blocks.finish_reading_internal_blocks()
                 blocks.write_internal_blocks_serial(fd)
                 blocks.write_block_index(fd, ctx)
+                blocks.close()
 
         # Swap in the new version of the file atomically:
         shutil.copy(temp_file.name, path)

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -122,8 +122,10 @@ def write_edited_yaml_larger(path, new_content, version):
     # Since the original file may be large, create the temporary
     # file in the same directory to avoid filling up the system
     # temporary area.
-    with tempfile.NamedTemporaryFile(dir=os.path.dirname(path), prefix=prefix, suffix=".asdf") as temp_file:
-        with generic_io.get_file(temp_file, mode="w") as fd:
+    temp_file = tempfile.NamedTemporaryFile(dir=os.path.dirname(path), prefix=prefix, suffix=".asdf", delete=False)
+    try:
+        temp_file.close()
+        with generic_io.get_file(temp_file.name, mode="w") as fd:
             fd.write(new_content)
             # Allocate additional space for future YAML updates:
             pad_length = util.calculate_padding(len(new_content), True, fd.block_size)
@@ -144,6 +146,8 @@ def write_edited_yaml_larger(path, new_content, version):
 
         # Swap in the new version of the file atomically:
         shutil.copy(temp_file.name, path)
+    finally:
+        os.unlink(temp_file.name)
 
 
 def write_edited_yaml(path, new_content, available_bytes):

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -182,7 +182,7 @@ def edit(path):
     """
     # Extract the YAML portion of the original file:
     with generic_io.get_file(path, mode="r") as fd:
-        if not is_asdf_file(path):
+        if not is_asdf_file(fd):
             print(f"Error: '{path}' is not an ASDF file.")
             return 1
 

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -3,6 +3,8 @@ import os
 import re
 
 import numpy as np
+from numpy.testing import assert_array_equal
+
 import pytest
 
 import asdf
@@ -149,8 +151,11 @@ def test_no_blocks_decrease_size(tmp_path, create_editor, version):
 def test_with_blocks(tmp_path, create_editor, version):
     file_path = str(tmp_path/"test.asdf")
 
+    array1 = np.random.rand(constants.DEFAULT_AUTO_INLINE + 1)
+    array2 = np.random.rand(constants.DEFAULT_AUTO_INLINE + 1)
     with asdf.AsdfFile(version=version) as af:
-        af["array"] = np.arange(constants.DEFAULT_AUTO_INLINE + 1)
+        af["array1"] = array1
+        af["array2"] = array2
         af["foo"] = "bar"
         af.write_to(file_path)
 
@@ -160,13 +165,19 @@ def test_with_blocks(tmp_path, create_editor, version):
 
     with asdf.open(file_path) as af:
         assert af["foo"] == "baz"
+        assert_array_equal(af["array1"], array1)
+        assert_array_equal(af["array2"], array2)
+
 
 
 def test_with_blocks_increase_size(tmp_path, create_editor, version, mock_input):
     file_path = str(tmp_path/"test.asdf")
 
+    array1 = np.random.rand(constants.DEFAULT_AUTO_INLINE + 1)
+    array2 = np.random.rand(constants.DEFAULT_AUTO_INLINE + 1)
     with asdf.AsdfFile(version=version) as af:
-        af["array"] = np.arange(constants.DEFAULT_AUTO_INLINE + 1)
+        af["array1"] = array1
+        af["array2"] = array2
         af["foo"] = "bar"
         af.write_to(file_path)
 
@@ -184,6 +195,9 @@ def test_with_blocks_increase_size(tmp_path, create_editor, version, mock_input)
 
     with asdf.open(file_path) as af:
         assert af["foo"] == new_value
+        assert_array_equal(af["array1"], array1)
+        assert_array_equal(af["array2"], array2)
+
 
 
 def test_with_blocks_decrease_size(tmp_path, create_editor, version):
@@ -191,7 +205,11 @@ def test_with_blocks_decrease_size(tmp_path, create_editor, version):
 
     original_value = "a" * 32768
 
+    array1 = np.random.rand(constants.DEFAULT_AUTO_INLINE + 1)
+    array2 = np.random.rand(constants.DEFAULT_AUTO_INLINE + 1)
     with asdf.AsdfFile(version=version) as af:
+        af["array1"] = array1
+        af["array2"] = array2
         af["foo"] = original_value
         af.write_to(file_path)
 
@@ -201,6 +219,8 @@ def test_with_blocks_decrease_size(tmp_path, create_editor, version):
 
     with asdf.open(file_path) as af:
         assert af["foo"] == "bar"
+        assert_array_equal(af["array1"], array1)
+        assert_array_equal(af["array2"], array2)
 
 
 def test_no_changes(tmp_path, create_editor, version):

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -250,6 +250,20 @@ def test_update_asdf_standard_version(tmp_path, create_editor, version, mock_inp
             assert main.main_from_args(["edit", file_path]) == 1
 
 
+def test_update_yaml_version(tmp_path, create_editor, version, mock_input):
+    file_path = str(tmp_path/"test.asdf")
+
+    with asdf.AsdfFile(version=version) as af:
+        af["foo"] = "bar"
+        af.write_to(file_path)
+
+    os.environ["EDITOR"] = create_editor(r"^%YAML 1.1$", "%YAML 1.2")
+
+    with file_not_modified(file_path):
+        with mock_input(r"\(c\)ontinue editing or \(a\)bort\?", "a"):
+            assert main.main_from_args(["edit", file_path]) == 1
+
+
 def test_bad_yaml(tmp_path, create_editor, version, mock_input):
     file_path = str(tmp_path/"test.asdf")
 

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -21,17 +21,22 @@ def create_editor(tmp_path):
     Fixture providing a function that generates an editor script.
     """
     def _create_editor(pattern, replacement):
+        if isinstance(pattern, str):
+            pattern = pattern.encode("utf-8")
+        if isinstance(replacement, str):
+            replacement = replacement.encode("utf-8")
+
         editor_path = tmp_path / "editor.py"
 
         content = f"""import re
 import sys
 
-with open(sys.argv[1], "r") as file:
+with open(sys.argv[1], "rb") as file:
     content = file.read()
 
 content = re.sub({pattern!r}, {replacement!r}, content, flags=(re.DOTALL | re.MULTILINE))
 
-with open(sys.argv[1], "w") as file:
+with open(sys.argv[1], "wb") as file:
     file.write(content)
 """
 

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -169,7 +169,6 @@ def test_with_blocks(tmp_path, create_editor, version):
         assert_array_equal(af["array2"], array2)
 
 
-
 def test_with_blocks_increase_size(tmp_path, create_editor, version, mock_input):
     file_path = str(tmp_path/"test.asdf")
 

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import os
 import re
 
@@ -6,214 +7,278 @@ import pytest
 
 import asdf
 from asdf.commands import main
+from asdf import constants
 
 
-def _create_base_asdf_stream(version, oname):
-    # Store the data in an arbitrarily nested dictionary
-    tree = {
-        "foo": 42,
-        "name": "Monty",
-        "my_stream": asdf.Stream([128], np.float64),
-    }
-    af = asdf.AsdfFile(tree)
-    with open(oname, "wb") as fd:
-        af.write_to(fd)
-        for k in range(5):
-            fd.write(np.array([k] * 128, np.float64).tobytes())
+@pytest.fixture(params=asdf.versioning.supported_versions)
+def version(request):
+    return request.param
 
 
-def _create_base_asdf(version, oname):
+@pytest.fixture
+def create_editor(tmp_path):
     """
-    In the test temp directory, create a base ASDF file to edit
-    and test against.
+    Fixture providing a function that generates an editor script.
     """
-    seq = np.arange(713)
+    def _create_editor(pattern, replacement):
+        editor_path = tmp_path / "editor.py"
 
-    # Store the data in an arbitrarily nested dictionary
-    tree = {
-        "foo": 42,
-        "name": "Monty",
-        "sequence": seq,
-    }
+        content = f"""import re
+import sys
 
-    with asdf.AsdfFile(tree, version=version) as af:
-        af.write_to(oname)
+with open(sys.argv[1], "r") as file:
+    content = file.read()
 
+content = re.sub({pattern!r}, {replacement!r}, content, flags=(re.DOTALL | re.MULTILINE))
 
-def _create_base_asdf_no_blocks(version, oname):
-    tree = {
-        "foo": 42,
-        "name": "Monty",
-    }
+with open(sys.argv[1], "w") as file:
+    file.write(content)
+"""
 
-    with asdf.AsdfFile(tree, version=version) as af:
-        af.write_to(oname)
+        with editor_path.open("w") as file:
+            file.write(content)
 
+        return f"python {editor_path}"
 
-def _create_edited_yaml(base_yaml, edited_yaml, pattern, replacement):
-    with open(base_yaml, "rb") as fd:
-        content = fd.read()
-        new_content = re.sub(pattern, replacement, content)
-        with open(edited_yaml, "wb") as fd:
-            fd.write(new_content)
+    return _create_editor
 
 
-def _initialize_test(tmpdir, version, create_asdf):
-    asdf_base = os.path.join(tmpdir, "base.asdf")
-    yaml_base = os.path.join(tmpdir, "base.yaml")
-    asdf_edit = os.path.join(tmpdir, "edit.asdf")
-    yaml_edit = os.path.join(tmpdir, "edit.yaml")
+@contextmanager
+def file_not_modified(path):
+    """
+    Assert that a file was not modified during the context.
+    """
+    original_mtime = os.stat(path).st_mtime_ns
 
-    create_asdf(version, asdf_base)
-    create_asdf(version, asdf_edit)
+    yield
 
-    args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{yaml_base}"]
-    main.main_from_args(args)
-
-    return asdf_base, yaml_base, asdf_edit, yaml_edit
+    assert os.stat(path).st_mtime_ns == original_mtime
 
 
-# --------------- Tests ---------------
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_tack_s_bad_args_bad_f(tmpdir, version):
-    asdf_base = os.path.join(tmpdir, "base.asdf")
+@pytest.fixture
+def mock_input(monkeypatch):
+    """
+    Fixture providing a function that mocks the edit module's
+    built-in input function.
+    """
+    @contextmanager
+    def _mock_input(pattern, response):
+        called = False
+        def _input(prompt=None):
+            nonlocal called
+            called = True
+            assert prompt is not None and re.match(pattern, prompt)
+            return response
 
-    args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{asdf_base}"]
-    with pytest.raises(SystemExit) as e:
-        main.main(args)
-    assert e.value.code == 1
+        with monkeypatch.context() as m:
+            m.setattr("builtins.input", _input)
+            yield
 
+        assert called, "input was not called as expected"
 
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_tack_s_bad_args_bad_o(tmpdir, version):
-    yaml_base = os.path.join(tmpdir, "base.yaml")
-
-    args = ["edit", "-e", "-f", f"{yaml_base}", "-o", f"{yaml_base}"]
-    with pytest.raises(SystemExit) as e:
-        main.main(args)
-    assert e.value.code == 1
-
-
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_tack_e_bad_args_bad_o(tmpdir, version):
-    asdf_base = os.path.join(tmpdir, "base.asdf")
-
-    args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{asdf_base}"]
-    with pytest.raises(SystemExit) as e:
-        main.main(args)
-    assert e.value.code == 1
+    return _mock_input
 
 
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_tack_e_bad_args_bad_f(tmpdir, version):
-    yaml_base = os.path.join(tmpdir, "base.yaml")
+@pytest.fixture(autouse=True)
+def default_mock_input(monkeypatch):
+    """
+    Fixture that raises an error when the program
+    requests unexpected input.
+    """
+    def _input(prompt=None):
+        raise AssertionError(f"Received unexpected request for input: {prompt}")
 
-    args = ["edit", "-e", "-f", f"{yaml_base}", "-o", f"{yaml_base}"]
-    with pytest.raises(SystemExit) as e:
-        main.main(args)
-    assert e.value.code == 1
-
-
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_bad_args(tmpdir, version):
-    asdf_base = os.path.join(tmpdir, "base.asdf")
-
-    args = ["edit", "-e", "-f", f"{asdf_base}"]
-    with pytest.raises(SystemExit) as e:
-        main.main(args)
-    assert e.value.code == 2
+    monkeypatch.setattr("builtins.input", _input)
 
 
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_save_to_no_binary(tmpdir, version):
-    asdf_base = os.path.join(tmpdir, "base.asdf")
-    yaml_base = os.path.join(tmpdir, "base.yaml")
-    yaml_edit = os.path.join(tmpdir, "edit.yaml")
+def test_no_blocks(tmp_path, create_editor, version):
+    file_path = str(tmp_path/"test.asdf")
 
-    _create_base_asdf_no_blocks(version, asdf_base)
-    _create_base_asdf_no_blocks(version, yaml_base)
+    with asdf.AsdfFile(version=version) as af:
+        af["foo"] = "bar"
+        af.write_to(file_path)
 
-    _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 2")
+    os.environ["EDITOR"] = create_editor(r"foo: bar", "foo: baz")
 
-    args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_base}"]
-    with pytest.raises(SystemExit) as e:
-        main.main(args)
-    assert e.value.code == 1
+    assert main.main_from_args(["edit", file_path]) == 0
+
+    with asdf.open(file_path) as af:
+        assert af["foo"] == "baz"
 
 
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_no_binary(tmpdir, version):
-    asdf_base = os.path.join(tmpdir, "base.asdf")
-    yaml_base = os.path.join(tmpdir, "base.yaml")
-    _create_base_asdf_no_blocks(version, asdf_base)
+def test_no_blocks_increase_size(tmp_path, create_editor, version):
+    file_path = str(tmp_path/"test.asdf")
 
-    args = ["edit", "-e", "-f", f"{asdf_base}", "-o", f"{yaml_base}"]
-    with pytest.raises(SystemExit) as e:
-        main.main(args)
-    assert e.value.code == 1
+    with asdf.AsdfFile(version=version) as af:
+        af["foo"] = "bar"
+        af.write_to(file_path)
 
+    new_value = "a" * 32768
+    os.environ["EDITOR"] = create_editor(r"foo: bar", f"foo: {new_value}")
 
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_smaller(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
-        tmpdir, version, _create_base_asdf
-    )
+    # With no blocks, we can expand the existing file, so this case
+    # shouldn't require confirmation from the user.
+    assert main.main_from_args(["edit", file_path]) == 0
 
-    _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 2")
-
-    args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
-    main.main_from_args(args)
-    assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
-
-    with asdf.open(asdf_edit) as af:
-        assert af.tree["foo"] == 2
+    with asdf.open(file_path) as af:
+        assert af["foo"] == new_value
 
 
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_equal(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
-        tmpdir, version, _create_base_asdf
-    )
+def test_no_blocks_decrease_size(tmp_path, create_editor, version):
+    file_path = str(tmp_path/"test.asdf")
 
-    _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 41")
+    original_value = "a" * 32768
 
-    args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
-    main.main_from_args(args)
-    assert os.path.getsize(asdf_edit) == os.path.getsize(asdf_base)
+    with asdf.AsdfFile(version=version) as af:
+        af["foo"] = original_value
+        af.write_to(file_path)
 
-    with asdf.open(asdf_edit) as af:
-        assert af.tree["foo"] == 41
+    os.environ["EDITOR"] = create_editor(f"foo: {original_value}", "foo: bar")
 
+    assert main.main_from_args(["edit", file_path]) == 0
 
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_larger(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
-        tmpdir, version, _create_base_asdf
-    )
-
-    _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 42\nbar: 13")
-
-    args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
-    main.main_from_args(args)
-    assert os.path.getsize(asdf_edit) - os.path.getsize(asdf_base) > 10000
-
-    with asdf.open(asdf_edit) as af:
-        assert "bar" in af.tree
-        assert af.tree["bar"] == 13
+    with asdf.open(file_path) as af:
+        assert af["foo"] == "bar"
 
 
-@pytest.mark.parametrize("version", asdf.versioning.supported_versions)
-def test_edit_larger_stream(tmpdir, version):
-    asdf_base, yaml_base, asdf_edit, yaml_edit = _initialize_test(
-        tmpdir, version, _create_base_asdf_stream
-    )
+def test_with_blocks(tmp_path, create_editor, version):
+    file_path = str(tmp_path/"test.asdf")
 
-    _create_edited_yaml(yaml_base, yaml_edit, b"foo: 42", b"foo: 42\nbar: 13")
+    with asdf.AsdfFile(version=version) as af:
+        af["array"] = np.arange(constants.DEFAULT_AUTO_INLINE + 1)
+        af["foo"] = "bar"
+        af.write_to(file_path)
 
-    args = ["edit", "-s", "-f", f"{yaml_edit}", "-o", f"{asdf_edit}"]
-    main.main_from_args(args)
-    assert os.path.getsize(asdf_edit) - os.path.getsize(asdf_base) > 10000
+    os.environ["EDITOR"] = create_editor(r"foo: bar", "foo: baz")
 
-    with asdf.open(asdf_edit) as af:
-        assert "bar" in af.tree
-        assert af.tree["bar"] == 13
+    assert main.main_from_args(["edit", file_path]) == 0
+
+    with asdf.open(file_path) as af:
+        assert af["foo"] == "baz"
+
+
+def test_with_blocks_increase_size(tmp_path, create_editor, version, mock_input):
+    file_path = str(tmp_path/"test.asdf")
+
+    with asdf.AsdfFile(version=version) as af:
+        af["array"] = np.arange(constants.DEFAULT_AUTO_INLINE + 1)
+        af["foo"] = "bar"
+        af.write_to(file_path)
+
+    new_value = "a" * 32768
+    os.environ["EDITOR"] = create_editor(r"foo: bar", f"foo: {new_value}")
+
+    # Abort without updating the file
+    with mock_input(r"\(c\)ontinue or \(a\)bort\?", "a"):
+        with file_not_modified(file_path):
+            assert main.main_from_args(["edit", file_path]) == 1
+
+    # Agree to allow the file to be rewritten
+    with mock_input(r"\(c\)ontinue or \(a\)bort\?", "c"):
+        assert main.main_from_args(["edit", file_path]) == 0
+
+    with asdf.open(file_path) as af:
+        assert af["foo"] == new_value
+
+
+def test_with_blocks_decrease_size(tmp_path, create_editor, version):
+    file_path = str(tmp_path/"test.asdf")
+
+    original_value = "a" * 32768
+
+    with asdf.AsdfFile(version=version) as af:
+        af["foo"] = original_value
+        af.write_to(file_path)
+
+    os.environ["EDITOR"] = create_editor(f"foo: {original_value}", "foo: bar")
+
+    assert main.main_from_args(["edit", file_path]) == 0
+
+    with asdf.open(file_path) as af:
+        assert af["foo"] == "bar"
+
+
+def test_no_changes(tmp_path, create_editor, version):
+    file_path = str(tmp_path/"test.asdf")
+
+    with asdf.AsdfFile(version=version) as af:
+        af["foo"] = "bar"
+        af.write_to(file_path)
+
+    os.environ["EDITOR"] = create_editor(r"non-existent-string", "non-existent-string")
+
+    with file_not_modified(file_path):
+        assert main.main_from_args(["edit", file_path]) == 0
+
+
+def test_update_asdf_standard_version(tmp_path, create_editor, version, mock_input):
+    file_path = str(tmp_path/"test.asdf")
+
+    with asdf.AsdfFile(version=version) as af:
+        af["foo"] = "bar"
+        af.write_to(file_path)
+
+    os.environ["EDITOR"] = create_editor(r"^#ASDF_STANDARD .*?$", "#ASDF_STANDARD 999.999.999")
+
+    with file_not_modified(file_path):
+        with mock_input(r"\(c\)ontinue editing or \(a\)bort\?", "a"):
+            assert main.main_from_args(["edit", file_path]) == 1
+
+
+def test_bad_yaml(tmp_path, create_editor, version, mock_input):
+    file_path = str(tmp_path/"test.asdf")
+
+    with asdf.AsdfFile(version=version) as af:
+        af["foo"] = "bar"
+        af.write_to(file_path)
+
+    os.environ["EDITOR"] = create_editor(r"foo: bar", "foo: [")
+
+    with file_not_modified(file_path):
+        with mock_input(r"\(c\)ontinue editing or \(a\)bort\?", "a"):
+            assert main.main_from_args(["edit", file_path]) == 1
+
+
+def test_validation_failure(tmp_path, create_editor, version, mock_input):
+    file_path = str(tmp_path/"test.asdf")
+
+    with asdf.AsdfFile(version=version) as af:
+        af["array"] = np.arange(constants.DEFAULT_AUTO_INLINE + 1)
+        af.write_to(file_path)
+
+    os.environ["EDITOR"] = create_editor(r"byteorder: .*?$", "byteorder: medium")
+
+    with file_not_modified(file_path):
+        with mock_input(r"\(c\)ontinue editing, \(f\)orce update, or \(a\)bort\?", "a"):
+            assert main.main_from_args(["edit", file_path]) == 1
+
+    with mock_input(r"\(c\)ontinue editing, \(f\)orce update, or \(a\)bort\?", "f"):
+        assert main.main_from_args(["edit", file_path]) == 0
+
+    with open(file_path, "rb") as f:
+        content = f.read()
+        assert b"byteorder: medium" in content
+
+
+def test_asdf_open_failure(tmp_path, create_editor, version, mock_input):
+    file_path = str(tmp_path/"test.asdf")
+
+    with asdf.AsdfFile(version=version) as af:
+        af["foo"] = "bar"
+        af.write_to(file_path)
+
+    os.environ["EDITOR"] = create_editor(r"^#ASDF .*?$", "#HJKL 1.0.0")
+
+    with file_not_modified(file_path):
+        with mock_input(r"\(c\)ontinue editing or \(a\)bort\?", "a"):
+            assert main.main_from_args(["edit", file_path]) == 1
+
+
+def test_non_asdf_file(tmp_path):
+    file_path = str(tmp_path/"test.asdf")
+
+    with open(file_path, "w") as f:
+        f.write("Dear diary...")
+
+    with file_not_modified(file_path):
+        assert main.main_from_args(["edit", file_path]) == 1


### PR DESCRIPTION
This updates the new "asdftool edit" subcommand to automatically generate a temporary file name and open an editor.  There are heavier changes than might be expected because I discovered/created some opportunities to share more code with asdf.py and block.py.