### PR TITLE
Use all the Draft 4 components in schema validator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,7 +63,10 @@
   filenames without recognizable extensions.  Remove the ``asdf.asdf.is_asdf_file``
   function. [#978]
 
-- Fix bug in ``asdf.schema.check_schema`` that caused relative references in
+2.7.5 (unreleased)
+------------------
+
+- Fix bug in ``asdf.schema.check_schema`` causing relative references in
   metaschemas to be resolved incorrectly. [#987]
 
 2.7.4 (2021-04-30)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,9 @@
   filenames without recognizable extensions.  Remove the ``asdf.asdf.is_asdf_file``
   function. [#978]
 
+- Fix bug in ``asdf.schema.check_schema`` that caused relative references in
+  metaschemas to be resolved incorrectly. [#987]
+
 2.7.4 (2021-04-30)
 ------------------
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -744,7 +744,11 @@ def check_schema(schema, validate_default=True):
 
     resolver = _make_resolver(extension.get_default_resolver())
 
-    cls = mvalidators.create(meta_schema=meta_schema,
-                             validators=validators)
+    cls = mvalidators.create(
+        meta_schema=meta_schema,
+        validators=validators,
+        type_checker=mvalidators.Draft4Validator.TYPE_CHECKER,
+        id_of=mvalidators.Draft4Validator.ID_OF,
+    )
     validator = cls(meta_schema, resolver=resolver)
     validator.validate(schema, _schema=meta_schema)


### PR DESCRIPTION
This fixes a bug causing relative references in metaschemas to be resolved incorrectly (for example, the reference `#/definitions/schemaArray` was being resolved to `http://json-schema.org/draft-04/schema#/definitions/schemaArray` instead of the the host document).  The problem turned out to be that we have been using some Draft 7 components when building up our schema validator.

Resolves #976