### PR TITLE
Resolve differences between seek_until docstring and implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,8 @@
 - Add argument to ``asdftool diff`` that ignores tree nodes that match
   a JMESPath expression. [#956]
 
+- Fix behavior of ``exception`` argument to ``GenericFile.seek_until``. [#980]
+
 2.7.4 (unreleased)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -872,7 +872,7 @@ class AsdfFile:
             # now, but we don't do anything special with it until
             # after the blocks have been read
             tree = yamlutil.load_tree(reader)
-            has_blocks = fd.seek_until(constants.BLOCK_MAGIC, 4, include=True)
+            has_blocks = fd.seek_until(constants.BLOCK_MAGIC, 4, include=True, exception=False)
         elif yaml_token == constants.BLOCK_MAGIC:
             has_blocks = True
         elif yaml_token != b'':

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -12,3 +12,9 @@ class AsdfConversionWarning(AsdfWarning):
     """
     Warning class used for failures to convert data into custom types.
     """
+
+class DelimiterNotFoundError(ValueError):
+    """
+    Indicates that a delimiter was not found when reading or
+    seeking through a file.
+    """

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -9,6 +9,7 @@ import urllib.request as urllib_request
 import numpy as np
 
 import asdf
+from asdf import exceptions
 from asdf import util
 from asdf import generic_io
 from asdf.asdf import is_asdf_file
@@ -550,14 +551,14 @@ def test_truncated_reader():
 
     # Simple cases where the delimiter is not found at all
     tr = generic_io._TruncatedReader(fd, b'x', 1)
-    with pytest.raises(ValueError):
+    with pytest.raises(exceptions.DelimiterNotFoundError):
         tr.read()
 
     fd.seek(0)
     tr = generic_io._TruncatedReader(fd, b'x', 1)
     assert tr.read(100) == content[:100]
     assert tr.read(1) == content[100:]
-    with pytest.raises(ValueError):
+    with pytest.raises(exceptions.DelimiterNotFoundError):
         tr.read()
 
     fd.seek(0)


### PR DESCRIPTION
The `GenericFile.seek_until` method turned out to have a couple of problems -- besides the mismatch on return code, the docstring also advertises an `exception` argument that is supposed to cause the method to raise an error when the delimiter isn't found.  I fixed both and also created a new subclass of `ValueError` so that users can catch the exception in a more targeted way.

Resolves #876

