### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,109 +20,104 @@ jobs:
         include:
           - name: Python 3.10 Testing
             os: ubuntu-latest
-            python-version: 3.10.0
+            python-version: "3.10"
             toxenv: py310
 
           - name: Code Coverage with Python 3.9
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
             toxenv: coverage
 
           - name: Python 3.8 Testing
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
             toxenv: py38
 
           - name: Python 3.7 Testing
             os: ubuntu-latest
-            python-version: 3.7.9
+            python-version: "3.7"
             toxenv: py37
 
-          - name: Python 3.6 Testing
+          - name: Python 3.7 with legacy packages
             os: ubuntu-latest
-            python-version: 3.6.10
-            toxenv: py36
-
-          - name: Python 3.6 with legacy packages
-            os: ubuntu-latest
-            python-version: 3.6.10
-            toxenv: py36-legacy
+            python-version: "3.7"
+            toxenv: py37-legacy
 
           - name: Documentation Build
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.9"
             toxenv: docbuild
 
           - name: Mac OS Latest
             os: macos-latest
-            python-version: 3.9
+            python-version: "3.9"
             toxenv: py39
 
           - name: Compatibility
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
             toxenv: compatibility
 
           - name: Bandit Security Checks
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
             toxenv: bandit
 
           - name: Code Style Checks
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.9"
             toxenv: style
 
           - name: Twine
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
             toxenv: twine
 
           - name: Checkdocs
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
             toxenv: checkdocs
 
           - name: Numpy 1.12
             os: ubuntu-latest
-            python-version: 3.6.10
-            toxenv: py36-numpy12
+            python-version: "3.7"
+            toxenv: py37-numpy12
 
           - name: Astropy Dev
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.9"
             toxenv: py38-astropydev
 
           - name: GWCS Dev
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.9"
             toxenv: py38-gwcsdev
 
           # Fail
           - name: Numpy Dev
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.9"
             toxenv: py38-numpydev
 
           # Fail
           - name: Pre-Release Dependencies
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.9"
             toxenv: prerelease
 
-          - name: Test Against Installed Packaged
+          - name: Test Against Installed Package
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.9"
             toxenv: packaged
 
           - name: Warnings Treated as Exceptions
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.9"
             toxenv: warnings
 
           - name: Windows
             os: windows-latest
-            python-version: 3.9
+            python-version: "3.9"
             toxenv: py39
     steps:
       - name: Install System Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,6 @@ jobs:
             python-version: "3.9"
             toxenv: checkdocs
 
-          - name: Numpy 1.12
-            os: ubuntu-latest
-            python-version: "3.7"
-            toxenv: py37-numpy12
-
           - name: Astropy Dev
             os: ubuntu-latest
             python-version: "3.9"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,13 @@
 ------------------
 
 - Added the capability for tag classes to provide an interface
-  to asdf info functionality to obtain information about the 
+  to asdf info functionality to obtain information about the
   class attributes rather than appear as an opaque class object.
   [#1052]
 
 - Fix tag listing when extension is not fully implemented. [#1034]
+
+- Drop support for Python 3.6. [#1054]
 
 2.8.3 (2021-12-13)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,14 +15,13 @@ project_urls =
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Development Status :: 5 - Production/Stable
 
 [options]
-python_requires= >=3.6
+python_requires= >=3.7
 setup_requires = setuptools_scm
 install_requires =
     importlib_resources>=3;python_version<"3.9"

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Development Status :: 5 - Production/Stable
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -35,11 +35,9 @@ commands=
 install_command= python -m pip install --no-cache-dir {opts} {packages}
 
 [testenv:prerelease]
-basepython= python3.8
 pip_pre= true
 
 [testenv:warnings]
-basepython= python3.8
 commands=
     pytest --remote-data -W error \
       -p no:unraisableexception \
@@ -48,7 +46,6 @@ commands=
       -W 'ignore:numpy.ndarray size changed:RuntimeWarning'
 
 [testenv:packaged]
-basepython= python3.8
 # The default tox working directory is in .tox in the source directory.  If we
 # execute pytest from there, it will discover tox.ini in the source directory
 # and load the asdf module from the unpackaged sourcee, which is not what we
@@ -72,7 +69,6 @@ commands=
     twine check {distdir}/*
 
 [testenv:docbuild]
-basepython= python3.8
 extras= docs
 commands=
     sphinx-build -W docs build/docs
@@ -85,7 +81,6 @@ commands=
     python setup.py checkdocs
 
 [testenv:style]
-basepython= python3.8
 deps=
     flake8
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -7,19 +7,16 @@ deps=
     astropydev: git+https://github.com/astropy/astropy
     gwcsdev: git+https://github.com/spacetelescope/gwcs
     numpydev: git+https://github.com/numpy/numpy
-    py36: importlib_resources
     # Newer versions of gwcs require astropy 4.x, which
     # isn't compatible with the older versions of numpy
     # that we test with.
-    numpy11,numpy12,legacy: gwcs==0.9.1
+    legacy: gwcs==0.9.1
     legacy: semantic_version==2.8
-    legacy: pyyaml==3.10
+    legacy: pyyaml==3.13
     legacy: jsonschema==3.0.2
-    legacy: numpy~=1.10.0
+    legacy: numpy~=1.14.6
     legacy: pytest~=4.6.11
-    numpy11,numpy12,legacy: astropy~=3.0.0
-    numpy11: numpy==1.11
-    numpy12: numpy==1.12
+    legacy: astropy~=3.0.0
     numpydev,s390x: cython
 extras= all,tests
 # astropy will complain if the home directory is missing


### PR DESCRIPTION
Our Python 3.6 CI job has started failing due to dependencies that require > Python 3.6, so it seems like a reasonable time to drop support for Python 3.6 in this package as well.