### PR TITLE
Unpin Pytest < 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - name: Python 3.10 Testing
             os: ubuntu-latest
             python-version: 3.10.0
-            toxenv: py38
+            toxenv: py310
 
           - name: Code Coverage with Python 3.9
             os: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,7 @@ docs =
     matplotlib
     docutils
 tests =
-    # As of 2020-07-28, pytest-doctestplus is not compatible
-    # with pytest 6.0.0.
-    pytest<6
+    pytest
     astropy
     gwcs
     pytest-doctestplus

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ pip_pre= true
 basepython= python3.8
 commands=
     pytest --remote-data -W error \
+      -p no:unraisableexception \
       -W ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes \
       -W 'ignore:numpy.ndarray size changed:astropy.utils.exceptions.AstropyWarning' \
       -W 'ignore:numpy.ndarray size changed:RuntimeWarning'

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,11 @@ deps=
 extras= all,tests
 # astropy will complain if the home directory is missing
 passenv= HOME
+# force import from current source dir
+setenv = 
+  PYTHONPATH=:x
 commands=
-    pytest --remote-data
+    pytest --remote-data --import-mode=append
 
 [testenv:s390x]
 # As of 2020-01-23, The s390x container on Travis has a bug where
@@ -39,8 +42,11 @@ pip_pre= true
 
 [testenv:warnings]
 basepython= python3.8
+# force import from current source dir
+setenv = 
+  PYTHONPATH=:x
 commands=
-    pytest --remote-data -W error \
+    pytest --remote-data -W error --import-mode=append \
       -W ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes \
       -W 'ignore:numpy.ndarray size changed:astropy.utils.exceptions.AstropyWarning' \
       -W 'ignore:numpy.ndarray size changed:RuntimeWarning'

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps=
 extras= all,tests
 # astropy will complain if the home directory is missing
 passenv= HOME
+usedevelop= true
 commands=
     pytest --remote-data
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ basepython= python3.8
 # and load the asdf module from the unpackaged sourcee, which is not what we
 # want.  The home directory does not have a tox.ini in any of its ancestors,
 # so this will allow us to test the installed package.
+usedevelop= false
 changedir= {homedir}
 commands=
     pytest --pyargs asdf --remote-data
@@ -63,6 +64,7 @@ commands=
     python setup.py egg_info
 
 [testenv:twine]
+usedevelop= false
 deps=
     twine
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,8 @@ deps=
 extras= all,tests
 # astropy will complain if the home directory is missing
 passenv= HOME
-# force import from current source dir
-setenv = 
-  PYTHONPATH=:x
 commands=
-    pytest --remote-data --import-mode=append
+    pytest --remote-data
 
 [testenv:s390x]
 # As of 2020-01-23, The s390x container on Travis has a bug where
@@ -42,11 +39,8 @@ pip_pre= true
 
 [testenv:warnings]
 basepython= python3.8
-# force import from current source dir
-setenv = 
-  PYTHONPATH=:x
 commands=
-    pytest --remote-data -W error --import-mode=append \
+    pytest --remote-data -W error \
       -W ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes \
       -W 'ignore:numpy.ndarray size changed:astropy.utils.exceptions.AstropyWarning' \
       -W 'ignore:numpy.ndarray size changed:RuntimeWarning'


### PR DESCRIPTION
pytest-doctestplus has been compatible with pytest 6 since version 0.8

As Pytest 5 is not compatible with Python 3.10, this is a blocker.
