### PR TITLE
Update specutils ref to reflect new default branch name

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -22,7 +22,7 @@ on:
       specutils_ref:
         description: specutils ref
         required: true
-        default: master
+        default: main
   schedule:
     # Run every Monday at 6am UTC
     - cron: '0 6 * * 1'
@@ -49,7 +49,7 @@ jobs:
             ref: ${{ github.event.inputs.jwst_ref || 'master' }}
           - package_name: specutils
             repository: astropy/specutils
-            ref: ${{ github.event.inputs.specutils_ref || 'master' }}
+            ref: ${{ github.event.inputs.specutils_ref || 'main' }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This catches up our downstream workflow with the recent change in the specutils default branch name.  I imagine astropy will change soon as well, but it looks like it hasn't quite yet so I'll leave it alone for now.