### PR TITLE
Fix sphinx build warning

### DIFF
--- a/docs/asdf/user_api.rst
+++ b/docs/asdf/user_api.rst
@@ -6,6 +6,7 @@ User API
     :include-all-objects:
     :inherited-members:
     :skip: ValidationError
+    :skip: AsdfExtension
 
 .. automodapi:: asdf.search
 


### PR DESCRIPTION
This fixes a warning that occurs in sphinx 4.0 due to multiple automodapi that include AsdfExtension.