### PR TITLE
Use 'python3' instead of 'python' in tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 
 - Fix array compression for non-native byte order [#1010]
 
+- Fix use of 'python' where 'python3' is intended. [#1026]
+
 2.8.1 (2021-06-09)
 ------------------
 

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -44,7 +44,7 @@ with open(sys.argv[1], "wb") as file:
         with editor_path.open("w") as file:
             file.write(content)
 
-        return f"python {editor_path}"
+        return f"python3 {editor_path}"
 
     return _create_editor
 


### PR DESCRIPTION
Resolves #1018 