### PR TITLE
Fix FITS array view tests

### DIFF
--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -12,6 +12,7 @@ from astropy.table import Table
 from jsonschema.exceptions import ValidationError
 
 import asdf
+from asdf.constants import DEFAULT_AUTO_INLINE
 from asdf import get_config
 from asdf import fits_embed
 from asdf import open as asdf_open
@@ -467,10 +468,8 @@ def test_array_view(tmp_path):
     """
     file_path = tmp_path / "test.fits"
 
-    data = np.arange(400, dtype=np.float64).reshape(20, 20)
-    data_view = data[:, :20]
-
-    assert data_view.size > asdf.constants.DEFAULT_AUTO_INLINE
+    data = np.arange(DEFAULT_AUTO_INLINE ** 2, dtype=np.float64).reshape(DEFAULT_AUTO_INLINE, DEFAULT_AUTO_INLINE)
+    data_view = data[:, :(DEFAULT_AUTO_INLINE // 2)]
 
     hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
     with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
@@ -488,11 +487,9 @@ def test_array_view_compatible_layout(tmp_path):
     """
     file_path = tmp_path / "test.fits"
 
-    data = np.arange(400, dtype=np.float64).reshape(20, 20)
-    data_view = data[:, :10]
+    data = np.arange(DEFAULT_AUTO_INLINE ** 2, dtype=np.float64).reshape(DEFAULT_AUTO_INLINE, DEFAULT_AUTO_INLINE)
+    data_view = data[:, :(DEFAULT_AUTO_INLINE // 2)]
     other_view = data_view[:, :]
-
-    assert data_view.size > asdf.constants.DEFAULT_AUTO_INLINE
 
     hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
     with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
@@ -514,11 +511,9 @@ def test_array_view_compatible_dtype(tmp_path):
     """
     file_path = tmp_path / "test.fits"
 
-    data = np.arange(400, dtype=np.float64).reshape(20, 20)
-    data_view = data[:, :10]
+    data = np.arange(DEFAULT_AUTO_INLINE ** 2, dtype=np.float64).reshape(DEFAULT_AUTO_INLINE, DEFAULT_AUTO_INLINE)
+    data_view = data[:, :(DEFAULT_AUTO_INLINE // 2)]
     other_view = data.view(np.int64)
-
-    assert data_view.size > asdf.constants.DEFAULT_AUTO_INLINE
 
     hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
     with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
@@ -539,11 +534,9 @@ def test_array_view_different_layout(tmp_path):
     """
     file_path = tmp_path / "test.fits"
 
-    data = np.arange(400, dtype=np.float64).reshape(20, 20)
-    data_view = data[:, :10]
-    other_view = data_view[:, 10:]
-
-    assert data_view.size > asdf.constants.DEFAULT_AUTO_INLINE
+    data = np.arange(DEFAULT_AUTO_INLINE ** 2, dtype=np.float64).reshape(DEFAULT_AUTO_INLINE, DEFAULT_AUTO_INLINE)
+    data_view = data[:, :(DEFAULT_AUTO_INLINE // 2)]
+    other_view = data_view[:, (DEFAULT_AUTO_INLINE // 2):]
 
     hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
     with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -467,8 +467,10 @@ def test_array_view(tmp_path):
     """
     file_path = tmp_path / "test.fits"
 
-    data = np.zeros((10, 10))
-    data_view = data[:, :5]
+    data = np.arange(400, dtype=np.float64).reshape(20, 20)
+    data_view = data[:, :20]
+
+    assert data_view.size > asdf.constants.DEFAULT_AUTO_INLINE
 
     hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
     with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
@@ -486,22 +488,47 @@ def test_array_view_compatible_layout(tmp_path):
     """
     file_path = tmp_path / "test.fits"
 
-    data = np.zeros((10, 10), dtype=np.float64)
-    data_view = data[:, :5]
+    data = np.arange(400, dtype=np.float64).reshape(20, 20)
+    data_view = data[:, :10]
     other_view = data_view[:, :]
-    different_dtype_view = data_view.view(np.int64)
+
+    assert data_view.size > asdf.constants.DEFAULT_AUTO_INLINE
 
     hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
     with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
         af["data"] = hdul[-1].data
         af["other"] = other_view
-        af["different_dtype"] = different_dtype_view
         af.write_to(file_path)
 
     with asdf.open(file_path) as af:
         assert_array_equal(af["data"], data_view)
         assert_array_equal(af["other"], other_view)
-        assert_array_equal(af["other"], different_dtype_view)
+
+
+@pytest.mark.xfail(reason="Outstanding bug in AsdfInFits", strict=True)
+def test_array_view_compatible_dtype(tmp_path):
+    """
+    We should be able to serialize additional views that have
+    the same memory layout and different dtype of the same
+    size.
+    """
+    file_path = tmp_path / "test.fits"
+
+    data = np.arange(400, dtype=np.float64).reshape(20, 20)
+    data_view = data[:, :10]
+    other_view = data.view(np.int64)
+
+    assert data_view.size > asdf.constants.DEFAULT_AUTO_INLINE
+
+    hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
+    with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
+        af["data"] = hdul[-1].data
+        af["other"] = other_view
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert_array_equal(af["data"], data_view)
+        assert_array_equal(af["other"], other_view)
 
 
 def test_array_view_different_layout(tmp_path):
@@ -512,13 +539,15 @@ def test_array_view_different_layout(tmp_path):
     """
     file_path = tmp_path / "test.fits"
 
-    data = np.zeros((10, 10))
-    data_view = data[:, :5]
-    other_view = data_view[:, ::-1]
+    data = np.arange(400, dtype=np.float64).reshape(20, 20)
+    data_view = data[:, :10]
+    other_view = data_view[:, 10:]
+
+    assert data_view.size > asdf.constants.DEFAULT_AUTO_INLINE
 
     hdul = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU(data_view)])
     with asdf.fits_embed.AsdfInFits(hdulist=hdul) as af:
-        af["fits"] = hdul[-1].data
+        af["data"] = hdul[-1].data
         af["other"] = other_view
         with pytest.raises(ValueError, match="ASDF has only limited support for serializing views over arrays stored in FITS HDUs"):
             af.write_to(file_path)


### PR DESCRIPTION
@kmacdonald-stsci pointed out a flaw in the tests I added to cover views over FITS arrays -- the base array was full of zeros, so the assertions were not checking what I thought they were.  Correcting the tests revealed a new bug (present in 2.7.2, so not caused by the 2.7.3 changes) where views over FITS arrays with a different dtype are not deserialized correctly.  This is an uncommon case but we should fix it eventually, so I added an xfail'ed test and will file an issue as well.