### PR TITLE
Fix strides issues over FITS arrays and base arrays with negative strides

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,15 +43,21 @@
 - Add ``edit`` subcommand to asdftool for efficient editing of
   the YAML portion of an ASDF file.  [#873, #922]
 
+2.7.3 (unreleased)
+------------------
+
+- Add pytest plugin options to skip and xfail individual tests
+  and xfail the unsupported ndarray-1.0.0 example. [#929]
+
+- Fix bugs resulting in invalid strides values for FITS arrays
+  and views over base arrays with negative strides. [#930]
+
 2.7.2 (2021-01-15)
 ------------------
 
 - Fix bug causing test collection failures in some environments. [#889]
 
 - Fix bug when decompressing arrays with numpy 1.20.  [#901, #909]
-
-- Add pytest plugin options to skip and xfail individual tests
-  and xfail the unsupported ndarray-1.0.0 example. [#929]
 
 2.7.1 (2020-08-18)
 ------------------

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -851,13 +851,6 @@ class Block:
         """
         return self.offset + self.header_size + self.allocated
 
-    def override_byteorder(self, byteorder):
-        """
-        Hook to permit overriding the byteorder value stored in the
-        tree.  This is used to support blocks stored in FITS files.
-        """
-        return byteorder
-
     @property
     def trust_data_dtype(self):
         """
@@ -910,11 +903,11 @@ class Block:
         else:
             self._checksum = checksum
 
-    def _calculate_checksum(self, data):
+    def _calculate_checksum(self, array):
         # The following line is safe because we're only using
         # the MD5 as a checksum.
         m = hashlib.new('md5') # nosec
-        m.update(self.data.ravel('K'))
+        m.update(array)
         return m.digest()
 
     def validate_checksum(self):
@@ -929,7 +922,7 @@ class Block:
             `False`.
         """
         if self._checksum:
-            checksum = self._calculate_checksum(self.data)
+            checksum = self._calculate_checksum(self._flattened_data)
             if checksum != self._checksum:
                 return False
         return True
@@ -938,7 +931,7 @@ class Block:
         """
         Update the checksum based on the current data contents.
         """
-        self._checksum = self._calculate_checksum(self.data)
+        self._checksum = self._calculate_checksum(self._flattened_data)
 
     def update_size(self):
         """
@@ -947,13 +940,14 @@ class Block:
         updating the file in-place, otherwise the work is redundant.
         """
         if self._data is not None:
-            self._data_size = self._data.data.nbytes
+            data = self._flattened_data
+            self._data_size = data.nbytes
 
             if not self.output_compression:
                 self._size = self._data_size
             else:
                 self._size = mcompression.get_compressed_size(
-                    self._data, self.output_compression)
+                    data, self.output_compression)
         else:
             self._data_size = self._size = 0
 
@@ -1098,22 +1092,55 @@ class Block:
             self._data = self._fd.memmap_array(self.data_offset, self._size)
             self._memmapped = True
 
+    @property
+    def _flattened_data(self):
+        """
+        Retrieve flattened data suitable for writing.
+
+        Returns
+        -------
+        np.ndarray
+            1D contiguous array.
+        """
+        data = self.data
+
+        # Reverse axes with negative strides so that we write the array
+        # according to the memory layout of the underlying buffer.
+        if any(s < 0 for s in data.strides):
+            slices = []
+            for stride in data.strides:
+                if stride < 0:
+                    slices.append(slice(None, None, -1))
+                else:
+                    slices.append(slice(None))
+            data = data[tuple(slices)]
+
+        # 'K' order flattens the array in the order that elements
+        # occur in memory (except negative strides are reversed,
+        # which we handled above).
+        return data.ravel(order='K')
+
     def write(self, fd):
         """
         Write an internal block to the given Python file-like object.
         """
         self._header_size = self._header.size
 
+        if self._data is not None:
+            data = self._flattened_data
+        else:
+            data = None
+
         flags = 0
         data_size = used_size = allocated_size = 0
         if self._array_storage == 'streamed':
             flags |= constants.BLOCK_FLAG_STREAMED
-        elif self._data is not None:
-            self.update_checksum()
-            data_size = self._data.nbytes
+        elif data is not None:
+            self._checksum = self._calculate_checksum(data)
+            data_size = data.nbytes
             if not fd.seekable() and self.output_compression:
                 buff = io.BytesIO()
-                mcompression.compress(buff, self._data,
+                mcompression.compress(buff, data,
                                       self.output_compression)
                 self.allocated = self._size = buff.tell()
             allocated_size = self.allocated
@@ -1138,7 +1165,7 @@ class Block:
             used_size=used_size, data_size=data_size,
             checksum=checksum))
 
-        if self._data is not None:
+        if data is not None:
             if self.output_compression:
                 if not fd.seekable():
                     fd.write(buff.getvalue())
@@ -1149,7 +1176,7 @@ class Block:
                     # header.
                     start = fd.tell()
                     mcompression.compress(
-                        fd, self._data, self.output_compression)
+                        fd, data, self.output_compression)
                     end = fd.tell()
                     self.allocated = self._size = end - start
                     fd.seek(self.offset + 6)
@@ -1161,7 +1188,7 @@ class Block:
             else:
                 if used_size != data_size:
                     raise RuntimeError(f"Block used size {used_size} is not equal to the data size {data_size}")
-                fd.write_array(self._data)
+                fd.write_array(data)
 
     @property
     def data(self):

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -46,13 +46,6 @@ class _FitsBlock:
     def array_storage(self):
         return 'fits'
 
-    def override_byteorder(self, byteorder):
-        # FITS data is always stored in big-endian byte order.
-        # The data array may not report big-endian, but we want
-        # the value written to the tree to match the actual
-        # byte order on disk.
-        return 'big'
-
     @property
     def trust_data_dtype(self):
         # astropy.io.fits returns arrays in native byte order

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -92,7 +92,7 @@ size : integer
 """
 
 
-def _array_tofile_chunked(write, array, chunksize):  # pragma: no cover
+def _array_tofile_chunked(write, array, chunksize):
     array = array.view(np.uint8)
     for i in range(0, array.nbytes, chunksize):
         write(array[i:i + chunksize].data)
@@ -101,8 +101,7 @@ def _array_tofile_chunked(write, array, chunksize):  # pragma: no cover
 def _array_tofile_simple(fd, write, array):
     return write(array.data)
 
-
-if sys.platform == 'darwin':  # pragma: no cover
+if sys.platform == 'darwin':
     def _array_tofile(fd, write, array):
         # This value is currently set as a workaround for a known bug in Python
         # on OSX. Individual writes must be less than 2GB, which necessitates
@@ -112,7 +111,7 @@ if sys.platform == 'darwin':  # pragma: no cover
         if fd is None or array.nbytes >= OSX_WRITE_LIMIT and array.nbytes % 4096 == 0:
             return _array_tofile_chunked(write, array, OSX_WRITE_LIMIT)
         return _array_tofile_simple(fd, write, array)
-elif sys.platform.startswith('win'):  # pragma: no cover
+elif sys.platform.startswith('win'):
     def _array_tofile(fd, write, array):
         WIN_WRITE_LIMIT = 2 ** 30
         return _array_tofile_chunked(write, array, WIN_WRITE_LIMIT)
@@ -370,7 +369,20 @@ class GenericFile(metaclass=util.InheritDocstrings):
     """
 
     def write_array(self, array):
-        _array_tofile(None, self.write, array.ravel(order='K'))
+        """
+        Write array content to the file.  Array must be 1D contiguous
+        so that this method can avoid making assumptions about the
+        intended memory layout.  Endianness is preserved.
+
+        Parameters
+        ----------
+        array : np.ndarray
+            Must be 1D contiguous.
+        """
+        if len(array.shape) != 1 or not array.flags.contiguous:
+            raise ValueError("Requires 1D contiguous array.")
+
+        _array_tofile(None, self.write, array)
 
     def seek(self, offset, whence=0):
         """
@@ -749,7 +761,10 @@ class RealFile(RandomAccessFile):
             arr.flush()
             self.fast_forward(len(arr.data))
         else:
-            _array_tofile(self._fd, self._fd.write, arr.ravel(order='K'))
+            if len(arr.shape) != 1 or not arr.flags.contiguous:
+                raise ValueError("Requires 1D contiguous array.")
+
+            _array_tofile(self._fd, self._fd.write, arr)
 
     def can_memmap(self):
         return True

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -81,7 +81,10 @@ def asdf_datatype_to_numpy_dtype(datatype, byteorder=None):
     raise ValueError("Unknown datatype {0}".format(datatype))
 
 
-def numpy_byteorder_to_asdf_byteorder(byteorder):
+def numpy_byteorder_to_asdf_byteorder(byteorder, override=None):
+    if override is not None:
+        return override
+
     if byteorder == '=':
         return sys.byteorder
     elif byteorder == '<':
@@ -90,7 +93,7 @@ def numpy_byteorder_to_asdf_byteorder(byteorder):
         return 'big'
 
 
-def numpy_dtype_to_asdf_datatype(dtype, include_byteorder=True):
+def numpy_dtype_to_asdf_datatype(dtype, include_byteorder=True, override_byteorder=None):
     dtype = np.dtype(dtype)
     if dtype.names is not None:
         fields = []
@@ -98,30 +101,30 @@ def numpy_dtype_to_asdf_datatype(dtype, include_byteorder=True):
             field = dtype.fields[name][0]
             d = {}
             d['name'] = name
-            field_dtype, byteorder = numpy_dtype_to_asdf_datatype(field)
+            field_dtype, byteorder = numpy_dtype_to_asdf_datatype(field, override_byteorder=override_byteorder)
             d['datatype'] = field_dtype
             if include_byteorder:
                 d['byteorder'] = byteorder
             if field.shape:
                 d['shape'] = list(field.shape)
             fields.append(d)
-        return fields, numpy_byteorder_to_asdf_byteorder(dtype.byteorder)
+        return fields, numpy_byteorder_to_asdf_byteorder(dtype.byteorder, override=override_byteorder)
 
     elif dtype.subdtype is not None:
-        return numpy_dtype_to_asdf_datatype(dtype.subdtype[0])
+        return numpy_dtype_to_asdf_datatype(dtype.subdtype[0], override_byteorder=override_byteorder)
 
     elif dtype.name in _datatype_names:
-        return dtype.name, numpy_byteorder_to_asdf_byteorder(dtype.byteorder)
+        return dtype.name, numpy_byteorder_to_asdf_byteorder(dtype.byteorder, override=override_byteorder)
 
     elif dtype.name == 'bool':
-        return 'bool8', numpy_byteorder_to_asdf_byteorder(dtype.byteorder)
+        return 'bool8', numpy_byteorder_to_asdf_byteorder(dtype.byteorder, override=override_byteorder)
 
     elif dtype.name.startswith('string') or dtype.name.startswith('bytes'):
         return ['ascii', dtype.itemsize], 'big'
 
     elif dtype.name.startswith('unicode') or dtype.name.startswith('str'):
         return (['ucs4', int(dtype.itemsize / 4)],
-                numpy_byteorder_to_asdf_byteorder(dtype.byteorder))
+                numpy_byteorder_to_asdf_byteorder(dtype.byteorder, override=override_byteorder))
 
     raise ValueError("Unknown dtype {0}".format(dtype))
 
@@ -408,31 +411,55 @@ class NDArrayType(AsdfType):
 
     @classmethod
     def to_tree(cls, data, ctx):
+        # The ndarray-1.0.0 schema does not permit 0 valued strides.
+        # Perhaps we'll want to allow this someday, to efficiently
+        # represent an array of all the same value.
         if any(stride == 0 for stride in data.strides):
             data = np.ascontiguousarray(data)
 
-        base = util.get_array_base(data)
         shape = data.shape
-        dtype = data.dtype
-        offset = data.ctypes.data - base.ctypes.data
-
-        if data.flags.c_contiguous:
-            strides = None
-        else:
-            strides = data.strides
 
         block = ctx.blocks.find_or_create_block_for_array(data, ctx)
+
+        if block.array_storage == "fits":
+            # Views over arrays stored in FITS files have some idiosyncracies.
+            # astropy.io.fits always writes arrays C-contiguous with big-endian
+            # byte order, whereas asdf preserves the "contiguousity" and byte order
+            # of the base array.
+            if (block.data.shape != data.shape or
+                block.data.dtype.itemsize != data.dtype.itemsize or
+                block.data.ctypes.data != data.ctypes.data or
+                block.data.strides != data.strides):
+                raise ValueError("Views over FITS arrays must have identical memory layout")
+
+            offset = 0
+            strides = None
+            dtype, byteorder = numpy_dtype_to_asdf_datatype(
+                data.dtype,
+                include_byteorder=(block.array_storage != "inline"),
+                override_byteorder="big",
+            )
+        else:
+            base = util.get_array_base(data)
+            # Compute the offset relative to the base array and not the
+            # block data, in case the block is compressed.
+            offset = data.ctypes.data - base.ctypes.data
+
+            if data.flags.c_contiguous:
+                strides = None
+            else:
+                strides = data.strides
+
+            dtype, byteorder = numpy_dtype_to_asdf_datatype(
+                data.dtype,
+                include_byteorder=(block.array_storage != "inline"),
+            )
 
         result = {}
 
         result['shape'] = list(shape)
         if block.array_storage == 'streamed':
             result['shape'][0] = '*'
-
-        dtype, byteorder = numpy_dtype_to_asdf_datatype(
-            dtype, include_byteorder=(block.array_storage != 'inline'))
-
-        byteorder = block.override_byteorder(byteorder)
 
         if block.array_storage == 'inline':
             listdata = numpy_array_to_list(data)

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -430,7 +430,12 @@ class NDArrayType(AsdfType):
                 block.data.dtype.itemsize != data.dtype.itemsize or
                 block.data.ctypes.data != data.ctypes.data or
                 block.data.strides != data.strides):
-                raise ValueError("Views over FITS arrays must have identical memory layout")
+                raise ValueError(
+                    "ASDF has only limited support for serializing views over arrays stored "
+                    "in FITS HDUs.  This error likely means that a slice of such an array "
+                    "was found in the ASDF tree.  The slice can be decoupled from the FITS "
+                    "array by calling copy() before assigning it to the tree."
+                )
 
             offset = 0
             strides = None

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -396,6 +396,7 @@ def test_serialize_table(tmpdir):
         data = ff.tree['my_table']
         assert data._source.startswith('fits:')
 
+
 def test_extension_check():
     testfile = get_test_data_path('extension_check.fits')
 
@@ -422,6 +423,7 @@ def test_verify_with_astropy(tmpdir, dtype):
 
     with fits.open(tmpfile) as hdu:
         hdu.verify('exception')
+
 
 def test_dangling_file_handle(tmpdir):
     """
@@ -456,3 +458,67 @@ def test_dangling_file_handle(tmpdir):
     gc.collect()
 
     del ctx
+
+
+def test_array_view(tmp_path):
+    """
+    Special handling is required when a view over a larger array
+    is assigned to an HDU and referenced from the ASDF tree.
+    """
+    file_path = tmp_path / "test.fits"
+
+    data = np.zeros((10, 10))
+    data_view = data[:, :5]
+
+    hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
+    with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
+        af["data"] = hdul[-1].data
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert_array_equal(af["data"], data_view)
+
+
+def test_array_view_compatible_layout(tmp_path):
+    """
+    We should be able to serialize additional views that have
+    the same memory layout.
+    """
+    file_path = tmp_path / "test.fits"
+
+    data = np.zeros((10, 10), dtype=np.float64)
+    data_view = data[:, :5]
+    other_view = data_view[:, :]
+    different_dtype_view = data_view.view(np.int64)
+
+    hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
+    with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
+        af["data"] = hdul[-1].data
+        af["other"] = other_view
+        af["different_dtype"] = different_dtype_view
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert_array_equal(af["data"], data_view)
+        assert_array_equal(af["other"], other_view)
+        assert_array_equal(af["other"], different_dtype_view)
+
+
+def test_array_view_different_layout(tmp_path):
+    """
+    A view over the FITS array with a different memory layout
+    might end up corrupted when astropy.io.fits changes the
+    array to C-contiguous and big-endian on write.
+    """
+    file_path = tmp_path / "test.fits"
+
+    data = np.zeros((10, 10))
+    data_view = data[:, :5]
+    other_view = data_view[:, ::-1]
+
+    hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
+    with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
+        af["fits"] = hdul[-1].data
+        af["other"] = other_view
+        with pytest.raises(ValueError, match="Views over FITS arrays must have identical memory layout"):
+            af.write_to(file_path)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -520,5 +520,5 @@ def test_array_view_different_layout(tmp_path):
     with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
         af["fits"] = hdul[-1].data
         af["other"] = other_view
-        with pytest.raises(ValueError, match="Views over FITS arrays must have identical memory layout"):
+        with pytest.raises(ValueError, match="ASDF has only limited support for serializing views over arrays stored in FITS HDUs"):
             af.write_to(file_path)


### PR DESCRIPTION
This PR fixes bugs in serializing views over FITS arrays and base arrays with negative strides.

The astropy.io.fits library always writes arrays in C-contiguous order, but this library has been serializing views as though the arrays were to be written in the same order that they are stored in memory.  This works fine for arrays that are already C-contiguous but corrupts views over F-contiguous or non-contiguous arrays.  The fix here will handle the most common case where the view and the array have the same memory layout.  It raises an error when they do not, which is better than writing unreadable files.  I ran the jwst regression tests on this branch and all tests passed except for 5 known and unrelated failures.

In the case of a base array with negative strides, we've been serializing views relative to the buffer that the base array is striding over, but writing the data in the memory order of the array itself.  The fix here is to write the array in the same order as the underlying buffer which keeps the views valid.  I don't have a test for this case because I haven't been able to create a base array with negative strides using numpy alone.  I did run the script from #916 with scipy 1.6.1 and the array read back in correctly.  If anyone knows how to create such an array do please let me know!

Resolves #916 and spacetelescope/jwst#5699