### PR TITLE
Fix test failures on s390x and add Docker image for future troubleshooting

### DIFF
--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -1,6 +1,7 @@
 name: s390x
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*'

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -284,7 +284,7 @@ def test_validation_failure(tmp_path, create_editor, version, mock_input):
         af["array"] = np.arange(constants.DEFAULT_AUTO_INLINE + 1)
         af.write_to(file_path)
 
-    os.environ["EDITOR"] = create_editor(r"byteorder: .*?$", "byteorder: medium")
+    os.environ["EDITOR"] = create_editor(r"byteorder: .*?$", "byteorder: med")
 
     with file_not_modified(file_path):
         with mock_input(r"\(c\)ontinue editing, \(f\)orce update, or \(a\)bort\?", "a"):
@@ -295,7 +295,7 @@ def test_validation_failure(tmp_path, create_editor, version, mock_input):
 
     with open(file_path, "rb") as f:
         content = f.read()
-        assert b"byteorder: medium" in content
+        assert b"byteorder: med" in content
 
 
 def test_asdf_open_failure(tmp_path, create_editor, version, mock_input):

--- a/docker/s390x/Dockerfile
+++ b/docker/s390x/Dockerfile
@@ -1,0 +1,33 @@
+FROM s390x/debian:buster
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -q -y
+
+RUN apt-get install -q -y git \
+                          python3 \
+                          python3-astropy \
+                          python3-lz4 \
+                          python3-numpy \
+                          python3-venv \
+                          python3-wheel
+
+WORKDIR /root
+
+RUN python3 -m venv --system-site-packages asdf-env
+
+RUN . /root/asdf-env/bin/activate && \
+    pip3 install --upgrade pip setuptools gwcs==0.9.1 pytest==5.4.3 pytest-doctestplus==0.8.0
+
+RUN git clone https://github.com/asdf-format/asdf.git
+
+WORKDIR /root/asdf
+
+RUN . /root/asdf-env/bin/activate &&\
+    git submodule init && \
+    git submodule update && \
+    pip3 install -e .[all,tests]
+
+RUN echo ". /root/asdf-env/bin/activate" >> /root/.bashrc
+
+CMD [ "/bin/bash" ]

--- a/docker/s390x/README.md
+++ b/docker/s390x/README.md
@@ -1,0 +1,25 @@
+# Troubleshooting asdf tests on S390X architecture
+
+1. Build the Docker image:
+
+```
+docker build -t asdf-s390x .
+```
+
+2. Run the container, which starts in the asdf repository root:
+
+```
+docker run -it asdf-s390x
+```
+
+Alternatively, bind-mount a checkout with local changes:
+
+```
+docker run -it --mount type=bind,source=/path/to/asdf,target=/root/asdf asdf-s390x
+```
+
+3. Run pytest:
+
+```
+pytest
+```


### PR DESCRIPTION
This fixes an asdftool edit test that has been failing on s390x architecture.  The difference there is that the initial byteorder string is "big" and not "little", so replacing it with "medium" causes an extra prompt to confirm that it's okay to rewrite the file.

I also checked in a Dockerfile that I used to troubleshoot the problem with some brief instructions on how to use it.

Resolves #928 