### PR TITLE
added support for __asdf_traverse__ method to allow custom introspect…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Added the capability for tag classes to provide an interface
   to asdf info functionality to obtain information about the 
   class attributes rather than appear as an opaque class object.
-  []
+  [#1052]
 
 - Fix tag listing when extension is not fully implemented. [#1034]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 2.8.4 (unreleased)
 ------------------
 
+- Added the capability for tag classes to provide an interface
+  to asdf info functionality to obtain information about the 
+  class attributes rather than appear as an opaque class object.
+  []
+
 - Fix tag listing when extension is not fully implemented. [#1034]
 
 2.8.3 (2021-12-13)

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -99,12 +99,11 @@ class _NodeInfo:
                         parent.children.append(info)
                     seen.add(id(node))
                     if cls.supports_info(node):
-                        info.tag = node._tag
-                        for child_identifier, child_node in node.__asdf_traverse__():
-                            next_nodes.append((info, child_identifier, child_node))
+                        tnode = node.__asdf_traverse__()
                     else:
-                        for child_identifier, child_node in get_children(node):
-                            next_nodes.append((info, child_identifier, child_node))
+                        tnode = node
+                    for child_identifier, child_node in get_children(tnode):
+                        next_nodes.append((info, child_identifier, child_node))
 
             if len(next_nodes) == 0:
                 break

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -88,7 +88,10 @@ class _NodeInfo:
             next_nodes = []
 
             for parent, identifier, node in current_nodes:
-                if (isinstance(node, dict) or isinstance(node, list) or isinstance(node, tuple)) and id(node) in seen:
+                if (isinstance(node, dict) or 
+                    isinstance(node, list) or 
+                    isinstance(node, tuple) or
+                    cls.supports_info(node)) and id(node) in seen:
                     info = _NodeInfo(parent, identifier, node, current_depth, recursive=True)
                     parent.children.append(info)
                 else:

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -129,7 +129,7 @@ class _NodeInfo:
 
     def supports_info(node):
         """
-        This method determines if the node is an instance of a class that 
+        This method determines if the node is an instance of a class that
         supports introspection by the info machinery. This determined by
         the presence of a __asdf_traverse__ method.
         """

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -88,8 +88,7 @@ class _NodeInfo:
             next_nodes = []
 
             for parent, identifier, node in current_nodes:
-                if (isinstance(node, dict) or 
-                    isinstance(node, list) or 
+                if (isinstance(node, dict) or
                     isinstance(node, tuple) or
                     cls.supports_info(node)) and id(node) in seen:
                     info = _NodeInfo(parent, identifier, node, current_depth, recursive=True)

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -1,8 +1,8 @@
 """
 Utilities for displaying the content of an ASDF tree.
 
-Normally these tools only will introspect dicts, lists, and primative values
-(with an exception for arrays). However, if the objecct that is generated
+Normally these tools only will introspect dicts, lists, and primitive values
+(with an exception for arrays). However, if the object that is generated
 by the converter mechanism has a __asdf_traverse__() method, then it will
 call that method expecting a dict or list to be returned. The method can
 return what it thinks is suitable for display.
@@ -115,9 +115,7 @@ class _NodeInfo:
         return root_info
 
     def __init__(
-        self, parent, identifier, node, depth, recursive=False, visible=True,
-        tag=None
-    ):
+        self, parent, identifier, node, depth, recursive=False, visible=True):
         self.parent = parent
         self.identifier = identifier
         self.node = node
@@ -125,9 +123,9 @@ class _NodeInfo:
         self.recursive = recursive
         self.visible = visible
         self.children = []
-        self.tag = tag
 
-    def supports_info(node):
+    @classmethod
+    def supports_info(cls, node):
         """
         This method determines if the node is an instance of a class that
         supports introspection by the info machinery. This determined by

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -543,6 +543,7 @@ def test_info_module(capsys, tmpdir):
         for val in tree["foo"][i-1:]:
             assert val not in captured.out
 
+
 def test_info_asdf_file(capsys, tmpdir):
     tree = dict(
         foo=42, bar="hello", baz=np.arange(20),
@@ -576,6 +577,7 @@ def test_info_object_support(capsys):
     assert "clown" in captured.out
     assert "42" in captured.out
     assert "Bozo" in captured.out
+
 
 class RecursiveObjectWithInfoSupport:
 

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -577,6 +577,29 @@ def test_info_object_support(capsys):
     assert "42" in captured.out
     assert "Bozo" in captured.out
 
+class RecursiveObjectWithInfoSupport:
+
+    def __init__(self):
+        self._tag = "foo"
+        self.the_meaning = 42
+        self.clown = "Bozo"
+        self.recursive = None
+
+    def __asdf_traverse__(self):
+        return {'the_meaning': self.the_meaning,
+                'clown': self.clown,
+                'recursive': self.recursive}
+
+
+def test_recursive_info_object_support(capsys):
+    recursive_obj = RecursiveObjectWithInfoSupport()
+    recursive_obj.recursive = recursive_obj
+    tree = dict(random=3.14159, rtest=recursive_obj)
+    af = asdf.AsdfFile(tree)
+    af.info()
+    captured = capsys.readouterr()
+    assert "recursive reference" in captured.out
+
 
 def test_search():
     tree = dict(foo=42, bar="hello", baz=np.arange(20))

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -563,8 +563,8 @@ class ObjectWithInfoSupport:
         self._tag = "foo"
 
     def __asdf_traverse__(self):
-        return list({'the_meaning_of_life_the_universe_and_everything': 42,
-                'clown': 'Bozo'}.items())
+        return {'the_meaning_of_life_the_universe_and_everything': 42,
+                'clown': 'Bozo'}
 
 
 def test_info_object_support(capsys):

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -557,6 +557,27 @@ def test_info_asdf_file(capsys, tmpdir):
     assert "baz" in captured.out
 
 
+class ObjectWithInfoSupport:
+
+    def __init__(self):
+        self._tag = "foo"
+
+    def __asdf_traverse__(self):
+        return list({'the_meaning_of_life_the_universe_and_everything': 42,
+                'clown': 'Bozo'}.items())
+
+
+def test_info_object_support(capsys):
+    tree = dict(random=3.14159, object=ObjectWithInfoSupport())
+    af = asdf.AsdfFile(tree)
+    af.info()
+    captured = capsys.readouterr()
+    assert "the_meaning_of_life_the_universe_and_everything" in captured.out
+    assert "clown" in captured.out
+    assert "42" in captured.out
+    assert "Bozo" in captured.out
+
+
 def test_search():
     tree = dict(foo=42, bar="hello", baz=np.arange(20))
     af = asdf.AsdfFile(tree)

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -191,11 +191,9 @@ Making converted object's contents visible to `info` and `search`
 
 If the object produced by the extension supports a class method
 `.__asdf_traverse__` then it can be used by those tools to expose the contents
-of the object. That method should accept no arguments and return a list.
-For most objects the list should consiste of tuple pairs of attribute names 
-and their values (much like the `dict` `.item` method returns).
-If instead the object is itself list-like, the list should consist of tuples
-of index position and value pairs.
+of the object. That method should accept no arguments and return either a
+dict of attributes and their values, or a list if the object itself is
+list-like.
 
 .. _extending_extensions_installing:
 

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -184,6 +184,19 @@ an additional list of class names that previously identified the extension:
             "foo_package.extensions.FooExtension",
         ]
 
+.. _exposing_extension_object_internals:
+
+Making converted object's contents visible to `info` and `search`
+-----------------------------------------------------------------
+
+If the object produced by the extension supports a class method
+`.__asdf_traverse__` then it can be used by those tools to expose the contents
+of the object. That method should accept no arguments and return a list.
+For most objects the list should consiste of tuple pairs of attribute names 
+and their values (much like the `dict` `.item` method returns).
+If instead the object is itself list-like, the list should consist of tuples
+of index position and value pairs.
+
 .. _extending_extensions_installing:
 
 Installing an extension

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -532,6 +532,12 @@ For example, to show all top-level nodes and 5 of each's children:
 The `AsdfFile.info` method behaves similarly to `asdf.info`, rendering
 the tree of the associated `AsdfFile`.
 
+Normally `asdf.info` will not show the contents of asdf nodes turned
+into Python custom objects, but if that object supports a special 
+method, you may see the contents of such objects. 
+See :ref:`exposing_extension_object_internals` for how
+to implement such support for `asdf.info` and `asdf.search`. 
+
 Searching the ASDF tree
 =======================
 


### PR DESCRIPTION
This PR allows the asdf info functionality to check tag classes for a method __asdf_traverse__. If that method exists, then it is called whereupon it should return information that the info method expects. This allows any tag class to present information about its contents to the `info` method. 

The original purpose was to allow Roman data files to be displayed just like JWST files, which previously wasn't possible since the Roman asdf tree uses tag classes unlike the JWST tree. Roman_datamodels has been correspondingly updated to take advantage of this new capability.