### PR TITLE
Use temporary working directory for all tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,9 +7,9 @@ import pytest
 @pytest.fixture(scope="session", autouse=True)
 def temp_cwd():
     original_cwd = os.getcwd()
-    try:
-        with tempfile.TemporaryDirectory() as tmp:
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
             os.chdir(tmp)
             yield
-    finally:
-        os.chdir(original_cwd)
+        finally:
+            os.chdir(original_cwd)

--- a/conftest.py
+++ b/conftest.py
@@ -1,20 +1,15 @@
+import os
+import tempfile
+
 import pytest
 
-@pytest.fixture(autouse=True)
-def _docdir(request):
-    """
-    Make sure that doctests run in a temporary directory so that any files that
-    are created as part of the test get removed automatically.
-    """
-    # Trigger ONLY for doctestplus.
+
+@pytest.fixture(scope="session", autouse=True)
+def temp_cwd():
+    original_cwd = os.getcwd()
     try:
-        doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
-        if isinstance(request.node.parent, doctest_plugin._doctest_textfile_item_cls):
-            tmpdir = request.getfixturevalue('tmpdir')
-            with tmpdir.as_cwd():
-                yield
-        else:
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
             yield
-    # Handle case where doctestplus is not available
-    except AttributeError:
-        yield
+    finally:
+        os.chdir(original_cwd)

--- a/conftest.py
+++ b/conftest.py
@@ -1,15 +1,17 @@
 import os
-import tempfile
 
 import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)
-def temp_cwd():
+def temp_cwd(tmpdir_factory):
+    """
+    This fixture creates a temporary current working directory
+    for the test session, so that docstring tests that write files
+    don't clutter up the real cwd.
+    """
     original_cwd = os.getcwd()
-    with tempfile.TemporaryDirectory() as tmp:
-        try:
-            os.chdir(tmp)
-            yield
-        finally:
-            os.chdir(original_cwd)
+    try:
+        os.chdir(tmpdir_factory.mktemp("cwd"))
+    finally:
+        os.chdir(original_cwd)


### PR DESCRIPTION
We apparently have a solution for this that used to work but something changed in the meantime.  It doesn't seem to hurt anything to use a temporary working directory for all tests, so I changed the fixture to do that.

Resolves #942 