### PR TITLE
Support https and redirects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,8 @@
 
 - Prohibit views over FITS arrays that change dtype. [#952]
 
+- Add support for HTTPS URLs and following redirects. [#971]
+
 2.7.3 (2021-02-25)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1763,7 +1763,7 @@ def is_asdf_file(fd):
         if parsed.scheme in ["http", "https"]:
             # We don't want to read URL content here because
             # that will cause the file to be downloaded twice.
-            return os.path.splitext(parsed.path)[1] == "asdf"
+            return os.path.splitext(parsed.path)[1] == ".asdf"
 
     to_close = False
     if isinstance(fd, AsdfFile):

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -30,7 +30,7 @@ from .extension import (
     get_cached_asdf_extension_list,
     get_cached_extension_manager,
 )
-from .util import NotSet
+from .util import NotSet, patched_urllib_parse
 from .search import AsdfSearchResult
 from ._helpers import validate_version
 
@@ -1744,7 +1744,10 @@ def is_asdf_file(fd):
     """
     Determine if fd is an ASDF file.
 
-    Reads the first five bytes and looks for the ``#ASDF`` string.
+    For most input, reads the first five bytes and looks
+    for the ``#ASDF`` string.
+
+    For URL input, looks for a .asdf extension.
 
     Parameters
     ----------
@@ -1754,6 +1757,13 @@ def is_asdf_file(fd):
     if isinstance(fd, generic_io.InputStream):
         # If it's an InputStream let ASDF deal with it.
         return True
+
+    if isinstance(fd, str):
+        parsed = patched_urllib_parse.urlparse(fd)
+        if parsed.scheme in ["http", "https"]:
+            # We don't want to read URL content here because
+            # that will cause the file to be downloaded twice.
+            return os.path.splitext(parsed.path)[1] == "asdf"
 
     to_close = False
     if isinstance(fd, AsdfFile):

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1740,6 +1740,13 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False, extensions=None
         **kwargs)
 
 
+# astropy.io.fits supports opening files that are externally
+# compressed with gzip or zip, and asdf does not, so we may as
+# well give those extensions to FITS.
+_FITS_EXTENSIONS = [".fits", ".gz", ".zip"]
+_ASDF_EXTENSIONS = [".asdf"]
+
+
 def is_asdf_file(fd):
     """
     Determine if fd is an ASDF file.
@@ -1747,7 +1754,8 @@ def is_asdf_file(fd):
     For most input, reads the first five bytes and looks
     for the ``#ASDF`` string.
 
-    For URL input, looks for a .asdf extension.
+    For URL input, looks for an extension that should be passed
+    to AsdfInFits, otherwise assumes ASDF.
 
     Parameters
     ----------
@@ -1763,7 +1771,20 @@ def is_asdf_file(fd):
         if parsed.scheme in ["http", "https"]:
             # We don't want to read URL content here because
             # that will cause the file to be downloaded twice.
-            return os.path.splitext(parsed.path)[1] == ".asdf"
+            ext = os.path.splitext(parsed.path)[1].lower()
+            if ext in _FITS_EXTENSIONS:
+                return False
+            elif ext in _ASDF_EXTENSIONS:
+                return True
+            else:
+                message = (
+                    f"The URL '{fd}' does not include an obvious FITS "
+                    "or ASDF filename extension.  Assuming ASDF.\n\n"
+                    "If this URL returns FITS content, it cannot be opened "
+                    "with asdf.open().  Use asdf.fits_embed.AsdfInFits.open() instead."
+                )
+                warnings.warn(message, AsdfWarning)
+                return True
 
     to_close = False
     if isinstance(fd, AsdfFile):

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -848,7 +848,8 @@ def _http_to_temp(init, mode, uri=None):
     """
     fd = tempfile.NamedTemporaryFile("w+b")
     try:
-        with urlopen(init) as response:
+        # This method is only called with http and https schemes:
+        with urlopen(init) as response: # nosec
             chunk = response.read(io.DEFAULT_BUFFER_SIZE)
             while len(chunk) > 0:
                 fd.write(chunk)

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -76,8 +76,9 @@ def test_sharing(tmpdir):
         assert len(list(asdf.blocks.internal_blocks)) == 1
         assert next(asdf.blocks.internal_blocks)._size == 80
 
-        tree['science_data'][0] = 42
-        assert tree['skipping'][0] == 42
+        if 'w' in asdf._mode:
+            tree['science_data'][0] = 42
+            assert tree['skipping'][0] == 42
 
     def check_raw_yaml(content):
         assert b'!core/ndarray' in content

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from asdf.asdf import AsdfFile, open_asdf, SerializationContext
+from asdf.asdf import AsdfFile, open_asdf, SerializationContext, is_asdf_file
 from asdf import config_context, get_config
 from asdf.versioning import AsdfVersion
 from asdf.exceptions import AsdfWarning
@@ -344,3 +344,25 @@ def test_reading_extension_metadata():
         buff = yaml_to_asdf(content)
         with assert_no_warnings():
             open_asdf(buff)
+
+
+@pytest.mark.parametrize("url,result", [
+    ("http://example.com/some/path/to/file.asdf", True),
+    ("https://example.com/some/path/to/file.asdf", True),
+    ("http://example.com/some/path/to/file.fits", False),
+    ("http://example.com/some/path/to/file.fits.gz", False),
+    ("http://example.com/some/path/to/file.gz", False),
+    ("http://example.com/some/path/to/file.zip", False),
+])
+def test_is_asdf_file_url(url, result):
+    assert is_asdf_file(url) is result
+
+
+@pytest.mark.parametrize("url", [
+    "http://example.com/some/path/to/b5dbeef4-cc58-4290-939e-5c73041537fd",
+    "http://example.com/some/path/to/file.txt",
+    "https://example.com/some/path/to/file.txt",
+])
+def test_is_asdf_file_unrecognized_url_ext(url):
+    with pytest.warns(AsdfWarning, match="does not include an obvious FITS or ASDF filename extension"):
+        assert is_asdf_file(url) is True

--- a/asdf/tests/test_file_format.py
+++ b/asdf/tests/test_file_format.py
@@ -126,7 +126,7 @@ def test_invalid_source(small_tree):
         with pytest.raises(ValueError):
             ff2.blocks.get_block(2)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(IOError):
             ff2.blocks.get_block("http://ABadUrl.verybad/test.asdf")
 
         with pytest.raises(TypeError):

--- a/asdf/tests/test_file_format.py
+++ b/asdf/tests/test_file_format.py
@@ -126,9 +126,8 @@ def test_invalid_source(small_tree):
         with pytest.raises(ValueError):
             ff2.blocks.get_block(2)
 
-        with pytest.raises(IOError):
-            # ff2.blocks.get_block("http://127.0.0.1/")
-            ff2.blocks.get_block("http://ABadUrl.verybad")
+        with pytest.raises(ValueError):
+            ff2.blocks.get_block("http://ABadUrl.verybad/test.asdf")
 
         with pytest.raises(TypeError):
             ff2.blocks.get_block(42.0)

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -262,7 +262,6 @@ def test_http_connection(tree, httpserver):
 
     def get_read_fd():
         fd = generic_io.get_file(httpserver.url + "test.asdf")
-        assert isinstance(fd, generic_io.InputStream)
         # This is to check for a "feature" in Python 3.x that reading zero
         # bytes from a socket causes it to stop.  We have code in generic_io.py
         # to workaround it.
@@ -271,7 +270,6 @@ def test_http_connection(tree, httpserver):
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(list(ff.blocks.internal_blocks)) == 2
-        assert not isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.ndarray)
         ff.tree['science_data'][0] == 42
 


### PR DESCRIPTION
This PR drops support for lazy-loading arrays over http and adds support for https and 3xx redirects.  The lazy-loading is a nice idea, but not useful in its current state and something we should revisit later when we have the time.

Resolves #965