### PR TITLE
Remove schema version parsing from the pytest plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Fix deprecation warnings stemming from the release of pytest 7.0.0. [#1075]
 
+- Fix bug in pytest plugin when schemas are not in a directory named "schemas". [#1076]
+
 2.9.1 (2022-02-03)
 ------------------
 


### PR DESCRIPTION
This fixes a bug that causes the schema tests to fail when the schemas are not located in a directory named "schemas".

I'm also removing checks related to astropy 3.0 that are no longer relevant and changing the plugin to use the latest ASDF Standard version always, so that we don't need to worry about inferring the tag URI from the schema and parsing the version.