### PR TITLE
Add --ignore-query flag to asdftool diff

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@
 
 - Drop support for bugs in older operating systems and Python versions. [#955]
 
-- Add argument to ``asdftool diff`` that ignores tree nodes based on
+- Add argument to ``asdftool diff`` that ignores tree nodes that match
   a JMESPath expression. [#956]
 
 2.7.4 (unreleased)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,9 @@
 
 - Drop support for bugs in older operating systems and Python versions. [#955]
 
+- Add argument to ``asdftool diff`` that ignores tree nodes based on
+  a JMESPath expression. [#956]
+
 2.7.4 (unreleased)
 ------------------
 

--- a/asdf/commands/tests/data/frames_ignore_asdf_library.diff
+++ b/asdf/commands/tests/data/frames_ignore_asdf_library.diff
@@ -1,0 +1,42 @@
+[32m> tree:[0m
+[32m> frames:[0m
+[32m>   - reference_frame:[0m
+[32m>       galcen_coord:[0m
+[32m>         dec:[0m
+[32m>           unit:[0m
+[32m>             deg[0m
+[32m>           value:[0m
+[32m>             -28.936175[0m
+[32m>         ra:[0m
+[32m>           unit:[0m
+[32m>             deg[0m
+[32m>           value:[0m
+[32m>             266.4051[0m
+[32m>           wrap_angle:[0m
+[32m>             unit:[0m
+[32m>               deg[0m
+[32m>             value:[0m
+[32m>               360.0[0m
+[32m>       galcen_v_sun:[0m
+[32m>         - unit:[0m
+[32m>             km s-1[0m
+[32m>           value:[0m
+[32m>             11.1[0m
+[32m>         - unit:[0m
+[32m>             km s-1[0m
+[32m>           value:[0m
+[32m>             232.24[0m
+[32m>         - unit:[0m
+[32m>             km s-1[0m
+[32m>           value:[0m
+[32m>             7.25[0m
+[31m<       galcen_dec:[0m
+[31m<         unit:[0m
+[31m<           rad[0m
+[31m<         value:[0m
+[31m<           1.0[0m
+[31m<       galcen_ra:[0m
+[31m<         unit:[0m
+[31m<           deg[0m
+[31m<         value:[0m
+[31m<           45.0[0m

--- a/asdf/commands/tests/data/frames_ignore_reference_frame.diff
+++ b/asdf/commands/tests/data/frames_ignore_reference_frame.diff
@@ -1,0 +1,5 @@
+tree:[0m
+  asdf_library:[0m
+    version:[0m
+[32m>     1.2.2.dev858[0m
+[31m<     1.2.2.dev846[0m

--- a/asdf/commands/tests/test_diff.py
+++ b/asdf/commands/tests/test_diff.py
@@ -9,11 +9,11 @@ from . import data as test_data
 get_test_data_path = partial(helpers.get_test_data_path, module=test_data)
 
 
-def _assert_diffs_equal(filenames, result_file, minimal=False, ignore_queries=None):
+def _assert_diffs_equal(filenames, result_file, minimal=False, ignore=None):
     iostream = io.StringIO()
 
     file_paths = [get_test_data_path(name) for name in filenames]
-    diff(file_paths, minimal=minimal, iostream=iostream, ignore_queries=ignore_queries)
+    diff(file_paths, minimal=minimal, iostream=iostream, ignore=ignore)
     iostream.seek(0)
 
     result_path = get_test_data_path(result_file)
@@ -33,14 +33,14 @@ def test_diff_minimal():
     _assert_diffs_equal(filenames, result_file, minimal=True)
 
 
-@pytest.mark.parametrize('result_file, ignore_queries', [
+@pytest.mark.parametrize('result_file, ignore', [
     ('frames_ignore_asdf_library.diff', ['asdf_library']),
     ('frames_ignore_reference_frame.diff', ['frames[*].reference_frame']),
     ('frames_ignore_both.diff', ['asdf_library', 'frames[*].reference_frame']),
 ])
-def test_diff_ignore(result_file, ignore_queries):
+def test_diff_ignore(result_file, ignore):
     filenames = ['frames0.asdf', 'frames1.asdf']
-    _assert_diffs_equal(filenames, result_file, minimal=False, ignore_queries=ignore_queries)
+    _assert_diffs_equal(filenames, result_file, minimal=False, ignore=ignore)
 
 
 def test_diff_block():

--- a/asdf/commands/tests/test_diff.py
+++ b/asdf/commands/tests/test_diff.py
@@ -9,42 +9,58 @@ from . import data as test_data
 get_test_data_path = partial(helpers.get_test_data_path, module=test_data)
 
 
-def _assert_diffs_equal(filenames, result_file, minimal=False):
+def _assert_diffs_equal(filenames, result_file, minimal=False, ignore_queries=None):
     iostream = io.StringIO()
 
     file_paths = [get_test_data_path(name) for name in filenames]
-    diff(file_paths, minimal=minimal, iostream=iostream)
+    diff(file_paths, minimal=minimal, iostream=iostream, ignore_queries=ignore_queries)
     iostream.seek(0)
 
     result_path = get_test_data_path(result_file)
     with open(result_path, 'r') as handle:
         assert handle.read() == iostream.read()
 
+
 def test_diff():
     filenames = ['frames0.asdf', 'frames1.asdf']
     result_file = 'frames.diff'
     _assert_diffs_equal(filenames, result_file, minimal=False)
+
 
 def test_diff_minimal():
     filenames = ['frames0.asdf', 'frames1.asdf']
     result_file = 'frames_minimal.diff'
     _assert_diffs_equal(filenames, result_file, minimal=True)
 
+
+@pytest.mark.parametrize('result_file, ignore_queries', [
+    ('frames_ignore_asdf_library.diff', ['asdf_library']),
+    ('frames_ignore_reference_frame.diff', ['frames[*].reference_frame']),
+    ('frames_ignore_both.diff', ['asdf_library', 'frames[*].reference_frame']),
+])
+def test_diff_ignore(result_file, ignore_queries):
+    filenames = ['frames0.asdf', 'frames1.asdf']
+    _assert_diffs_equal(filenames, result_file, minimal=False, ignore_queries=ignore_queries)
+
+
 def test_diff_block():
     filenames = ['block0.asdf', 'block1.asdf']
     result_file = 'blocks.diff'
     _assert_diffs_equal(filenames, result_file, minimal=False)
+
 
 def test_diff_simple_inline_array():
     filenames = ['simple_inline_array0.asdf', 'simple_inline_array1.asdf']
     result_file = 'simple_inline_array.diff'
     _assert_diffs_equal(filenames, result_file, minimal=False)
 
+
 def test_file_not_found():
     # Try to open files that exist but are not valid asdf
     filenames = ['frames.diff', 'blocks.diff']
     with pytest.raises(RuntimeError):
         diff([get_test_data_path(name) for name in filenames], False)
+
 
 def test_diff_command():
     filenames = ['frames0.asdf', 'frames1.asdf']

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,12 +25,13 @@ classifiers =
 python_requires= >=3.6
 setup_requires = setuptools_scm
 install_requires =
-    semantic_version>=2.8
-    pyyaml>=3.10
+    importlib_resources>=3;python_version<"3.9"
+    jmespath>=0.6.2
     jsonschema>=3.0.2,<4
     numpy>=1.10
-    importlib_resources>=3;python_version<"3.9"
     packaging>=16.0
+    pyyaml>=3.10
+    semantic_version>=2.8
 
 [options.extras_require]
 all =


### PR DESCRIPTION
This adds a `--ignore-query` (or `-i`) flag to the asdftool diff command.  It accepts a JMESPath expression and ignores matching nodes when computing the diff.