### PR TITLE
Search for block index starting from end of file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,7 +70,7 @@
   search results. [#981]
 
 - Search for block index starting from end of file. Fixes rare bug when
-  a data block contains a block index. [#989]
+  a data block contains a block index. [#990]
 
 2.7.5 (unreleased)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,9 @@
 - Add ``AsdfSearchResult.replace`` method for assigning new values to
   search results. [#981]
 
+- Search for block index starting from end of file. Fixes rare bug when
+  a data block contains a block index. [#989]
+
 2.7.5 (unreleased)
 ------------------
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -455,7 +455,7 @@ class BlockManager:
         # Read blocks in reverse order from the end of the file
         while True:
             # Look for the index header
-            idx = content.find(constants.INDEX_HEADER)
+            idx = content.rfind(constants.INDEX_HEADER)
             if idx != -1:
                 content = content[idx:]
                 index_start = block_start + idx


### PR DESCRIPTION
An earth-shattering, one-character PR to use the last block index found in the file, in case a pathological data block also contains something that looks like a block index header.  This can especially happen if uninitialized arrays are written to disk, because the uninitialized regions could contain recycled memory that has a block index (which happened in #989).

I confirm this fixes the reading of this file, which exhibits the pathology: https://drive.google.com/file/d/1DJr2qkdC2Qm3tos1cigmbUK8ngFzha5K/view?usp=sharing
