### PR TITLE
Restore TagDefinition.schema_uri property but add deprecation warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@
   not been run. [#1057]
 
 - Add ability for tags to correspond to multiple schema_uri, with an
-  implied allOf among the schema_uris. [#1058]
+  implied allOf among the schema_uris. [#1058, #1069]
 
 - Add the URI of the file being parsed to ``SerializationContext``. [#1065]
 

--- a/asdf/extension/_tag.py
+++ b/asdf/extension/_tag.py
@@ -1,3 +1,8 @@
+import warnings
+
+from asdf.exceptions import AsdfDeprecationWarning
+
+
 class TagDefinition:
     """
     Container for properties of a custom YAML tag.
@@ -43,14 +48,38 @@ class TagDefinition:
         return self._tag_uri
 
     @property
-    def schema_uris(self):
+    def schema_uri(self):
         """
+        DEPRECATED
+
         Get the URI of the schema that should be used to validate
-        objects wtih this tag.
+        objects with this tag.
 
         Returns
         -------
         str or None
+        """
+        warnings.warn(
+            "The TagDefinition.schema_uri property is deprecated.  Use TagDefinition.schema_uris instead.",
+            AsdfDeprecationWarning
+        )
+
+        if len(self._schema_uris) == 0:
+            return None
+        elif len(self._schema_uris) == 1:
+            return self._schema_uris[0]
+        else:
+            raise RuntimeError("Cannot use TagDefinition.schema_uri when multiple schema URIs are present")
+
+    @property
+    def schema_uris(self):
+        """
+        Get the URIs of the schemas that should be used to validate
+        objects with this tag.
+
+        Returns
+        -------
+        list
         """
         return self._schema_uris
 

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -17,6 +17,7 @@ from asdf.extension import (
 )
 
 from asdf import config_context
+from asdf.exceptions import AsdfDeprecationWarning
 from asdf.types import CustomType
 
 from asdf.tests.helpers import assert_extension_correctness
@@ -436,6 +437,21 @@ def test_tag_definition():
     assert tag_def.description == "Some description"
 
     assert "URI: asdf://somewhere.org/extensions/foo/tags/foo-1.0" in repr(tag_def)
+
+    with pytest.warns(AsdfDeprecationWarning):
+        assert tag_def.schema_uri == "asdf://somewhere.org/extensions/foo/schemas/foo-1.0"
+
+    tag_def = TagDefinition(
+        "asdf://somewhere.org/extensions/foo/tags/foo-1.0",
+        schema_uris=["asdf://somewhere.org/extensions/foo/schemas/foo-1.0", "asdf://somewhere.org/extensions/foo/schemas/base-1.0"],
+        title="Some title",
+        description="Some description",
+    )
+
+    assert tag_def.schema_uris == ["asdf://somewhere.org/extensions/foo/schemas/foo-1.0", "asdf://somewhere.org/extensions/foo/schemas/base-1.0"]
+    with pytest.warns(AsdfDeprecationWarning):
+        with pytest.raises(RuntimeError):
+            tag_def.schema_uri
 
     with pytest.raises(ValueError):
         TagDefinition("asdf://somewhere.org/extensions/foo/tags/foo-*")


### PR DESCRIPTION
@WilliamJamieson I was wrong about this property, it is in fact in use by roman_datamodels.  I'm adding it back here (with a deprecation warning) so that roman_datamodels can have a chance to switch to the new property.