### PR TITLE
Fix schema URI resolving when the URI prefix is also claimed by a legacy extension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
 
 - Fix use of 'python' where 'python3' is intended. [#1026]
 
+- Fix schema URI resolving when the URI prefix is also
+  claimed by a legacy extension. [#1029]
+
 2.8.1 (2021-06-09)
 ------------------
 


### PR DESCRIPTION
This fixes a bug where the schema loader looks for content on disk when it should be retrieving it from the ResourceManager instance.

Resolves #1028 