### PR TITLE
Fix tag listing when extension is not fully implemented

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.8.4 (unreleased)
+------------------
+
+- Fix tag listing when extension is not fully implemented. [#1034]
+
 2.8.3 (2021-12-13)
 ------------------
 

--- a/asdf/commands/tags.py
+++ b/asdf/commands/tags.py
@@ -45,7 +45,7 @@ def list_tags(display_classes=False, iostream=sys.stdout):
     af = AsdfFile()
 
     tag_pairs = []
-    for tag in af.extension_manager._tag_defs_by_tag:
+    for tag in af.extension_manager._converters_by_tag:
         tag_pairs.append((tag, af.extension_manager.get_converter_for_tag(tag).types))
     for tag in af.type_index._type_by_tag:
         tag_pairs.append((tag, [af.type_index._type_by_tag[tag]]))

--- a/asdf/commands/tests/test_tags.py
+++ b/asdf/commands/tests/test_tags.py
@@ -21,5 +21,5 @@ def test_all_tags_present():
     af = AsdfFile()
     for tag in af.type_index._type_by_tag:
         assert tag in tags
-    for tag in af.extension_manager._tag_defs_by_tag:
+    for tag in af.extension_manager._converters_by_tag:
         assert tag in tags

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -604,47 +604,6 @@ flow_thing:
         asdf.open(buff, extensions=CustomFlowExtension())
 
 
-def test_extension_override(tmpdir):
-
-    gwcs = pytest.importorskip('gwcs', '0.12.0')
-
-    version = str(versioning.default_version)
-    tmpfile = str(tmpdir.join('override.asdf'))
-
-    with asdf.AsdfFile() as aa:
-        assert aa.type_index.from_custom_type(gwcs.WCS, version=version) is gwcs.tags.wcs.WCSType
-        aa.tree['wcs'] = gwcs.WCS(output_frame='icrs')
-        aa.write_to(tmpfile)
-
-    with open(tmpfile, 'rb') as ff:
-        contents = str(ff.read())
-        assert gwcs.tags.wcs.WCSType.yaml_tag in contents
-
-
-def test_extension_override_subclass(tmpdir):
-
-    gwcs = pytest.importorskip('gwcs', '0.12.0')
-    pytest.importorskip('astropy', '4.0.0')
-
-    version = str(versioning.default_version)
-    tmpfile = str(tmpdir.join('override.asdf'))
-
-    class SubclassWCS(gwcs.WCS):
-        pass
-
-    with asdf.AsdfFile() as aa:
-        assert aa.type_index.from_custom_type(gwcs.WCS, version=version) is gwcs.tags.wcs.WCSType
-        assert aa.type_index.from_custom_type(SubclassWCS, version=version) is gwcs.tags.wcs.WCSType
-        # The duplication here is deliberate: make sure that nothing has changed
-        assert aa.type_index.from_custom_type(gwcs.WCS, version=version) is gwcs.tags.wcs.WCSType
-        aa.tree['wcs'] = SubclassWCS(output_frame='icrs')
-        aa.write_to(tmpfile)
-
-    with open(tmpfile, 'rb') as ff:
-        contents = str(ff.read())
-        assert gwcs.tags.wcs.WCSType.yaml_tag in contents
-
-
 def test_tag_without_schema(tmpdir):
 
     tmpfile = str(tmpdir.join('foo.asdf'))


### PR DESCRIPTION
This fixes a bug in the `asdftool tags` command when an extension does not implement all the tags in its manifest.

I'm also removing two tests that involve gwcs that haven't really been testing anything since support for WCS serialization was removed from this library.  These tests fail with gwcs master due to the removal of the gwcs.tags module.