### PR TITLE
Fix array compression for non-native byte order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 
 - Update documentation to reflect new 2.8 features. [#998]
 
+- Fix array compression for non-native byte order [#1010]
+
 2.8.1 (2021-06-09)
 ------------------
 

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -305,7 +305,7 @@ def compress(fd, data, compression, config=None):
     data = memoryview(data)
     if not data.contiguous:
         data = memoryview(data.tobytes())  # make a contiguous copy
-    data = data.cast('c').cast(data.format)  # we get a 1D array by a cast to byte, then a cast to data.format
+    data = memoryview(np.frombuffer(data, dtype=data.format))  # get a 1D array that preserves byteorder
     if not data.contiguous:
         # the data will be contiguous by construction, but better safe than sorry!
         raise ValueError(data.contiguous)

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -194,6 +194,17 @@ def test_set_array_compression(tmpdir):
         assert af_in.get_array_compression(af_in.tree['bzp2_data']) == 'bzp2'
 
 
+def test_nonnative_endian_compression(tmpdir):
+    tmpfile = os.path.join(str(tmpdir), 'compressed.asdf')
+
+    ledata = np.arange(1000, dtype='<i8')
+    bedata = np.arange(1000, dtype='>i8')
+
+    _roundtrip(tmpdir,
+               dict(ledata=ledata, bedata=bedata),
+               'lz4')
+
+
 class LzmaCompressor(Compressor):
     def compress(self, data, **kwargs):
         comp = lzma.compress(data, **kwargs)

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -195,8 +195,6 @@ def test_set_array_compression(tmpdir):
 
 
 def test_nonnative_endian_compression(tmpdir):
-    tmpfile = os.path.join(str(tmpdir), 'compressed.asdf')
-
     ledata = np.arange(1000, dtype='<i8')
     bedata = np.arange(1000, dtype='>i8')
 


### PR DESCRIPTION
Use a round-trip to Numpy to create a 1D `memoryview` that has the right byte order, because `memoryview` can't cast to all types it can represent.

Closes #1009.