### PR TITLE
Allow manifest tags to list multiple `schema_uri` values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@
 - Update setup.py to raise error if "git submodule update --init" has
   not been run. [#1057]
 
+- Add ability for tags to correspond to multiple schema_uri, with an
+  implied allOf among the schema_uris. [#1058]
+
 2.8.3 (2021-12-13)
 ------------------
 

--- a/asdf/extension/_manifest.py
+++ b/asdf/extension/_manifest.py
@@ -102,7 +102,7 @@ class ManifestExtension(Extension):
                 result.append(
                     TagDefinition(
                         tag["tag_uri"],
-                        schema_uri=tag.get("schema_uri"),
+                        schema_uris=tag.get("schema_uri"),
                         title=tag.get("title"),
                         description=tag.get("description"),
                     )

--- a/asdf/extension/_tag.py
+++ b/asdf/extension/_tag.py
@@ -14,12 +14,12 @@ class TagDefinition:
     description : str, optional
         Long description of the tag.
     """
-    def __init__(self, tag_uri, *, schema_uri=None, title=None, description=None):
+    def __init__(self, tag_uri, *, schema_uris=None, title=None, description=None):
         if "*" in tag_uri:
             raise ValueError("URI patterns are not permitted in TagDefinition")
 
         self._tag_uri = tag_uri
-        self._schema_uri = schema_uri
+        self._schema_uris = schema_uris
         self._title = title
         self._description = description
 
@@ -35,7 +35,7 @@ class TagDefinition:
         return self._tag_uri
 
     @property
-    def schema_uri(self):
+    def schema_uris(self):
         """
         Get the URI of the schema that should be used to validate
         objects wtih this tag.
@@ -44,7 +44,7 @@ class TagDefinition:
         -------
         str or None
         """
-        return self._schema_uri
+        return self._schema_uris
 
     @property
     def title(self):

--- a/asdf/extension/_tag.py
+++ b/asdf/extension/_tag.py
@@ -44,7 +44,11 @@ class TagDefinition:
         -------
         str or None
         """
-        return self._schema_uris
+
+        if isinstance(self._schema_uris, list):
+            return self._schema_uris
+        else:
+            return [self._schema_uris]
 
     @property
     def title(self):

--- a/asdf/extension/_tag.py
+++ b/asdf/extension/_tag.py
@@ -21,7 +21,7 @@ class TagDefinition:
         self._tag_uri = tag_uri
 
         if schema_uris is None:
-            self._schema_uris = None
+            self._schema_uris = []
         else:
             if isinstance(schema_uris, list):
                 self._schema_uris = schema_uris

--- a/asdf/extension/_tag.py
+++ b/asdf/extension/_tag.py
@@ -19,7 +19,15 @@ class TagDefinition:
             raise ValueError("URI patterns are not permitted in TagDefinition")
 
         self._tag_uri = tag_uri
-        self._schema_uris = schema_uris
+
+        if schema_uris is None:
+            self._schema_uris = None
+        else:
+            if isinstance(schema_uris, list):
+                self._schema_uris = schema_uris
+            else:
+                self._schema_uris = [schema_uris]
+
         self._title = title
         self._description = description
 
@@ -44,11 +52,7 @@ class TagDefinition:
         -------
         str or None
         """
-
-        if isinstance(self._schema_uris, list):
-            return self._schema_uris
-        else:
-            return [self._schema_uris]
+        return self._schema_uris
 
     @property
     def title(self):

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -308,7 +308,7 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
                     if tag is not None:
                         if self.serialization_context.extension_manager.handles_tag(tag):
                             tag_def = self.serialization_context.extension_manager.get_tag_definition(tag)
-                            schema_uri = tag_def.schema_uri
+                            schema_uri = tag_def.schema_uris
                         else:
                             schema_uri = self.ctx.tag_mapping(tag)
                             if schema_uri == tag:

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -312,21 +312,20 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
                         else:
                             schema_uris = [self.ctx.tag_mapping(tag)]
                             if schema_uris[0] == tag:
-                                schema_uris = None
+                                schema_uris = []
 
-                        if schema_uris is not None:
-                            # Must validate against all schema_uris
-                            for schema_uri in schema_uris:
-                                try:
-                                    s = _load_schema_cached(schema_uri, self.ctx.resolver, False, False)
-                                except FileNotFoundError:
-                                    msg = "Unable to locate schema file for '{}': '{}'"
-                                    warnings.warn(msg.format(tag, schema_uri), AsdfWarning)
-                                    s = {}
-                                if s:
-                                    with self.resolver.in_scope(schema_uri):
-                                        for x in super(ASDFValidator, self).iter_errors(instance, s):
-                                            yield x
+                        # Must validate against all schema_uris
+                        for schema_uri in schema_uris:
+                            try:
+                                s = _load_schema_cached(schema_uri, self.ctx.resolver, False, False)
+                            except FileNotFoundError:
+                                msg = "Unable to locate schema file for '{}': '{}'"
+                                warnings.warn(msg.format(tag, schema_uri), AsdfWarning)
+                                s = {}
+                            if s:
+                                with self.resolver.in_scope(schema_uri):
+                                    for x in super(ASDFValidator, self).iter_errors(instance, s):
+                                        yield x
 
 
                     if isinstance(instance, dict):

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -431,7 +431,7 @@ def test_tag_definition():
     )
 
     assert tag_def.tag_uri == "asdf://somewhere.org/extensions/foo/tags/foo-1.0"
-    assert tag_def.schema_uris == "asdf://somewhere.org/extensions/foo/schemas/foo-1.0"
+    assert tag_def.schema_uris == ["asdf://somewhere.org/extensions/foo/schemas/foo-1.0"]
     assert tag_def.title == "Some title"
     assert tag_def.description == "Some description"
 
@@ -640,7 +640,7 @@ tags:
         assert len(extension.tags) == 2
         assert extension.tags[0] == "asdf://somewhere.org/tags/bar"
         assert extension.tags[1].tag_uri == "asdf://somewhere.org/tags/baz"
-        assert extension.tags[1].schema_uris == "asdf://somewhere.org/schemas/baz"
+        assert extension.tags[1].schema_uris == ["asdf://somewhere.org/schemas/baz"]
         assert extension.tags[1].title == "Baz title"
         assert extension.tags[1].description == "Bar description"
 
@@ -653,7 +653,7 @@ tags:
         assert len(proxy.tags) == 2
         assert proxy.tags[0].tag_uri == "asdf://somewhere.org/tags/bar"
         assert proxy.tags[1].tag_uri == "asdf://somewhere.org/tags/baz"
-        assert proxy.tags[1].schema_uris == "asdf://somewhere.org/schemas/baz"
+        assert proxy.tags[1].schema_uris == ["asdf://somewhere.org/schemas/baz"]
         assert proxy.tags[1].title == "Baz title"
         assert proxy.tags[1].description == "Bar description"
 

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -260,7 +260,7 @@ def test_extension_proxy_tags():
     foo_tag_uri = "asdf://somewhere.org/extensions/full/tags/foo-1.0"
     foo_tag_def = TagDefinition(
         foo_tag_uri,
-        schema_uri="asdf://somewhere.org/extensions/full/schemas/foo-1.0",
+        schema_uris="asdf://somewhere.org/extensions/full/schemas/foo-1.0",
         title="Some tag title",
         description="Some tag description"
     )
@@ -268,7 +268,7 @@ def test_extension_proxy_tags():
     bar_tag_uri = "asdf://somewhere.org/extensions/full/tags/bar-1.0"
     bar_tag_def = TagDefinition(
         bar_tag_uri,
-        schema_uri="asdf://somewhere.org/extensions/full/schemas/bar-1.0",
+        schema_uris="asdf://somewhere.org/extensions/full/schemas/bar-1.0",
         title="Some other tag title",
         description="Some other tag description"
     )
@@ -425,13 +425,13 @@ def test_get_cached_extension_manager():
 def test_tag_definition():
     tag_def = TagDefinition(
         "asdf://somewhere.org/extensions/foo/tags/foo-1.0",
-        schema_uri="asdf://somewhere.org/extensions/foo/schemas/foo-1.0",
+        schema_uris="asdf://somewhere.org/extensions/foo/schemas/foo-1.0",
         title="Some title",
         description="Some description",
     )
 
     assert tag_def.tag_uri == "asdf://somewhere.org/extensions/foo/tags/foo-1.0"
-    assert tag_def.schema_uri == "asdf://somewhere.org/extensions/foo/schemas/foo-1.0"
+    assert tag_def.schema_uris == "asdf://somewhere.org/extensions/foo/schemas/foo-1.0"
     assert tag_def.title == "Some title"
     assert tag_def.description == "Some description"
 
@@ -514,13 +514,13 @@ def test_converter_proxy():
         tags=[
             TagDefinition(
                 "asdf://somewhere.org/extensions/test/tags/foo-1.0",
-                schema_uri="asdf://somewhere.org/extensions/test/schemas/foo-1.0",
+                schema_uris="asdf://somewhere.org/extensions/test/schemas/foo-1.0",
                 title="Foo tag title",
                 description="Foo tag description"
             ),
             TagDefinition(
                 "asdf://somewhere.org/extensions/test/tags/bar-1.0",
-                schema_uri="asdf://somewhere.org/extensions/test/schemas/bar-1.0",
+                schema_uris="asdf://somewhere.org/extensions/test/schemas/bar-1.0",
                 title="Bar tag title",
                 description="Bar tag description"
             ),
@@ -640,7 +640,7 @@ tags:
         assert len(extension.tags) == 2
         assert extension.tags[0] == "asdf://somewhere.org/tags/bar"
         assert extension.tags[1].tag_uri == "asdf://somewhere.org/tags/baz"
-        assert extension.tags[1].schema_uri == "asdf://somewhere.org/schemas/baz"
+        assert extension.tags[1].schema_uris == "asdf://somewhere.org/schemas/baz"
         assert extension.tags[1].title == "Baz title"
         assert extension.tags[1].description == "Bar description"
 
@@ -653,7 +653,7 @@ tags:
         assert len(proxy.tags) == 2
         assert proxy.tags[0].tag_uri == "asdf://somewhere.org/tags/bar"
         assert proxy.tags[1].tag_uri == "asdf://somewhere.org/tags/baz"
-        assert proxy.tags[1].schema_uri == "asdf://somewhere.org/schemas/baz"
+        assert proxy.tags[1].schema_uris == "asdf://somewhere.org/schemas/baz"
         assert proxy.tags[1].title == "Baz title"
         assert proxy.tags[1].description == "Bar description"
 

--- a/asdf/tests/test_integration.py
+++ b/asdf/tests/test_integration.py
@@ -46,7 +46,7 @@ class FooExtension:
     tags = [
         TagDefinition(
             "asdf://somewhere.org/extensions/foo/tags/foo-1.0",
-            schema_uri=FOO_SCHEMA_URI,
+            schema_uris=FOO_SCHEMA_URI,
         )
     ]
 

--- a/asdf/tests/test_integration.py
+++ b/asdf/tests/test_integration.py
@@ -97,7 +97,6 @@ class FooFooConverter:
     tags = ["asdf://somewhere.org/extensions/foo/tags/foo_foo-*"]
 
     def to_yaml_tree(self, obj, tag, ctx):
-        print("HERE")
         return {
             "value": obj.value,
             "value_value": obj.value_value

--- a/asdf/tests/test_integration.py
+++ b/asdf/tests/test_integration.py
@@ -8,14 +8,14 @@ from asdf.extension import TagDefinition
 
 
 FOO_SCHEMA_URI = "asdf://somewhere.org/extensions/foo/schemas/foo-1.0"
-FOO_SCHEMA = """
-id: {}
+FOO_SCHEMA = f"""
+id: {FOO_SCHEMA_URI}
 type: object
 properties:
   value:
     type: string
 required: ["value"]
-""".format(FOO_SCHEMA_URI)
+"""
 
 
 class Foo:
@@ -67,4 +67,77 @@ def test_serialize_custom_type(tmpdir):
 
         with pytest.raises(asdf.ValidationError):
             af["foo"] = Foo(12)
+            af.write_to(path)
+
+
+FOOFOO_SCHEMA_URI = "asdf://somewhere.org/extensions/foo/schemas/foo_foo-1.0"
+FOOFOO_SCHEMA = f"""
+id: {FOOFOO_SCHEMA_URI}
+type: object
+properties:
+  value_value:
+    type: string
+required: ["value_value"]
+"""
+
+
+class FooFoo(Foo):
+    def __init__(self, value, value_value):
+        super().__init__(value)
+
+        self._value_value = value_value
+
+    @property
+    def value_value(self):
+        return self._value_value
+
+
+class FooFooConverter:
+    types = [FooFoo]
+    tags = ["asdf://somewhere.org/extensions/foo/tags/foo_foo-*"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        print("HERE")
+        return {
+            "value": obj.value,
+            "value_value": obj.value_value
+        }
+
+    def from_yaml_tree(self, obj, tag, ctx):
+        return FooFoo(obj["value"], obj["value_value"])
+
+
+class FooFooExtension:
+    extension_uri = "asdf://somewhere.org/extensions/foo_foo-1.0"
+    converters = [FooFooConverter()]
+    tags = [
+        TagDefinition(
+            "asdf://somewhere.org/extensions/foo/tags/foo_foo-1.0",
+            schema_uris=[FOO_SCHEMA_URI, FOOFOO_SCHEMA_URI],
+        )
+    ]
+
+
+def test_serialize_with_multiple_schemas(tmpdir):
+    with asdf.config_context() as config:
+        config.add_resource_mapping({FOO_SCHEMA_URI: FOO_SCHEMA,
+                                     FOOFOO_SCHEMA_URI: FOOFOO_SCHEMA})
+        config.add_extension(FooFooExtension())
+
+        path = str(tmpdir/"test.asdf")
+
+        af = asdf.AsdfFile()
+        af["foo_foo"] = FooFoo("bar", "bar_bar")
+        af.write_to(path)
+
+        with asdf.open(path) as af2:
+            assert af2["foo_foo"].value == "bar"
+            assert af2["foo_foo"].value_value == "bar_bar"
+
+        with pytest.raises(asdf.ValidationError):
+            af["foo_foo"] = FooFoo(12, "bar_bar")
+            af.write_to(path)
+
+        with pytest.raises(asdf.ValidationError):
+            af["foo_foo"] = FooFoo("bar", 34)
             af.write_to(path)


### PR DESCRIPTION
Currently, manifest tags will only allow one `schema_uri` per tag. For example, this forces every transform schema in `asdf-transform-schemas`, to perform an `allOf` between the new properties added by that transform and one of the `transform-*` schemas. What this means is that if we want to create a new `transform-*` schema, we have to create a new schema for every other transform. This will allow us to only need to create an updated manifest along side the new `transform-*` schema, which will be less prone to human error.

Note that when validating against a `tag` with multiple `schema_uri`, one assumes an `allOf` condition between all of the schemas referenced (meaning it must be a valid for every schema listed under the tag).