### PR TITLE
Revert attempted fix for base arrays with negative strides

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,8 +49,8 @@
 - Add pytest plugin options to skip and xfail individual tests
   and xfail the unsupported ndarray-1.0.0 example. [#929]
 
-- Fix bugs resulting in invalid strides values for FITS arrays
-  and views over base arrays with negative strides. [#930]
+- Fix bug resulting in invalid strides values for views over
+  FITS arrays. [#930]
 
 2.7.2 (2021-01-15)
 ------------------

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -1104,20 +1104,10 @@ class Block:
         """
         data = self.data
 
-        # Reverse axes with negative strides so that we write the array
-        # according to the memory layout of the underlying buffer.
-        if any(s < 0 for s in data.strides):
-            slices = []
-            for stride in data.strides:
-                if stride < 0:
-                    slices.append(slice(None, None, -1))
-                else:
-                    slices.append(slice(None))
-            data = data[tuple(slices)]
-
         # 'K' order flattens the array in the order that elements
-        # occur in memory (except negative strides are reversed,
-        # which we handled above).
+        # occur in memory, except axes with negative strides which
+        # are reversed.  That is a problem for base arrays with
+        # negative strides and is an outstanding bug in this library.
         return data.ravel(order='K')
 
     def write(self, fd):

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -445,9 +445,10 @@ class NDArrayType(AsdfType):
                 override_byteorder="big",
             )
         else:
-            base = util.get_array_base(data)
             # Compute the offset relative to the base array and not the
             # block data, in case the block is compressed.
+            base = util.get_array_base(data)
+
             offset = data.ctypes.data - base.ctypes.data
 
             if data.flags.c_contiguous:

--- a/docs/asdf/changes.rst
+++ b/docs/asdf/changes.rst
@@ -11,8 +11,8 @@ The ASDF Standard is at v1.5.0.
 
 Changes include:
 
-- Fix bugs resulting in invalid strides values for FITS arrays
-  and views over base arrays with negative strides.
+- Fix bug resulting in invalid strides values for views over
+  FITS arrays.
 
 - Add pytest plugin options to skip and xfail individual tests
   and xfail the unsupported ndarray-1.0.0 schema example.


### PR DESCRIPTION
I only fooled myself into thinking that this issue was fixed -- when testing I had forgotten that a change in master inlines arrays with < 100 elements.  Reversing the strides is one piece of the puzzle but the offset still needs to be recomputed for that memory layout, and that's a difficult problem that I don't know how to solve yet.  This PR reverts the partial fix for base arrays with negative strides so that the fix for FITS arrays can be released.