### PR TITLE
Adjustments to compression tests and documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
 
 - Drop support for Python 3.6. [#1054]
 
+- Adjustments to compression plugin tests and documentation. [#1053]
+
 2.8.3 (2021-12-13)
 ------------------
 

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -6,6 +6,7 @@ from ..util import get_class_name
 from ._tag import TagDefinition
 from ._legacy import AsdfExtension
 from ._converter import ConverterProxy
+from ._compressor import Compressor
 
 
 class Extension(abc.ABC):
@@ -92,7 +93,7 @@ class Extension(abc.ABC):
 
         Returns
         -------
-        iterable of asdf.extension.Compressor instances
+        iterable of asdf.extension.Compressor
         """
         return []
 
@@ -178,7 +179,13 @@ class ExtensionProxy(Extension, AsdfExtension):
         # Process the converters last, since they expect ExtensionProxy
         # properties to already be available.
         self._converters = [ConverterProxy(c, self) for c in getattr(self._delegate, "converters", [])]
-        self._compressors = self._delegate.compressors if hasattr(self._delegate, "compressors") else []
+
+        self._compressors = []
+        if hasattr(self._delegate, "compressors"):
+            for compressor in self._delegate.compressors:
+                if not isinstance(compressor, Compressor):
+                    raise TypeError("Extension property 'compressors' must contain instances of asdf.extension.Compressor")
+                self._compressors.append(compressor)
 
     @property
     def extension_uri(self):

--- a/asdf/extension/_manifest.py
+++ b/asdf/extension/_manifest.py
@@ -16,6 +16,9 @@ class ManifestExtension(Extension):
     converters : iterable of asdf.extension.Converter, optional
         Converter instances for the tags and Python types
         supported by this extension.
+    compressors : iterable of asdf.extension.Compressor, optional
+        Compressor instances to support additional binary
+        block compression options.
     legacy_class_names : iterable of str, optional
         Fully-qualified class names used by older versions
         of this extension.

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -178,6 +178,7 @@ def test_extension_proxy():
     assert subclassed_proxy.legacy_class_names == proxy.legacy_class_names
     assert subclassed_proxy.asdf_standard_requirement == proxy.asdf_standard_requirement
     assert subclassed_proxy.converters == proxy.converters
+    assert subclassed_proxy.compressors == proxy.compressors
     assert subclassed_proxy.tags == proxy.tags
     assert subclassed_proxy.types == proxy.types
     assert subclassed_proxy.tag_mapping == proxy.tag_mapping
@@ -195,9 +196,12 @@ def test_extension_proxy():
             types=[]
         )
     ]
+    compressors = [
+        MinimalCompressor()
+    ]
     extension = FullExtension(
         converters=converters,
-        compressors=[MinimalCompressor],
+        compressors=compressors,
         asdf_standard_requirement=">=1.4.0",
         tags=["asdf://somewhere.org/extensions/full/tags/foo-1.0"],
         legacy_class_names=["foo.extensions.SomeOldExtensionClass"]
@@ -208,7 +212,7 @@ def test_extension_proxy():
     assert proxy.legacy_class_names == {"foo.extensions.SomeOldExtensionClass"}
     assert proxy.asdf_standard_requirement == SpecifierSet(">=1.4.0")
     assert proxy.converters == [ConverterProxy(c, proxy) for c in converters]
-    assert proxy.compressors == [MinimalCompressor]
+    assert proxy.compressors == compressors
     assert len(proxy.tags) == 1
     assert proxy.tags[0].tag_uri == "asdf://somewhere.org/extensions/full/tags/foo-1.0"
     assert proxy.types == []
@@ -620,18 +624,19 @@ tags:
                 pass
 
         converter = FooConverter()
+        compressor = MinimalCompressor()
 
         extension = ManifestExtension.from_uri(
             "asdf://somewhere.org/extensions/foo",
             legacy_class_names=["foo.extension.LegacyExtension"],
             converters=[converter],
-            compressors=[MinimalCompressor],
+            compressors=[compressor],
         )
         assert extension.extension_uri == "asdf://somewhere.org/extensions/foo"
         assert extension.legacy_class_names == ["foo.extension.LegacyExtension"]
         assert extension.asdf_standard_requirement == SpecifierSet(">=1.6.0,<2.0.0")
         assert extension.converters == [converter]
-        assert extension.compressors == [MinimalCompressor]
+        assert extension.compressors == [compressor]
         assert len(extension.tags) == 2
         assert extension.tags[0] == "asdf://somewhere.org/tags/bar"
         assert extension.tags[1].tag_uri == "asdf://somewhere.org/tags/baz"
@@ -644,7 +649,7 @@ tags:
         assert proxy.legacy_class_names == {"foo.extension.LegacyExtension"}
         assert proxy.asdf_standard_requirement == SpecifierSet(">=1.6.0,<2.0.0")
         assert proxy.converters == [ConverterProxy(converter, proxy)]
-        assert proxy.compressors == [MinimalCompressor]
+        assert proxy.compressors == [compressor]
         assert len(proxy.tags) == 2
         assert proxy.tags[0].tag_uri == "asdf://somewhere.org/tags/bar"
         assert proxy.tags[1].tag_uri == "asdf://somewhere.org/tags/baz"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist= py38,style
+envlist= py38,flake8
 
 [testenv]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist= py38,flake8
+envlist= py38,style
 
 [testenv]
 deps=


### PR DESCRIPTION
This pulls some compression plugin-related changes out of https://github.com/asdf-format/asdf/pull/1050 and into a separate PR.