### PR TITLE
Add error message to setup.py.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@
 
 - Adjustments to compression plugin tests and documentation. [#1053]
 
+- Update setup.py to raise error if "git submodule update --init" has
+  not been run. [#1057]
+
 2.8.3 (2021-12-13)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,11 @@
 import os
 from setuptools import setup, find_packages
 
+if not os.listdir('./asdf-standard'):
+    from setuptools.errors import SetupError
+
+    raise SetupError("asdf-standard is empty. Need to run `git submodule update --init` and try again!")
+
 
 packages = find_packages()
 packages.append('asdf.schemas')

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 import os
+from pathlib import Path
 from setuptools import setup, find_packages
 
-if not os.listdir('./asdf-standard'):
+if not any((Path(__file__).parent / "asdf-standard").iterdir()):
     from setuptools.errors import SetupError
 
     raise SetupError("asdf-standard is empty. Need to run `git submodule update --init` and try again!")


### PR DESCRIPTION
If one runs `pip install .` without running `git submodule update --init`, then pip spits out an incomprehensible error due to `asdf-standard` being empty. This PR adds a check that for `asdf-standard` being empty, with an error raised which describes what to do.