### PR TITLE
Prevent astropy warnings in tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,8 @@
 
 - Add support for HTTPS URLs and following redirects. [#971]
 
+- Prevent astropy warnings in tests when opening known bad files. [#977]
+
 2.7.3 (2021-02-25)
 ------------------
 

--- a/asdf/commands/tests/test_diff.py
+++ b/asdf/commands/tests/test_diff.py
@@ -55,6 +55,7 @@ def test_diff_simple_inline_array():
     _assert_diffs_equal(filenames, result_file, minimal=False)
 
 
+@pytest.mark.filterwarnings('ignore::astropy.io.fits.verify.VerifyWarning')
 def test_file_not_found():
     # Try to open files that exist but are not valid asdf
     filenames = ['frames.diff', 'blocks.diff']

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -207,6 +207,7 @@ history:
             pass
 
     # Make sure to test for incompatibility with ignore_missing_extensions
+    buff.seek(0)
     with pytest.raises(ValueError):
         with asdf.open(buff, strict_extension_check=True, ignore_missing_extensions=True):
             pass

--- a/asdf/tests/test_file_format.py
+++ b/asdf/tests/test_file_format.py
@@ -64,6 +64,7 @@ baz: 42
             assert len(ff.tree) == 2
 
 
+@pytest.mark.filterwarnings('ignore::astropy.io.fits.verify.VerifyWarning')
 def test_no_asdf_header(tmpdir):
     content = b"What? This ain't no ASDF file"
 
@@ -155,6 +156,7 @@ def test_empty_file():
         assert len(ff.blocks) == 0
 
 
+@pytest.mark.filterwarnings('ignore::astropy.io.fits.verify.VerifyWarning')
 def test_not_asdf_file():
     buff = io.BytesIO(b"SIMPLE")
     buff.seek(0)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -345,6 +345,8 @@ def test_open_gzipped():
     with asdf.open(testfile) as af:
         assert af.tree['stuff'].shape == (20, 20)
 
+
+@pytest.mark.filterwarnings('ignore::astropy.io.fits.verify.VerifyWarning')
 def test_bad_input(tmpdir):
     """Make sure these functions behave properly with bad input"""
     text_file = os.path.join(str(tmpdir), 'test.txt')


### PR DESCRIPTION
astropy 4.2.1 started emitting an additional warning when opening bad files.  This PR marks tests that open known bad files to ignore that warning.

Resolves #966 