### PR TITLE
Revive changelog check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,19 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
+
+jobs:
+  changelog:
+    name: Confirm changelog entry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Grep for PR number in CHANGES.rst
+        run: grep -P '\[[^\]]*#${{github.event.number}}[,\]]' CHANGES.rst
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-entry-needed') }}


### PR DESCRIPTION
This adds a workflow that checks for a CHANGES.rst entry for the current PR.  It also responds to the same label that we used before, `no-changelog-entry-needed`.

Resolves #820 