### PR TITLE
Remove 'name' and 'version' attributes from NDArrayType instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@
 - Fix schema URI resolving when the URI prefix is also
   claimed by a legacy extension. [#1029]
 
+- Remove 'name' and 'version' attributes from NDArrayType
+  instances. [#1031]
+
 2.8.1 (2021-06-09)
 ------------------
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -368,6 +368,18 @@ class NDArrayType(AsdfType):
             self._array = None
             raise e from None
 
+    def __getattribute__(self, name):
+        # The presence of these attributes on an NDArrayType instance
+        # can cause problems when the array is passed to other
+        # libraries.
+        # See https://github.com/asdf-format/asdf/issues/1015
+        if name in ("name", "version"):
+            raise AttributeError(
+                f"'{self.__class__.name}' object has no attribute '{name}'"
+            )
+        else:
+            return super().__getattribute__(name)
+
     @classmethod
     def from_tree(cls, node, ctx):
         if isinstance(node, list):

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -895,3 +895,26 @@ def test_block_data_change(tmpdir):
         af.update()
         array_after = af.tree["data"].__array__()
         assert array_before is not array_after
+
+
+def test_problematic_class_attributes(tmp_path):
+    """
+    The presence of the "name" and "version" attributes
+    in NDArrayType cause problems when our arrays are used
+    with other libraries.
+
+    See https://github.com/asdf-format/asdf/issues/1015
+    """
+    file_path = tmp_path / "test.asdf"
+    with asdf.AsdfFile() as af:
+        af["arr"] = np.arange(100)
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert isinstance(af["arr"], ndarray.NDArrayType)
+
+        with pytest.raises(AttributeError):
+            af["arr"].name
+
+        with pytest.raises(AttributeError):
+            af["arr"].version


### PR DESCRIPTION
@CagtayFabry what do you think about this alternative fix?  My concern with #1016 is that we won't catch all the cases where an NDArrayType is created.

Resolves #1015