### PR TITLE
Prohibit views over FITS arrays that change dtype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@
 
 - Copy array views when the base array is non-contiguous. [#949]
 
+- Prohibit views over FITS arrays that change dtype. [#952]
+
 2.7.3 (2021-02-25)
 ------------------
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -435,7 +435,7 @@ class NDArrayType(AsdfType):
             # byte order, whereas asdf preserves the "contiguousity" and byte order
             # of the base array.
             if (block.data.shape != data.shape or
-                block.data.dtype.itemsize != data.dtype.itemsize or
+                block.data.dtype != data.dtype or
                 block.data.ctypes.data != data.ctypes.data or
                 block.data.strides != data.strides):
                 raise ValueError(


### PR DESCRIPTION
This PR modifies the check on views over FITS array to prohibit any change in dtype (not just change in item size).  This is needed to prevent the issue described in #937 where such arrays are deserialized with the wrong dtype.  For other reasons (see https://github.com/asdf-format/asdf/pull/810) we need to accept the dtype reported by astropy.io.fits, so it seems our best option is just to further limit what can be done with views over FITS arrays.

Resolves #937 