### PR TITLE
fix `TaggedString` docstring

### DIFF
--- a/asdf/tagged.py
+++ b/asdf/tagged.py
@@ -98,7 +98,7 @@ class TaggedList(Tagged, UserList, list):
 
 class TaggedString(Tagged, UserString, str):
     """
-    A Python list with a tag attached.
+    A Python string with a tag attached.
     """
     style = None
 


### PR DESCRIPTION
The docstring doesn't seem 100% accurate since `TaggedString` doesn't have an `__init__` method and one cannot tag it directly upon creating (in contrast to `TaggedList`)