### PR TITLE
Fix for base arrays with negative strides

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,13 @@
 
 - Remove the ``asdf.test`` method and ``asdf.__githash__`` attribute. [#943]
 
+2.7.4 (unreleased)
+------------------
+
+- Fix pytest plugin failure under older versions of pytest. [#934]
+
+- Copy array views when the base array is non-contiguous. [#949]
+
 2.7.3 (2021-02-25)
 ------------------
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -417,6 +417,14 @@ class NDArrayType(AsdfType):
         if any(stride == 0 for stride in data.strides):
             data = np.ascontiguousarray(data)
 
+        # The view computations that follow assume that the base array
+        # is contiguous.  If not, we need to make a copy to avoid
+        # writing a nonsense view.
+        base = util.get_array_base(data)
+        if not base.flags.contiguous:
+            data = np.ascontiguousarray(data)
+            base = util.get_array_base(data)
+
         shape = data.shape
 
         block = ctx.blocks.find_or_create_block_for_array(data, ctx)
@@ -447,8 +455,6 @@ class NDArrayType(AsdfType):
         else:
             # Compute the offset relative to the base array and not the
             # block data, in case the block is compressed.
-            base = util.get_array_base(data)
-
             offset = data.ctypes.data - base.ctypes.data
 
             if data.flags.c_contiguous:


### PR DESCRIPTION
Here's my second attempt at a fix for #916.  I noticed that we have a precedent where we copy the view when it has strides unsupported by ASDF (in the existing case, 0 strides).  Since re-computing the view against the base array as serialized is hard, I propose that we do the same here and simply copy the view when its base is non-contiguous.  I also added scipy to our test dependencies so that we can test this using the example in the issue description.

Fixes #916