### PR TITLE
Update documentation to reflect new 2.8 features

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 2.9.0 (unreleased)
 ------------------
 
+2.8.2 (unreleased)
+------------------
+
+- Update documentation to reflect new 2.8 features. [#998]
+
 2.8.1 (2021-06-09)
 ------------------
 
@@ -53,6 +58,8 @@
 
 - Add ``edit`` subcommand to asdftool for efficient editing of
   the YAML portion of an ASDF file.  [#873, #922]
+
+- Increase limit on integer literals to signed 64-bit. [#894]
 
 - Remove the ``asdf.test`` method and ``asdf.__githash__`` attribute. [#943]
 

--- a/README.rst
+++ b/README.rst
@@ -139,8 +139,9 @@ It is possible to compress the array data when writing the file:
 
     af.write_to('compressed.asdf', all_array_compression='zlib')
 
-Available compression algorithms are ``'zlib'``, ``'bzp2'``, and
-``'lz4'``.
+The built-in compression algorithms are ``'zlib'``, and ``'bzp2'``.  The
+``'lz4'`` algorithm becomes available when the `lz4 <https://python-lz4.readthedocs.io/>`__ package
+is installed.  Other compression algorithms may be available via extensions.
 
 .. _end-create-file-text:
 
@@ -165,39 +166,49 @@ The `open` function also works as a context handler:
     with asdf.open('example.asdf') as af:
         ...
 
-To access the data stored in the file, use the top-level `AsdfFile.tree`
-attribute:
+To get a quick overview of the data stored in the file, use the top-level
+`AsdfFile.info()` method:
 
 .. code:: python
 
     >>> import asdf
     >>> af = asdf.open('example.asdf')
-    >>> af.tree
-    {'asdf_library': {'author': 'The ASDF Developers',
-      'homepage': 'http://github.com/asdf-format/asdf',
-      'name': 'asdf',
-      'version': '1.3.1'},
-     'foo': 42,
-     'name': 'Monty',
-     'powers': {'squares': <array (unloaded) shape: [100] dtype: int64>},
-     'random': <array (unloaded) shape: [100] dtype: float64>,
-     'sequence': <array (unloaded) shape: [100] dtype: int64>}
+    >>> af.info()
+    root (AsdfObject)
+    ├─asdf_library (Software)
+    │ ├─author (str): The ASDF Developers
+    │ ├─homepage (str): http://github.com/asdf-format/asdf
+    │ ├─name (str): asdf
+    │ └─version (str): 2.8.0
+    ├─history (dict)
+    │ └─extensions (list)
+    │   └─[0] (ExtensionMetadata)
+    │     ├─extension_class (str): asdf.extension.BuiltinExtension
+    │     └─software (Software)
+    │       ├─name (str): asdf
+    │       └─version (str): 2.8.0
+    ├─foo (int): 42
+    ├─name (str): Monty
+    ├─powers (dict)
+    │ └─squares (NDArrayType): shape=(100,), dtype=int64
+    ├─random (NDArrayType): shape=(100,), dtype=float64
+    └─sequence (NDArrayType): shape=(100,), dtype=int64
 
-The tree is simply a Python `dict`, and nodes are accessed like any other
-dictionary entry:
+The `AsdfFile` behaves like a Python `dict`, and nodes are accessed like
+any other dictionary entry:
 
 .. code:: python
 
-    >>> af.tree['name']
+    >>> af['name']
     'Monty'
-    >>> af.tree['powers']
+    >>> af['powers']
     {'squares': <array (unloaded) shape: [100] dtype: int64>}
 
 Array data remains unloaded until it is explicitly accessed:
 
 .. code:: python
 
-    >>> af.tree['powers']['squares']
+    >>> af['powers']['squares']
     array([   0,    1,    4,    9,   16,   25,   36,   49,   64,   81,  100,
             121,  144,  169,  196,  225,  256,  289,  324,  361,  400,  441,
             484,  529,  576,  625,  676,  729,  784,  841,  900,  961, 1024,
@@ -211,7 +222,7 @@ Array data remains unloaded until it is explicitly accessed:
 
     >>> import numpy as np
     >>> expected = [x**2 for x in range(100)]
-    >>> np.equal(af.tree['powers']['squares'], expected).all()
+    >>> np.equal(af['powers']['squares'], expected).all()
     True
 
 By default, uncompressed data blocks are memory mapped for efficient
@@ -232,9 +243,9 @@ Extending ASDF
 
 Out of the box, the ``asdf`` package automatically serializes and
 deserializes native Python types. It is possible to extend ``asdf`` by
-implementing custom tag types that correspond to custom user types. More
+implementing custom tags that correspond to custom user types. More
 information on extending ASDF can be found in the `official
-documentation <http://asdf.readthedocs.io/en/latest/asdf/extensions.html>`__.
+documentation <http://asdf.readthedocs.io/en/latest/#extending-asdf>`__.
 
 Installation
 ------------

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -209,31 +209,6 @@ class AsdfConfig:
             self._extensions = None
 
     @property
-    def validate_on_read(self):
-        """
-        Get configuration that controls schema validation of
-        ASDF files on read.
-
-        Returns
-        -------
-        bool
-        """
-        return self._validate_on_read
-
-    @validate_on_read.setter
-    def validate_on_read(self, value):
-        """
-        Set the configuration that controls schema validation of
-        ASDF files on read.  If `True`, newly opened files will
-        be validated.
-
-        Parameters
-        ----------
-        value : bool
-        """
-        self._validate_on_read = value
-
-    @property
     def default_version(self):
         """
         Get the default ASDF Standard version used for
@@ -256,6 +231,34 @@ class AsdfConfig:
         value : str
         """
         self._default_version = validate_version(value)
+
+    @property
+    def io_block_size(self):
+        """
+        Get the block size used when reading and writing
+        files.
+
+        Returns
+        -------
+        int
+            Block size, or -1 to use the filesystem's
+            preferred block size.
+        """
+        return self._io_block_size
+
+    @io_block_size.setter
+    def io_block_size(self, value):
+        """
+        Set the block size used when reading and writing
+        files.
+
+        Parameters
+        ----------
+        value : int
+            Block size, or -1 to use the filesystem's
+            preferred block size.
+        """
+        self._io_block_size = value
 
     @property
     def legacy_fill_schema_defaults(self):
@@ -286,32 +289,6 @@ class AsdfConfig:
         self._legacy_fill_schema_defaults = value
 
     @property
-    def io_block_size(self):
-        """
-        Get the chunk size used when reading or writing
-        files.
-
-        Returns
-        -------
-        int
-            Block size, or -1 to auto-select.
-        """
-        return self._io_block_size
-
-    @io_block_size.setter
-    def io_block_size(self, value):
-        """
-        Set the chunk size used when reading or writing
-        files.
-
-        Parameters
-        ----------
-        value : int
-            Block size, or -2 to auto-select.
-        """
-        self._io_block_size = value
-
-    @property
     def array_inline_threshold(self):
         """
         Get the threshold below which arrays are automatically written
@@ -340,6 +317,31 @@ class AsdfConfig:
             of the array storage type.
         """
         self._array_inline_threshold = value
+
+    @property
+    def validate_on_read(self):
+        """
+        Get configuration that controls schema validation of
+        ASDF files on read.
+
+        Returns
+        -------
+        bool
+        """
+        return self._validate_on_read
+
+    @validate_on_read.setter
+    def validate_on_read(self, value):
+        """
+        Set the configuration that controls schema validation of
+        ASDF files on read.  If `True`, newly opened files will
+        be validated.
+
+        Parameters
+        ----------
+        value : bool
+        """
+        self._validate_on_read = value
 
     def __repr__(self):
         return (

--- a/asdf/extension/_compressor.py
+++ b/asdf/extension/_compressor.py
@@ -48,7 +48,7 @@ class Compressor(abc.ABC):
 
         Parameters
         ----------
-        data : bytes-like
+        data : memoryview
             The data to compress. Must be contiguous and 1D, with
             the underlying `itemsize` preserved.
         **kwargs
@@ -69,8 +69,9 @@ class Compressor(abc.ABC):
 
         Parameters
         ----------
-        data : bytes-like
-            The data to decompress. Must be contiguous and 1D.
+        data : Iterable of bytes-like
+            An Iterable of bytes-like objects containing chunks
+            of compressed data.
         out : read-write bytes-like
             A contiguous, 1D output array, of equal or greater length
             than the decompressed data.

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -103,7 +103,7 @@ class Extension(abc.ABC):
 
         The dictionary key indicates the TAG handles to be placed in the YAML header,
         the value defines the string for tag replacement.
-        See https://yaml.org/spec/1.2/spec.html#tag/shorthand/
+        See https://yaml.org/spec/1.1/#tag%20shorthand/
 
         Example: ``{"!foo!": "tag:nowhere.org:custom/"}``
 
@@ -349,7 +349,7 @@ class ExtensionProxy(Extension, AsdfExtension):
 
         The dictionary key indicates the TAG handles to be placed in the YAML header,
         the value defines the string for tag replacement.
-        See https://yaml.org/spec/1.2/spec.html#tag/shorthand/
+        See https://yaml.org/spec/1.1/#tag%20shorthand/
 
         Example: ``{"!foo!": "tag:nowhere.org:custom/"}``
 

--- a/asdf/extension/_manifest.py
+++ b/asdf/extension/_manifest.py
@@ -39,7 +39,7 @@ class ManifestExtension(Extension):
         return cls(manifest, **kwargs)
 
     def __init__(self, manifest, *, legacy_class_names=None, converters=None,
-                compressors=None, decompressors=None):
+                compressors=None):
         self._manifest = manifest
 
         if legacy_class_names is None:
@@ -56,11 +56,6 @@ class ManifestExtension(Extension):
             self._compressors = []
         else:
             self._compressors = compressors
-
-        if decompressors is None:
-            self._decompressors = []
-        else:
-            self._decompressors = decompressors
 
     @property
     def extension_uri(self):
@@ -92,10 +87,6 @@ class ManifestExtension(Extension):
     @property
     def compressors(self):
         return self._compressors
-
-    @property
-    def decompressors(self):
-        return self._decompressors
 
     @property
     def tags(self):

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -286,10 +286,12 @@ def test_config_repr():
     with asdf.config_context() as config:
         config.validate_on_read = True
         config.default_version = "1.5.0"
+        config.io_block_size = 9999
         config.legacy_fill_schema_defaults = False
         config.array_inline_threshold = 14
 
         assert "validate_on_read: True" in repr(config)
         assert "default_version: 1.5.0" in repr(config)
+        assert "io_block_size: 9999" in repr(config)
         assert "legacy_fill_schema_defaults: False" in repr(config)
         assert "array_inline_threshold: 14" in repr(config)

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from . import tagged
 from .exceptions import AsdfWarning
 
-__all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container"]
+__all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container", "PendingValue"]
 
 
 def walk(top, callback):

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -31,7 +31,7 @@ patched_urllib_parse.uses_netloc.append('asdf')
 
 __all__ = ['human_list', 'get_array_base', 'get_base_uri', 'filepath_to_url',
            'iter_subclasses', 'calculate_padding', 'resolve_name', 'NotSet',
-           'is_primitive', 'uri_match']
+           'is_primitive', 'uri_match', 'get_class_name']
 
 
 def human_list(l, separator="and"):

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -92,6 +92,9 @@ format of all arrays in the file.
     # This controls the output format of all arrays in the file
     ff.write_to("test.asdf", all_array_storage='inline')
 
+For automatic management of the array storage type based on number of elements,
+see :ref:`config_options_array_inline_threshold`.
+
 .. _exploded:
 
 Saving external arrays
@@ -105,12 +108,6 @@ corresponding to the following data items:
 - *n* ASDF files, each containing a single array data block.
 
 Exploded form is useful in the following scenarios:
-
-- Not all text editors may handle the hybrid text and binary nature of
-  the ASDF file, and therefore either can't open a ASDF file or would
-  break a ASDF file upon saving.  In this scenario, a user may explode
-  the ASDF file, edit the YAML portion as a pure YAML file, and
-  implode the parts back together.
 
 - Over a network protocol, such as HTTP, a client may only need to
   access some of the blocks.  While reading a subset of the file can
@@ -147,9 +144,6 @@ To save a block in an external file, set its block type to
 .. asdf:: test.asdf
 
 .. asdf:: test0000.asdf
-
-Like inline arrays, this can also be controlled using the ``set_array_storage``
-parameter of `AsdfFile.write_to` and `AsdfFile.update`.
 
 Streaming array data
 --------------------
@@ -283,7 +277,7 @@ permitted:
     with asdf.open('my_data.asdf') as af:
         ...
 
-     af.tree
+    af.tree
 
 Specifically, if an ASDF file has been opened using a `with` context, it is not
 possible to access the file contents outside of the scope of that context,

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -152,7 +152,7 @@ In certain scenarios, you may want to stream data to disk, rather than
 writing an entire array of data at once.  For example, it may not be
 possible to fit the entire array in memory, or you may want to save
 data from a device as it comes in to prevent data loss.  The ASDF
-standard allows exactly one streaming block per file where the size of
+Standard allows exactly one streaming block per file where the size of
 the block isn't included in the block header, but instead is
 implicitly determined to include all of the remaining contents of the
 file.  By definition, it must be the last block in the file.

--- a/docs/asdf/asdf_tool.rst
+++ b/docs/asdf/asdf_tool.rst
@@ -1,3 +1,5 @@
+.. asdf_tool:
+
 Command line tool
 -----------------
 
@@ -12,7 +14,9 @@ useful operations:
 
   - ``defragment``: Remove unused blocks and extra space.
 
-  - ``diff``: Report differences between two ASDF files
+  - ``diff``: Report differences between two ASDF files.
+
+  - ``edit``: Edit the YAML portion of an ASDF file.
 
   - ``remove-hdu``: Remove ASDF extension from ASDF-in-FITS file (requires
     `astropy`, see :ref:`asdf-in-fits`).
@@ -22,7 +26,7 @@ useful operations:
   - ``extensions``: Show information about installed extensions (see
     :ref:`other_packages`).
 
-  - ``tags``: List currently available tags
+  - ``tags``: List currently available tags.
 
   - ``to_yaml``: Inline all of the data in an ASDF file so that it is
     pure YAML.

--- a/docs/asdf/asdf_tool.rst
+++ b/docs/asdf/asdf_tool.rst
@@ -3,7 +3,7 @@
 Command line tool
 -----------------
 
-``asdf`` includes a command-line tool, ``asdftool`` that performs a number of
+`asdf` includes a command-line tool, ``asdftool`` that performs a number of
 useful operations:
 
   - ``explode``: Convert a self-contained ASDF file into exploded form (see

--- a/docs/asdf/changes.rst
+++ b/docs/asdf/changes.rst
@@ -4,7 +4,7 @@
 Changes
 *******
 
-What's new in ASDF 2.8.1?
+What's new in asdf 2.8.1?
 =========================
 
 The ASDF Standard is at v1.6.0.
@@ -14,7 +14,7 @@ Changes include:
 - Fix bug that corrupts ndarray views when a new block is added
   to an existing file in absence of a block index.
 
-What's new in ASDF 2.8.0?
+What's new in asdf 2.8.0?
 =========================
 
 The ASDF Standard is at v1.6.0.
@@ -42,7 +42,7 @@ Changes include:
 
 - And more, see full changelog below for details.
 
-What's new in ASDF 2.7.5?
+What's new in asdf 2.7.5?
 =========================
 
 The ASDF Standard is at v1.5.0.
@@ -55,7 +55,7 @@ Changes include:
 - Fix bug that corrupts ndarray views when a new block is added
   to an existing file in absence of a block index.
 
-What's New in ASDF 2.7.4?
+What's New in asdf 2.7.4?
 =========================
 
 The ASDF Standard is at v1.5.0.
@@ -70,7 +70,7 @@ Changes include:
 - Add support for opening files from HTTPS URLs and following
   HTTP/HTTPS redirects.
 
-What's New in ASDF 2.7.3?
+What's New in asdf 2.7.3?
 =========================
 
 The ASDF Standard is at v1.5.0.
@@ -83,7 +83,7 @@ Changes include:
 - Add pytest plugin options to skip and xfail individual tests
   and xfail the unsupported ndarray-1.0.0 schema example.
 
-What's New in ASDF 2.7.2?
+What's New in asdf 2.7.2?
 =========================
 
 The ASDF Standard is at v1.5.0.
@@ -97,7 +97,7 @@ Changes include:
 * Replace ``assert`` statements with ``raise`` at the behest
   of the bandit security linter.
 
-What's New in ASDF 2.7.1?
+What's New in asdf 2.7.1?
 =========================
 
 The ASDF Standard is at v1.5.0.
@@ -107,7 +107,7 @@ The sole change in this release:
 * Fix bug preventing access to copied array data after
   an ``AsdfFile`` is closed.
 
-What's New in ASDF 2.7.0?
+What's New in asdf 2.7.0?
 =========================
 
 The ASDF Standard is at v1.5.0.
@@ -121,18 +121,18 @@ Changes include:
 
 * Add option to ``asdf.open`` that disables schema validation on read.
 
-* Improved warning messages.  All asdf library warnings now
+* Improved warning messages.  All `asdf` library warnings now
   subclass ``asdf.exceptions.AsdfWarning``.
 
 * Drop support for filling default values from subschemas
   within oneOf or anyOf combiners.
 
-* Resolve deprecation warnings from the ASDF pytest plugin
+* Resolve deprecation warnings from the `asdf` pytest plugin
   when used with newer versions of pytest.
 
 * Drop support for 2.x versions of the jsonschema package.
 
-What's New in ASDF 2.6.0?
+What's New in asdf 2.6.0?
 =========================
 
 The ASDF Standard is at v1.5.0.
@@ -163,7 +163,7 @@ Changes include:
 * Expand developer documentation to cover the details of pyyaml
   integration and conversion between tagged trees and custom trees.
 
-What's New in ASDF 2.5.2?
+What's New in asdf 2.5.2?
 =========================
 
 The ASDF Standard is at v1.4.0.
@@ -175,7 +175,7 @@ Changes include:
 
 * Add general and versioning-specific developer documentation.
 
-What's New in ASDF 2.5.1?
+What's New in asdf 2.5.1?
 =========================
 
 The ASDF Standard is at v1.4.0.
@@ -183,9 +183,9 @@ The ASDF Standard is at v1.4.0.
 Changes include:
 
 * Fix bug in test causing failure when test suite is run against
-  an installed asdf package.
+  an installed `asdf` package.
 
-What's New in ASDF 2.5.0?
+What's New in asdf 2.5.0?
 =========================
 
 The ASDF Standard is at v1.4.0.
@@ -198,7 +198,7 @@ Changes include:
 
 * Fixed bug causing segfault after update of a memory-mapped file.
 
-What's New in ASDF 2.4.2?
+What's New in asdf 2.4.2?
 =========================
 
 The ASDF Standard is at v1.3.0. Changes include:
@@ -217,9 +217,8 @@ The ASDF Standard is at v1.3.0. Changes include:
 * Fix bug in ``NDArrayType.__len__``.  It must be a method, not a
   property.
 
-What's New in ASDF 2.3.3?
+What's New in asdf 2.3.3?
 =========================
-
 
 The ASDF Standard is at v1.3.0. Changes include:
 
@@ -235,7 +234,7 @@ The ASDF Standard is at v1.3.0. Changes include:
 
 * Allow use of ``pathlib.Path`` objects for ``custom_schema`` option.
 
-What's New in ASDF 2.3.1?
+What's New in asdf 2.3.1?
 =========================
 
 he ASDF Standard is at v1.3.0. Changes include:
@@ -248,10 +247,10 @@ he ASDF Standard is at v1.3.0. Changes include:
 * Fix bug in ``asdftool`` that prevented ``extract`` command from being
   visible.
 
-What's New in ASDF 2.3?
+What's New in asdf 2.3?
 =======================
 
-ASDF 2.3 reflects the update of ASDF Standard to v1.3.0, and contains a few
+`asdf` 2.3 reflects the update of ASDF Standard to v1.3.0, and contains a few
 notable features and an API change:
 
 * Storage of arbitrary precision integers is now provided by
@@ -260,7 +259,7 @@ notable features and an API change:
 
 * Reading a file with integer literals that are too large now causes only a
   warning instead of a validation error. This is to provide backwards
-  compatibility for files that were created with a buggy version of ASDF.
+  compatibility for files that were created with a buggy version of `asdf`.
 
 * The functions `asdf.open` and `AsdfFile.write_to` now support the use of
   `pathlib.Path`.
@@ -268,10 +267,10 @@ notable features and an API change:
 * The `asdf.asdftypes` module has been deprecated in favor of `asdf.types`. The
   old module will be removed entirely in the 3.0 release.
 
-What's New in ASDF 2.2?
+What's New in asdf 2.2?
 =======================
 
-ASDF 2.2 contains several API changes, although backwards compatibilty is
+`asdf` 2.2 contains several API changes, although backwards compatibilty is
 preserved for now. The most significant changes are:
 
 * The function `AsdfFile.open` has been deprecated in favor of `asdf.open`.
@@ -292,10 +291,10 @@ preserved for now. The most significant changes are:
   convert nodes in the ASDF tree into custom tagged types. This makes it easier
   for users to filter specifically for this failure case.
 
-What's New in ASDF 2.1?
+What's New in asdf 2.1?
 =======================
 
-ASDF 2.1 is a minor release, and most of the changes affect only a subset of
+`asdf` 2.1 is a minor release, and most of the changes affect only a subset of
 users. The most notable changes are the following:
 
 * `namedtuple` objects can now be serialized. They are automatically converted
@@ -314,8 +313,8 @@ Please see the :ref:`change_log` for additional details.
 What's New in ASDF 2.0?
 =======================
 
-ASDF 2.0 is a major release that includes many improvements, new features, and
-some API changes. It is the first release of the ASDF package that only
+`asdf` 2.0 is a major release that includes many improvements, new features, and
+some API changes. It is the first release of the `asdf` package that only
 supports Python 3.
 
 The full list of changes, including bug fixes, can be found in the
@@ -328,7 +327,7 @@ The full list of changes, including bug fixes, can be found in the
   have been moved to the Astropy package itself.
 * External packages can now install and register custom ASDF extensions using
   `setuptools` entry points (see :ref:`other_packages` and
-  :ref:`packaging_extensions`). ASDF detects extensions that are installed in
+  :ref:`packaging_extensions`). `asdf` detects extensions that are installed in
   this way and automatically uses them when reading and writing files with
   custom types.
 * A bug was fixed that now allows fully-specified tags from external packages

--- a/docs/asdf/config.rst
+++ b/docs/asdf/config.rst
@@ -1,0 +1,169 @@
+.. currentmodule:: asdf.config
+
+=============
+Configuration
+=============
+
+Version 2.8 of this library introduced a new mechanism, `AsdfConfig`, for setting
+global configuration options.  Currently available options are limited, but we expect
+to eventually move many of the ``AsdfFile.__init__`` and ``AsdfFile.write_to``
+keyword arguments to `AsdfConfig`.
+
+AsdfConfig and you
+==================
+
+The `AsdfConfig` class provides properties that can be adjusted to change the
+behavior of the asdf library for all files.  For example, to disable schema validation
+on read:
+
+.. code-block:: python
+
+    >>> import asdf
+    >>> asdf.get_config().validate_on_read = False # doctest: +SKIP
+
+This will prevent validation on any subsequent call to `~asdf.open`.
+
+Obtaining an AsdfConfig instance
+--------------------------------
+
+There are two methods available that give access to an `AsdfConfig` instance:
+`~asdf.get_config` and `~asdf.config_context`.  The former simply returns
+the currently active config:
+
+.. code-block:: python
+
+    >>> import asdf
+    >>> asdf.get_config()
+    <AsdfConfig
+      array_inline_threshold: None
+      default_version: 1.5.0
+      io_block_size: -1
+      legacy_fill_schema_defaults: True
+      validate_on_read: True
+    >
+
+The latter method, `~asdf.config_context`, returns a context manager that
+yields a copy of the currently active config.  The copy is also returned by
+subsequent calls to `~asdf.get_config`, but only until the context manager exits.
+This allows for short-lived configuration changes that do not impact other code:
+
+.. code-block:: python
+
+    >>> import asdf
+    >>> with asdf.config_context() as config:
+    ...   config.validate_on_read = False
+    ...   asdf.get_config()
+    ...
+    <AsdfConfig
+      array_inline_threshold: None
+      default_version: 1.5.0
+      io_block_size: -1
+      legacy_fill_schema_defaults: True
+      validate_on_read: False
+    >
+    >>> asdf.get_config()
+    <AsdfConfig
+      array_inline_threshold: None
+      default_version: 1.5.0
+      io_block_size: -1
+      legacy_fill_schema_defaults: True
+      validate_on_read: True
+    >
+
+Special note to library maintainers
+-----------------------------------
+
+Libraries that use asdf are encouraged to only modify `AsdfConfig` within a
+surrounding call to `~asdf.config_context`.  The downstream library will then
+be able to customize asdf's behavior without impacting other libraries or
+clobbering changes made by the user.
+
+Config options
+==============
+
+.. _config_options_array_inline_threshold:
+
+array_inline_threshold
+----------------------
+
+The threshold number of array elements under which arrays are automatically stored
+inline in the ASDF tree instead of in binary blocks.  If ``None``, array storage
+type is not managed automatically.
+
+Defaults to ``None``.
+
+default_version
+---------------
+
+The default ASDF Standard version used for new files.  This can be overridden
+on an individual file basis (using the version argument to ``AsdfFile.__init__``)
+or set here to change the default for all new files created in the current session.
+
+Defaults to the latest supported ASDF Standard version.
+
+io_block_size
+-------------
+
+The buffer size used when reading and writing to the filesystem.  Users may wish
+to adjust this value to improve I/O performance.  Set to -1 to use the preferred
+block size for each file, as reported by st_blksize.
+
+Defaults to -1.
+
+legacy_fill_schema_defaults
+---------------------------
+
+Flag that controls filling default values from schemas for older versions of
+the ASDF Standard.  This library used to remove nodes from the tree whose
+values matched the default property in the schema.  That behavior was changed
+in asdf 2.8, but in order to read files produced by older versions of the library,
+default values must still be filled from the schema for ASDF Standard <= 1.5.0.
+
+Set to False to disable filling default values from the schema for these
+older ASDF Standard versions.  The flag has no effect for ASDF Standard >= 1.6.0.
+
+Defaults to True.
+
+validate_on_read
+----------------
+
+Flag that controls schema validation of the ASDF tree when opening files.  Users
+who trust the source of their files may wish to disable validation on read to
+improve performance.
+
+Defaults to True.
+
+Additional AsdfConfig features
+==============================
+
+`AsdfConfig` also provides methods for adding and removing plugins at runtime.
+For example, the `AsdfConfig.add_resource_mapping` method can be used to register
+a schema, which can then be used to validate a file:
+
+.. code-block:: python
+
+    >>> import asdf
+    >>> content = b"""
+    ... %YAML 1.1
+    ... ---
+    ... $schema: http://stsci.edu/schemas/yaml-schema/draft-01
+    ... id: http://example.com/example-project/schemas/foo-1.0.0
+    ... type: object
+    ... properties:
+    ...   foo:
+    ...   type: string
+    ... required: [foo]
+    ... ...
+    ... """
+    >>> asdf.get_config().add_resource_mapping({"http://example.com/example-project/schemas/foo-1.0.0": content})
+    >>> af = asdf.AsdfFile(custom_schema="http://example.com/example-project/schemas/foo-1.0.0")
+    >>> af.validate()
+    Traceback (most recent call last):
+    ...
+    jsonschema.exceptions.ValidationError: 'foo' is a required property
+    ...
+    >>> af["foo"] = "bar"
+    >>> af.validate()
+
+See the `AsdfConfig` API documentation for more detail.
+

--- a/docs/asdf/config.rst
+++ b/docs/asdf/config.rst
@@ -13,7 +13,7 @@ AsdfConfig and you
 ==================
 
 The `AsdfConfig` class provides properties that can be adjusted to change the
-behavior of the asdf library for all files.  For example, to disable schema validation
+behavior of the `asdf` library for all files.  For example, to disable schema validation
 on read:
 
 .. code-block:: python
@@ -73,9 +73,9 @@ This allows for short-lived configuration changes that do not impact other code:
 Special note to library maintainers
 -----------------------------------
 
-Libraries that use asdf are encouraged to only modify `AsdfConfig` within a
+Libraries that use `asdf` are encouraged to only modify `AsdfConfig` within a
 surrounding call to `~asdf.config_context`.  The downstream library will then
-be able to customize asdf's behavior without impacting other libraries or
+be able to customize `asdf`'s behavior without impacting other libraries or
 clobbering changes made by the user.
 
 Config options
@@ -116,7 +116,7 @@ legacy_fill_schema_defaults
 Flag that controls filling default values from schemas for older versions of
 the ASDF Standard.  This library used to remove nodes from the tree whose
 values matched the default property in the schema.  That behavior was changed
-in asdf 2.8, but in order to read files produced by older versions of the library,
+in `asdf` 2.8, but in order to read files produced by older versions of the library,
 default values must still be filled from the schema for ASDF Standard <= 1.5.0.
 
 Set to False to disable filling default values from the schema for these
@@ -166,4 +166,3 @@ a schema, which can then be used to validate a file:
     >>> af.validate()
 
 See the `AsdfConfig` API documentation for more detail.
-

--- a/docs/asdf/developer_versioning.rst
+++ b/docs/asdf/developer_versioning.rst
@@ -102,7 +102,7 @@ in the code; that list is assembled at runtime by AsdfType's
 metaclass, ``asdf.types.AsdfTypeMeta``.  The list can be inspected in
 the console like so:
 
-.. code-block:: pycon
+.. code-block:: python
 
     >>> import asdf
     >>> asdf.types._all_asdftypes # doctest: +SKIP

--- a/docs/asdf/extending/compressors.rst
+++ b/docs/asdf/extending/compressors.rst
@@ -14,6 +14,9 @@ will be available to users as an argument to `~asdf.AsdfFile.set_array_compressi
 the ``all_array_compression`` argument to `~asdf.AsdfFile.write_to` and
 `~asdf.AsdfFile.update`.
 
+See :ref:`extending_extensions_compressors` for details on including
+a Compressor in an extension.
+
 The Compressor interface
 ========================
 

--- a/docs/asdf/extending/compressors.rst
+++ b/docs/asdf/extending/compressors.rst
@@ -18,7 +18,7 @@ The Compressor interface
 ========================
 
 Every Compressor implementation must provide one required property
-two required methods:
+and two required methods:
 
 `Compressor.label` - A 4-byte compression code.  This code is used
 by users to select a compression algorithm and also stored in the
@@ -45,7 +45,7 @@ number of bytes written to the output array.
 Entry point performance considerations
 ======================================
 
-For the good of asdf users everywhere, it's important that entry point
+For the good of `asdf` users everywhere, it's important that entry point
 methods load as quickly as possible.  All extensions must be loaded before
 reading an ASDF file, and therefore all compressors are created as well.  Any
 compressor module or ``__init__`` method that lingers will introduce a delay
@@ -54,4 +54,4 @@ authors minimize the number of imports that occur in the module containing the
 Compressor implementation, and defer imports of compression libraries to inside
 the `Comrpessor.compress` and `Compressor.decompress` methods.  This will
 prevent the library from ever being imported when reading ASDF files that
-to not utilize the Compressor's algorithm.
+do not utilize the Compressor's algorithm.

--- a/docs/asdf/extending/compressors.rst
+++ b/docs/asdf/extending/compressors.rst
@@ -1,0 +1,57 @@
+.. currentmodule:: asdf.extension
+
+.. _extending_compressors:
+
+========================
+Binary block compressors
+========================
+
+The `Compressor` interface provides an implementation of a compression algorithm
+that can be used to transform binary blocks in an `~asdf.AsdfFile`.  Each
+Compressor must provide a 4-byte compression code that identifies the algorithm.
+Once the Compressor is installed as part of an Extension plugin, this code
+will be available to users as an argument to `~asdf.AsdfFile.set_array_compression` and
+the ``all_array_compression`` argument to `~asdf.AsdfFile.write_to` and
+`~asdf.AsdfFile.update`.
+
+The Compressor interface
+========================
+
+Every Compressor implementation must provide one required property
+two required methods:
+
+`Compressor.label` - A 4-byte compression code.  This code is used
+by users to select a compression algorithm and also stored in the
+binary block header to identify the algorithm that was applied to
+the block's data.
+
+`Compressor.compress` - The method that transforms the block's bytes
+before they are written to an ASDF file.  The positional argument
+is a `memoryview` object which is guaranteed to be 1D and contiguous.
+Compressors must be prepared to handle `memoryview.itemsize` > 1.
+Any keyword arguments are passed through from the user and may be used
+to tune the compression algorithm.  ``compress`` methods have no return
+value and instead are expected to yield bytes-like values until the
+input data has been fully compressed.
+
+`Compressor.decompress` - The method that transforms the block's bytes
+after they are read from an ASDF file.  The first positional argument
+is an `~collections.abc.Iterable` of bytes-like objects that each
+contain a chunk of the compressed input data.  The second positional
+argument is a pre-allocated output array where the decompressed
+bytes should be written.  The method is expected to return the
+number of bytes written to the output array.
+
+Entry point performance considerations
+======================================
+
+For the good of asdf users everywhere, it's important that entry point
+methods load as quickly as possible.  All extensions must be loaded before
+reading an ASDF file, and therefore all compressors are created as well.  Any
+compressor module or ``__init__`` method that lingers will introduce a delay
+to the initial call to `asdf.open`.  For that reason, we recommend that compressor
+authors minimize the number of imports that occur in the module containing the
+Compressor implementation, and defer imports of compression libraries to inside
+the `Comrpessor.compress` and `Compressor.decompress` methods.  This will
+prevent the library from ever being imported when reading ASDF files that
+to not utilize the Compressor's algorithm.

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -31,7 +31,7 @@ class's implementation and not just a module where it is imported for convenienc
 For example, if class ``Foo`` is implemented in ``example_package.foo.Foo`` but
 imported as ``example_package.Foo`` for convenience, it is the former name that
 must be used.  The `~asdf.util.get_class_name` method will return the name that
-asdf expects.
+`asdf` expects.
 
 The string type name is recommended over a type object for performance reasons,
 see :ref:`extending_converters_performance`.
@@ -269,7 +269,7 @@ at the time that we retrieved it.  We can handle this situation by making our
 
 The generator version of ``from_yaml_tree`` yields the partially constructed
 ``FractionWithInverse`` object before setting its inverse property.  This allows
-asdf to proceed to constructing the inverse ``FractionWithInverse`` object,
+`asdf` to proceed to constructing the inverse ``FractionWithInverse`` object,
 and resume the original ``from_yaml_tree`` execution only when the inverse
 is actually available.
 
@@ -287,7 +287,7 @@ With this modification we can successfully deserialize our ASDF file:
 Entry point performance considerations
 ======================================
 
-For the good of asdf users everywhere, it's important that entry point
+For the good of `asdf` users everywhere, it's important that entry point
 methods load as quickly as possible.  All extensions must be loaded before
 reading an ASDF file, and therefore all converters are created as well.  Any
 converter module or ``__init__`` method that lingers will introduce a delay

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -1,0 +1,298 @@
+.. currentmodule:: asdf.extension
+
+.. _extending_converters:
+
+==========
+Converters
+==========
+
+The `~asdf.extension.Converter` interface defines a mapping between
+tagged objects in the ASDF tree and their corresponding Python object(s).
+Typically a Converter will map one YAML tag to one Python type, but
+the interface also supports many-to-one and many-to-many mappings.  A
+Converter provides the software support for a tag and is responsible
+for both converting from parsed YAML to more complex Python objects
+and vice versa.
+
+The Converter interface
+=======================
+
+Every Converter implementation must provide two required properties and
+two required methods:
+
+`Converter.tags` - a list of tag URIs or URI patterns handled by the converter.
+Patterns may include the wildcard character `*`, which matches any sequence of
+characters up to a `/`, or `**`, which matches any sequence of characters.
+The `~asdf.util.uri_match` method can be used to test URI patterns.
+
+`Converter.types` - a list of Python types or fully-qualified Python type names handled
+by the converter.  Note that a string name must reflect the actual location of the
+class's implementation and not just a module where it is imported for convenience.
+For example, if class ``Foo`` is implemented in ``example_package.foo.Foo`` but
+imported as ``example_package.Foo`` for convenience, it is the former name that
+must be used.  The `~asdf.util.get_class_name` method will return the name that
+asdf expects.
+
+The string type name is recommended over a type object for performance reasons,
+see :ref:`extending_converters_performance`.
+
+`Converter.to_yaml_tree` - a method that accepts a complex Python object and returns
+a simple node object (typically a `dict`) suitable for serialization to YAML.  The
+node is permitted to contain nested complex objects; these will in turn
+be passed to other ``to_yaml_tree`` methods in other Converters.
+
+`Converter.from_yaml_tree` - a method that accepts a simple node object from parsed YAML and
+returns the appropriate complex Python object.  Nested nodes in the received node
+will have already been converted to complex objects by other calls to ``from_yaml_tree``
+methods, except where reference cycles are present -- see
+:ref:`extending_converters_reference_cycles` for information on how to handle that
+situation.
+
+Additionally, the Converter interface includes a method that must be implemented
+when some logic is required to select the tag to assign to a ``to_yaml_tree`` result:
+
+`Converter.select_tag` - a method that accepts a complex Python object and a list
+candidate tags and returns the tag that should be used to serialize the object.
+
+A simple example
+================
+
+Say we have a Python class, ``Rectangle``, that we wish to serialize
+to an ASDF file.  A ``Rectangle`` instance has two attributes, width
+and height, and a convenient method that computes its area:
+
+.. code-block:: python
+
+    # in module example_package.shapes
+    class Rectangle:
+        def __init__(self, width, height):
+            self.width = width
+            self.height = height
+
+        def get_area(self):
+            return self.width * self.height
+
+We'll need to designate a tag URI to represent this object's type
+in the ASDF tree -- let's use ``asdf://example.com/example-project/tags/rectangle-1.0.0``.
+Here is a simple Converter implementation for this type and tag:
+
+.. code-block:: python
+
+    from asdf.extension import Converter
+
+    class RectangleConverter(Converter):
+        tags = ["asdf://example.com/shapes/tags/rectangle-1.0.0"]
+        types = ["example_package.shapes.Rectangle"]
+
+        def to_yaml_tree(self, obj, tag, ctx):
+            return {
+                "width": obj.width,
+                "height": obj.height,
+            }
+
+        def from_yaml_tree(self, node, tag, ctx):
+            from example_package.shapes import Rectangle
+
+            return Rectangle(node["width"], node["height"])
+
+Note that import of the ``Rectangle`` class has been deferred to
+inside the ``from_yaml_tree`` method.  This is a performance consideration
+that is discussed in :ref:`extending_converters_performance`.
+
+In order to use this Converter, we'll need to create a simple extension
+around it and install that extension:
+
+.. code-block:: python
+
+    import asdf
+    from asdf.extension import Extension
+
+    class ShapesExtension(Extension):
+        extension_uri = "asdf://example.com/shapes/extensions/shapes-1.0.0"
+        converters = [RectangleConverter()]
+        tags = ["asdf://example.com/shapes/tags/rectangle-1.0.0"]
+
+    asdf.get_config().add_extension(ShapesExtension())
+
+Now we can include a Rectangle object in an `~asdf.asdf.AsdfFile` tree
+and write out a file:
+
+.. code-block:: python
+
+    with asdf.AsdfFile() as af:
+        af["rect"] = Rectangle(5, 4)
+        af.write_to("test.asdf")
+
+The portion of the ASDF file that represents the rectangle looks like this:
+
+.. code-block:: yaml
+
+    rect: !<asdf://example.com/shapes/tags/rectangle-1.0.0> {height: 4, width: 5}
+
+Multiple tags
+=============
+
+Now say we want to map our one Rectangle class to one of two tags, either
+rectangle-1.0.0 or square-1.0.0.  We'll need to add square-1.0.0 to
+the converter's list of tags and implement a ``select_tag`` method:
+
+.. code-block:: python
+
+    RETANGLE_TAG = "asdf://example.com/shapes/tags/rectangle-1.0.0"
+    SQUARE_TAG = "asdf://example.com/shapes/tags/square-1.0.0"
+
+    class RectangleConverter(Converter):
+        tags = [RECTANGLE_TAG, SQUARE_TAG]
+        types = ["example_package.shapes.Rectangle"]
+
+        def select_tag(self, obj, tags, ctx):
+            if obj.width == obj.height:
+                return SQUARE_TAG
+            else:
+                return RECTANGLE_TAG
+
+        def to_yaml_tree(self, obj, tag, ctx):
+            if tag == SQUARE_TAG:
+                return {
+                    "side_length": obj.width,
+                }
+            else:
+                return {
+                    "width": obj.width,
+                    "height": obj.height,
+                }
+
+        def from_yaml_tree(self, node, tag, ctx):
+            from example_package.shapes import Rectangle
+
+            if tag == SQUARE_TAG:
+                return Rectangle(node["side_length"], node["side_length"])
+            else:
+                return Rectangle(node["width"], node["height"])
+
+.. _extending_converters_reference_cycles:
+
+Reference cycles
+================
+
+Special considerations must be made when deserializing a tagged object that
+contains a reference to itself among its descendants.  Consider a
+`fractions.Fraction` subclass that maintains a reference to its multiplicative
+inverse:
+
+.. code-block:: python
+
+    # in the example_project.fractions module
+    class FractionWithInverse(fractions.Fraction):
+        def __init__(self, *args, **kwargs):
+            self._inverse = None
+
+        @property
+        def inverse(self):
+            return self._inverse
+
+        @inverse.setter
+        def inverse(self, value):
+            self._inverse = value
+
+The inverse of the inverse of a fraction is the fraction itself,
+we might wish to construct the objects in the following way:
+
+.. code-block:: python
+
+    f1 = FractionWithInverse(3, 5)
+    f2 = FractionWithInverse(5, 3)
+    f1.inverse = f2
+    f2.inverse = f1
+
+Which creates an "infinite loop" between the two fractions.  An ordinary
+Converter wouldn't be able to deserialize this, since each fraction
+requires that the other be deserialized first!  Let's see what happens
+when we define our ``from_yaml_tree`` method in a naive way:
+
+.. code-block:: python
+
+    class FractionWithInverseConverter(Converter):
+        tags = ["asdf://example.com/fractions/tags/fraction-1.0.0"]
+        types = ["example_project.fractions.FractionWithInverse"]
+
+        def to_yaml_tree(self, obj, tag, ctx):
+            return {
+                "numerator": obj.width,
+                "denominator": obj.height,
+                "inverse": obj.inverse,
+            }
+
+        def from_yaml_tree(self, node, tag, ctx):
+            from example_project.fractions import FractionWithInverse
+
+            obj = FractionWithInverse(
+                tree["numerator"],
+                tree["denominator"]
+            )
+            obj.inverse = tree["inverse"]
+            return obj
+
+After adding this Converter to an Extension and installing it, the fraction
+will serialize correctly:
+
+.. code-block:: python
+
+    with asdf.AsdfFile({"fraction": f1}) as af:
+        af.write_to("with_inverse.asdf")
+
+But upon deserialization, we notice a problem:
+
+.. code-block:: python
+
+    with asdf.open("with_inverse.asdf") as af:
+        reconstituted_f1 = af["fraction"]
+
+    assert reconstituted_f1.inverse.inverse is asdf.treeutil.PendingValue
+
+The presence of `~asdf.treeutil.PendingValue` is asdf's way of telling us
+that the value corresponding to the key ``inverse`` was not fully deserialized
+at the time that we retrieved it.  We can handle this situation by making our
+``from_yaml_tree`` a generator function:
+
+.. code-block:: python
+
+        def from_yaml_tree(self, node, tag, ctx):
+            from example_project.fractions import FractionWithInverse
+
+            obj = FractionWithInverse(
+                tree["numerator"],
+                tree["denominator"]
+            )
+            yield obj
+            obj.inverse = tree["inverse"]
+
+The generator version of ``from_yaml_tree`` yields the partially constructed
+``FractionWithInverse`` object before setting its inverse property.  This allows
+asdf to proceed to constructing the inverse ``FractionWithInverse`` object,
+and resume the original ``from_yaml_tree`` execution only when the inverse
+is actually available.
+
+With this modification we can successfully deserialize our ASDF file:
+
+.. code-block:: python
+
+    with asdf.open("with_inverse.asdf") as af:
+            reconstituted_f1 = ff["fraction"]
+
+    assert reconstituted_f1.inverse.inverse is reconstituted_f1
+
+.. _extending_converters_performance:
+
+Entry point performance considerations
+======================================
+
+For the good of asdf users everywhere, it's important that entry point
+methods load as quickly as possible.  All extensions must be loaded before
+reading an ASDF file, and therefore all converters are created as well.  Any
+converter module or ``__init__`` method that lingers will introduce a delay
+to the initial call to `asdf.open`.  For that reason, we recommend that converter
+authors minimize the number of imports that occur in the module containing the
+Converter implementation, and defer imports of serializable types to within the
+``from_yaml_tree`` method.  This will prevent the type from ever being imported
+when reading ASDF files that do not contain the associated tag.

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -1,0 +1,340 @@
+.. currentmodule:: asdf.extension
+
+.. _extending_extensions:
+
+==========
+Extensions
+==========
+
+An ASDF "extension" is a supplement to the core ASDF specification that
+describes additional YAML tags or binary block compressors which
+may be used when writing files.  In this library, extensions implement the
+`Extension` interface and can be installed manually
+by the user or automatically by a package using Python's entry points
+mechanism.
+
+Extension features
+==================
+
+Basics
+------
+
+Every extension to ASDF must be uniquely identified by a URI; this URI is
+written to the file's metadata when the extension is used and allows
+software to determine if the necessary extensions are installed when the file
+is read.  An ASDF extension implementation intended for use with this library
+must, at a minimum, implement the `Extension` interface and
+provide its URI as a property:
+
+.. code-block:: python
+
+    from asdf.extension import Extension
+
+    class FooExtension(Extension):
+        extension_uri = "asdf://example.com/example-project/extensions/foo-1.0.0"
+
+Note that this is an "empty" extension that does not extend the library in
+any meaningful way; other attributes must be implemented to actually
+support additional tags and/or compressors.  Read on for a description of the rest
+of the Extension interface.
+
+Additional tags
+---------------
+
+In order to implement support for additional YAML tags, an Extension subclass
+must provide both a list of relevant tags and a list of `Converter`
+instances that translate objects with those tags to and from YAML.  These lists
+are provided in the ``tags`` and ``converters`` properties, respectively:
+
+.. code-block:: python
+
+    from asdf.extension import Extension, Converter
+
+    class FooConverter(Converter):
+        # ...
+
+    class FooExtension(Extension):
+        extension_uri = "asdf://example.com/example-project/extensions/foo-1.0.0"
+        tags = ["asdf://example.com/example-project/tags/foo-1.0.0"]
+        converters = [FooConverter()]
+
+The implementation of a Converter is a topic unto itself and is discussed in
+detail in :ref:`extending_converters`.
+
+The Extension implemented above will happily convert between ``foo-1.0.0``
+tagged YAML objects and the appropriate Python representation, but it will
+not perform any schema validation.  In order to associate the tag with
+a schema, we'll need to provide a `TagDefinition` object
+instead of just a string:
+
+.. code-block:: python
+
+    from asdf.extension import Extension, Converter, TagDefinition
+
+    class FooConverter(Converter):
+        # ...
+
+    class FooExtension(Extension):
+        extension_uri = "asdf://example.com/example-project/extensions/foo-1.0.0"
+        tags = [
+            TagDefinition(
+                "asdf://example.com/example-project/tags/foo-1.0.0",
+                schema_uri="asdf://example.com/example-project/schemas/foo-1.0.0",
+            )
+        ]
+        converters = [FooConverter()]
+
+Additional block compressors
+----------------------------
+
+Binary block compressors implement the `Compressor` interface
+and are included in an extension via the ``compressors`` property:
+
+.. code-block:: python
+
+    from asdf.extension import Extension, Compressor
+
+    class FooCompressor(Compressor):
+        # ...
+
+    class FooExtension(Extension):
+        extension_uri = "asdf://example.com/example-project/extensions/foo-1.0.0"
+        compressors = [FooCompressor()]
+
+See :ref:`extending_compressors` for details on implementing the Compressor interface.
+
+Additional YAML tag handles
+---------------------------
+
+The YAML format permits use of "tag handles" as shorthand prefixes
+in tags.  For example, these two YAML files are equivalent:
+
+.. code-block:: yaml
+
+    %YAML 1.1
+    ---
+    value: !<asdf://example.com/example-project/tags/foo-1.0.0>
+      # etc
+    ...
+
+.. code-block:: yaml
+
+    %YAML 1.1
+    %TAG !example! asdf://example.com/example-project/tags/
+    ---
+    value: !example!foo-1.0.0
+      # etc
+    ...
+
+In both cases the ``value`` object has tag asdf://example.com/example-project/tags/foo-1.0.0,
+but in the second example the tag is abbreviated as ``!example!foo-1.0.0`` through use of
+a handle.  This has no impact on the interpretation of the file but can make the raw ASDF
+tree easier to read for humans.
+
+Tag handles can be defined in the ``yaml_tag_handles`` property of an extension:
+
+.. code-block:: python
+
+    from asdf.extension import Extension
+
+    class FooExtension(Extension):
+        extension_uri = "asdf://example.com/example-project/extensions/foo-1.0.0"
+        yaml_tag_handles = {
+            "!example!": "asdf://example.com/example-project/tags/"
+        }
+
+ASDF Standard version requirement
+---------------------------------
+
+Some extensions may only work with specific version(s) of the ASDF
+Standard -- for example, the schema associated with one of an extension's
+tags may reference specific versions of ASDF core tags.  This requirement
+can be expressed as a PEP 440 version specifier in an Extension's
+``asdf_standard_requirement`` property:
+
+.. code-block:: python
+
+    from asdf.extension import Extension
+
+    class FooExtension(Extension):
+        extension_uri = "asdf://example.com/example-project/extensions/foo-1.0.0"
+        asdf_standard_requirement = ">= 1.2.0, < 1.5.0"
+
+Now the extension will only be used with ASDF Standard 1.3.0 and 1.4.0 files.
+
+Legacy class names
+------------------
+
+Previous versions of this library referred to extensions by their Python class
+names instead of by URI.  These class names were written to ASDF file metadata
+and allowed the library to warn users when an extension used to write the file
+was not available on read.  Now the extension URI is written to the metadata, but
+to prevent warnings when reading older files, extension authors can provide
+an additional list of class names that previously identified the extension:
+
+.. code-block:: python
+
+    from asdf.extension import Extension
+
+    class FooExtension(Extension):
+        extension_uri = "asdf://example.com/example-project/extensions/foo-1.0.0"
+        legacy_class_names = [
+            "foo_package.extensions.FooExtension",
+        ]
+
+.. _extending_extensions_installing:
+
+Installing an extension
+=======================
+
+Once an extension is implemented, it must be installed so that the asdf
+library knows to use it.  There are two options for installing an extension:
+manually per session using `~asdf.config.AsdfConfig`, or automatically
+for every session using the ``asdf.resource_mappings`` entry point
+
+.. _extending_extensions_installing_asdf_config:
+
+Installing extensions via AsdfConfig
+------------------------------------
+
+The simplest way to install an extension is to add it at runtime using the
+`AsdfConfig.add_extension <asdf.config.AsdfConfig.add_extension>` method.
+For example, the following code defines and installs a minimal extension:
+
+.. code-block:: python
+
+    import asdf
+    from asdf.extension import Extension
+
+    class FooExtension(Extension):
+        extension_uri = "asdf://example.com/example-project/extensions/foo-1.0.0"
+
+    asdf.get_config().add_extension(FooExtension())
+
+Now the extension will be available when working with ASDF files, but only
+for the duration of the current Python session.
+
+.. _extending_extensions_installing_entry_points:
+
+Installing extensions via entry points
+--------------------------------------
+
+The asdf package also offers an entry point for installing extensions
+This registers a package's extensions automatically on package install
+without requiring calls to the AsdfConfig method.  The entry point is
+called ``asdf.extensions`` and expects to receive a method that returns
+a list of ``Extension`` instances.
+
+For example, let's say we're creating a package named ``asdf-foo-extension``
+that provides the not-particularly-useful ``FooExtension`` from the previous
+section.  We'll need to define an entry point method that returns a list
+containing an instance of ``FooExtension``:
+
+.. code-block:: python
+
+    def get_extensions():
+        return [FooExtension()]
+
+We'll assume that method is located in the module ``asdf_foo_extension.integration``.
+
+Next, in the package's ``setup.cfg``, define an ``[options.entry_points]`` section that
+identifies the method as an ``asdf.extensions`` entry point:
+
+.. code-block:: cfg
+
+    # setup.cfg
+    [options.entry_points]
+    asdf.resource_mappings =
+        asdf_foo_extension = asdf_foo_extension.integration:get_extensions
+
+After installing the package, the extension should be automatically available in any
+new Python session.
+
+Entry point performance considerations
+--------------------------------------
+
+For the good of asdf users everywhere, it's important that entry point
+methods load as quickly as possible.  All extensions must be loaded before
+reading an ASDF file, so any entry point method that lingers will introduce a delay
+to the initial call to `asdf.open`.  For that reason, we recommend that extension
+authors minimize the number of imports that occur in the module containing
+the entry point method, particularly imports of modules outside of the
+Python standard library or asdf itself.
+
+.. _extending_extensions_manifest:
+
+Populating an extension from a manifest
+=======================================
+
+An "extension manifest" is a language-independent description of an ASDF extension (little 'e')
+that includes information such as the extension URI, list of tags, ASDF Standard
+requirement, etc.  Instructions on writing a manifest can be found in
+:ref:`extending_manifests`, but once written, we'll still need a Python Extension (big 'E')
+whose content mirrors the manifest. Rather than duplicate that information in Python code,
+we recommend use of the `ManifestExtension` class, which reads a manifest
+and maps its content to the appropriate Extension interface properties.
+
+Assuming the manifest is installed as a resource (see :ref:`extending_resources`), an extension
+instance can be created using the ``from_uri`` factory method:
+
+.. code-block:: python
+
+    from asdf.extension import ManifestExtension
+
+    extension = ManifestExtension.from_uri("asdf://example.com/example-project/manifests/foo-1.0.0")
+
+Compressors and converters can be included in the extension by adding them as keyword arguments:
+
+.. code-block:: python
+
+    from asdf.extension import ManifestExtension
+
+    extension = ManifestExtension.from_uri(
+        "asdf://example.com/example-project/manifests/foo-1.0.0",
+        converters=[FooConverter()],
+        compressors=[FooCompressor()],
+    )
+
+The extension may then be installed by one of the two methods described above.
+
+Warning on ManifestExtension and entry points
+---------------------------------------------
+
+When implementing a package that automatically installs a ManifestExtension, we'll need to
+utilize both the ``asdf.resource_mappings`` entry point (to install the manifest) and
+the ``asdf.extensions`` entry point (to install the extension).  Because the manifest must be
+installed before the extension can be instantiated, it's easy to end up trapped in an import
+loop.  For example, this seemingly innocuous set of entry point methods cannot be successfully
+loaded:
+
+.. code-block:: python
+
+    from asdf.extension import ManifestExtension
+
+    RESOURCES = {
+        "asdf://example.com/example-project/manifests/foo-1.0.0": open("foo-1.0.0.yaml").read()
+    }
+
+    def get_resource_mappings():
+        return [RESOURCES]
+
+    EXTENSION = ManifestExtension.from_uri("asdf://example.com/example-project/manifests/foo-1.0.0")
+
+    def get_extensions():
+        return [EXTENSION]
+
+When the module is imported, ``ManifestExtension.from_uri`` asks the asdf library to load
+all available resources so that it can retrieve the manifest content.  But loading the resources
+requires importing this module to get at the ``get_resource_mappings`` method, so now we're stuck!
+
+The solution is to instantiate the ManifestExtension inside of its entry point method:
+
+.. code-block:: python
+
+    def get_extensions():
+        return [
+            ManifestExtension.from_uri("asdf://example.com/example-project/manifests/foo-1.0.0")
+        ]
+
+This is not as inefficient as it might seem, since the asdf library only calls the method once
+and reuses a cached result thereafter.

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -187,7 +187,7 @@ an additional list of class names that previously identified the extension:
 Installing an extension
 =======================
 
-Once an extension is implemented, it must be installed so that the asdf
+Once an extension is implemented, it must be installed so that the `asdf`
 library knows to use it.  There are two options for installing an extension:
 manually per session using `~asdf.config.AsdfConfig`, or automatically
 for every session using the ``asdf.extensions`` entry point
@@ -219,7 +219,7 @@ for the duration of the current Python session.
 Installing extensions via entry points
 --------------------------------------
 
-The asdf package also offers an entry point for installing extensions
+The `asdf` package also offers an entry point for installing extensions
 This registers a package's extensions automatically on package install
 without requiring calls to the AsdfConfig method.  The entry point is
 called ``asdf.extensions`` and expects to receive a method that returns
@@ -253,13 +253,13 @@ new Python session.
 Entry point performance considerations
 --------------------------------------
 
-For the good of asdf users everywhere, it's important that entry point
+For the good of `asdf` users everywhere, it's important that entry point
 methods load as quickly as possible.  All extensions must be loaded before
 reading an ASDF file, so any entry point method that lingers will introduce a delay
 to the initial call to `asdf.open`.  For that reason, we recommend that extension
 authors minimize the number of imports that occur in the module containing
 the entry point method, particularly imports of modules outside of the
-Python standard library or asdf itself.
+Python standard library or `asdf` itself.
 
 .. _extending_extensions_manifest:
 
@@ -323,7 +323,7 @@ loaded:
     def get_extensions():
         return [EXTENSION]
 
-When the module is imported, ``ManifestExtension.from_uri`` asks the asdf library to load
+When the module is imported, ``ManifestExtension.from_uri`` asks the `asdf` library to load
 all available resources so that it can retrieve the manifest content.  But loading the resources
 requires importing this module to get at the ``get_resource_mappings`` method, so now we're stuck!
 
@@ -336,5 +336,5 @@ The solution is to instantiate the ManifestExtension inside of its entry point m
             ManifestExtension.from_uri("asdf://example.com/example-project/manifests/foo-1.0.0")
         ]
 
-This is not as inefficient as it might seem, since the asdf library only calls the method once
+This is not as inefficient as it might seem, since the `asdf` library only calls the method once
 and reuses a cached result thereafter.

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -84,6 +84,8 @@ instead of just a string:
         ]
         converters = [FooConverter()]
 
+.. _extending_extensions_compressors:
+
 Additional block compressors
 ----------------------------
 

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -190,7 +190,7 @@ Installing an extension
 Once an extension is implemented, it must be installed so that the asdf
 library knows to use it.  There are two options for installing an extension:
 manually per session using `~asdf.config.AsdfConfig`, or automatically
-for every session using the ``asdf.resource_mappings`` entry point
+for every session using the ``asdf.extensions`` entry point
 
 .. _extending_extensions_installing_asdf_config:
 
@@ -244,7 +244,7 @@ identifies the method as an ``asdf.extensions`` entry point:
 
     # setup.cfg
     [options.entry_points]
-    asdf.resource_mappings =
+    asdf.extensions =
         asdf_foo_extension = asdf_foo_extension.integration:get_extensions
 
 After installing the package, the extension should be automatically available in any

--- a/docs/asdf/extending/legacy.rst
+++ b/docs/asdf/extending/legacy.rst
@@ -5,9 +5,9 @@
 Deprecated extension API
 ========================
 
-This page documents the original asdf extension API, which has been
+This page documents the original `asdf` extension API, which has been
 deprecated in favor of :ref:`extending_extensions`.  Since support
-for the deprecated API will be removed in asdf 3.0, we recommend that
+for the deprecated API will be removed in `asdf` 3.0, we recommend that
 all new extensions be implemented with the new API.
 
 Extensions provide a way for ASDF to represent complex types that are not
@@ -134,7 +134,7 @@ components) is reflected in `~asdf.AsdfExtension.tag_mapping` property of the
 `~asdf.AsdfExtension.url_mapping` is used to map URLs (of the same form as the
 ``id`` field in the schema) to the actual location of a schema file.
 
-Once these classes and the schema have been defined, we can save an asdf file
+Once these classes and the schema have been defined, we can save an ASDF file
 using them:
 
 .. runcode::
@@ -457,7 +457,7 @@ But upon deserialization, we notice a problem:
 
     assert reconstituted_f1.inverse.inverse is asdf.treeutil.PendingValue
 
-The presence of `~asdf.treeutil.PendingValue` is asdf's way of telling you
+The presence of `~asdf.treeutil.PendingValue` is `asdf`'s way of telling you
 that the value corresponding to the key ``inverse`` was not fully deserialized
 at the time that you retrieved it.  We can handle this situation by making our
 `~asdf.CustomType.from_tree` a generator function:
@@ -633,7 +633,7 @@ this, we will make use of the `~asdf.CustomType.supported_versions` attribute
 for our tag class. This will allow us to declare explicit support for the
 schema versions our tag class implements.
 
-Under the hood, ASDF creates multiple copies of our ``PersonType`` tag class,
+Under the hood, `asdf` creates multiple copies of our ``PersonType`` tag class,
 each with a different `~asdf.CustomType.version` attribute corresponding to one
 of the supported versions. This means that in our new tag class implementation,
 we can condition our `~asdf.CustomType.from_tree` implementation on the value
@@ -673,13 +673,13 @@ the older version of the schema.
 Handling subclasses
 *******************
 
-By default, if a custom type is serialized by an ASDF tag class, then all
+By default, if a custom type is serialized by an `asdf` tag class, then all
 subclasses of that type can also be serialized. However, no attributes that are
 specific to the subclass will be stored in the file. When reading the file, an
 instance of the base custom type will be returned instead of the subclass that
 was written.
 
-To properly handle subclasses of custom types already recognized by ASDF, it is
+To properly handle subclasses of custom types already recognized by `asdf`, it is
 necessary to implement a separate tag class that is specific to the subclass to
 be serialized.
 
@@ -690,7 +690,7 @@ this feature was dropped as it produced files that were not portable.
 Creating custom schemas
 -----------------------
 
-All custom types to be serialized by ASDF require custom schemas. The best
+All custom types to be serialized by `asdf` require custom schemas. The best
 resource for creating ASDF schemas can be found in the `ASDF Standard
 <https://asdf-standard.readthedocs.io/en/latest/schemas.html>`_ documentation.
 
@@ -757,7 +757,7 @@ asserts that the corresponding fraction is in simplified form:
 Defining custom extension classes
 ---------------------------------
 
-Extension classes are the mechanism that ASDF uses to register custom tag types
+Extension classes are the mechanism that `asdf` uses to register custom tag types
 so that they can be used when processing ASDF files. Packages that define their
 own custom tag types must also define extensions in order for those types to be
 used.
@@ -777,20 +777,20 @@ Overriding built-in extensions
 ******************************
 
 It is possible for externally defined extensions to override tag types that are
-provided by ASDF's built-in extension. For example, maybe an external package
+provided by `asdf`'s built-in extension. For example, maybe an external package
 wants to provide a different implementation of `~asdf.tags.core.NDArrayType`.
 In this case, the external package does not need to provide custom schemas
 since the schema for the type to be overridden is already provided as part of
 the ASDF standard.
 
-Instead, the extension class may inherit from ASDF's
+Instead, the extension class may inherit from `asdf`'s
 `~asdf.extension.BuiltinExtension` and simply override the
 `~asdf.AsdfExtension.types` property to indicate the type that is being
 overridden.  Doing this preserves the `~asdf.AsdfExtension.tag_mapping` and
 `~asdf.AsdfExtension.url_mapping` that is used by the `BuiltinExtension`, which
-allows the schemas that are packaged by ASDF to be located.
+allows the schemas that are packaged by `asdf` to be located.
 
-ASDF will give precedence to the type that is provided by the external
+`asdf` will give precedence to the type that is provided by the external
 extension, effectively overriding the corresponding type in the built-in
 extension. Note that it is currently undefined if multiple external extensions
 are provided that override the same built-in type.
@@ -803,7 +803,7 @@ Packaging schemas
 
 If a package provides custom schemas, the schema files must be installed as
 part of that package distribution. In general, schema files must be installed
-into a subdirectory of the package distribution. The ASDF extension class must
+into a subdirectory of the package distribution. The `asdf` extension class must
 supply a `~asdf.AsdfExtension.url_mapping` that maps to the installed location
 of the schemas. See :ref:`defining_extensions` for more details.
 
@@ -811,13 +811,13 @@ Registering entry points
 ************************
 
 Packages that provide their own ASDF extensions can (and should!) install them
-so that they are automatically detectable by the ASDF Python package. This is
+so that they are automatically detectable by the `asdf` Python package. This is
 accomplished using Python's `setuptools` entry points. Entry points are
 registered in a package's `setup.py` file.
 
 Consider a package that provides an extension class `MyPackageExtension` in the
 submodule `mypackage.asdf.extensions`. We need to register this class as an
-extension entry point that ASDF will recognize. First, we create a dictionary:
+extension entry point that `asdf` will recognize. First, we create a dictionary:
 
 .. code:: python
 
@@ -858,9 +858,9 @@ The entry points must be passed to the call to `setuptools.setup`:
 
 When running ``python setup.py install`` or ``python setup.py develop`` on this
 package, the entry points will be registered automatically. This allows the
-ASDF package to recognize the extensions without any user intervention. Users
+`asdf` package to recognize the extensions without any user intervention. Users
 of your package that wish to read ASDF files using types that you have
-registered will not need to use any extension explicitly. Instead, ASDF will
+registered will not need to use any extension explicitly. Instead, `asdf` will
 automatically recognize the types you have registered and will process them
 appropriately. See :ref:`other_packages` for more information on using
 extensions.
@@ -870,12 +870,12 @@ extensions.
 Testing custom schemas
 ----------------------
 
-Packages that provide their own schemas can test them using ASDF's
+Packages that provide their own schemas can test them using `asdf`'s
 `pytest <https://docs.pytest.org/en/latest/>`_ plugin for schema testing.
 Schemas are tested for overall validity, and any examples given within the
 schemas are also tested.
 
-The schema tester plugin is automatically registered when the ASDF package is
+The schema tester plugin is automatically registered when the `asdf` package is
 installed. In order to enable testing, it is necessary to add the directory
 containing your schema files to the pytest section of your project's
 `setup.cfg` file. If you do not already have such a file, creating a
@@ -889,20 +889,20 @@ containing your schema files to the pytest section of your project's
 The schema directory paths should be paths that are relative to the top of the
 package directory **when it is installed**. If this is different from the path
 in the source directory, then both paths can be used to facilitate in-place
-testing (see ASDF's own `setup.cfg` for an example of this).
+testing (see `asdf`'s own `setup.cfg` for an example of this).
 
 .. note::
 
-   Older versions of ASDF (prior to 2.4.0) required the plugin to be registered
+   Older versions of `asdf` (prior to 2.4.0) required the plugin to be registered
    in your project's `conftest.py` file. As of 2.4.0, the plugin is now
    registered automatically and so this line should be removed from your
    `conftest.py` file, unless you need to retain compatibility with older
-   versions of ASDF.
+   versions of `asdf`.
 
 The ``asdf_schema_skip_names`` configuration variable can be used to skip
 schema files that live within one of the ``asdf_schema_root`` directories but
 should not be tested. The names should be given as simple base file names
-(without directory paths or extensions). Again, see ASDF's own `setup.cfg` file
+(without directory paths or extensions). Again, see `asdf`'s own `setup.cfg` file
 for an example.
 
 The schema tests do **not** run by default. In order to enable the tests by

--- a/docs/asdf/extending/legacy.rst
+++ b/docs/asdf/extending/legacy.rst
@@ -1,9 +1,14 @@
 .. currentmodule:: asdf.extensions
 
-.. _extensions:
+.. _extending_legacy:
 
-Writing ASDF extensions
-=======================
+Deprecated extension API
+========================
+
+This page documents the original asdf extension API, which has been
+deprecated in favor of :ref:`extending_extensions`.  Since support
+for the deprecated API will be removed in asdf 3.0, we recommend that
+all new extensions be implemented with the new API.
 
 Extensions provide a way for ASDF to represent complex types that are not
 defined by the ASDF standard. Examples of types that require custom extensions

--- a/docs/asdf/extending/manifests.rst
+++ b/docs/asdf/extending/manifests.rst
@@ -1,0 +1,105 @@
+.. _extending_manifests:
+
+===================
+Extension manifests
+===================
+
+An extension "manifest" is a YAML document that defines an extension
+in a language-independent way.  Use of a manifest is recommended for
+ASDF extensions that are intended to be implemented by ASDF libraries
+in multiple languages, so that other implementers do not need to go
+spelunking through Python code to discover the tags and schemas that
+are included in the extension.  This library provides support for
+automatically populating a `~asdf.extension.Extension` object from
+a manifest; see :ref:`extending_extensions_manifest` for more information.
+
+Anatomy of a manifest
+=====================
+
+Here is an example of a simple manifest that describes an extension
+with one tag and schema:
+
+.. code-block:: yaml
+    :linenos:
+
+    %YAML 1.1
+    ---
+    id: asdf://example.com/example-project/manifests/example-1.0.0
+    extension_uri: asdf://example.com/example-project/extensions/example-1.0.0
+    title: Example extension 1.0.0
+    description: Tags for example objects.
+    asdf_standard_requirement:
+        gte: 1.3.0
+        lt: 1.5.0
+    tags:
+      - tag_uri: asdf://example.com/example-project/tags/foo-1.0.0
+        schema_uri: asdf://example.com/example-project/schemas/foo-1.0.0
+    ...
+
+.. code-block:: yaml
+    :lineno-start: 3
+
+    id: asdf://example.com/example-project/manifests/example-1.0.0
+
+The ``id`` property contains the URI that uniquely identifies our manifest.  This
+URI is how we'll refer to the manifest document's content when using the asdf
+library.
+
+.. code-block:: yaml
+    :lineno-start: 4
+
+    extension_uri: asdf://example.com/example-project/extensions/example-1.0.0
+
+The ``extension_uri`` property contains the URI of the extension that the manifest
+describes.  This is the URI written to ASDF file metadata to document that an
+extension was used when writing the file.
+
+.. code-block:: yaml
+    :lineno-start: 5
+
+    title: Example extension 1.0.0
+    description: Tags for example objects.
+
+``title`` and ``description`` are optional documentation properties.
+
+.. code-block:: yaml
+    :lineno-start: 7
+
+    asdf_standard_requirement:
+        gte: 1.3.0
+        lt: 1.5.0
+
+The optional ``asdf_standard_requirement`` property describes the
+ASDF Standard versions that are compatible with this extension.  The
+``gte`` and ``lt`` properties are used here to restrict ASDF Standard
+versions to greater-than-or-equal 1.3.0 and less-than 1.5.0, respectively.
+``gt`` and ``lte`` properties are also available.
+
+.. code-block:: yaml
+    :lineno-start: 10
+
+    tags:
+      - tag_uri: asdf://example.com/example-project/tags/foo-1.0.0
+        schema_uri: asdf://example.com/example-project/schemas/foo-1.0.0
+
+The ``tags`` property contains a list of objects, each representing a new
+tag that the extension brings to ASDF.  The ``tag_uri`` property contains
+the tag itself, while the (optional, but recommended) ``schema_uri``
+property contains the URI of a schema that can be used to validate objects
+with that tag.  Tag objects may also include ``title`` and ``description``
+documentation properties.
+
+Validating a manifest
+=====================
+
+This library includes a schema, ``asdf://asdf-format.org/core/schemas/extension_manifest-1.0.0``,
+that can be used to validate a manifest document:
+
+.. code-block:: python
+
+    import asdf
+    import yaml
+
+    schema = asdf.schema.load_schema("asdf://asdf-format.org/core/schemas/extension_manifest-1.0.0")
+    manifest = yaml.safe_load(open("path/to/manifests/example-1.0.0.yaml").read())
+    asdf.schema.validate(manifest, schema=schema)

--- a/docs/asdf/extending/manifests.rst
+++ b/docs/asdf/extending/manifests.rst
@@ -42,7 +42,7 @@ with one tag and schema:
     id: asdf://example.com/example-project/manifests/example-1.0.0
 
 The ``id`` property contains the URI that uniquely identifies our manifest.  This
-URI is how we'll refer to the manifest document's content when using the asdf
+URI is how we'll refer to the manifest document's content when using the `asdf`
 library.
 
 .. code-block:: yaml

--- a/docs/asdf/extending/resources.rst
+++ b/docs/asdf/extending/resources.rst
@@ -1,0 +1,234 @@
+.. currentmodule:: asdf.resource
+
+.. _extending_resources:
+
+===============================
+Resources and resource mappings
+===============================
+
+In the terminology of this library, a "resource" is a sequence of bytes associated
+with a URI.  Currently the two types of resources recognized by asdf are schemas
+and extension manifests.  Both of these are YAML documents whose associated URI
+is expected to match the ``id`` property of the document.
+
+A "resource mapping" is an asdf plugin that provides access to
+the content for a URI.  These plugins must implement the
+`~collections.abc.Mapping` interface (a simple `dict` qualifies) and map
+`str` URI keys to `bytes` values.  Resource mappings are installed into
+the asdf library via one of two routes: the `AsdfConfig.add_resource_mapping <asdf.config.AsdfConfig.add_resource_mapping>`
+method or the ``asdf.resource_mappings`` entry point.
+
+Installing resources via AsdfConfig
+===================================
+
+The simplest way to isntall a resource into asdf is to add it at runtime using the
+`AsdfConfig.add_resource_mapping <asdf.config.AsdfConfig.add_resource_mapping>` method.
+For example, the following code istalls a schema for use with the `asdf.AsdfFile`
+custom_schema argument:
+
+.. code-block:: python
+
+    import asdf
+
+    content = b"""
+    %YAML 1.1
+    ---
+    $schema: http://stsci.edu/schemas/yaml-schema/draft-01
+    id: asdf://example.com/example-project/schemas/foo-1.0.0
+    type: object
+    properties:
+      foo:
+        type: string
+    required: [foo]
+    ...
+    """
+
+    asdf.get_config().add_resource_mapping({
+      "asdf://example.com/example-project/schemas/foo-1.0.0": content
+    })
+
+The schema will now be available for validating files:
+
+.. code-block:: python
+
+    af = asdf.AsdfFile(custom_schema="asdf://example.com/example-project/schemas/foo-1.0.0")
+    af.validate() # Error, "foo" is missing
+
+The DirectoryResourceMapping class
+==================================
+
+But what if we don't want to store our schemas in variables in the code?
+Storing resources in a directory tree is a common use case, so asdf provides
+a `~collections.abc.Mapping` implementation that reads schema content from
+a filesystem.  This is the `DirectoryResourceMapping` class.
+
+Consider these three schemas:
+
+.. code-block:: yaml
+
+    # foo-1.0.0.yaml
+    id: asdf://example.com/example-project/schemas/foo-1.0.0
+    # ...
+
+    # bar-2.3.4.yaml
+    id: asdf://example.com/example-project/nested/bar-2.3.4
+    # ...
+
+    # baz-8.1.1.yaml
+    id: asdf://example.com/example-project/nested/baz-8.1.1
+    # ...
+
+which are arranged in the following directory structure::
+
+    schemas
+    ├─ foo-1.0.0.yaml
+    ├─ README
+    └─ nested
+        ├─ bar-2.3.4.yaml
+        └─ baz-8.1.1.yaml
+
+Our goal is to install all schemas in the directory tree so that they
+are available for use with asdf.  The `DirectoryResourceMapping` class
+can do that for us, but we need to show it how to construct the schema URIs
+from the file paths *without reading the id property from the files*.  This
+requirement is a performance consideration; not all resources are used
+in every session, and if asdf were to read and parse all available files
+when plugins are loaded, the first call to `asdf.open` would be
+intolerably slow.
+
+We should configure `DirectoryResourceMapping` like this:
+
+.. code-block:: python
+
+    import asdf
+    from asdf.resource import DirectoryResourceMapping
+
+    mapping = DirectoryResourceMapping(
+        "/path/to/schemas",
+        "asdf://example.com/example-project/schemas/",
+        recursive=True,
+        filename_pattern="*.yaml",
+        stem_filename=True
+    )
+
+    asdf.get_config().add_resource_mapping(mapping)
+
+The first argument is the path to the schemas directory on the filesystem.  The
+second argument is the prefix that should be prepended to file paths
+relative to that root when constructing the schema URIs.  The ``recursive``
+argument tells the class to descend into the ``nested`` directory when
+searching for schemas, ``filename_pattern`` is a glob pattern chosen to exclude
+our README file, and ``stem_filename`` causes the class to drop the ``.yaml`` suffix
+when constructing URIs.
+
+We can test that our configuration is correct by asking asdf to read
+and parse one of the schemas:
+
+.. code-block:: python
+
+    from asdf.schema import load_schema
+
+    uri = "asdf://example.com/example-project/schemas/nested/bar-2.3.4.yaml"
+    schema = load_schema(uri)
+    assert schema["id"] == uri
+
+.. _extending_resources_entry_points:
+
+Installing resources via entry points
+=====================================
+
+The asdf package also offers an entry point for installing resource
+mapping plugins.  This installs a package's resources automatically
+without requiring calls to the AsdfConfig method.  The entry point is
+called ``asdf.resource_mappings`` and expects to receive
+a method that returns a list of `~abc.collections.Mapping` instances.
+
+For example, let's say we're creating a package named ``asdf-foo-schemas``
+that provides the same schemas described in the previous section.  Our
+directory structure might look something like this::
+
+    asdf-foo-schemas
+    ├─ setup.cfg
+    ├─ setup.py
+    └─ src
+       └─ asdf_foo_schemas
+          ├─ __init__.py
+          ├─ integration.py
+          └─ schemas
+             ├─ __init__.py
+             ├─ foo-1.0.0.yaml
+             ├─ README
+             └─ nested
+                ├─ __init__.py
+                ├─ bar-2.3.4.yaml
+                └─ baz-8.1.1.yaml
+
+In ``integration.py``, we'll define the entry point method
+and have it return a list with a single element, our `DirectoryResourceMapping`
+instance:
+
+.. code-block:: python
+
+    # integration.py
+    from pathlib import Path
+
+    from asdf.resource import DirectoryResourceMapping
+
+
+    def get_resource_mappings():
+        # Get path to schemas directory relative to this file
+        schemas_path = Path(__file__).parent / "schemas"
+        mapping = DirectoryResourceMapping(
+            schemas_path,
+            "asdf://example.com/example-project/schemas/",
+            recursive=True,
+            filename_pattern="*.yaml",
+            stem_filename=True
+        )
+        return [mapping]
+
+Then in ``setup.cfg``, define an ``[options.entry_points]`` section that
+identifies the method as an ``asdf.resource_mappings`` entry point:
+
+.. code-block:: cfg
+
+    # setup.cfg
+    [options.entry_points]
+    asdf.resource_mappings =
+        asdf_foo_schemas = asdf_foo_schemas.integration:get_resource_mappings
+
+After installing the package, it should be possible to load one of our schemas
+in a new session without any additional setup:
+
+.. code-block:: python
+
+    from asdf.schema import load_schema
+
+    uri = "asdf://example.com/example-project/schemas/nested/bar-2.3.4.yaml"
+    schema = load_schema(uri)
+    assert schema["id"] == uri
+
+Note that the package will need to be configured to include the
+YAML files.  There are multiple ways to accomplish this, but one easy option
+is to add an ``[options.package_data]`` section to ``setup.cfg`` requesting
+that all files with a ``.yaml`` extension be installed:
+
+.. code-block:: cfg
+
+    # setup.cfg
+    [options.package_data]
+    * = *.yaml
+
+Entry point performance considerations
+--------------------------------------
+
+For the good of asdf users everywhere, it's important that entry point
+methods load as quickly as possible.  All resource URIs must be loaded
+before reading an ASDF file, so any entry point method that lingers
+will introduce a delay to the initial call to `asdf.open`.  For that reason,
+we recommend to minimize the number of imports that occur in the module
+containing the entry point method, particularly imports of modules outside
+of the Python standard library or asdf itself.  When resources are stored
+in a filesystem, it's also helpful to delay reading a file until its URI
+is actually requested, which may not occur in a given session.  The
+DirectoryResourceMapping class is implemented with this behavior.

--- a/docs/asdf/extending/resources.rst
+++ b/docs/asdf/extending/resources.rst
@@ -7,21 +7,21 @@ Resources and resource mappings
 ===============================
 
 In the terminology of this library, a "resource" is a sequence of bytes associated
-with a URI.  Currently the two types of resources recognized by asdf are schemas
+with a URI.  Currently the two types of resources recognized by `asdf` are schemas
 and extension manifests.  Both of these are YAML documents whose associated URI
 is expected to match the ``id`` property of the document.
 
-A "resource mapping" is an asdf plugin that provides access to
+A "resource mapping" is an `asdf` plugin that provides access to
 the content for a URI.  These plugins must implement the
 `~collections.abc.Mapping` interface (a simple `dict` qualifies) and map
 `str` URI keys to `bytes` values.  Resource mappings are installed into
-the asdf library via one of two routes: the `AsdfConfig.add_resource_mapping <asdf.config.AsdfConfig.add_resource_mapping>`
+the `asdf` library via one of two routes: the `AsdfConfig.add_resource_mapping <asdf.config.AsdfConfig.add_resource_mapping>`
 method or the ``asdf.resource_mappings`` entry point.
 
 Installing resources via AsdfConfig
 ===================================
 
-The simplest way to isntall a resource into asdf is to add it at runtime using the
+The simplest way to isntall a resource into `asdf` is to add it at runtime using the
 `AsdfConfig.add_resource_mapping <asdf.config.AsdfConfig.add_resource_mapping>` method.
 For example, the following code istalls a schema for use with the `asdf.AsdfFile`
 custom_schema argument:
@@ -58,7 +58,7 @@ The DirectoryResourceMapping class
 ==================================
 
 But what if we don't want to store our schemas in variables in the code?
-Storing resources in a directory tree is a common use case, so asdf provides
+Storing resources in a directory tree is a common use case, so `asdf` provides
 a `~collections.abc.Mapping` implementation that reads schema content from
 a filesystem.  This is the `DirectoryResourceMapping` class.
 
@@ -88,11 +88,11 @@ which are arranged in the following directory structure::
         └─ baz-8.1.1.yaml
 
 Our goal is to install all schemas in the directory tree so that they
-are available for use with asdf.  The `DirectoryResourceMapping` class
+are available for use with `asdf`.  The `DirectoryResourceMapping` class
 can do that for us, but we need to show it how to construct the schema URIs
 from the file paths *without reading the id property from the files*.  This
 requirement is a performance consideration; not all resources are used
-in every session, and if asdf were to read and parse all available files
+in every session, and if `asdf` were to read and parse all available files
 when plugins are loaded, the first call to `asdf.open` would be
 intolerably slow.
 
@@ -121,7 +121,7 @@ searching for schemas, ``filename_pattern`` is a glob pattern chosen to exclude
 our README file, and ``stem_filename`` causes the class to drop the ``.yaml`` suffix
 when constructing URIs.
 
-We can test that our configuration is correct by asking asdf to read
+We can test that our configuration is correct by asking `asdf` to read
 and parse one of the schemas:
 
 .. code-block:: python
@@ -137,7 +137,7 @@ and parse one of the schemas:
 Installing resources via entry points
 =====================================
 
-The asdf package also offers an entry point for installing resource
+The `asdf` package also offers an entry point for installing resource
 mapping plugins.  This installs a package's resources automatically
 without requiring calls to the AsdfConfig method.  The entry point is
 called ``asdf.resource_mappings`` and expects to receive
@@ -222,13 +222,13 @@ that all files with a ``.yaml`` extension be installed:
 Entry point performance considerations
 --------------------------------------
 
-For the good of asdf users everywhere, it's important that entry point
+For the good of `asdf` users everywhere, it's important that entry point
 methods load as quickly as possible.  All resource URIs must be loaded
 before reading an ASDF file, so any entry point method that lingers
 will introduce a delay to the initial call to `asdf.open`.  For that reason,
 we recommend to minimize the number of imports that occur in the module
 containing the entry point method, particularly imports of modules outside
-of the Python standard library or asdf itself.  When resources are stored
+of the Python standard library or `asdf` itself.  When resources are stored
 in a filesystem, it's also helpful to delay reading a file until its URI
 is actually requested, which may not occur in a given session.  The
 DirectoryResourceMapping class is implemented with this behavior.

--- a/docs/asdf/extending/schemas.rst
+++ b/docs/asdf/extending/schemas.rst
@@ -1,0 +1,246 @@
+.. _extending_schemas:
+
+============
+ASDF schemas
+============
+
+ASDF schemas are YAML documents that describe validations to be performed
+on tagged objects nested within the ASDF tree or on the tree itself.  Schemas
+can validate the presence, datatype, and value of objects and their properties,
+and can be combined in different ways to facilitate reuse.
+
+These schemas, though expressed in YAML, are structured according to
+the `JSON Schema Draft 4`_ specification.  The excellent `Understanding JSON Schema`_
+book is a great place to start for users not already familiar with
+JSON Schema.  Just keep in mind that the book includes coverage of later drafts
+of the JSON Schema spec, so certain features (constant values, conditional
+subschemas, etc) will not be available when writing schemas for ASDF.
+The book makes clear which features were introduced after Draft 4.
+
+Anatomy of a schema
+===================
+
+Here is an example of an ASDF schema that validates an object with a
+numeric value and corresponding unit:
+
+.. code-block:: yaml
+    :linenos:
+
+    %YAML 1.1
+    ---
+    $schema: http://stsci.edu/schemas/yaml-schema/draft-01
+    id: asdf://asdf-format.org/core/schemas/quantity-2.0.0
+
+    title: Quantity object containing numeric value and unit
+    description: >-
+      An object with a numeric value, which may be a scalar
+      or an array, and associated unit.
+
+    type: object
+    properties:
+      value:
+        description: A vector of one or more values
+        anyOf:
+          - type: number
+          - tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+      unit:
+        description: The unit corresponding to the values
+        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+      required: [value, unit]
+    ...
+
+This is similar to the `quantity schema`_ in the ASDF Standard, but
+has been updated to reflect current recommendations regarding schemas.
+Let's walk through this schema line by line.
+
+.. code-block:: yaml
+    :linenos:
+
+    %YAML 1.1
+    ---
+
+These first two lines form the header of the file.  The ``%YAML 1.1``
+indicates that we're following version 1.1 of the YAML spec.  The
+``---`` marks the start of a new YAML document.
+
+.. code-block:: yaml
+    :lineno-start: 3
+
+    $schema: http://stsci.edu/schemas/yaml-schema/draft-01
+
+The ``$schema`` property contains the URI of the schema that validates
+this document.  Since our document is itself a schema, the URI refers to
+a *metaschema*.  ASDF comes with three built-in metaschemas:
+
+- ``http://json-schema.org/draft-04/schema`` - The JSON Schema Draft 4 metaschema.
+  Includes basic validators and combiners.
+
+- ``http://stsci.edu/schemas/yaml-schema/draft-01`` - The YAML Schema metaschema.
+  Includes everything in JSON Schema Draft 4, plus additional YAML-specific
+  validators including ``tag`` and ``propertyOrder``.
+
+- ``http://stsci.edu/schemas/asdf/asdf-schema-1.0.0`` - The ASDF Schema metaschema.
+  Includes everything in YAML Schema, plus additional ASDF-specific validators
+  that check ndarray properties.
+
+Our schema makes use of the ``tag`` validator, so we're specifying the YAML Schema
+URI here.
+
+.. code-block:: yaml
+    :lineno-start: 4
+
+    id: asdf://asdf-format.org/core/schemas/quantity-2.0.0
+
+The ``id`` property contains the URI that uniquely identifies our schema.  This
+URI is how we'll refer to the schema when using the asdf library.
+
+.. code-block:: yaml
+    :lineno-start: 6
+
+    title: Quantity object containing numeric value and unit
+    description: >-
+      An object with a numeric value, which may be a scalar
+      or an array, and associated unit.
+
+Title and description are optional (but recommended) documentation properties.
+These properties can be placed multiple times at any level of the schema and do
+not have an impact on the validation process.
+
+.. code-block:: yaml
+    :lineno-start: 11
+
+    type: object
+
+This line invokes the ``type`` validator to check the data type of the
+top-level value.  We're asserting that the type must be a YAML mapping,
+which in Python is represented as a `dict`.
+
+.. code-block:: yaml
+    :lineno-start: 12
+
+    properties:
+
+The ``properties`` validator announces that we'd like to validate certain
+named properties of mapping.  If a property is listed here and is present
+in the ASDF, it will be validated accordingly.
+
+.. code-block:: yaml
+    :lineno-start: 13
+
+      value:
+        description: A vector of one or more values
+
+Here we're identifying a property named ``value`` that we'd like to
+validate.  The ``description`` is used to add some additional
+documentation.
+
+.. code-block:: yaml
+    :lineno-start: 15
+
+      anyOf:
+
+The ``anyOf`` validator is one of JSON Schema's combiners.  The ``value``
+property will be validated against each of the following subschemas, and
+if any validates successfully, the entire ``anyOf`` will be considered
+valid.  Other available combiners are ``allOf``, which requires that all
+subschemas validate successfully, ``oneOf``, which requires that one and
+only one of the subschemas validates, and ``not``, which requires that
+a single subschema does *not* validate.
+
+.. code-block:: yaml
+    :lineno-start: 16
+
+        - type: number
+
+The first subschema in the list contains a ``type`` validator that
+succeeds if the entity assigned to ``value`` is a numeric literal.
+
+.. code-block:: yaml
+    :lineno-start: 17
+
+        - tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+
+The second subschema contains a ``tag`` validator, which makes an
+assertion regarding the YAML tag URI of the object assigned to ``value``.
+In this subschema we're requiring the tag of an ndarray-1.0.0 object,
+which is how n-dimensional arrays are represented in an ASDF tree.
+
+The net effect of the ``anyOf`` combiner and its two subschemas is:
+validate successfully if the ``value`` object is either a numeric
+literal or an n-dimensional array.
+
+.. code-block:: yaml
+    :lineno-start: 18
+
+      unit:
+        description: The unit corresponding to the values
+        tag: tag:stsci.edu:asdf/unit/unit-1.0.0
+
+The ``unit`` property has another bit of documentation and a
+``tag`` validator that requires it to be a unit-1.0.0 object.
+
+.. code-block:: yaml
+    :lineno-start: 21
+
+    required: [value, unit]
+
+Since the ``properties`` validator does not require the presence of
+its listed properties, we need another validator to do that.  The ``required``
+validator defines a list of properties that need to be present if validation
+is to succeed.
+
+.. code-block:: yaml
+    :lineno-start: 21
+
+    ...
+
+Finally, the YAML document end indicator indicates the end of the schema.
+
+Checking schema syntax
+======================
+
+The `~asdf.schema.check_schema` function performs basic syntax checks on a schema and
+will raise an error if it discovers a problem.  It does not currently accept URIs and
+requires that the schema already be loaded into Python objects.  If the schema is already
+registered with the asdf library as a resource (see :ref:`extending_resources`), it can
+be loaded and checked like this:
+
+.. code-block:: python
+
+    from asdf.schema import load_schema, check_schema
+
+    schema = load_schema("asdf://example.com/example-project/schemas/foo-1.0.0")
+    check_schema(schema)
+
+Otherwise, the schema can be loaded using pyyaml directly:
+
+.. code-block:: python
+
+    from asdf.schema import check_schema
+    import yaml
+
+    schema = yaml.safe_load(open("/path/to/foo-1.0.0.yaml").read())
+    check_schema(schema)
+
+Testing validation
+==================
+
+Getting a schema to validate as intended can be a tricky business, so it's helpful
+to test validation against some example objects as you go along.  The `~asdf.schema.validate`
+function will validate a Python object against a schema:
+
+.. code-block:: python
+
+  from asdf.schema import validate
+  import yaml
+
+  schema = yaml.safe_load(open("/path/to/foo-1.0.0.yaml").read())
+  obj = {"foo": "bar"}
+  validate(obj, schema=schema)
+
+The validate function will return successfully if the object is valid, or raise
+an error if not.
+
+.. _JSON Schema Draft 4: https://json-schema.org/specification-links.html#draft-4
+.. _Understanding JSON Schema: https://json-schema.org/understanding-json-schema/
+.. _quantity schema: https://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/unit/quantity-1.1.0.html

--- a/docs/asdf/extending/uris.rst
+++ b/docs/asdf/extending/uris.rst
@@ -35,7 +35,7 @@ downside that users expect to be able to retrieve the document contents from tha
 The asdf:// URI scheme
 ======================
 
-To counter the problem of URIs vs URLs, asdf 2.8 introduced support for the ``asdf://`` URI
+To counter the problem of URIs vs URLs, `asdf` 2.8 introduced support for the ``asdf://`` URI
 scheme.  These URIs are constructed just like ``http://`` or ``https://`` URIs, but the ASDF-specific
 scheme makes clear that the content cannot be fetched from a webserver.
 
@@ -50,7 +50,7 @@ Schemas
 -------
 
 Schemas are expected to include an ``id`` property that contains the URI that identifies them.
-That URI is used when referring to the schema in calls to asdf library functions.
+That URI is used when referring to the schema in calls to `asdf` library functions.
 We recommend the following pattern for schema URIs:
 
 ``asdf://<domain>/<project>/schemas/<name>-<version>``
@@ -84,7 +84,7 @@ Manifests
 
 Manifest documents are language-independent definitions of extensions to ASDF and
 include an ``id`` property that contains the URI that identifies them.  That URI is
-used when referring to the manifest in calls to asdf library functions.  We
+used when referring to the manifest in calls to `asdf` library functions.  We
 recommend the following pattern for manifest URIs:
 
 ``asdf://<domain>/<project>/manifests/<name>-<version>``
@@ -100,7 +100,7 @@ Extensions
 
 Finally, extensions URIs identify extensions to the ASDF format.  These URIs are included
 in an ASDF file's metadata to advertise the fact that additional software support (beyond
-a core asdf library) is needed to properly interpret the file.  Like tags, these URIs
+a core ASDF library) is needed to properly interpret the file.  Like tags, these URIs
 are not associated with a particular resource.  We recommend the following pattern
 for extension URIs:
 

--- a/docs/asdf/extending/uris.rst
+++ b/docs/asdf/extending/uris.rst
@@ -1,0 +1,113 @@
+.. _extending_uris:
+
+============
+URIs in ASDF
+============
+
+The ASDF format uses **U**\ niform **R**\ esource **I**\ dentifiers to refer to various
+entities such as schemas or tags.  These are string identifiers that often resemble
+web addresses that uniquely identify the associated entity.  Here are some examples
+of URIs that might be encountered in an ASDF file:
+
+- ``http://stsci.edu/schemas/asdf/core/ndarray-1.0.0`` (URI of the ndarray-1.0.0 schema)
+- ``tag:stsci.edu:asdf/core/asdf-1.1.0`` (URI of the asdf-1.0.0 YAML tag)
+- ``asdf://example.com/schemas/foo-1.0.0`` (URI of the foo-1.0.0 schema)
+
+Each of these uses a different URI *scheme*, and each is a valid URI format in ASDF.
+
+URI vs URL
+==========
+
+One common point of confusion is the distinction between a URI and a URL.  The two are easily
+conflated -- for example, consider the URI of the ndarray-1.0.0 schema above.
+
+``http://stsci.edu/schemas/asdf/core/ndarray-1.0.0``
+
+This string looks just like the URL of a web page, but if we were to attempt to visit that location
+in a browser, we'd get a 404 Not Found from stsci.edu.  And yet it is still a valid URI!
+
+The similarity arises from the need for URIs to be globally unique.  Since web domains are
+already controlled by a single organization or individual, they offer a convenient way to
+define URIs -- just reserve some path prefix off a domain you control and dole out strings
+with that prefix where unique identifiers are needed.  But using ``http://`` as a URI scheme has the
+downside that users expect to be able to retrieve the document contents from that address.
+
+The asdf:// URI scheme
+======================
+
+To counter the problem of URIs vs URLs, asdf 2.8 introduced support for the ``asdf://`` URI
+scheme.  These URIs are constructed just like ``http://`` or ``https://`` URIs, but the ASDF-specific
+scheme makes clear that the content cannot be fetched from a webserver.
+
+Entities identified by URI
+==========================
+
+The following is a complete list of entity types that are identified by URI in ASDF:
+
+.. _extending_uris_entities_schemas:
+
+Schemas
+-------
+
+Schemas are expected to include an ``id`` property that contains the URI that identifies them.
+That URI is used when referring to the schema in calls to asdf library functions.
+We recommend the following pattern for schema URIs:
+
+``asdf://<domain>/<project>/schemas/<name>-<version>``
+
+Where ``<domain>`` is some domain that you control, ``<project>`` collects all entities
+for a particular ASDF project, ``<name>`` is the name of the schema, and ``<version>``
+is the schema's version number.  For example:
+
+``asdf://example.com/example-project/schemas/foo-1.2.3``
+
+.. _extending_uris_entities_tags:
+
+Tags
+----
+
+Tags, which annotate typed objects in an ASDF file's YAML tree, are represented as URIs.  Unlike
+schemas, there is no resource associated with the tag; no blob of bytes exists that corresponds
+to the URI.  Instead, the URI alone communicates the type of a YAML object.  We recommend
+the following pattern for tag URIs:
+
+``asdf://<domain>/<project>/tags/<name>-<version>``
+
+Where ``<domain>`` is some domain that you control, ``<project>`` collects all entities
+for a particular ASDF project, ``<name>`` is the name of the tag, and ``<version>``
+is the tag's version number.  For example:
+
+``asdf://example.com/example-project/tags/foo-1.2.3``
+
+Manifests
+---------
+
+Manifest documents are language-independent definitions of extensions to ASDF and
+include an ``id`` property that contains the URI that identifies them.  That URI is
+used when referring to the manifest in calls to asdf library functions.  We
+recommend the following pattern for manifest URIs:
+
+``asdf://<domain>/<project>/manifests/<name>-<version>``
+
+Where ``<domain>`` is some domain that you control, ``<project>`` collects all entities
+for a particular ASDF project, ``<name>`` is the name of the manifest, and ``<version>``
+is the manifest's version number.  For example:
+
+``asdf://example.com/example-project/manifests/foo-1.2.3``
+
+Extensions
+----------
+
+Finally, extensions URIs identify extensions to the ASDF format.  These URIs are included
+in an ASDF file's metadata to advertise the fact that additional software support (beyond
+a core asdf library) is needed to properly interpret the file.  Like tags, these URIs
+are not associated with a particular resource.  We recommend the following pattern
+for extension URIs:
+
+``asdf://<domain>/<project>/extensions/<name>-<version>``
+
+Where ``<domain>`` is some domain that you control, ``<project>`` collects all entities
+for a particular ASDF project, ``<name>`` is the name of the extension, and ``<version>``
+is the extension's version number.  For example:
+
+``asdf://example.com/example-project/extensions/foo-1.2.3``

--- a/docs/asdf/extending/use_cases.rst
+++ b/docs/asdf/extending/use_cases.rst
@@ -1,0 +1,172 @@
+.. _extending_use_cases:
+
+================
+Common use cases
+================
+
+This section is intended as a kind of index to the rest of the
+"Extending ASDF" documentation.  Here we list common use cases
+and link to the relevant documentation sections that are needed
+to get the job done.
+
+Validate an ASDF tree against a schema
+======================================
+
+The asdf library already validates individual tagged objects within the tree,
+but what if we want to validate the structure of the tree itself?  Such
+"document schemas" can be associated with an `~asdf.AsdfFile` using the
+``custom_schema`` argument, but this argument accepts a URI and the asdf
+library needs to know how to access the schema content associated with that
+URI.
+
+1. Designate a URI for the schema.  See :ref:`extending_uris_entities_schemas` for
+   recommendations on schema URI structure.
+2. Write the schema.  See :ref:`extending_schemas` if you're new to authoring schemas.
+3. Install the schema as an asdf library resource.  See :ref:`extending_resources`
+   for an overview of resources in asdf and options for installing them.
+
+Serialize a new type
+====================
+
+This section summarizes the steps needed to serialize a new type to an ASDF file.
+We'll describe three options, starting with the most expedient and growing
+progressively more formal.
+
+Quick and dirty, for personal use
+---------------------------------
+
+In this scenario, we want to serialize a new Python type to an ASDF file, but
+we're not planning on widely sharing the file, so we want to cut as many corners
+as possible.  Here are the minimal steps needed to get instances of that type
+into the file and back again:
+
+1. Identify the Python type to serialize.  We'll need to know the fully-qualified
+   name of the type (module path + class name).
+
+2. Select a tag URI that will signify the type in YAML.  See :ref:`extending_uris_entities_tags`
+   for recommendations on tag URI structure.
+
+3. Implement a `~asdf.extension.Converter` class that converts the type to
+   YAML-serializable objects and back again.  See :ref:`extending_converters`
+   for a discussion of the Converter interface.
+
+4. Implement an `~asdf.extension.Extension` class which is the vehicle
+   for plugging our converter into the asdf library.  See :ref:`extending_extensions`
+   for a discussion of the Extension interface.
+
+5. Install the extension.  There are multiple ways to do this, but the path
+   of least resistance is to install the extension at runtime using `~asdf.config.AsdfConfig`.
+   See :ref:`extending_extensions_installing_asdf_config`.
+
+Now instances of our type can be added to an `~asdf.AsdfFile`'s tree and
+serialized to an ASDF file.
+
+For sharing with other Python users
+-----------------------------------
+
+Now say our files are getting out into the world and into the hands of
+other Python users.  We'll want to build an installable package
+around our code and use the asdf library's entry points to make our
+extension more convenient to use.  We should also think about adding
+a schema that validates our tagged objects, so if someone manually edits
+a file and makes a mistake, we get a clear error when asdf opens the file.
+
+1. Identify the Python type to serialize.  We'll need to know the fully-qualified
+   name of the type (module path + class name).
+
+2. Select a tag URI that will signify the type in YAML.  See :ref:`extending_uris_entities_tags`
+   for recommendations on tag URI structure.
+
+3. Designate a URI for the schema.  See :ref:`extending_uris_entities_schemas` for
+   recommendations on schema URI structure.
+
+4. Write the schema that will validate the tagged object.  See :ref:`extending_schemas`
+   if you're new to authoring schemas.
+
+5. Make the schema installable as an asdf library resource.  See :ref:`extending_resources`
+   for an overview of resources in asdf and :ref:`extending_resources_entry_points` for
+   information on installing resources via an entry point.
+
+6. Implement a `~asdf.extension.Converter` class that converts the type to
+   YAML-serializable objects and back again.  See :ref:`extending_converters`
+   for a discussion of the Converter interface.  Refer to the schema to ensure
+   that the Converter is writing YAML objects correctly.
+
+7. Implement an `~asdf.extension.Extension` class which is the vehicle
+   for plugging our converter into the asdf library.  See :ref:`extending_extensions`
+   for a discussion of the Extension interface.  We'll need to associate the schema
+   URI with the tag URI in our tag's `~asdf.extension.TagDefinition` object.
+
+8. Install the extension via an entry point.  See :ref:`extending_extensions_installing_entry_points`.
+
+Now anyone who installs the package containing the entry points will be able
+to read, write, and validate ASDF files containing our new tag!
+
+For sharing with users of other languages
+-----------------------------------------
+
+Finally, let's consider the case where we want to serialize instances of our type
+to an ASDF file that will be read using ASDF libraries written in other languages.
+The problem with our previous efforts is that the extension definition exists
+only as Python code, so here we'll want to create an additional YAML document
+called an extension manifest that defines the extension in a language-independent way.
+
+1. Identify the Python type to serialize.  We'll need to know the fully-qualified
+   name of the type (module path + class name).
+
+2. Select a tag URI that will signify the type in YAML.  See :ref:`extending_uris_entities_tags`
+   for recommendations on tag URI structure.
+
+3. Designate a URI for the schema.  See :ref:`extending_uris_entities_schemas` for
+   recommendations on schema URI structure.
+
+4. Write the schema that will validate the tagged object.  See :ref:`extending_schemas`
+   if you're new to authoring schemas.
+
+5. Write an extension manifest document that describes the tag and schema that
+   we're including in our extension.  See :ref:`extending_manifests` for information
+   on the manifest format.
+
+5. Make the schema and manifest installable as asdf library resources.  See
+   :ref:`extending_resources` for an overview of resources in asdf and
+   :ref:`extending_resources_entry_points` for information on installing resources
+   via an entry point.
+
+6. Implement a `~asdf.extension.Converter` class that converts the type to
+   YAML-serializable objects and back again.  See :ref:`extending_converters`
+   for a discussion of the Converter interface.  Refer to the schema to ensure
+   that the Converter is writing YAML objects correctly.
+
+7. Use `asdf.extension.ManifestExtension.from_uri` to populate an extension with the Converter
+   and information from the manifest document.  See :ref:`extending_extensions_manifest` for
+   instructions on using ManifestExtension.
+
+8. Install the extension via an entry point.  See :ref:`extending_extensions_installing_entry_points`.
+
+That's it!  Python users should experience the same convenience, but now the manifest
+document is available as a reference for developers who wish to implement support
+for reading our tagged objects in their language of choice.
+
+Support a new block compressor
+==============================
+
+In order to support a new compression algorithm for ASDF binary blocks,
+we need to implement the `~asdf.extension.Compressor` interface and install
+that in an extension.
+
+1. Select a 4-byte compression code that will signify the compression algorithm.
+
+1. Implement a `~asdf.extension.Compressor` class that associates the 4-byte code with
+   compression and decompression methods.  See :ref:`extending_compressors` for a discussion
+   of the Compressor interface.
+
+2. Implement an `~asdf.extension.Extension` class which is the vehicle
+   for plugging our compressor into the asdf library.  See :ref:`extending_extensions`
+   for a discussion of the Extension interface.
+
+3. Install the extension via one of the two available methods.  See
+   :ref:`extending_extensions_installing` for instructions.
+
+Now the compression algorithm will be available for both reading and writing ASDF files.
+Users writing files will simply need to specify the new 4-byte compression code when making calls
+to `asdf.AsdfFile.set_array_compression`.

--- a/docs/asdf/extending/use_cases.rst
+++ b/docs/asdf/extending/use_cases.rst
@@ -12,7 +12,7 @@ to get the job done.
 Validate an ASDF tree against a schema
 ======================================
 
-The asdf library already validates individual tagged objects within the tree,
+The `asdf` library already validates individual tagged objects within the tree,
 but what if we want to validate the structure of the tree itself?  Such
 "document schemas" can be associated with an `~asdf.AsdfFile` using the
 ``custom_schema`` argument, but this argument accepts a URI and the asdf
@@ -22,8 +22,8 @@ URI.
 1. Designate a URI for the schema.  See :ref:`extending_uris_entities_schemas` for
    recommendations on schema URI structure.
 2. Write the schema.  See :ref:`extending_schemas` if you're new to authoring schemas.
-3. Install the schema as an asdf library resource.  See :ref:`extending_resources`
-   for an overview of resources in asdf and options for installing them.
+3. Install the schema as an `asdf` library resource.  See :ref:`extending_resources`
+   for an overview of resources in `asdf` and options for installing them.
 
 Serialize a new type
 ====================
@@ -66,10 +66,10 @@ For sharing with other Python users
 
 Now say our files are getting out into the world and into the hands of
 other Python users.  We'll want to build an installable package
-around our code and use the asdf library's entry points to make our
+around our code and use the `asdf` library's entry points to make our
 extension more convenient to use.  We should also think about adding
 a schema that validates our tagged objects, so if someone manually edits
-a file and makes a mistake, we get a clear error when asdf opens the file.
+a file and makes a mistake, we get a clear error when `asdf` opens the file.
 
 1. Identify the Python type to serialize.  We'll need to know the fully-qualified
    name of the type (module path + class name).
@@ -83,8 +83,8 @@ a file and makes a mistake, we get a clear error when asdf opens the file.
 4. Write the schema that will validate the tagged object.  See :ref:`extending_schemas`
    if you're new to authoring schemas.
 
-5. Make the schema installable as an asdf library resource.  See :ref:`extending_resources`
-   for an overview of resources in asdf and :ref:`extending_resources_entry_points` for
+5. Make the schema installable as an `asdf` library resource.  See :ref:`extending_resources`
+   for an overview of resources in `asdf` and :ref:`extending_resources_entry_points` for
    information on installing resources via an entry point.
 
 6. Implement a `~asdf.extension.Converter` class that converts the type to
@@ -93,7 +93,7 @@ a file and makes a mistake, we get a clear error when asdf opens the file.
    that the Converter is writing YAML objects correctly.
 
 7. Implement an `~asdf.extension.Extension` class which is the vehicle
-   for plugging our converter into the asdf library.  See :ref:`extending_extensions`
+   for plugging our converter into the `asdf` library.  See :ref:`extending_extensions`
    for a discussion of the Extension interface.  We'll need to associate the schema
    URI with the tag URI in our tag's `~asdf.extension.TagDefinition` object.
 
@@ -127,8 +127,8 @@ called an extension manifest that defines the extension in a language-independen
    we're including in our extension.  See :ref:`extending_manifests` for information
    on the manifest format.
 
-5. Make the schema and manifest installable as asdf library resources.  See
-   :ref:`extending_resources` for an overview of resources in asdf and
+5. Make the schema and manifest installable as `asdf` library resources.  See
+   :ref:`extending_resources` for an overview of resources in `asdf` and
    :ref:`extending_resources_entry_points` for information on installing resources
    via an entry point.
 
@@ -161,7 +161,7 @@ that in an extension.
    of the Compressor interface.
 
 2. Implement an `~asdf.extension.Extension` class which is the vehicle
-   for plugging our compressor into the asdf library.  See :ref:`extending_extensions`
+   for plugging our compressor into the `asdf` library.  See :ref:`extending_extensions`
    for a discussion of the Extension interface.
 
 3. Install the extension via one of the two available methods.  See

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -20,15 +20,15 @@ and reading trees, see :ref:`overview`.
 
 .. note::
 
-   The ASDF Standard imposes a maximum size of 52 bits for integer literals in
+   The ASDF Standard imposes a maximum size of 64-bit signed integers literals in
    the tree (see `the docs <https://asdf-standard.readthedocs.io/en/latest/known_limits.html#literal-integer-values-in-the-tree>`_
-   for details and justification). Attempting to store a larger value will
+   for details and justification). Attempting to store a larger value as a YAML literal will
    result in a validation error.
+
+   For arbitrary precision integer support, see `IntegerType`.
 
    Integers and floats of up to 64 bits can be stored inside of :mod:`numpy`
    arrays (see below).
-
-   For arbitrary precision integer support, see `IntegerType`.
 
 
 One of the key features of ASDF is its ability to serialize :mod:`numpy`
@@ -38,7 +38,7 @@ While the core ASDF package supports serialization of basic data types and
 Numpy arrays, its true power comes from its ability to be extended to support
 serialization of a wide range of custom data types. Details on using ASDF
 extensions can be found in :ref:`using_extensions`. Details on creating custom
-ASDF extensions to support custom data types can be found in :ref:`extensions`.
+ASDF extensions to support custom data types can be found in :ref:`extending`.
 
 .. _array-data:
 
@@ -71,7 +71,7 @@ deserialization.
 While ASDF is capable of serializing basic Python types and Numpy arrays out of
 the box, it can also be extended to serialize arbitrary custom data types. This
 section discusses the extension mechanism from a user's perspective. For
-documentation on creating extensions, see :ref:`extensions`.
+documentation on creating extensions, see :ref:`extending_extensions`.
 
 Even though this particular implementation of ASDF necessarily serializes
 Python data types, in theory an ASDF implementation in another language could
@@ -96,7 +96,7 @@ when reading ASDF files (using `asdf.open`), and also when writing them out
 (using `AsdfFile.write_to` or `AsdfFile.update`).
 
 Schema validation also plays a role when using custom extensions (see
-:ref:`using_extensions` and :ref:`extensions`). Extensions must provide schemas
+:ref:`using_extensions` and :ref:`extending_extensions`). Extensions must provide schemas
 for the types that they serialize. When writing a file with custom types, the
 output is validated against the schemas corresponding to those types. If the
 appropriate extension is installed when reading a file with custom types, then
@@ -191,35 +191,33 @@ There are several different versions to keep in mind when discussing ASDF:
 * The software package version
 * The ASDF Standard version
 * The ASDF file format version
-* Individual tag and schema versions
+* Individual tag, schema, and extension versions
 
 Each ASDF file contains information about the various versions that were used
 to create the file. The most important of these are the ASDF Standard version
 and the ASDF file format version. A particular version of the ASDF software
-package will explicitly provide support for a specific combination of these
+package will explicitly provide support for specific combinations of these
 versions.
 
-Tag and schema versions are also important for serializing and deserializing
-data types that are stored in ASDF files. A detailed discussion of tag and
-schema versions from a user perspective can be found in
-:ref:`custom_type_versions`.
+Tag, schema, and extension versions are also important for serializing and
+deserializing data types that are stored in ASDF files. A detailed discussion
+of these versions from a user perspective can be found in :ref:`custom_type_versions`.
 
-Since ASDF is designed to serve as an archival format, the software attempts to
-provide backwards compatibility when reading older versions of the ASDF
-Standard and ASDF file format. However, since deserializing ASDF types
-sometimes requires other software packages, backwards compatibility is often
+Since ASDF is designed to serve as an archival format, this library is careful
+to maintain backwards compatibility with older versions of the ASDF Standard, ASDF
+file format, and core tags.  However, since deserializing custom tags
+requires other software packages, backwards compatibility is often
 contingent on the available versions of such software packages.
 
 In general, forward compatibility with newer versions of the ASDF Standard and
-ASDF file format is not supported by the software. However, if newer tag and
-schema versions are detected, the software will attempt to process them.
+ASDF file format is not supported by the software.
 
 When creating new ASDF files, it is possible to control the version of the file
 format that is used. This can be specified by passing the `version` argument to
 either the `AsdfFile` constructor when the file object is created, or to the
 `AsdfFile.write_to` method when it is written. By default, the latest version
 of the file format will be used. Note that this option has no effect on the
-versions of tag types from custom extensions.
+versions of tags from custom extensions.
 
 External References
 ===================

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -31,10 +31,10 @@ and reading trees, see :ref:`overview`.
    arrays (see below).
 
 
-One of the key features of ASDF is its ability to serialize :mod:`numpy`
+One of the key features of `asdf` is its ability to serialize :mod:`numpy`
 arrays. This is discussed in detail in :ref:`array-data`.
 
-While the core ASDF package supports serialization of basic data types and
+While the core `asdf` package supports serialization of basic data types and
 Numpy arrays, its true power comes from its ability to be extended to support
 serialization of a wide range of custom data types. Details on using ASDF
 extensions can be found in :ref:`using_extensions`. Details on creating custom
@@ -227,7 +227,7 @@ Tree References
 
 ASDF files may reference items in the tree in other ASDF files.  The
 syntax used in the file for this is called "JSON Pointer", but users
-of ``asdf`` can largely ignore that.
+of `asdf` can largely ignore that.
 
 First, we'll create a ASDF file with a couple of arrays in it:
 
@@ -293,14 +293,14 @@ literal content in its place.
 
 A similar feature provided by YAML, anchors and aliases, also provides
 a way to support references within the same file.  These are supported
-by asdf, however the JSON Pointer approach is generally favored because:
+by `asdf`, however the JSON Pointer approach is generally favored because:
 
    - It is possible to reference elements in another file
 
    - Elements are referenced by location in the tree, not an
      identifier, therefore, everything can be referenced.
 
-Anchors and aliases are handled automatically by ``asdf`` when the
+Anchors and aliases are handled automatically by `asdf` when the
 data structure is recursive.  For example here is a dictionary that is
 included twice in the same tree:
 
@@ -373,12 +373,12 @@ file and retrieve the associated array data.
 Saving history entries
 ======================
 
-``asdf`` has a convenience method for notating the history of transformations
+`asdf` has a convenience method for notating the history of transformations
 that have been performed on a file.
 
 Given a `~asdf.AsdfFile` object, call `~asdf.AsdfFile.add_history_entry`, given
 a description of the change and optionally a description of the software (i.e.
-your software, not ``asdf``) that performed the operation.
+your software, not `asdf`) that performed the operation.
 
 .. runcode::
 
@@ -400,7 +400,7 @@ your software, not ``asdf``) that performed the operation.
 
 .. asdf:: example.asdf
 
-ASDF automatically saves history metadata about the extensions that were used
+`asdf` automatically saves history metadata about the extensions that were used
 to create the file. This information is used when opening files to determine if
 the proper extensions are installed (see :ref:`extension_checking` for more
 details).

--- a/docs/asdf/install.rst
+++ b/docs/asdf/install.rst
@@ -10,27 +10,15 @@ described in detail below.
 Requirements
 ============
 
-The ``asdf`` package has the following dependencies:
+The ``asdf`` package has several dependencies which are listed in the project's
+setup.cfg file.  All dependencies are available on pypi and will be automatically
+installed along with ``asdf``.
 
-- `python <https://www.python.org/>`__  3.6 or later
-
-- `numpy <https://www.numpy.org/>`__ 1.10 or later
-
-- `jsonschema <https://python-jsonschema.readthedocs.io/>`__ 3.0.2 or later
-
-- `pyyaml <https://pyyaml.org>`__ 3.10 or later
-
-- `semantic_version <https://python-semanticversion.readthedocs.io/>`__ 2.8 or later
-
-Support for units, time, transform, wcs, or running the tests also
-requires:
-
-- `astropy <https://www.astropy.org/>`__ 3.0 or later
+Support for units, time, and transform tags requires an implementation of these
+types.  One recommended option is the `astropy <https://www.astropy.org/>`__ package.
 
 Optional support for `lz4 <https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)>`__
-compression is provided by:
-
-- `lz4 <https://python-lz4.readthedocs.io/>`__ 0.10 or later
+compression is provided by the `lz4 <https://python-lz4.readthedocs.io/>`__ package.
 
 Installing with pip
 ===================

--- a/docs/asdf/install.rst
+++ b/docs/asdf/install.rst
@@ -4,15 +4,15 @@
 Installation
 ************
 
-There are several different ways to install the ``asdf`` package. Each is
+There are several different ways to install the `asdf` package. Each is
 described in detail below.
 
 Requirements
 ============
 
-The ``asdf`` package has several dependencies which are listed in the project's
+The `asdf` package has several dependencies which are listed in the project's
 setup.cfg file.  All dependencies are available on pypi and will be automatically
-installed along with ``asdf``.
+installed along with `asdf`.
 
 Support for units, time, and transform tags requires an implementation of these
 types.  One recommended option is the `astropy <https://www.astropy.org/>`__ package.
@@ -30,16 +30,16 @@ Installing with pip
 Installing with conda
 =====================
 
-ASDF is also distributed as a `conda <https://conda.io/docs/>`__ package via
+`asdf` is also distributed as a `conda <https://conda.io/docs/>`__ package via
 the `conda-forge <https://conda-forge.org/>`__ channel. It is also available
 through the `astroconda <https://astroconda.readthedocs.io/en/latest/>`__
 channel.
 
-To install ``asdf`` within an existing conda environment::
+To install `asdf` within an existing conda environment::
 
     $ conda install -c conda-forge asdf
 
-To create a new conda environment and install ``asdf``::
+To create a new conda environment and install `asdf`::
 
     $ conda create -n new-env-name -c conda-forge python asdf
 

--- a/docs/asdf/using_extensions.rst
+++ b/docs/asdf/using_extensions.rst
@@ -3,7 +3,7 @@
 The built-in extension
 ----------------------
 
-The ability to serialize the following types is provided by ASDF's built-in
+The ability to serialize the following types is provided by `asdf`'s built-in
 extension:
 
 * `dict`
@@ -14,7 +14,7 @@ extension:
 * `complex`
 * `numpy.ndarray`
 
-The built-in extension is packaged with ASDF and is automatically used when
+The built-in extension is packaged with `asdf` and is automatically used when
 reading and writing files. Users can not control the use of the built-in
 extension and in general they need not concern themselves with the details of
 its implementation. However, it is useful to be aware that the built-in
@@ -30,7 +30,7 @@ In order for a particular custom type to be serialized, a special class called
 a "converter" must be implemented. Each converter defines how the corresponding
 custom type will be serialized and deserialized. More details on how converters
 are implemented can be found in :ref:`extending_converters`. Users should never
-have to refer to converter implementations directly; they simply enable ASDF to
+have to refer to converter implementations directly; they simply enable `asdf` to
 recognize and process custom types.
 
 In addition to converters, each custom type may have a corresponding schema,
@@ -45,9 +45,9 @@ implementation) changes.
 Extensions
 ----------
 
-In order for the converters and schemas to be used by ASDF, they must be
+In order for the converters and schemas to be used by `asdf`, they must be
 packaged into an **extension** class. In general, the details of extensions are
-irrelevant to users of ASDF. However, users need to be aware of extensions in
+irrelevant to users of `asdf`. However, users need to be aware of extensions in
 the following two scenarios:
 
 * when storing custom data types to files to be written
@@ -60,7 +60,7 @@ below in :ref:`other_packages` and :ref:`explicit_extensions`.
 Writing custom types to files
 *****************************
 
-ASDF is not capable of serializing any custom type unless an extension is
+`asdf` is not capable of serializing any custom type unless an extension is
 provided that defines how to serialize that type. Attempting to do so will
 cause an error when trying to write the file. For details on developing support
 for custom types and extensions, see :ref:`extending_extensions`.
@@ -70,7 +70,7 @@ for custom types and extensions, see :ref:`extending_extensions`.
 Reading files with custom types
 *******************************
 
-The ASDF software is capable of reading files that contain custom data types
+The `asdf` software is capable of reading files that contain custom data types
 even if the extension that was used to create the file is not present. However,
 the extension is required in order to properly deserialize the original type.
 
@@ -96,7 +96,7 @@ Custom types, extensions, and versioning
 ----------------------------------------
 
 Tags and schemas that follow best practices are versioned. This allows changes
-to tags and schemas to be recorded, and it allows ASDF to define behavior with
+to tags and schemas to be recorded, and it allows `asdf` to define behavior with
 respect to version compatibility.
 
 Tag and schema versions may change for several reasons. One common reason is to
@@ -110,7 +110,7 @@ encouraged to maintain backwards compatibility with all older tag versions.
 Reading files
 *************
 
-When ASDF encounters a tagged object in a file, it will compare the URI of
+When `asdf` encounters a tagged object in a file, it will compare the URI of
 the tag in the file with the list of tags handled by available converters.
 The first matching converter will be selected to deserialize the object.  If
 no such converters exist, the library will emit a warning and the object will
@@ -123,7 +123,7 @@ its extension with the `~asdf.config.AsdfConfig.remove_extension` method.
 Writing files
 *************
 
-When writing a object to a file, ASDF compares the object's type to the list
+When writing a object to a file, `asdf` compares the object's type to the list
 of types handled by available converters.  The first matching converter will
 be selected to serialize the object.  If no such converters exist, the library
 will raise an error.
@@ -137,12 +137,12 @@ its extension with the `~asdf.config.AsdfConfig.remove_extension` method.
 Extensions from other packages
 ------------------------------
 
-Some external packages may define extensions that allow ASDF to recognize some
+Some external packages may define extensions that allow `asdf` to recognize some
 or all of the types that are defined by that package. Such packages may install
 the extension class as part of the package itself (details for developers can
 be found in :ref:`extending_extensions_installing_entry_points`).
 
-If the package installs its extension, then ASDF will automatically detect the
+If the package installs its extension, then `asdf` will automatically detect the
 extension and use it when processing any files. No specific action is required
 by the user in order to successfully read and write custom types defined by
 the extension for that particular package.
@@ -214,9 +214,9 @@ were used to create the file will be added to the file itself.  This includes
 the extension's URI, which uniquely identifies a particular version of the
 extension.
 
-When reading files with extension metadata, ASDF can check whether the required
+When reading files with extension metadata, `asdf` can check whether the required
 extensions are present before processing the file. If a required extension is
-not present, ASDF will issue a warning.
+not present, `asdf` will issue a warning.
 
 It is possible to turn these warnings into errors by using the
 `strict_extension_check` parameter of `asdf.open`. If this parameter is set to

--- a/docs/asdf/using_extensions.rst
+++ b/docs/asdf/using_extensions.rst
@@ -27,27 +27,27 @@ For the purposes of this documentation, a "custom type" is any data type that
 can not be serialized by the built-in extension.
 
 In order for a particular custom type to be serialized, a special class called
-a "tag type" (or "tag" for short) must be implemented. Each tag type defines
-how the corresponding custom type will be serialized and deserialized. More
-details on how tag types are implemented can be found in :ref:`extensions`.
-Users should never have to refer to tag implementations directly; they simply
-enable ASDF to recognize and process custom types.
+a "converter" must be implemented. Each converter defines how the corresponding
+custom type will be serialized and deserialized. More details on how converters
+are implemented can be found in :ref:`extending_converters`. Users should never
+have to refer to converter implementations directly; they simply enable ASDF to
+recognize and process custom types.
 
-In addition to tag types, each custom type must have a corresponding schema,
-which is used for validation. The definition of the schema is closely tied to
-the definition of the tag type. More details on schema validation can be found
-in :ref:`schema_validation`.
+In addition to converters, each custom type may have a corresponding schema,
+which is used for validation. The definition of the schema if present is closely
+tied to the definition of the converter. More details on schema validation can
+be found in :ref:`schema_validation`.
 
-All schemas and their associated tag types have versions that move in sync. The
-version will change whenever a schemas (and therefore the tag type
+Schemas are generally versioned and change in sync with their associated converters.
+The version number will increase whenever a schema (and therefore the converter
 implementation) changes.
 
 Extensions
 ----------
 
-In order for the tag types and schemas to be used by ASDF, they must be
+In order for the converters and schemas to be used by ASDF, they must be
 packaged into an **extension** class. In general, the details of extensions are
-transparent to users of ASDF. However, users need to be aware of extensions in
+irrelevant to users of ASDF. However, users need to be aware of extensions in
 the following two scenarios:
 
 * when storing custom data types to files to be written
@@ -62,8 +62,8 @@ Writing custom types to files
 
 ASDF is not capable of serializing any custom type unless an extension is
 provided that defines how to serialize that type. Attempting to do so will
-cause an error when trying to write the file. For details on writing custom tag
-types and extensions, see :ref:`extensions`.
+cause an error when trying to write the file. For details on developing support
+for custom types and extensions, see :ref:`extending_extensions`.
 
 .. _reading_custom_types:
 
@@ -76,8 +76,8 @@ the extension is required in order to properly deserialize the original type.
 
 If the necessary extension is **not** present, the custom data types will
 simply appear in the tree as a nested combination of basic data types. The
-structure of this data will mirror the structure of the schema used serialize
-the custom type.
+structure of this data will mirror the structure of the YAML objects in the
+ASDF file.
 
 In this case, a warning will occur by default to indicate to the user that the
 custom type in the file was not recognized and can not be deserialized. To
@@ -95,78 +95,42 @@ that are required for instantiating custom types when reading ASDF files.
 Custom types, extensions, and versioning
 ----------------------------------------
 
-All tag types and schemas are versioned. This allows changes to tags and
-schemas to be recorded, and it allows ASDF to define behavior with respect to
-version compatibility.
+Tags and schemas that follow best practices are versioned. This allows changes
+to tags and schemas to be recorded, and it allows ASDF to define behavior with
+respect to version compatibility.
 
 Tag and schema versions may change for several reasons. One common reason is to
 reflect a change to the API of the custom type that a tag represents. This
 typically corresponds to an update to the version of the software that defines
 that custom type.
 
-Since ASDF is designed to be an archival file format, it attempts to maintain
-backwards compatibility with all older tag and schema versions, at least when
-reading files. However, there are some caveats, which are described below.
+Since ASDF is designed to be an archival file format, extension authors are
+encouraged to maintain backwards compatibility with all older tag versions.
 
 Reading files
 *************
 
-When ASDF encounters a tagged object in a file, it will compare the
-version of the tag in the file with the version of the corresponding tag type
-(if one is provided by an available extension).
+When ASDF encounters a tagged object in a file, it will compare the URI of
+the tag in the file with the list of tags handled by available converters.
+The first matching converter will be selected to deserialize the object.  If
+no such converters exist, the library will emit a warning and the object will
+be presented to the user in its primitive form.
 
-In general, when reading files ASDF abides by the following principles:
-
-* If a tag type is available and its version matches that of the tag in the
-  file, ASDF will return an instance of the original custom type.
-* If no corresponding tag type is found in any available extension, ASDF will
-  return a basic data structure representing the type. A warning will occur
-  unless the option ``ignore_unrecognized_tag=True`` was given. (see
-  :ref:`reading_custom_types`).
-* If a tag type is available but its version is **older** than that in the file
-  (meaning that the file was written using a newer version of the tag type),
-  ASDF will attempt to deserialize the tag using the existing tag type. If this
-  fails, ASDF will return a basic data structure representing the type, and a
-  warning will occur.
-* If a tag type is available but its version is **newer** than that in the
-  file, ASDF will attempt to deserialize the tag using the existing tag type.
-  If this fails, ASDF will return a basic data structure representing the type,
-  and a warning will occur.
-
-In cases where the available tag type version does not match the version of the
-tag in the file, warnings can be enabled by passing
-``ignore_version_mismatch=False`` to `asdf.open`. These warnings are ignored by
-default.
+If multiple converters are present that both handle the same tag, the first
+found by the library will be used.  Users may disable a converter by removing
+its extension with the `~asdf.config.AsdfConfig.remove_extension` method.
 
 Writing files
 *************
 
-In general, ASDF makes no guarantee of being able to write older versions of
-tag types.
+When writing a object to a file, ASDF compares the object's type to the list
+of types handled by available converters.  The first matching converter will
+be selected to serialize the object.  If no such converters exist, the library
+will raise an error.
 
-Explicit version support
-************************
-
-Some tag types explicitly support reading only particular versions of the tag
-and schema (see `asdf.CustomType.supported_versions`). In these cases,
-deserialization is only possible if the version in the file matches one of the
-explicitly supported versions. Otherwise, ASDF will return a basic data
-structure representing the type, and a warning will occur.
-
-Caveats
-*******
-
-While ASDF makes every attempt to deserialize stored objects even in the
-case of a tag version mismatch, deserialization will not always be possible. In
-most cases, if the versions do not match, ASDF will be able to return a basic
-data structure representing the original type.
-
-However, tag version mismatches often indicate a mismatch between the versions
-of the software packages that define the type being serialized. In some cases,
-these version incompatibilities may lead to errors when attempting to read a
-file (especially when multiple tags/packages are involved). In these cases, the
-best course of action is to try to install the necessary versions of the
-packages (and extensions) involved.
+If multiple converters are present that both handle the same type, the first
+found by the library will be used.  Users may disable a converter by removing
+its extension with the `~asdf.config.AsdfConfig.remove_extension` method.
 
 .. _other_packages:
 
@@ -176,7 +140,7 @@ Extensions from other packages
 Some external packages may define extensions that allow ASDF to recognize some
 or all of the types that are defined by that package. Such packages may install
 the extension class as part of the package itself (details for developers can
-be found in :ref:`packaging_extensions`).
+be found in :ref:`extending_extensions_installing_entry_points`).
 
 If the package installs its extension, then ASDF will automatically detect the
 extension and use it when processing any files. No specific action is required
@@ -202,18 +166,18 @@ Explicit use of extensions
 --------------------------
 
 Sometimes no packaged extensions are provided for the types you wish to
-serialize. In this case, it is necessary to explicitly provide any necessary
+serialize. In this case, it is necessary to explicitly install any necessary
 extension classes when reading and writing files that contain custom types.
 
-Both `asdf.open` and the `AsdfFile` constructor take an optional `extensions`
-keyword argument to control which extensions are used when reading or creating
-ASDF files.
+The config object returned from `asdf.get_config` offers an `~asdf.config.AsdfConfig.add_extension`
+method that can be used to install an extension for the remainder of the current
+Python session.
 
 Consider the following example where there exists a custom type
 ``MyCustomType`` that needs to be written to a file. An extension is defined
-``MyCustomExtension`` that contains a tag type that can serialize and
+``MyCustomExtension`` that contains a converter that can serialize and
 deserialize ``MyCustomType``. Since ``MyCustomExtension`` is not installed by
-any package, we will need to pass it directly to the `AsdfFile` constructor:
+any package, we will need to manually install it:
 
 .. code-block:: python
 
@@ -221,36 +185,24 @@ any package, we will need to pass it directly to the `AsdfFile` constructor:
 
     ...
 
-    af = asdf.AsdfFile(extensions=MyCustomExtension())
+    asdf.get_config().add_extension(MyCustomExtension())
+    af = asdf.AsdfFile()
     af.tree = {'thing': MyCustomType('foo') }
     # This call would cause an error if the proper extension was not
     # provided to the constructor
     af.write_to('custom.asdf')
 
 Note that the extension class must actually be instantiated when it is passed
-as the `extensions` argument.
+to `~asdf.config.AsdfConfig.add_extension`.
 
-To read the file, we pass the same extension to `asdf.open`:
+To read the file (in a new session) we again need to install the extension first:
 
 .. code-block:: python
 
     import asdf
 
-    af = asdf.open('custom.asdf', extensions=MyCustomExtension())
-
-If necessary, it is also possible to pass a list of extension instances to
-`asdf.open` and the `AsdfFile` constructor:
-
-.. code-block:: python
-
-    extensions = [MyCustomExtension(), AnotherCustomExtension()]
-    af = asdf.AsdfFile(extensions=extensions)
-
-Passing either a single extension instance or a list of extension instances to
-either `asdf.open` or the `AsdfFile` constructor will not override any
-extensions that are installed in the environment. Instead, the custom types
-provided by the explicitly provided extensions will be added to the list of any
-types that are provided by installed extensions.
+    asdf.get_config().add_extension(MyCustomExtension())
+    af = asdf.open('custom.asdf')
 
 .. _extension_checking:
 
@@ -258,15 +210,14 @@ Extension checking
 ------------------
 
 When writing ASDF files using this software, metadata about the extensions that
-were used to create the file will be added to the file itself. For extensions
-that were provided with another software package, the metadata includes the
-version of that package.
+were used to create the file will be added to the file itself.  This includes
+the extension's URI, which uniquely identifies a particular version of the
+extension.
 
 When reading files with extension metadata, ASDF can check whether the required
 extensions are present before processing the file. If a required extension is
-not present, or if the wrong version of a package that provides an extension is
-installed, ASDF will issue a warning.
+not present, ASDF will issue a warning.
 
 It is possible to turn these warnings into errors by using the
 `strict_extension_check` parameter of `asdf.open`. If this parameter is set to
-`True`, then opening the file will fail if the required extensions are missing.
+`True`, then opening the file will fail if any of the required extensions are missing.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ html_theme_options = {
     'github_repo': 'asdf',
     'github_button': 'true',
     'fixed_sidebar': 'true',
-    'page_width': '45%',
+    'page_width': '90%',
 }
 
 html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,8 +25,11 @@ Getting Started
    asdf/install
    asdf/overview
    asdf/features
+   asdf/config
    asdf/asdf_tool
    asdf/changes
+
+.. _extending:
 
 Extending ASDF
 ==============
@@ -34,7 +37,15 @@ Extending ASDF
 .. toctree::
   :maxdepth: 2
 
-  asdf/extensions.rst
+  asdf/extending/use_cases
+  asdf/extending/uris
+  asdf/extending/schemas
+  asdf/extending/resources
+  asdf/extending/converters
+  asdf/extending/extensions
+  asdf/extending/manifests
+  asdf/extending/compressors
+  asdf/extending/legacy
 
 API Documentation
 =================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 ASDF - Advanced Scientific Data Format
 **************************************
 
-``asdf`` is a tool for reading and writing Advanced Scientific Data
+`asdf` is a tool for reading and writing Advanced Scientific Data
 Format (ASDF) files.
 
 .. include:: ../README.rst
@@ -75,7 +75,7 @@ We welcome feedback and contributions of all kinds. Contributions of code,
 documentation, or general feedback are all appreciated.
 
 Feature requests and bug reports for the Python implementation can be posted at
-`ASDF's github page <https://github.com/asdf-format/asdf>`_.
+`asdf's github page <https://github.com/asdf-format/asdf>`_.
 
 The ASDF Standard itself also has a repository on github. Suggestions for
 improvements to the ASDF Standard can be reported `here
@@ -87,7 +87,7 @@ See also
 - The `Advanced Scientific Data Format (ASDF) standard
   <https://asdf-standard.readthedocs.io/>`__
 
-- ASDF Python package distribution on `pypi <https://pypi.org/project/asdf/>`_
+- `asdf` Python package distribution on `pypi <https://pypi.org/project/asdf/>`_
 
 Index
 =====


### PR DESCRIPTION
This PR adds a whole mess of new documentation sections and updates existing sections to reflect changes introduced in version 2.8.0.  It might be easier to review in the HTML render, which can be found here: https://asdf.readthedocs.io/en/al-503-document-2.8-features/