### PR TITLE
Astropy master to main in downstream workflow

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -10,7 +10,7 @@ on:
       astropy_ref:
         description: astropy ref
         required: true
-        default: master
+        default: main
       gwcs_ref:
         description: gwcs ref
         required: true
@@ -79,7 +79,7 @@ jobs:
         run: ${{ matrix.test_command }}
 
   astropy:
-    name: astropy@${{ github.event.inputs.astropy_ref || 'master' }} unit tests
+    name: astropy@${{ github.event.inputs.astropy_ref || 'main' }} unit tests
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.9
@@ -89,6 +89,6 @@ jobs:
       - name: Install asdf
         run: pip install git+https://github.com/asdf-format/asdf@${{ github.event.inputs.asdf_ref || 'master' }}
       - name: Install astropy
-        run: pip install git+https://github.com/astropy/astropy@${{ github.event.inputs.astropy_ref || 'master' }}#egg=astropy[test]
+        run: pip install git+https://github.com/astropy/astropy@${{ github.event.inputs.astropy_ref || 'main' }}#egg=astropy[test]
       - name: Run astropy tests
         run: pytest --pyargs astropy


### PR DESCRIPTION
This updates our downstream workflow to run astropy tests from the `main` branch instead of `master`.  The name changed this past week.  It was failing this morning:

https://github.com/asdf-format/asdf/runs/2321003190?check_suite_focus=true

Also, it seems this workflow is a bit fragile.  Generally, we should be running the _default_ branch of all these repos, assuming the default branch is the dev branch.  Is there a reason we need to even be naming this branch?

```
pip install git+https://github.com/org/repo
```

will install the project from the default branch without needing to specify it.  Maybe we should simplify this downstream workflow?