### PR TITLE
Drop .tree from search result paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@
 
 - Remove the ``asdf.test`` method and ``asdf.__githash__`` attribute. [#943]
 
+- Remove unnecessary ``.tree`` from search result paths. [#954]
+
 2.7.4 (unreleased)
 ------------------
 

--- a/asdf/_convenience.py
+++ b/asdf/_convenience.py
@@ -41,8 +41,8 @@ def info(node_or_path, max_rows=DEFAULT_MAX_ROWS, max_cols=DEFAULT_MAX_COLS, sho
         Set to False to disable display of primitive values in
         the rendered tree.
     """
-    with _manage_node(node_or_path) as (identifier, node):
-        lines = render_tree(node, max_rows=max_rows, max_cols=max_cols, show_values=show_values, identifier=identifier)
+    with _manage_node(node_or_path) as node:
+        lines = render_tree(node, max_rows=max_rows, max_cols=max_cols, show_values=show_values, identifier="root")
         print("\n".join(lines))
 
 
@@ -50,9 +50,9 @@ def info(node_or_path, max_rows=DEFAULT_MAX_ROWS, max_cols=DEFAULT_MAX_COLS, sho
 def _manage_node(node_or_path):
     if isinstance(node_or_path, str) or isinstance(node_or_path, pathlib.Path):
         with open_asdf(node_or_path) as af:
-            yield "root.tree", af.tree
+            yield af.tree
     else:
         if isinstance(node_or_path, AsdfFile):
-            yield "root.tree", node_or_path.tree
+            yield node_or_path.tree
         else:
-            yield "root", node_or_path
+            yield node_or_path

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1527,7 +1527,7 @@ class AsdfFile:
             Set to False to disable display of primitive values in
             the rendered tree.
         """
-        lines = display.render_tree(self.tree, max_rows=max_rows, max_cols=max_cols, show_values=show_values, identifier="root.tree")
+        lines = display.render_tree(self.tree, max_rows=max_rows, max_cols=max_cols, show_values=show_values, identifier="root")
         print("\n".join(lines))
 
     def search(self, key=NotSet, type=NotSet, value=NotSet, filter=None):
@@ -1572,7 +1572,7 @@ class AsdfFile:
         asdf.search.AsdfSearchResult
             the result of the search
         """
-        result = AsdfSearchResult(["root.tree"], self.tree)
+        result = AsdfSearchResult(["root"], self.tree)
         return result.search(key=key, type=type, value=value, filter=filter)
 
     # This function is called from within TypeIndex when deserializing

--- a/asdf/commands/tests/test_info.py
+++ b/asdf/commands/tests/test_info.py
@@ -20,13 +20,13 @@ def test_info_command(capsys):
 
     assert main.main_from_args(["info", file_path]) == 0
     captured = capsys.readouterr()
-    assert "root.tree" in captured.out
+    assert "root" in captured.out
     assert "frames" in captured.out
     original_len = len(captured.out.split("\n"))
 
     assert main.main_from_args(["info", "--max-rows", str(original_len - 5), file_path]) == 0
     captured = capsys.readouterr()
-    assert "root.tree" in captured.out
+    assert "root" in captured.out
     assert "frames" in captured.out
     new_len = len(captured.out.split("\n"))
     assert new_len < original_len

--- a/asdf/tests/test_search.py
+++ b/asdf/tests/test_search.py
@@ -36,7 +36,7 @@ def test_single_result(asdf_file):
     assert len(result.paths) == 1
     assert len(result.nodes) == 1
     assert result.node == "hello"
-    assert result.path == "root.tree['bar']"
+    assert result.path == "root['bar']"
 
 
 def test_multiple_results(asdf_file):
@@ -45,8 +45,8 @@ def test_multiple_results(asdf_file):
     assert len(result.nodes) == 2
     assert 42 in result.nodes
     assert 24 in result.nodes
-    assert "root.tree['foo']" in result.paths
-    assert "root.tree['nested']['foo']" in result.paths
+    assert "root['foo']" in result.paths
+    assert "root['nested']['foo']" in result.paths
 
     with pytest.raises(RuntimeError):
         result.path

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -502,7 +502,7 @@ tree to stdout.  For example:
 .. code:: python
 
     >>> asdf.info('path/to/some/file.asdf') # doctest: +SKIP
-    root.tree (AsdfObject)
+    root (AsdfObject)
     ├─asdf_library (Software)
     │ ├─author (str): The ASDF Developers
     │ ├─homepage (str): http://github.com/asdf-format/asdf
@@ -549,7 +549,7 @@ Initiate a search by calling `AsdfFile.search` on an open file:
 .. code:: python
 
     >>> af.search() # doctest: +SKIP
-    root.tree (AsdfObject)
+    root (AsdfObject)
     ├─asdf_library (Software)
     │ ├─author (str): The ASDF Developers
     │ ├─homepage (str): http://github.com/asdf-format/asdf
@@ -561,7 +561,7 @@ Initiate a search by calling `AsdfFile.search` on an open file:
       └─example_key (str): example value
 
     >>> af.search('example') # doctest: +SKIP
-    root.tree (AsdfObject)
+    root (AsdfObject)
     └─data (dict)
       └─example_key (str): example value
 
@@ -575,7 +575,7 @@ reference that node directly:
 .. code:: python
 
     >>> af.search('example').path # doctest: +SKIP
-    "root.tree['data']['example_key']"
+    "root['data']['example_key']"
 
 While the `AsdfSearchResult.node` property contains the actual value of the node:
 
@@ -590,7 +590,7 @@ properties instead:
 .. code:: python
 
     >>> af.search('duplicate_key').paths # doctest: +SKIP
-    ["root.tree['data']['duplicate_key']", "root.tree['other_data']['duplicate_key']"]
+    ["root['data']['duplicate_key']", "root['other_data']['duplicate_key']"]
     >>> af.search('duplicate_key').nodes # doctest: +SKIP
     ["value 1", "value 2"]
 


### PR DESCRIPTION
The `.tree` is unnecessary given that we have an `AsdfFile.__getitem__` defined.

Resolves #875 