### PR TITLE
Drop support for Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - master
       - stable
       - '*.x'
+      - asdf-3.0-epic
     tags:
       - '*'
   pull_request:
@@ -18,115 +19,93 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Python 3.10 Testing
+          - name: Python 3.10
             os: ubuntu-latest
-            python-version: 3.10.0
+            python-version: '3.10'
             toxenv: py310
 
-          - name: Code Coverage with Python 3.9
+          - name: Python 3.9 (with code coverage)
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.9'
             toxenv: coverage
 
-          - name: Python 3.8 Testing
+          - name: Python 3.8
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: '3.8'
             toxenv: py38
 
-          - name: Python 3.7 Testing
+          - name: Python 3.8 with oldest supported dependencies
             os: ubuntu-latest
-            python-version: 3.7.9
-            toxenv: py37
+            python-version: '3.8'
+            toxenv: py38-oldestdeps
 
-          - name: Python 3.6 Testing
+          - name: Build documentation
             os: ubuntu-latest
-            python-version: 3.6.10
-            toxenv: py36
+            python-version: '3.9'
+            toxenv: docs
 
-          - name: Python 3.6 with legacy packages
-            os: ubuntu-latest
-            python-version: 3.6.10
-            toxenv: py36-legacy
-
-          - name: Documentation Build
-            os: ubuntu-latest
-            python-version: 3.8
-            toxenv: docbuild
-
-          - name: Mac OS Latest
+          - name: macOS
             os: macos-latest
-            python-version: 3.9
+            python-version: '3.9'
             toxenv: py39
 
-          - name: Compatibility
+          - name: Compatibility with older asdf libraries
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.9'
             toxenv: compatibility
 
-          - name: Bandit Security Checks
+          - name: Bandit security checks
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.9'
             toxenv: bandit
 
-          - name: Code Style Checks
+          - name: Flake8 checks
             os: ubuntu-latest
-            python-version: 3.8
-            toxenv: style
+            python-version: '3.9'
+            toxenv: flake8
 
-          - name: Twine
+          - name: Twine checks
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.9'
             toxenv: twine
 
-          - name: Checkdocs
+          - name: astropy dev
             os: ubuntu-latest
-            python-version: 3.9
-            toxenv: checkdocs
+            python-version: '3.9'
+            toxenv: py39-astropydev
 
-          - name: Numpy 1.12
+          - name: gwcs dev
             os: ubuntu-latest
-            python-version: 3.6.10
-            toxenv: py36-numpy12
+            python-version: '3.9'
+            toxenv: py39-gwcsdev
 
-          - name: Astropy Dev
+          - name: numpy dev
             os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-astropydev
+            python-version: '3.9'
+            toxenv: py39-numpydev
 
-          - name: GWCS Dev
+          - name: Pre-release dependencies
             os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-gwcsdev
-
-          # Fail
-          - name: Numpy Dev
-            os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-numpydev
-
-          # Fail
-          - name: Pre-Release Dependencies
-            os: ubuntu-latest
-            python-version: 3.8
+            python-version: '3.9'
             toxenv: prerelease
 
-          - name: Test Against Installed Packaged
+          - name: Test against installed package
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: '3.9'
             toxenv: packaged
 
-          - name: Warnings Treated as Exceptions
+          - name: Warnings treated as exceptions
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: '3.9'
             toxenv: warnings
 
           - name: Windows
             os: windows-latest
-            python-version: 3.9
+            python-version: '3.9'
             toxenv: py39
     steps:
-      - name: Install System Packages
-        if: ${{ contains(matrix.toxenv,'docbuild') }}
+      - name: Install system packages for documentation
+        if: ${{ contains(matrix.toxenv,'docs') }}
         run: |
           sudo apt update -y
           sudo apt-get install graphviz texlive-latex-extra dvipng
@@ -143,5 +122,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Run tox
+      - name: Run tox environment '${{ matrix.toxenv }}'
         run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -12,31 +12,28 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-18.04
-    name: Python 3.7
+    name: Python 3.8
+    timeout-minutes: 600
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           submodules: true
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2.1.1
         name: Run tests
         id: build
         with:
           arch: s390x
-          distro: buster
+          distro: ubuntu18.04
           shell: /bin/bash
           install: |
             apt-get update -q -y
-            apt-get install -q -y git \
-                                  python3 \
-                                  python3-astropy \
-                                  python3-lz4 \
-                                  python3-numpy \
-                                  python3-venv \
-                                  python3-wheel
+            apt-get install -q -y build-essential gfortran libopenblas-dev liblapack-dev
+            apt-get install -q -y software-properties-common
+            add-apt-repository -y ppa:deadsnakes/ppa
+            apt-get install -q -y git python3.8 python3.8-dev python3.8-venv
           run: |
-            python3 -m venv --system-site-packages tests
-            source tests/bin/activate
-            pip3 install --upgrade pip setuptools gwcs==0.9.1 pytest==5.4.3 pytest-doctestplus==0.8.0
-            pip3 install -e .[all,tests]
-            python3 -m pytest --remote-data
+            /usr/bin/python3.8 -m venv .venv
+            source .venv/bin/activate
+            pip install -e .[all,tests]
+            pytest --remote-data

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+3.0.0 (unreleased)
+------------------
+
+- Drop support for Python 3.6 and 3.7 [#1043]
+
 2.8.4 (unreleased)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,20 +15,19 @@ project_urls =
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Development Status :: 5 - Production/Stable
 
 [options]
-python_requires= >=3.6
+python_requires= >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    importlib_resources>=3;python_version<"3.9"
+    importlib_resources>=5.0.7;python_version<"3.9"
     jmespath>=0.6.2
     jsonschema>=3.0.2,<4
-    numpy>=1.10
+    numpy>=1.19
     packaging>=16.0
     pyyaml>=3.10
     semantic_version>=2.8
@@ -39,6 +38,8 @@ all =
 docs =
     sphinx
     sphinx-astropy
+    # We can't use 0.14.x until https://github.com/astropy/sphinx-automodapi/pull/142 is released:
+    sphinx-automodapi<0.14
     astropy
     graphviz
     matplotlib

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist= py38,style
+envlist= py39,style
 
 [testenv]
 deps=
@@ -7,20 +7,13 @@ deps=
     astropydev: git+https://github.com/astropy/astropy
     gwcsdev: git+https://github.com/spacetelescope/gwcs
     numpydev: git+https://github.com/numpy/numpy
-    py36: importlib_resources
-    # Newer versions of gwcs require astropy 4.x, which
-    # isn't compatible with the older versions of numpy
-    # that we test with.
-    numpy11,numpy12,legacy: gwcs==0.9.1
-    legacy: semantic_version==2.8
-    legacy: pyyaml==3.10
-    legacy: jsonschema==3.0.2
-    legacy: numpy~=1.10.0
-    legacy: pytest~=4.6.11
-    numpy11,numpy12,legacy: astropy~=3.0.0
-    numpy11: numpy==1.11
-    numpy12: numpy==1.12
     numpydev,s390x: cython
+    oldestdeps: jmespath==0.6.2
+    oldestdeps: jsonschema==3.0.2
+    oldestdeps: numpy~=1.19.0
+    oldestdeps: pyyaml==3.10
+    oldestdeps: semantic_version==2.8
+
 extras= all,tests
 # astropy will complain if the home directory is missing
 passenv= HOME
@@ -28,18 +21,10 @@ usedevelop= true
 commands=
     pytest --remote-data
 
-[testenv:s390x]
-# As of 2020-01-23, The s390x container on Travis has a bug where
-# /home/travis/.cache/pip/wheels is owned by root, which prevents
-# us from installing packages unless we disable caching.
-install_command= python -m pip install --no-cache-dir {opts} {packages}
-
 [testenv:prerelease]
-basepython= python3.8
 pip_pre= true
 
 [testenv:warnings]
-basepython= python3.8
 commands=
     pytest --remote-data -W error \
       -p no:unraisableexception \
@@ -48,7 +33,6 @@ commands=
       -W 'ignore:numpy.ndarray size changed:RuntimeWarning'
 
 [testenv:packaged]
-basepython= python3.8
 # The default tox working directory is in .tox in the source directory.  If we
 # execute pytest from there, it will discover tox.ini in the source directory
 # and load the asdf module from the unpackaged sourcee, which is not what we
@@ -59,11 +43,6 @@ changedir= {homedir}
 commands=
     pytest --pyargs asdf --remote-data
 
-[testenv:egg_info]
-deps=
-commands=
-    python setup.py egg_info
-
 [testenv:twine]
 usedevelop= false
 deps=
@@ -71,21 +50,12 @@ deps=
 commands=
     twine check {distdir}/*
 
-[testenv:docbuild]
-basepython= python3.8
+[testenv:docs]
 extras= docs
 commands=
     sphinx-build -W docs build/docs
 
-[testenv:checkdocs]
-deps=
-    collective.checkdocs
-    pygments
-commands=
-    python setup.py checkdocs
-
-[testenv:style]
-basepython= python3.8
+[testenv:flake8]
 deps=
     flake8
 commands=
@@ -100,7 +70,7 @@ commands=
                  -m pytest --remote-data --open-files
     coverage report -m
     codecov -e TOXENV
-passenv= TOXENV CI TRAVIS TRAVIS_* CODECOV_* DISPLAY HOME
+passenv= TOXENV CI CODECOV_* DISPLAY HOME
 
 [testenv:compatibility]
 deps=


### PR DESCRIPTION
This PR drops support for Python 3.6 and Python 3.7 and removes tests and test environments that are only relevant to these versions.