### PR TITLE
MNT: Replace distutils with packaging

### DIFF
--- a/asdf/util.py
+++ b/asdf/util.py
@@ -321,7 +321,7 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
 
     By default this uses `pkg_resources.parse_version` to do the version
     comparison if available.  Otherwise it falls back on
-    `distutils.version.LooseVersion`.
+    `packaging.version.Version`.
 
     Parameters
     ----------
@@ -366,7 +366,7 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
     try:
         from pkg_resources import parse_version
     except ImportError:
-        from distutils.version import LooseVersion as parse_version
+        from packaging.version import Version as parse_version
 
     if inclusive:
         return parse_version(have_version) >= parse_version(version)

--- a/compatibility_tests/test_file_compatibility.py
+++ b/compatibility_tests/test_file_compatibility.py
@@ -57,7 +57,7 @@ def fetch_package_versions(package_name):
     version_strings = json.loads(content)["releases"].keys()
     return [
         Version(v) for v in version_strings
-        if v not in BAD_VERSIONS and (v >= MIN_VERSION_NEW_FILES or v >= MIN_VERSION_OLD_FILES)
+        if v not in BAD_VERSIONS and (Version(v) >= MIN_VERSION_NEW_FILES or Version(v) >= MIN_VERSION_OLD_FILES)
     ]
 
 

--- a/compatibility_tests/test_file_compatibility.py
+++ b/compatibility_tests/test_file_compatibility.py
@@ -1,6 +1,6 @@
 import json
 import urllib.request
-from distutils.version import StrictVersion
+from packaging.version import Version
 from itertools import groupby
 from pathlib import Path
 import subprocess
@@ -16,18 +16,18 @@ import asdf
 from common import generate_file, assert_file_correct
 
 
-# Strange version present on pypi that doesn't parse as a StrictVersion
+# Strange version present on pypi that doesn't parse as a Version
 BAD_VERSIONS = {"0"}
 
 # Minimum library version to read files produced by the current
 # version of the code.  We're not maintaining < 2.7.x and bugs in older
 # versions prevent valid files from being read.
-MIN_VERSION_NEW_FILES = StrictVersion("2.7.0")
+MIN_VERSION_NEW_FILES = Version("2.7.0")
 
 # Minimum library version to produce files read by the current
 # version of the code.  Earlier versions aren't able to generate
 # files for all the ASDF Standard versions that they claim to support.
-MIN_VERSION_OLD_FILES = StrictVersion("2.3.0")
+MIN_VERSION_OLD_FILES = Version("2.3.0")
 
 GENERATE_SCRIPT_PATH = Path(__file__).parent/"generate_file.py"
 ASSERT_SCRIPT_PATH = Path(__file__).parent/"assert_file_correct.py"
@@ -56,7 +56,7 @@ def fetch_package_versions(package_name):
     content = urllib.request.urlopen("https://pypi.org/pypi/{}/json".format(package_name)).read()
     version_strings = json.loads(content)["releases"].keys()
     return [
-        StrictVersion(v) for v in version_strings
+        Version(v) for v in version_strings
         if v not in BAD_VERSIONS and (v >= MIN_VERSION_NEW_FILES or v >= MIN_VERSION_OLD_FILES)
     ]
 
@@ -110,7 +110,7 @@ def get_installed_version(env_path):
     virtual environment.
     """
     script = r"""import asdf; print(asdf.__version__)"""
-    return StrictVersion(env_check_output(env_path, "python3", "-c", script))
+    return Version(env_check_output(env_path, "python3", "-c", script))
 
 
 @pytest.fixture(scope="module", params=PATCH_VERSIONS)

--- a/compatibility_tests/test_file_compatibility.py
+++ b/compatibility_tests/test_file_compatibility.py
@@ -66,7 +66,7 @@ def fetch_latest_patch_versions(package_name):
     Return the latest patch version within each of the package's
     minor versions.
     """
-    key_fn = lambda v: v.version[0:2]
+    key_fn = lambda v: v.release[0:2]
 
     versions = sorted(fetch_package_versions(package_name), key=key_fn)
     return [max(group) for _, group in groupby(versions, key=key_fn)]


### PR DESCRIPTION
`distutils` is deprecated. cc @eslavich 