### PR TITLE
Update downstream workflow to install jwst with --editable

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -3,10 +3,6 @@ name: Downstream
 on:
   workflow_dispatch:
     inputs:
-      asdf_ref:
-        description: asdf ref
-        required: true
-        default: master
       astropy_ref:
         description: astropy ref
         required: true
@@ -48,46 +44,64 @@ jobs:
           - package_name: gwcs
             repository: spacetelescope/gwcs
             ref: ${{ github.event.inputs.gwcs_ref || 'master' }}
+            install_command: pip install .[test]
             test_command: pytest
           - package_name: jwst
             repository: spacetelescope/jwst
             ref: ${{ github.event.inputs.jwst_ref || 'master' }}
+            install_command: pip install --editable .[test]
             test_command: pytest
           - package_name: specutils
             repository: astropy/specutils
             ref: ${{ github.event.inputs.specutils_ref || 'main' }}
+            install_command: pip install .[test]
             test_command: pytest
           - package_name: weldx
             repository: BAMWelDX/weldx
             ref: ${{ github.event.inputs.weldx_ref || 'asdf_2.8' }}
+            install_command: pip install .[test]
             test_command: pytest weldx/tests/asdf_tests weldx/asdf/schemas --asdf-tests
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout asdf
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+          path: asdf
+      - name: Checkout ${{ matrix.package_name }}
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
           repository: ${{ matrix.repository }}
           ref: ${{ matrix.ref }}
+          path: target
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - name: Install asdf
-        run: pip install git+https://github.com/asdf-format/asdf@${{ github.event.inputs.asdf_ref || 'master' }}
+        run: cd asdf && pip install .
       - name: Install remaining ${{ matrix.package_name }} dependencies
-        run: pip install .[test]
+        run: cd target && ${{ matrix.install_command }}
       - name: Run ${{ matrix.package_name}} tests
-        run: ${{ matrix.test_command }}
+        run: cd target && ${{ matrix.test_command }}
 
   astropy:
     name: astropy@${{ github.event.inputs.astropy_ref || 'main' }} unit tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout asdf
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+          path: asdf
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - name: Install asdf
-        run: pip install git+https://github.com/asdf-format/asdf@${{ github.event.inputs.asdf_ref || 'master' }}
+        run: cd asdf && pip install .
       - name: Install astropy
         run: pip install git+https://github.com/astropy/astropy@${{ github.event.inputs.astropy_ref || 'main' }}#egg=astropy[test]
       - name: Run astropy tests


### PR DESCRIPTION
This fixes the jwst job by installing with --editable, and also cleans up the workflow so that the asdf ref doesn't have to be specified twice.

Here's a test run of this version of the workflow: https://github.com/asdf-format/asdf/actions/runs/829268692