### PR TITLE
Remove wildcard from converter tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
 
 - Move support for AsdfObject to Converter. [#1048]
 
+- Remove wildcard from Converter tag matchers and handle extra properties. [#1049]
+
 2.8.4 (unreleased)
 ------------------
 

--- a/asdf/core/_converters/complex.py
+++ b/asdf/core/_converters/complex.py
@@ -10,7 +10,7 @@ _REPLACEMENTS = {
 
 
 class ComplexConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/core/complex-*"]
+    tags = ["tag:stsci.edu:asdf/core/complex-1.0.0"]
     types = ["builtins.complex", "numpy.complex64", "numpy.complex128", "numpy.complex256"]
 
     def to_yaml_tree(self, obj, tag, ctx):

--- a/asdf/core/_converters/entities.py
+++ b/asdf/core/_converters/entities.py
@@ -20,30 +20,41 @@ class AsdfObjectConverter(Converter):
 
 
 class ExternalArrayReferenceConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/core/externalarray-*"]
+    tags = ["tag:stsci.edu:asdf/core/externalarray-1.0.0"]
     types = ["asdf.core._entities.ExternalArrayReference"]
 
     def to_yaml_tree(self, obj, tag, ctx):
-        return {
+        node = {
             "fileuri": obj.fileuri,
             "target": obj.target,
             "datatype": obj.datatype,
             "shape": list(obj.shape),
         }
 
+        node.update(obj.extra)
+
+        return node
+
     def from_yaml_tree(self, node, tag, ctx):
         from asdf.core import ExternalArrayReference
 
+        extra = dict(node)
+        fileuri = extra.pop("fileuri")
+        target = extra.pop("target")
+        datatype = extra.pop("datatype")
+        shape = tuple(extra.pop("shape"))
+
         return ExternalArrayReference(
-            fileuri=node["fileuri"],
-            target=node["target"],
-            datatype=node["datatype"],
-            shape=tuple(node["shape"]),
+            fileuri=fileuri,
+            target=target,
+            datatype=datatype,
+            shape=shape,
+            extra=extra,
         )
 
 
 class SoftwareConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/core/software-*"]
+    tags = ["tag:stsci.edu:asdf/core/software-1.0.0"]
     types = ["asdf.core._entities.Software"]
 
     def to_yaml_tree(self, obj, tag, ctx):
@@ -58,21 +69,38 @@ class SoftwareConverter(Converter):
         if obj.homepage is not None:
             node["homepage"] = obj.homepage
 
+        node.update(obj.extra)
+
         return node
 
     def from_yaml_tree(self, node, tag, ctx):
         from asdf.core import Software
 
+        extra = dict(node)
+        name = extra.pop("name")
+        version = extra.pop("version")
+
+        try:
+            author = extra.pop("author")
+        except KeyError:
+            author = None
+
+        try:
+            homepage = extra.pop("homepage")
+        except KeyError:
+            homepage = None
+
         return Software(
-            name=node["name"],
-            version=node["version"],
-            author=node.get("author"),
-            homepage=node.get("homepage"),
+            name=name,
+            version=version,
+            author=author,
+            homepage=homepage,
+            extra=extra,
         )
 
 
 class HistoryEntryConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/core/history_entry-*"]
+    tags = ["tag:stsci.edu:asdf/core/history_entry-1.0.0"]
     types = ["asdf.core._entities.HistoryEntry"]
 
     def to_yaml_tree(self, obj, tag, ctx):
@@ -86,24 +114,40 @@ class HistoryEntryConverter(Converter):
         if len(obj.software) > 0:
             node["software"] = obj.software
 
+        node.update(obj.extra)
+
         return node
 
     def from_yaml_tree(self, node, tag, ctx):
         from asdf.core import HistoryEntry, Software
 
-        software = node.get("software", [])
+        extra = dict(node)
+
+        description = extra.pop("description")
+
+        try:
+            time = extra.pop("time")
+        except KeyError:
+            time = None
+
+        try:
+            software = extra.pop("software")
+        except KeyError:
+            software = []
+
         if isinstance(software, Software):
             software = [software]
 
         return HistoryEntry(
-            description=node["description"],
-            time=node.get("time"),
+            description=description,
+            time=time,
             software=software,
+            extra=extra,
         )
 
 
 class ExtensionMetadataConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/core/extension_metadata-*"]
+    tags = ["tag:stsci.edu:asdf/core/extension_metadata-1.0.0"]
     types = ["asdf.core._entities.ExtensionMetadata"]
 
     def to_yaml_tree(self, obj, tag, ctx):

--- a/asdf/core/_converters/integer.py
+++ b/asdf/core/_converters/integer.py
@@ -5,7 +5,7 @@ from asdf.extension import Converter
 
 
 class IntegerConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/core/integer-*"]
+    tags = ["tag:stsci.edu:asdf/core/integer-1.0.0"]
     types = [
         "builtins.int",
         "numpy.int8",

--- a/asdf/core/_converters/tests/test_entities.py
+++ b/asdf/core/_converters/tests/test_entities.py
@@ -20,7 +20,13 @@ def test_asdf_object():
 
 
 def test_external_array_reference():
-    ref = ExternalArrayReference("./nonexistant.fits", 1, "np.float64", (100, 100))
+    ref = ExternalArrayReference(
+        fileuri="./nonexistant.fits",
+        target=1,
+        datatype="np.float64",
+        shape=(100, 100),
+        extra={"extra": "property"},
+    )
 
     result = helpers.roundtrip_object(ref)
 
@@ -29,10 +35,10 @@ def test_external_array_reference():
 
 def test_extension_metadata():
     metadata = ExtensionMetadata(
-        "foo.extension.FooExtension",
-        "http://foo.biz/extensions/foo-1.0.0",
-        Software("FooSoft", "1.5"),
-        {"extra": "property"}
+        extension_class="foo.extension.FooExtension",
+        extension_uri="http://foo.biz/extensions/foo-1.0.0",
+        software=Software("FooSoft", "1.5"),
+        extra={"extra": "property"},
     )
 
     result = helpers.roundtrip_object(metadata)
@@ -63,10 +69,11 @@ metadata: !core/extension_metadata-1.0.0
 
 def test_software():
     software = Software(
-        "FooSoft",
-        "1.5.0",
-        "The Foo Developers",
-        "http://nowhere.org",
+        name="FooSoft",
+        version="1.5.0",
+        author="The Foo Developers",
+        homepage="http://nowhere.org",
+        extra={"extra": "property"},
     )
 
     result = helpers.roundtrip_object(software)
@@ -78,7 +85,8 @@ def test_history_entry():
     history_entry = HistoryEntry(
         "Some history happened here",
         time=datetime.datetime.now(),
-        software=[Software("FooSoft", "1.5.0")]
+        software=[Software("FooSoft", "1.5.0")],
+        extra={"extra": "property"},
     )
 
     result = helpers.roundtrip_object(history_entry)

--- a/asdf/core/_entities.py
+++ b/asdf/core/_entities.py
@@ -38,6 +38,9 @@ class ExternalArrayReference:
     shape: tuple of int
         The shape of the array to be loaded.
 
+    extra : dict, optional
+        Additional metadata to include when serializing this
+        object.
 
     Examples
     --------
@@ -53,6 +56,7 @@ class ExternalArrayReference:
     target: Union[str, int]
     datatype: str
     shape: Tuple[int]
+    extra: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -74,11 +78,16 @@ class Software:
 
     homepage: str, optional
         A URI to the homepage of the software.
+
+    extra : dict, optional
+        Additional metadata to include when serializing this
+        object.
     """
     name: str
     version: str
     author: Union[str, None] = None
     homepage: Union[str, None] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -97,10 +106,15 @@ class HistoryEntry:
 
     software : list of Software, optional
         The software that performed the operation.
+
+    extra : dict, optional
+        Additional metadata to include when serializing this
+        object.
     """
     description: str
     time: Union[datetime.datetime, None] = None
     software: List[Software] = field(default_factory=list)
+    extra: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass


### PR DESCRIPTION
@CagtayFabry's question [here](https://github.com/asdf-format/asdf/pull/1048#discussion_r783782316) revealed some flaws in the new Converters.  I've updated them to claim specific tag versions and also to retain additional properties in an "extra" dict where the schema allows them.