### PR TITLE
Switch to using `asdf-standard` as a PyPi package.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.10.0 (unreleased)
+-------------------
+
+- Replace asdf-standard submodule with pypi package. [#1079]
+
 2.9.2 (2022-02-07)
 ------------------
 

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -1,21 +1,8 @@
 import sys
-import os.path
 import warnings
 
 from . import constants
-from . import util
 from .exceptions import AsdfDeprecationWarning
-
-
-def find_schema_path():
-    dirname = os.path.dirname(__file__)
-
-    # This means we are working within a development build
-    if os.path.exists(os.path.join(dirname, '..', 'asdf-standard')):
-        return os.path.join(dirname, '..', 'asdf-standard', 'schemas')
-
-    # Otherwise, we return the installed location
-    return os.path.join(dirname, 'schemas')
 
 
 class Resolver:
@@ -149,11 +136,8 @@ class ResolverChain:
         return self._resolvers == other._resolvers
 
 
-DEFAULT_URL_MAPPING = [
-    (constants.STSCI_SCHEMA_URI_BASE,
-     util.filepath_to_url(
-         os.path.join(find_schema_path(), 'stsci.edu')) +
-         '/{url_suffix}.yaml')]
+DEFAULT_URL_MAPPING = []
+
 DEFAULT_TAG_TO_URL_MAPPING = [
     (constants.STSCI_SCHEMA_TAG_BASE,
      'http://stsci.edu/schemas/asdf{tag_suffix}')

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -7,14 +7,7 @@ from pathlib import Path
 import fnmatch
 import os
 import pkgutil
-import sys
 
-if sys.version_info < (3, 9):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
-
-import asdf
 
 from .util import get_class_name
 
@@ -24,7 +17,7 @@ __all__ = [
     "DirectoryResourceMapping",
     "ResourceManager",
     "JsonschemaResourceMapping",
-    "get_core_resource_mappings",
+    "get_json_schema_resource_mappings",
 ]
 
 

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -272,29 +272,7 @@ class JsonschemaResourceMapping(Mapping):
         return "JsonschemaResourceMapping()"
 
 
-def get_core_resource_mappings():
-    """
-    Get the resource mapping instances for the core schemas.
-    This method is registered with the asdf.resource_mappings entry point.
-    """
-    core_schemas_root = importlib_resources.files(asdf)/"schemas"/"stsci.edu"
-    if not core_schemas_root.is_dir():
-        # In an editable install, the schemas can be found in the
-        # asdf-standard submodule.
-        core_schemas_root = Path(__file__).parent.parent/"asdf-standard"/"schemas"/"stsci.edu"
-        if not core_schemas_root.is_dir():
-            raise RuntimeError("Unable to locate core schemas")
-
-    resources_root = importlib_resources.files(asdf)/"resources"
-    if not resources_root.is_dir():
-        # In an editable install, the resources can be found in the
-        # asdf-standard submodule.
-        resources_root = Path(__file__).parent.parent/"asdf-standard"/"resources"
-        if not resources_root.is_dir():
-            raise RuntimeError("Unable to locate core resources")
-
+def get_json_schema_resource_mappings():
     return [
-        DirectoryResourceMapping(core_schemas_root, "http://stsci.edu/schemas", recursive=True),
-        DirectoryResourceMapping(resources_root / "asdf-format.org", "asdf://asdf-format.org", recursive=True),
         JsonschemaResourceMapping(),
     ]

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -318,7 +318,7 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
                         for schema_uri in schema_uris:
                             try:
                                 s = _load_schema_cached(schema_uri, self.ctx.resolver, False, False)
-                            except FileNotFoundError:
+                            except IOError:
                                 msg = "Unable to locate schema file for '{}': '{}'"
                                 warnings.warn(msg.format(tag, schema_uri), AsdfWarning)
                                 s = {}
@@ -362,6 +362,13 @@ def _make_schema_loader(resolver):
         # Check if this is a URI provided by the new
         # Mapping API:
         resource_manager = get_config().resource_manager
+
+        if url not in resource_manager:
+            # Allow the resolvers to do their thing, in case they know
+            # how to turn this string into a URI that the resource manager
+            # recognizes.
+            url = resolver(str(url))
+
         if url in resource_manager:
             content = resource_manager[url]
             # The jsonschema metaschemas are JSON, but pyyaml
@@ -371,8 +378,8 @@ def _make_schema_loader(resolver):
             result = yaml.load(content, Loader=yamlutil.AsdfLoader) # nosec
             return result, url
 
-        # If not, fall back to fetching the schema the old way:
-        url = resolver(str(url))
+        # If not, this must be a URL (or missing).  Fall back to fetching
+        # the schema the old way:
         return _load_schema(url)
     return load_schema
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -318,7 +318,7 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
                         for schema_uri in schema_uris:
                             try:
                                 s = _load_schema_cached(schema_uri, self.ctx.resolver, False, False)
-                            except IOError:
+                            except FileNotFoundError:
                                 msg = "Unable to locate schema file for '{}': '{}'"
                                 warnings.warn(msg.format(tag, schema_uri), AsdfWarning)
                                 s = {}
@@ -346,6 +346,9 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
 
 @lru_cache()
 def _load_schema(url):
+    if url.startswith("http://") or url.startswith("https://") or url.startswith("asdf://"):
+        raise FileNotFoundError("Unable to fetch schema from non-file URL: " + url)
+
     with generic_io.get_file(url) as fd:
         if isinstance(url, str) and url.endswith('json'):
             json_data = fd.read().decode('utf-8')

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -431,24 +431,13 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
             "properties on the related extension ({}).".format(extension_type.__name__)
         )
 
-        try:
-            with generic_io.get_file(schema_location) as f:
-                schema = yaml.safe_load(f.read())
-        except Exception:
-            assert False, (
-                "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +
-                "which resolves to schema at {}, but ".format(schema_location) +
-                "schema cannot be read."
-            )
-
-        assert "tag" in schema, (
-            "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +
-            "but tag resolves to a schema at {} that is ".format(schema_location) +
-            "missing its tag field."
-        )
-
-        assert schema["tag"] == check_type.yaml_tag, (
-            "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +
-            "but tag resolves to a schema at {} that ".format(schema_location) +
-            "describes a different tag: {}".format(schema["tag"])
-        )
+        if schema_location not in asdf.get_config().resource_manager:
+            try:
+                with generic_io.get_file(schema_location) as f:
+                    schema = yaml.safe_load(f.read())
+            except Exception:
+                assert False, (
+                    "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +
+                    "which resolves to schema at {}, but ".format(schema_location) +
+                    "schema cannot be read."
+                )

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -434,7 +434,7 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
         if schema_location not in asdf.get_config().resource_manager:
             try:
                 with generic_io.get_file(schema_location) as f:
-                    schema = yaml.safe_load(f.read())
+                    yaml.safe_load(f.read())
             except Exception:
                 assert False, (
                     "{} supports tag, {}, ".format(extension_type.__name__, check_type.yaml_tag) +

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -484,7 +484,7 @@ def test_get_default_resolver():
 
     result = resolver('tag:stsci.edu:asdf/core/ndarray-1.0.0')
 
-    assert result.endswith("/schemas/stsci.edu/asdf/core/ndarray-1.0.0.yaml")
+    assert result == 'http://stsci.edu/schemas/asdf/core/ndarray-1.0.0'
 
 
 def test_info_module(capsys, tmpdir):

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -1,6 +1,7 @@
 import threading
 
 import pytest
+import asdf_standard.integration
 
 import asdf
 from asdf import get_config
@@ -110,7 +111,7 @@ def test_array_inline_threshold():
 
 def test_resource_mappings():
     with asdf.config_context() as config:
-        core_mappings = resource.get_core_resource_mappings()
+        core_mappings = resource.get_json_schema_resource_mappings() + asdf_standard.integration.get_resource_mappings()
 
         default_mappings = config.resource_mappings
         assert len(default_mappings) >= len(core_mappings)

--- a/asdf/tests/test_resource.py
+++ b/asdf/tests/test_resource.py
@@ -14,7 +14,7 @@ from asdf.resource import (
     DirectoryResourceMapping,
     ResourceManager,
     ResourceMappingProxy,
-    get_core_resource_mappings,
+    get_json_schema_resource_mappings,
     JsonschemaResourceMapping,
 )
 
@@ -232,12 +232,9 @@ def test_jsonschema_resource_mapping():
 
 @pytest.mark.parametrize("uri", [
     "http://json-schema.org/draft-04/schema",
-    "http://stsci.edu/schemas/yaml-schema/draft-01",
-    "http://stsci.edu/schemas/asdf/core/asdf-1.1.0",
-    "asdf://asdf-format.org/core/schemas/extension_manifest-1.0.0",
 ])
-def test_get_core_resource_mappings(uri):
-    mappings = get_core_resource_mappings()
+def test_get_json_schema_resource_mappings(uri):
+    mappings = get_json_schema_resource_mappings()
 
     mapping = next(m for m in mappings if uri in m)
     assert mapping is not None

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -14,9 +14,6 @@ else:  # pragma: no cover
 
 from semantic_version import Version, SimpleSpec
 
-from . import generic_io
-from . import resolver
-
 
 __all__ = ['AsdfVersion', 'AsdfSpec', 'split_tag_version', 'join_tag_version']
 
@@ -45,7 +42,7 @@ def get_version_map(version):
         from .config import get_config
 
         uri = f"http://stsci.edu/schemas/asdf/version_map-{version}"
-        version_map = yaml.load(get_config().resource_manager[uri],
+        version_map = yaml.load(get_config().resource_manager[uri], # nosec
                                 Loader=_yaml_base_loader)
 
         # Separate the core tags from the rest of the standard for convenience

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -42,17 +42,11 @@ def get_version_map(version):
     version_map = _version_map.get(version)
 
     if version_map is None:
-        version_map_path = resolver.DEFAULT_URL_MAPPING[0][1].replace(
-            '{url_suffix}', 'asdf/version_map-{0}'.format(version))
-        try:
-            with generic_io.get_file(version_map_path, 'r') as fd:
-                # The following call to yaml.load is safe because we're
-                # using a loader that inherits from pyyaml's SafeLoader.
-                version_map = yaml.load( # nosec
-                    fd, Loader=_yaml_base_loader)
-        except Exception:
-            raise ValueError(
-                "Could not load version map for version {0}".format(version))
+        from .config import get_config
+
+        uri = f"http://stsci.edu/schemas/asdf/version_map-{version}"
+        version_map = yaml.load(get_config().resource_manager[uri],
+                                Loader=_yaml_base_loader)
 
         # Separate the core tags from the rest of the standard for convenience
         version_map['core'] = {}

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
-testpaths = asdf docs asdf-standard/schemas
+testpaths = asdf docs
 minversion = 4.6
 norecursedirs = build docs/_build docs/sphinxext
 doctest_plus = enabled

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     packaging>=16.0
     pyyaml>=3.10
     semantic_version>=2.8
+    asdf-standard @ git+https://github.com/WilliamJamieson/asdf-standard.git@feature/package_for_pypi
 
 [options.extras_require]
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Development Status :: 5 - Production/Stable
 
 [options]
+packages = find:
 python_requires= >=3.7
 setup_requires = setuptools_scm
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,8 +59,6 @@ asdf_extensions =
     builtin = asdf.extension:BuiltinExtension
 pytest11 =
     asdf_schema_tester = pytest_asdf.plugin
-asdf.resource_mappings =
-    asdf = asdf.resource:get_core_resource_mappings
 
 [build_sphinx]
 source-dir = docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,8 @@ console_scripts =
     asdftool = asdf.commands.main:main
 asdf_extensions =
     builtin = asdf.extension:BuiltinExtension
+asdf.resource_mappings =
+    asdf = asdf.resource:get_json_schema_resource_mappings
 pytest11 =
     asdf_schema_tester = pytest_asdf.plugin
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     packaging>=16.0
     pyyaml>=3.10
     semantic_version>=2.8
-    asdf-standard @ git+https://github.com/WilliamJamieson/asdf-standard.git@feature/package_for_pypi
+    asdf-standard>=1.0.0
 
 [options.extras_require]
 all =

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os
 from pathlib import Path
-from setuptools import setup, find_packages
+from setuptools import setup
 
 def package_yaml_files(directory):
     paths = sorted(Path(directory).rglob("*.yaml"))

--- a/setup.py
+++ b/setup.py
@@ -3,23 +3,6 @@ import os
 from pathlib import Path
 from setuptools import setup, find_packages
 
-if not any((Path(__file__).parent / "asdf-standard").iterdir()):
-    from setuptools.errors import SetupError
-
-    raise SetupError("asdf-standard is empty. Need to run `git submodule update --init` and try again!")
-
-
-packages = find_packages()
-packages.append('asdf.schemas')
-packages.append('asdf.reference_files')
-packages.append('asdf.resources')
-
-package_dir = {
-    'asdf.schemas': 'asdf-standard/schemas',
-    'asdf.reference_files': 'asdf-standard/reference_files',
-    'asdf.resources': 'asdf-standard/resources',
-}
-
 def package_yaml_files(directory):
     paths = sorted(Path(directory).rglob("*.yaml"))
     return [str(p.relative_to(directory)) for p in paths]
@@ -28,14 +11,9 @@ package_data = {
     'asdf.commands.tests.data': ['*'],
     'asdf.tags.core.tests.data': ['*'],
     'asdf.tests.data': ['*'],
-    'asdf.reference_files': ['*', '**/*'],
-    'asdf.schemas':  package_yaml_files("asdf-standard/schemas"),
-    'asdf.resources': package_yaml_files("asdf-standard/resources"),
 }
 
 setup(
     use_scm_version={"write_to": os.path.join("asdf", "version.py"), "write_to_template": 'version = "{version}"\n'},
-    packages=packages,
-    package_dir=package_dir,
     package_data=package_data,
 )


### PR DESCRIPTION
PR asdf-format/asdf-standard#292 packages asdf-standard so that it can be released on PyPi. Once `asdf-standard` is available as a pypi package, the `git submodule` used to include asdf-standard into asdf will no longer be required. This PR aims to accomplish this.