### PR TITLE
replace deprecated isSet()

### DIFF
--- a/asdf/tests/httpserver.py
+++ b/asdf/tests/httpserver.py
@@ -41,7 +41,7 @@ def run_server(tmpdir, handler_class, stop_event, queue):  # pragma: no cover
     # Using server.serve_forever does not work here since it ignores the
     # timeout value set above. Having an explicit loop also allows us to kill
     # the server from the parent thread.
-    while not stop_event.isSet():
+    while not stop_event.is_set():
         server.handle_request()
 
     server.server_close()


### PR DESCRIPTION
Building 2.8.3 for Python 3.10 on openSUSE fails two tests with a deprecation warning:

```
[  605s] =================================== FAILURES ===================================
[  605s] __________________________ test_no_warning_nan_array ___________________________
[  605s] 
[  605s] tmpdir = local('/tmp/pytest-of-abuild/pytest-0/test_no_warning_nan_array0')
[  605s] 
[  605s]     def test_no_warning_nan_array(tmpdir):
[  605s]         """
[  605s]         Tests for a regression that was introduced by
[  605s]         https://github.com/asdf-format/asdf/pull/557
[  605s]         """
[  605s]     
[  605s]         tree = dict(array=np.array([1, 2, np.nan]))
[  605s]     
[  605s] >       with assert_no_warnings():
[  605s] 
[  605s] /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/test_api.py:58: 
[  605s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[  605s] /usr/lib64/python3.10/contextlib.py:142: in __exit__
[  605s]     next(self.gen)
[  605s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[  605s] 
[  605s] warning_class = None
[  605s] 
[  605s]     @contextmanager
[  605s]     def assert_no_warnings(warning_class=None):
[  605s]         """
[  605s]         Assert that no warnings were emitted within the context.
[  605s]         Requires that pytest be installed.
[  605s]     
[  605s]         Parameters
[  605s]         ----------
[  605s]         warning_class : type, optional
[  605s]             Assert only that no warnings of the specified class were
[  605s]             emitted.
[  605s]         """
[  605s]         import pytest
[  605s]         with pytest.warns(None) as recorded_warnings:
[  605s]             yield
[  605s]     
[  605s]         if warning_class is not None:
[  605s]             assert not any(isinstance(w.message, warning_class) for w in recorded_warnings), \
[  605s]                 display_warnings(recorded_warnings)
[  605s]         else:
[  605s] >           assert len(recorded_warnings) == 0, display_warnings(recorded_warnings)
[  605s] E           AssertionError: Unexpected warning(s) occurred:
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             
[  605s] E           assert 11 == 0
[  605s] E             +11
[  605s] E             -0
[  605s] 
[  605s] /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/helpers.py:380: AssertionError
[  605s] ----------------------------- Captured stderr call -----------------------------
[  605s] 127.0.0.1 - - [13/Dec/2021 20:45:44] "GET /test.asdf HTTP/1.1" 200 -
[  605s] _____________________ test_assert_roundtrip_with_extension _____________________
[  605s] 
[  605s] tmpdir = local('/tmp/pytest-of-abuild/pytest-0/test_assert_roundtrip_with_ext0')
[  605s] 
[  605s]     def test_assert_roundtrip_with_extension(tmpdir):
[  605s]         called_custom_assert_equal = [False]
[  605s]     
[  605s]         class CustomType(dict, types.CustomType):
[  605s]             name = 'custom_flow'
[  605s]             organization = 'nowhere.org'
[  605s]             version = (1, 0, 0)
[  605s]             standard = 'custom'
[  605s]     
[  605s]             @classmethod
[  605s]             def assert_equal(cls, old, new):
[  605s]                 called_custom_assert_equal[0] = True
[  605s]     
[  605s]         class CustomTypeExtension(CustomExtension):
[  605s]             @property
[  605s]             def types(self):
[  605s]                 return [CustomType]
[  605s]     
[  605s]         tree = {
[  605s]             'custom': CustomType({'a': 42, 'b': 43})
[  605s]         }
[  605s]     
[  605s]         def check(ff):
[  605s]             assert isinstance(ff.tree['custom'], CustomType)
[  605s]     
[  605s] >       with helpers.assert_no_warnings():
[  605s] 
[  605s] /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/test_schema.py:892: 
[  605s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[  605s] /usr/lib64/python3.10/contextlib.py:142: in __exit__
[  605s]     next(self.gen)
[  605s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[  605s] 
[  605s] warning_class = None
[  605s] 
[  605s]     @contextmanager
[  605s]     def assert_no_warnings(warning_class=None):
[  605s]         """
[  605s]         Assert that no warnings were emitted within the context.
[  605s]         Requires that pytest be installed.
[  605s]     
[  605s]         Parameters
[  605s]         ----------
[  605s]         warning_class : type, optional
[  605s]             Assert only that no warnings of the specified class were
[  605s]             emitted.
[  605s]         """
[  605s]         import pytest
[  605s]         with pytest.warns(None) as recorded_warnings:
[  605s]             yield
[  605s]     
[  605s]         if warning_class is not None:
[  605s]             assert not any(isinstance(w.message, warning_class) for w in recorded_warnings), \
[  605s]                 display_warnings(recorded_warnings)
[  605s]         else:
[  605s] >           assert len(recorded_warnings) == 0, display_warnings(recorded_warnings)
[  605s] E           AssertionError: Unexpected warning(s) occurred:
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/httpserver.py:44: DeprecationWarning: isSet() is deprecated, use is_set() instead
[  605s] E             
[  605s] E           assert 3 == 0
[  605s] E             +3
[  605s] E             -0
[  605s] 
[  605s] /home/abuild/rpmbuild/BUILD/asdf-2.8.3/asdf/tests/helpers.py:380: AssertionError
[  605s] ----------------------------- Captured stderr call -----------------------------
[  605s] 127.0.0.1 - - [13/Dec/2021 20:49:04] "GET /test.asdf HTTP/1.1" 200 -
[  605s] =============================== warnings summary ===============================
```

`threading.Event.isSet()` has been replaced by `.is_set()` as far ago as [Python 2.6](https://docs.python.org/2.7/library/threading.html#threading.Event.is_set).