### PR TITLE
Remove various ignore flags/arguments from ASDF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@
 
 - Remove all deprecations to be removed in 3.0 (see issue #588). [#1059]
 
+- Remove ignore_version_mismatch, ignore_unrecognized_tag, and ignore_implicit_conversion
+  from AsdfFile. [#1060]
+
 2.8.4 (unreleased)
 ------------------
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -22,7 +22,7 @@ from . import version
 from . import versioning
 from . import yamlutil
 from . import _display as display
-from .exceptions import AsdfWarning, AsdfConversionWarning
+from .exceptions import AsdfWarning
 from .extension import (
     AsdfExtensionList,
     AsdfExtension,

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -56,7 +56,7 @@ class AsdfFile:
     The main class that represents an ASDF file object.
     """
     def __init__(self, tree=None, uri=None, extensions=None, version=None,
-                 ignore_version_mismatch=True, ignore_unrecognized_tag=False,
+                 ignore_unrecognized_tag=False,
                  ignore_implicit_conversion=False, copy_arrays=False,
                  lazy_load=True, custom_schema=None, _readonly=False):
         """
@@ -81,10 +81,6 @@ class AsdfFile:
         version : str, optional
             The ASDF Standard version.  If not provided, defaults to the
             configured default version.  See `asdf.config.AsdfConfig.default_version`.
-
-        ignore_version_mismatch : bool, optional
-            When `True`, do not raise warnings for mismatched schema versions.
-            Set to `True` by default.
 
         ignore_unrecognized_tag : bool, optional
             When `True`, do not raise warnings for unrecognized tags. Set to
@@ -133,7 +129,6 @@ class AsdfFile:
         else:
             self._custom_schema = None
 
-        self._ignore_version_mismatch = ignore_version_mismatch
         self._ignore_unrecognized_tag = ignore_unrecognized_tag
         self._ignore_implicit_conversion = ignore_implicit_conversion
 
@@ -904,7 +899,6 @@ class AsdfFile:
                 return fits_embed.AsdfInFits._open_impl(generic_file, uri=uri,
                             validate_checksums=validate_checksums,
                             extensions=extensions,
-                            ignore_version_mismatch=self._ignore_version_mismatch,
                             strict_extension_check=strict_extension_check,
                             ignore_missing_extensions=ignore_missing_extensions,
                             ignore_unrecognized_tag=self._ignore_unrecognized_tag,
@@ -1476,20 +1470,6 @@ class AsdfFile:
         result = AsdfSearchResult(["root"], self.tree)
         return result.search(key=key, type=type, value=value, filter=filter)
 
-    # This function is called from within TypeIndex when deserializing
-    # the tree for this file.  It is kept here so that we can keep
-    # state on the AsdfFile and prevent a flood of warnings for the
-    # same tag.
-    def _warn_tag_mismatch(self, tag, best_tag):
-        if not self._ignore_version_mismatch and (tag, best_tag) not in self._warned_tag_pairs:
-            message = (
-                "No explicit ExtensionType support provided for tag '{}'. "
-                "The ExtensionType subclass for tag '{}' will be used instead. "
-                "This fallback behavior will be removed in asdf 3.0."
-            ).format(tag, best_tag)
-            warnings.warn(message, AsdfConversionWarning)
-            self._warned_tag_pairs.add((tag, best_tag))
-
     # This function is called from within yamlutil methods to create
     # a context when one isn't explicitly passed in.
     def _create_serialization_context(self):
@@ -1520,7 +1500,7 @@ def _check_and_set_mode(fileobj, asdf_mode):
 
 
 def open_asdf(fd, uri=None, mode=None, validate_checksums=False, extensions=None,
-              ignore_version_mismatch=True, ignore_unrecognized_tag=False,
+              ignore_unrecognized_tag=False,
               _force_raw_types=False, copy_arrays=False, lazy_load=True,
               custom_schema=None, strict_extension_check=False,
               ignore_missing_extensions=False, _compat=False,
@@ -1551,10 +1531,6 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False, extensions=None
         May be any of the following: `asdf.extension.AsdfExtension`,
         `asdf.extension.Extension`, `asdf.extension.AsdfExtensionList`
         or a `list` of extensions.
-
-    ignore_version_mismatch : bool, optional
-        When `True`, do not raise warnings for mismatched schema versions.
-        Set to `True` by default.
 
     ignore_unrecognized_tag : bool, optional
         When `True`, do not raise warnings for unrecognized tags. Set to
@@ -1607,7 +1583,6 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False, extensions=None
         readonly = (mode == 'r' and not copy_arrays)
 
     instance = AsdfFile(
-                   ignore_version_mismatch=ignore_version_mismatch,
                    ignore_unrecognized_tag=ignore_unrecognized_tag,
                    copy_arrays=copy_arrays, lazy_load=lazy_load,
                    custom_schema=custom_schema, _readonly=readonly)

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -56,8 +56,7 @@ class AsdfFile:
     The main class that represents an ASDF file object.
     """
     def __init__(self, tree=None, uri=None, extensions=None, version=None,
-                 ignore_implicit_conversion=False, copy_arrays=False,
-                 lazy_load=True, custom_schema=None, _readonly=False):
+                 copy_arrays=False, lazy_load=True, custom_schema=None, _readonly=False):
         """
         Parameters
         ----------
@@ -80,12 +79,6 @@ class AsdfFile:
         version : str, optional
             The ASDF Standard version.  If not provided, defaults to the
             configured default version.  See `asdf.config.AsdfConfig.default_version`.
-
-        ignore_implicit_conversion : bool
-            When `True`, do not raise warnings when types in the tree are
-            implicitly converted into a serializable object. The motivating
-            case for this is currently `namedtuple`, which cannot be serialized
-            as-is.
 
         copy_arrays : bool, optional
             When `False`, when reading files, attempt to memmap underlying data
@@ -123,8 +116,6 @@ class AsdfFile:
             self._custom_schema = schema._load_schema_cached(custom_schema, self.resolver, True)
         else:
             self._custom_schema = None
-
-        self._ignore_implicit_conversion = ignore_implicit_conversion
 
         # Set of (string, string) tuples representing tag version mismatches
         # that we've already warned about for this file.
@@ -1281,8 +1272,7 @@ class AsdfFile:
             if hook is not None:
                 return hook(node, self)
             return node
-        tree = treeutil.walk_and_modify(self.tree, walker,
-            ignore_implicit_conversion=self._ignore_implicit_conversion)
+        tree = treeutil.walk_and_modify(self.tree, walker)
 
         if validate:
             self._validate(tree)

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -56,7 +56,6 @@ class AsdfFile:
     The main class that represents an ASDF file object.
     """
     def __init__(self, tree=None, uri=None, extensions=None, version=None,
-                 ignore_unrecognized_tag=False,
                  ignore_implicit_conversion=False, copy_arrays=False,
                  lazy_load=True, custom_schema=None, _readonly=False):
         """
@@ -81,10 +80,6 @@ class AsdfFile:
         version : str, optional
             The ASDF Standard version.  If not provided, defaults to the
             configured default version.  See `asdf.config.AsdfConfig.default_version`.
-
-        ignore_unrecognized_tag : bool, optional
-            When `True`, do not raise warnings for unrecognized tags. Set to
-            `False` by default.
 
         ignore_implicit_conversion : bool
             When `True`, do not raise warnings when types in the tree are
@@ -129,7 +124,6 @@ class AsdfFile:
         else:
             self._custom_schema = None
 
-        self._ignore_unrecognized_tag = ignore_unrecognized_tag
         self._ignore_implicit_conversion = ignore_implicit_conversion
 
         # Set of (string, string) tuples representing tag version mismatches
@@ -901,7 +895,6 @@ class AsdfFile:
                             extensions=extensions,
                             strict_extension_check=strict_extension_check,
                             ignore_missing_extensions=ignore_missing_extensions,
-                            ignore_unrecognized_tag=self._ignore_unrecognized_tag,
                             **kwargs)
             except ValueError:
                 raise ValueError(
@@ -1500,7 +1493,6 @@ def _check_and_set_mode(fileobj, asdf_mode):
 
 
 def open_asdf(fd, uri=None, mode=None, validate_checksums=False, extensions=None,
-              ignore_unrecognized_tag=False,
               _force_raw_types=False, copy_arrays=False, lazy_load=True,
               custom_schema=None, strict_extension_check=False,
               ignore_missing_extensions=False, _compat=False,
@@ -1531,10 +1523,6 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False, extensions=None
         May be any of the following: `asdf.extension.AsdfExtension`,
         `asdf.extension.Extension`, `asdf.extension.AsdfExtensionList`
         or a `list` of extensions.
-
-    ignore_unrecognized_tag : bool, optional
-        When `True`, do not raise warnings for unrecognized tags. Set to
-        `False` by default.
 
     copy_arrays : bool, optional
         When `False`, when reading files, attempt to memmap underlying data
@@ -1583,7 +1571,6 @@ def open_asdf(fd, uri=None, mode=None, validate_checksums=False, extensions=None
         readonly = (mode == 'r' and not copy_arrays)
 
     instance = AsdfFile(
-                   ignore_unrecognized_tag=ignore_unrecognized_tag,
                    copy_arrays=copy_arrays, lazy_load=lazy_load,
                    custom_schema=custom_schema, _readonly=readonly)
 

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -168,7 +168,6 @@ class AsdfInFits(asdf.AsdfFile):
 
     @classmethod
     def open(cls, fd, uri=None, validate_checksums=False, extensions=None,
-             ignore_unrecognized_tag=False,
              strict_extension_check=False, ignore_missing_extensions=False,
              **kwargs):
         """Creates a new AsdfInFits object based on given input data
@@ -210,14 +209,12 @@ class AsdfInFits(asdf.AsdfFile):
         return cls._open_impl(fd, uri=uri,
                        validate_checksums=validate_checksums,
                        extensions=extensions,
-                       ignore_unrecognized_tag=ignore_unrecognized_tag,
                        strict_extension_check=strict_extension_check,
                        ignore_missing_extensions=ignore_missing_extensions,
                        **kwargs)
 
     @classmethod
     def _open_impl(cls, fd, uri=None, validate_checksums=False, extensions=None,
-             ignore_unrecognized_tag=False,
              strict_extension_check=False,
              ignore_missing_extensions=False, **kwargs):
 
@@ -235,8 +232,7 @@ class AsdfInFits(asdf.AsdfFile):
                 msg = "Failed to parse given file '{}'. Is it FITS?"
                 raise ValueError(msg.format(uri))
 
-        self = cls(hdulist, uri=uri,
-                   ignore_unrecognized_tag=ignore_unrecognized_tag)
+        self = cls(hdulist, uri=uri)
 
         self._close_hdulist = close_hdulist
 

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -168,7 +168,7 @@ class AsdfInFits(asdf.AsdfFile):
 
     @classmethod
     def open(cls, fd, uri=None, validate_checksums=False, extensions=None,
-             ignore_version_mismatch=True, ignore_unrecognized_tag=False,
+             ignore_unrecognized_tag=False,
              strict_extension_check=False, ignore_missing_extensions=False,
              **kwargs):
         """Creates a new AsdfInFits object based on given input data
@@ -195,9 +195,6 @@ class AsdfInFits(asdf.AsdfFile):
             `asdf.extension.Extension`, `asdf.extension.AsdfExtensionList`
             or a `list` extensions.
 
-        ignore_version_mismatch : bool, optional
-            When `True`, do not raise warnings for mismatched schema versions.
-
         strict_extension_check : bool, optional
             When `True`, if the given ASDF file contains metadata about the
             extensions used to create it, and if those extensions are not
@@ -213,7 +210,6 @@ class AsdfInFits(asdf.AsdfFile):
         return cls._open_impl(fd, uri=uri,
                        validate_checksums=validate_checksums,
                        extensions=extensions,
-                       ignore_version_mismatch=ignore_version_mismatch,
                        ignore_unrecognized_tag=ignore_unrecognized_tag,
                        strict_extension_check=strict_extension_check,
                        ignore_missing_extensions=ignore_missing_extensions,
@@ -221,7 +217,7 @@ class AsdfInFits(asdf.AsdfFile):
 
     @classmethod
     def _open_impl(cls, fd, uri=None, validate_checksums=False, extensions=None,
-             ignore_version_mismatch=True, ignore_unrecognized_tag=False,
+             ignore_unrecognized_tag=False,
              strict_extension_check=False,
              ignore_missing_extensions=False, **kwargs):
 
@@ -240,7 +236,6 @@ class AsdfInFits(asdf.AsdfFile):
                 raise ValueError(msg.format(uri))
 
         self = cls(hdulist, uri=uri,
-                   ignore_version_mismatch=ignore_version_mismatch,
                    ignore_unrecognized_tag=ignore_unrecognized_tag)
 
         self._close_hdulist = close_hdulist

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -135,8 +135,7 @@ def find_references(tree, ctx):
             return Reference(tree['$ref'], json_id, asdffile=ctx)
         return tree
 
-    return treeutil.walk_and_modify(
-        tree, do_find, ignore_implicit_conversion=ctx._ignore_implicit_conversion)
+    return treeutil.walk_and_modify(tree, do_find)
 
 
 def resolve_references(tree, ctx, **kwargs):
@@ -151,8 +150,7 @@ def resolve_references(tree, ctx, **kwargs):
 
     tree = find_references(tree, ctx)
 
-    return treeutil.walk_and_modify(
-        tree, do_resolve, ignore_implicit_conversion=ctx._ignore_implicit_conversion)
+    return treeutil.walk_and_modify(tree, do_resolve)
 
 
 def make_reference(asdffile, path):

--- a/asdf/tests/test_history.py
+++ b/asdf/tests/test_history.py
@@ -209,7 +209,7 @@ def test_metadata_with_custom_extension(tmp_path):
             assert len(af["history"]["extensions"]) == 2
 
     with pytest.warns(AsdfWarning, match="was created with extension"):
-        with asdf.open(file_path, ignore_unrecognized_tag=True):
+        with asdf.open(file_path):
             pass
 
     # If we use the extension but we don't serialize any types that require it,

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -357,6 +357,7 @@ def test_property_order():
             last_index = index
 
 
+@pytest.mark.filterwarnings(r'ignore:.*is not recognized, converting to raw Python data structure.')
 def test_invalid_nested():
     class CustomType(str, types.CustomType):
         name = 'custom'

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -377,9 +377,8 @@ custom: !<tag:nowhere.org:custom/custom-1.0.0>
     # This should cause a warning but not an error because without explicitly
     # providing an extension, our custom type will not be recognized and will
     # simply be converted to a raw type.
-    with pytest.warns(AsdfConversionWarning, match="tag:nowhere.org:custom/custom-1.0.0"):
-        with asdf.open(buff):
-            pass
+    with asdf.open(buff):
+        pass
 
     buff.seek(0)
     with pytest.raises(ValidationError):

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -197,8 +197,7 @@ flow_thing:
 """
     buff = helpers.yaml_to_asdf(yaml)
     with helpers.assert_no_warnings():
-        asdf.open(buff, ignore_version_mismatch=False,
-            extensions=CustomFlowExtension())
+        asdf.open(buff, extensions=CustomFlowExtension())
 
 
 def test_longest_match():

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -264,7 +264,7 @@ undefined_data:
         - !core/complex-1.0.0 3.14j
 """
     buff = helpers.yaml_to_asdf(yaml)
-    with pytest.warns(None) as warning:
+    with pytest.warns(None):
         afile = asdf.open(buff)
         missing = afile.tree['undefined_data']
 
@@ -274,17 +274,10 @@ undefined_data:
     assert (missing[3][0] == array([[7],[8],[9],[10]])).all()
     assert missing[3][1] == 3.14j
 
-    # There are two undefined tags, so we expect two warnings
-    assert len(warning) == 2
-    for i, tag in enumerate(["also_undefined-1.3.0", "undefined_tag-1.0.0"]):
-        assert str(warning[i].message) == (
-            "tag:nowhere.org:custom/{} is not recognized, converting to raw "
-            "Python data structure".format(tag))
-
     # Make sure no warning occurs if explicitly ignored
     buff.seek(0)
     with helpers.assert_no_warnings():
-        afile = asdf.open(buff, ignore_unrecognized_tag=True)
+        afile = asdf.open(buff)
 
 
 def test_newer_tag():

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -264,7 +264,7 @@ undefined_data:
         - !core/complex-1.0.0 3.14j
 """
     buff = helpers.yaml_to_asdf(yaml)
-    with pytest.warns(None):
+    with pytest.warns(None) as warning:
         afile = asdf.open(buff)
         missing = afile.tree['undefined_data']
 
@@ -274,10 +274,12 @@ undefined_data:
     assert (missing[3][0] == array([[7],[8],[9],[10]])).all()
     assert missing[3][1] == 3.14j
 
-    # Make sure no warning occurs if explicitly ignored
-    buff.seek(0)
-    with helpers.assert_no_warnings():
-        afile = asdf.open(buff)
+    # There are two undefined tags, so we expect two warnings
+    assert len(warning) == 2
+    for i, tag in enumerate(["also_undefined-1.3.0", "undefined_tag-1.0.0"]):
+        assert str(warning[i].message) == (
+            "tag:nowhere.org:custom/{} is not recognized, converting to raw "
+            "Python data structure.".format(tag))
 
 
 def test_newer_tag():

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -13,7 +13,6 @@ from asdf import tagged
 from asdf import treeutil
 from asdf import yamlutil
 from asdf.compat.numpycompat import NUMPY_LT_1_14
-from asdf.exceptions import AsdfWarning
 
 from . import helpers
 

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -13,6 +13,7 @@ from asdf import tagged
 from asdf import treeutil
 from asdf import yamlutil
 from asdf.compat.numpycompat import NUMPY_LT_1_14
+from asdf.exceptions import AsdfWarning
 
 from . import helpers
 
@@ -115,6 +116,7 @@ def test_python_tuple(tmpdir):
     run_tuple_test(tree, tmpdir)
 
 
+@pytest.mark.filterwarnings('ignore:Failed to serialize instance of')
 def test_named_tuple_collections(tmpdir):
     # Ensure that we are able to serialize a collections.namedtuple.
 
@@ -126,6 +128,7 @@ def test_named_tuple_collections(tmpdir):
 
     run_tuple_test(tree, tmpdir)
 
+@pytest.mark.filterwarnings('ignore:Failed to serialize instance of')
 def test_named_tuple_typing(tmpdir):
     # Ensure that we are able to serialize a typing.NamedTuple.
 
@@ -138,6 +141,7 @@ def test_named_tuple_typing(tmpdir):
     run_tuple_test(tree, tmpdir)
 
 
+@pytest.mark.filterwarnings('ignore:Failed to serialize instance of')
 def test_named_tuple_collections_recursive(tmpdir):
     nt = namedtuple("TestNamedTuple3", ("one", "two", "three"))
 
@@ -153,6 +157,7 @@ def test_named_tuple_collections_recursive(tmpdir):
                                   init_options=init_options)
 
 
+@pytest.mark.filterwarnings('ignore:Failed to serialize instance of')
 def test_named_tuple_typing_recursive(tmpdir):
     nt = NamedTuple("TestNamedTuple4",
                     (("one", int), ("two", int), ("three", np.ndarray)))
@@ -176,10 +181,9 @@ def test_implicit_conversion_warning():
         "val": nt(1, 2, np.ones(3))
     }
 
-    with helpers.assert_no_warnings():
+    with pytest.warns(AsdfWarning, match="Failed to serialize instance"):
         with asdf.AsdfFile(tree):
             pass
-
 
 @pytest.mark.xfail(reason='pyyaml has a bug and does not support tuple keys')
 def test_python_tuple_key(tmpdir):

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -97,7 +97,7 @@ def run_tuple_test(tree, tmpdir):
         assert b'tuple' not in content
 
     # Ignore these warnings for the tests that don't actually test the warning
-    init_options = dict(ignore_implicit_conversion=True)
+    init_options = dict()
 
     helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf,
                                   raw_yaml_check_func=check_raw_yaml,
@@ -149,7 +149,7 @@ def test_named_tuple_collections_recursive(tmpdir):
     def check_asdf(asdf):
         assert (asdf.tree['val'][2] == np.ones(3)).all()
 
-    init_options = dict(ignore_implicit_conversion=True)
+    init_options = dict()
     helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf,
                                   init_options=init_options)
 
@@ -165,7 +165,7 @@ def test_named_tuple_typing_recursive(tmpdir):
     def check_asdf(asdf):
         assert (asdf.tree['val'][2] == np.ones(3)).all()
 
-    init_options = dict(ignore_implicit_conversion=True)
+    init_options = dict()
     helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf,
                                   init_options=init_options)
 
@@ -177,12 +177,8 @@ def test_implicit_conversion_warning():
         "val": nt(1, 2, np.ones(3))
     }
 
-    with pytest.warns(AsdfWarning, match="Failed to serialize instance"):
-        with asdf.AsdfFile(tree):
-            pass
-
     with helpers.assert_no_warnings():
-        with asdf.AsdfFile(tree, ignore_implicit_conversion=True):
+        with asdf.AsdfFile(tree):
             pass
 
 

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -3,9 +3,11 @@ Utility functions for managing tree-like data structures.
 """
 
 import types
+import warnings
 from contextlib import contextmanager
 
 from . import tagged
+from .exceptions import AsdfWarning
 
 __all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container", "PendingValue"]
 
@@ -348,6 +350,9 @@ def walk_and_modify(top, callback, postorder=True, _context=None):
             # The derived class signature is different, so simply store the
             # list representing the contents. Currently this is primarly
             # intended to handle namedtuple and NamedTuple instances.
+            msg = f"Failed to serialize instance of {type(node)}, converting to list instead"
+            warnings.warn(msg, AsdfWarning)
+
             result = contents
 
         return result

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -2,12 +2,10 @@
 Utility functions for managing tree-like data structures.
 """
 
-import warnings
 import types
 from contextlib import contextmanager
 
 from . import tagged
-from .exceptions import AsdfWarning
 
 __all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container", "PendingValue"]
 

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -217,7 +217,7 @@ class _RemoveNode:
 RemoveNode = _RemoveNode()
 
 
-def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=True, _context=None):
+def walk_and_modify(top, callback, postorder=True, _context=None):
     """Modify a tree by walking it with a callback function.  It also has
     the effect of doing a deep copy.
 
@@ -248,13 +248,6 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
         the tree.  If `True`, the callable will be invoked on children
         before their parents.  If `False`, the callable is invoked on the
         parents first.  Defaults to `True`.
-
-    ignore_implicit_conversion : bool
-        Controls whether warnings should be issued when implicitly converting a
-        given type instance in the tree into a serializable object. The primary
-        case for this is currently `namedtuple`.
-
-        Defaults to `False`.
 
     Returns
     -------
@@ -357,9 +350,6 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
             # The derived class signature is different, so simply store the
             # list representing the contents. Currently this is primarly
             # intended to handle namedtuple and NamedTuple instances.
-            if not ignore_implicit_conversion:
-                msg = "Failed to serialize instance of {}, converting to list instead"
-                warnings.warn(msg.format(type(node)), AsdfWarning)
             result = contents
 
         return result

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -269,7 +269,6 @@ class AsdfTypeIndex:
 
         if tag in self._best_matches:
             best_tag = self._best_matches[tag]
-            ctx._warn_tag_mismatch(tag, best_tag)
             return best_tag
 
         name, version = split_tag_version(tag)
@@ -284,7 +283,6 @@ class AsdfTypeIndex:
         i = max(0, i - 1)
         best_version = versions[i]
         best_tag = join_tag_version(name, best_version)
-        ctx._warn_tag_mismatch(tag, best_tag)
         self._best_matches[tag] = best_tag
         return best_tag
 

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -310,9 +310,6 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False, _serialization_
         tag_type = ctx.type_index.from_yaml_tag(ctx, tag, _serialization_context=_serialization_context)
         # This means the tag did not correspond to any type in our type index.
         if tag_type is None:
-            if not ctx._ignore_unrecognized_tag:
-                warnings.warn("{} is not recognized, converting to raw Python "
-                    "data structure".format(tag), AsdfConversionWarning)
             return node
 
         tag_name, tag_version = split_tag_version(tag)

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -309,6 +309,9 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False, _serialization_
         tag_type = ctx.type_index.from_yaml_tag(ctx, tag, _serialization_context=_serialization_context)
         # This means the tag did not correspond to any type in our type index.
         if tag_type is None:
+            msg = f"{tag} is not recognized, converting to raw Python data structure."
+            warnings.warn(msg, AsdfConversionWarning)
+
             return node
 
         tag_name, tag_version = split_tag_version(tag)

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -275,7 +275,6 @@ def custom_tree_to_tagged_tree(tree, ctx, _serialization_context=None):
     return treeutil.walk_and_modify(
         tree,
         _walker,
-        ignore_implicit_conversion=ctx._ignore_implicit_conversion,
         # Walk the tree in preorder, so that extensions can return
         # container nodes with unserialized children.
         postorder=False,
@@ -340,7 +339,6 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False, _serialization_
     return treeutil.walk_and_modify(
         tree,
         _walker,
-        ignore_implicit_conversion=ctx._ignore_implicit_conversion,
         # Walk the tree in postorder, so that extensions receive
         # container nodes with children already deserialized.
         postorder=True,

--- a/docs/asdf/extending/legacy.rst
+++ b/docs/asdf/extending/legacy.rst
@@ -144,8 +144,6 @@ using them:
     with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
         ff.write_to("test.asdf")
 
-.. asdf:: test.asdf ignore_unrecognized_tag
-
 Defining custom types
 ---------------------
 
@@ -254,8 +252,6 @@ In this case, the associated schema would look like the following::
     ...
 
 We can compare the output using this representation to the example above:
-
-.. asdf:: test.asdf ignore_unrecognized_tag
 
 
 Serializing more complex types
@@ -366,8 +362,6 @@ Now we can use this extension to create an ASDF file:
 
     with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
         ff.write_to("coord.asdf")
-
-.. asdf:: coord.asdf ignore_unrecognized_tag
 
 Note that in the resulting ASDF file, the ``x`` and ``y`` components of
 our new `fraction_2d_coord` type are tagged as `fraction-1.0.0`.

--- a/docs/asdf/using_extensions.rst
+++ b/docs/asdf/using_extensions.rst
@@ -79,11 +79,6 @@ simply appear in the tree as a nested combination of basic data types. The
 structure of this data will mirror the structure of the YAML objects in the
 ASDF file.
 
-In this case, a warning will occur by default to indicate to the user that the
-custom type in the file was not recognized and can not be deserialized. To
-suppress these warnings, users should pass ``ignore_unrecognized_tag=True`` to
-`asdf.open`.
-
 Even if an extension for the custom type is present, it does not guarantee that
 the type can be deserialized successfully. Instantiating the custom type may
 involve additional software dependencies, which, if not present, will cause an

--- a/docs/sphinxext/example.py
+++ b/docs/sphinxext/example.py
@@ -83,8 +83,6 @@ class AsdfDirective(Directive):
 
             kwargs = dict()
             # Use the ignore_unrecognized_tag parameter as a proxy for both options
-            kwargs['ignore_unrecognized_tag'] = 'ignore_unrecognized_tag' in self.arguments
-            kwargs['ignore_missing_extensions'] = 'ignore_unrecognized_tag' in self.arguments
 
             with asdf.open(filename, **kwargs) as ff:
                 for i, block in enumerate(ff.blocks.internal_blocks):

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -44,12 +44,6 @@ def pytest_addoption(parser):
         type="bool",
         default=False,
     )
-    parser.addini(
-        "asdf_schema_ignore_version_mismatch",
-        "Set to true to disable warnings when missing explicit support for a tag",
-        type="bool",
-        default=True
-    )
     parser.addoption('--asdf-tests', action='store_true',
         help='Enable ASDF schema tests')
 
@@ -57,7 +51,7 @@ def pytest_addoption(parser):
 class AsdfSchemaFile(pytest.File):
     @classmethod
     def from_parent(cls, parent, *, fspath, skip_examples=False, validate_default=True,
-        ignore_unrecognized_tag=False, ignore_version_mismatch=False, skip_tests=[], xfail_tests=[], **kwargs):
+        ignore_unrecognized_tag=False, skip_tests=[], xfail_tests=[], **kwargs):
         if hasattr(super(), "from_parent"):
             result = super().from_parent(parent, fspath=fspath, **kwargs)
         else:
@@ -66,7 +60,6 @@ class AsdfSchemaFile(pytest.File):
         result.skip_examples = skip_examples
         result.validate_default = validate_default
         result.ignore_unrecognized_tag = ignore_unrecognized_tag
-        result.ignore_version_mismatch = ignore_version_mismatch
         result.skip_tests = skip_tests
         result.xfail_tests = xfail_tests
 
@@ -92,7 +85,6 @@ class AsdfSchemaFile(pytest.File):
                     example,
                     index,
                     ignore_unrecognized_tag=self.ignore_unrecognized_tag,
-                    ignore_version_mismatch=self.ignore_version_mismatch,
                     name=name,
                 )
                 self._set_markers(item)
@@ -178,7 +170,7 @@ def parse_schema_filename(filename):
 class AsdfSchemaExampleItem(pytest.Item):
     @classmethod
     def from_parent(cls, parent, schema_path, example, example_index,
-        ignore_unrecognized_tag=False, ignore_version_mismatch=False, **kwargs):
+        ignore_unrecognized_tag=False, **kwargs):
         if hasattr(super(), "from_parent"):
             result = super().from_parent(parent, **kwargs)
         else:
@@ -188,7 +180,6 @@ class AsdfSchemaExampleItem(pytest.Item):
         result.filename = str(schema_path)
         result.example = example
         result.ignore_unrecognized_tag = ignore_unrecognized_tag
-        result.ignore_version_mismatch = ignore_version_mismatch
         return result
 
     def _find_standard_version(self, name, version):
@@ -218,7 +209,6 @@ class AsdfSchemaExampleItem(pytest.Item):
         ff = AsdfFile(
             uri=util.filepath_to_url(os.path.abspath(self.filename)),
             ignore_unrecognized_tag=self.ignore_unrecognized_tag,
-            ignore_version_mismatch=self.ignore_version_mismatch,
         )
 
         # Fake an external file
@@ -292,7 +282,6 @@ def pytest_collect_file(path, parent):
     skip_examples = parent.config.getini('asdf_schema_skip_examples')
     validate_default = parent.config.getini('asdf_schema_validate_default')
     ignore_unrecognized_tag = parent.config.getini('asdf_schema_ignore_unrecognized_tag')
-    ignore_version_mismatch = parent.config.getini('asdf_schema_ignore_version_mismatch')
 
     skip_tests = _parse_test_list(parent.config.getini('asdf_schema_skip_tests'))
     xfail_tests = _parse_test_list(parent.config.getini('asdf_schema_xfail_tests'))
@@ -321,7 +310,6 @@ def pytest_collect_file(path, parent):
                 skip_examples=(path.purebasename in skip_examples),
                 validate_default=validate_default,
                 ignore_unrecognized_tag=ignore_unrecognized_tag,
-                ignore_version_mismatch=ignore_version_mismatch,
                 skip_tests=schema_skip_tests,
                 xfail_tests=schema_xfail_tests,
             )

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -38,12 +38,6 @@ def pytest_addoption(parser):
         type="bool",
         default=True,
     )
-    parser.addini(
-        "asdf_schema_ignore_unrecognized_tag",
-        "Set to true to disable warnings when tag serializers are missing",
-        type="bool",
-        default=False,
-    )
     parser.addoption('--asdf-tests', action='store_true',
         help='Enable ASDF schema tests')
 
@@ -51,7 +45,7 @@ def pytest_addoption(parser):
 class AsdfSchemaFile(pytest.File):
     @classmethod
     def from_parent(cls, parent, *, fspath, skip_examples=False, validate_default=True,
-        ignore_unrecognized_tag=False, skip_tests=[], xfail_tests=[], **kwargs):
+        skip_tests=[], xfail_tests=[], **kwargs):
         if hasattr(super(), "from_parent"):
             result = super().from_parent(parent, fspath=fspath, **kwargs)
         else:
@@ -59,7 +53,6 @@ class AsdfSchemaFile(pytest.File):
 
         result.skip_examples = skip_examples
         result.validate_default = validate_default
-        result.ignore_unrecognized_tag = ignore_unrecognized_tag
         result.skip_tests = skip_tests
         result.xfail_tests = xfail_tests
 
@@ -84,7 +77,6 @@ class AsdfSchemaFile(pytest.File):
                     self.fspath,
                     example,
                     index,
-                    ignore_unrecognized_tag=self.ignore_unrecognized_tag,
                     name=name,
                 )
                 self._set_markers(item)
@@ -169,8 +161,7 @@ def parse_schema_filename(filename):
 
 class AsdfSchemaExampleItem(pytest.Item):
     @classmethod
-    def from_parent(cls, parent, schema_path, example, example_index,
-        ignore_unrecognized_tag=False, **kwargs):
+    def from_parent(cls, parent, schema_path, example, example_index, **kwargs):
         if hasattr(super(), "from_parent"):
             result = super().from_parent(parent, **kwargs)
         else:
@@ -179,7 +170,6 @@ class AsdfSchemaExampleItem(pytest.Item):
 
         result.filename = str(schema_path)
         result.example = example
-        result.ignore_unrecognized_tag = ignore_unrecognized_tag
         return result
 
     def _find_standard_version(self, name, version):
@@ -208,7 +198,6 @@ class AsdfSchemaExampleItem(pytest.Item):
 
         ff = AsdfFile(
             uri=util.filepath_to_url(os.path.abspath(self.filename)),
-            ignore_unrecognized_tag=self.ignore_unrecognized_tag,
         )
 
         # Fake an external file
@@ -281,7 +270,6 @@ def pytest_collect_file(path, parent):
     skip_names = parent.config.getini('asdf_schema_skip_names')
     skip_examples = parent.config.getini('asdf_schema_skip_examples')
     validate_default = parent.config.getini('asdf_schema_validate_default')
-    ignore_unrecognized_tag = parent.config.getini('asdf_schema_ignore_unrecognized_tag')
 
     skip_tests = _parse_test_list(parent.config.getini('asdf_schema_skip_tests'))
     xfail_tests = _parse_test_list(parent.config.getini('asdf_schema_xfail_tests'))
@@ -309,7 +297,6 @@ def pytest_collect_file(path, parent):
                 fspath=path,
                 skip_examples=(path.purebasename in skip_examples),
                 validate_default=validate_default,
-                ignore_unrecognized_tag=ignore_unrecognized_tag,
                 skip_tests=schema_skip_tests,
                 xfail_tests=schema_xfail_tests,
             )

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -184,6 +184,7 @@ class AsdfSchemaExampleItem(pytest.Item):
     def runtest(self):
         from asdf import AsdfFile, block, util
         from asdf.tests import helpers
+        from asdf.exceptions import AsdfConversionWarning
 
         name, version = parse_schema_filename(self.filename)
         if should_skip(name, version):
@@ -220,7 +221,12 @@ class AsdfSchemaExampleItem(pytest.Item):
             with pytest.warns(None) as w:
                 ff._open_impl(ff, buff, mode='rw')
             # Do not tolerate any warnings that occur during schema validation
-            assert len(w) == 0, helpers.display_warnings(w)
+            if len(w) > 0:
+                for warning in w:
+                    assert warning.category == AsdfConversionWarning
+                    assert "is not recognized, converting to raw Python data structure." in str(warning.message)
+            else:
+                assert len(w) == 0, helpers.display_warnings(w)
         except Exception:
             print("From file:", self.filename)
             raise

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,7 +106,6 @@ asdf_schema_xfail_tests =
     stsci.edu/asdf/core/ndarray-1.0.0.yaml::test_example_2
 # Enable the schema tests by default
 asdf_schema_tests_enabled = true
-asdf_schema_ignore_unrecognized_tag = true
 addopts = --doctest-rst
 
 [flake8]


### PR DESCRIPTION
Removes the following flags/arguments:

- `ignore_version_mismatch`
- `ignore_unrecognized_tag`
- `ignore_inplicit_conversion`
for `AsdfFile`.

This is part of the process to make asdf-3.0 more strict.