### PR TITLE
Share config between pre-commit and manual use of tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,7 @@ repos:
   rev: 5.10.1
   hooks:
     - id: isort
-      args: ["--profile", "black", "--filter-files"]
-      exclude: "asdf/extern/.*"
+      args: ["--filter-files"]
 
 - repo: https://github.com/psf/black
   rev: 22.1.0
@@ -30,11 +29,10 @@ repos:
   rev: 4.0.1
   hooks:
     - id: flake8
-      args: ["--count", "--ignore", "E501, E203, W503, W504"]
-      exclude: "asdf/extern/.*"
+      exclude: "asdf/extern/.*|docs/.*"
 
 - repo: https://github.com/PyCQA/bandit
   rev: 1.7.2
   hooks:
     - id: bandit
-      args: ["-x", "asdf/tests,asdf/commands/tests,asdf/tags/core/tests,asdf/extern,compatibility_tests,docs"]
+      args: ["-c", "bandit.yaml"]

--- a/asdf/_convenience.py
+++ b/asdf/_convenience.py
@@ -5,12 +5,7 @@ around _display module code.
 import pathlib
 from contextlib import contextmanager
 
-from ._display import (
-    DEFAULT_MAX_COLS,
-    DEFAULT_MAX_ROWS,
-    DEFAULT_SHOW_VALUES,
-    render_tree,
-)
+from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES, render_tree
 from .asdf import AsdfFile, open_asdf
 
 __all__ = ["info"]

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -10,18 +10,7 @@ from jsonschema import ValidationError
 from pkg_resources import parse_version
 
 from . import _display as display
-from . import (
-    block,
-    constants,
-    generic_io,
-    reference,
-    schema,
-    treeutil,
-    util,
-    version,
-    versioning,
-    yamlutil,
-)
+from . import block, constants, generic_io, reference, schema, treeutil, util, version, versioning, yamlutil
 from ._helpers import validate_version
 from .config import config_context, get_config
 from .exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -12,17 +12,7 @@ import yaml
 from jsonschema import validators as mvalidators
 from jsonschema.exceptions import ValidationError
 
-from . import (
-    constants,
-    extension,
-    generic_io,
-    reference,
-    tagged,
-    treeutil,
-    util,
-    versioning,
-    yamlutil,
-)
+from . import constants, extension, generic_io, reference, tagged, treeutil, util, versioning, yamlutil
 from .config import get_config
 from .exceptions import AsdfDeprecationWarning, AsdfWarning
 from .util import patched_urllib_parse

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -11,24 +11,11 @@ from jsonschema.exceptions import ValidationError
 from numpy.testing import assert_array_equal
 
 import asdf
-from asdf import (
-    config_context,
-    extension,
-    get_config,
-    resolver,
-    schema,
-    treeutil,
-    versioning,
-)
+from asdf import config_context, extension, get_config, resolver, schema, treeutil, versioning
 from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
 from asdf.extension import ExtensionProxy
 
-from .helpers import (
-    assert_no_warnings,
-    assert_roundtrip_tree,
-    assert_tree_match,
-    yaml_to_asdf,
-)
+from .helpers import assert_no_warnings, assert_roundtrip_tree, assert_tree_match, yaml_to_asdf
 
 
 def test_get_data_from_closed_file(tmpdir):

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -15,12 +15,7 @@ from asdf import fits_embed, get_config
 from asdf import open as asdf_open
 from asdf.exceptions import AsdfConversionWarning, AsdfWarning
 
-from .helpers import (
-    assert_no_warnings,
-    assert_tree_match,
-    get_test_data_path,
-    yaml_to_asdf,
-)
+from .helpers import assert_no_warnings, assert_tree_match, get_test_data_path, yaml_to_asdf
 
 TEST_DTYPES = ["<f8", ">f8", "<u4", ">u4", "<i4", ">i4"]
 

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -7,18 +7,7 @@ from jsonschema import ValidationError
 from numpy.testing import assert_array_equal
 
 import asdf
-from asdf import (
-    config_context,
-    constants,
-    extension,
-    get_config,
-    resolver,
-    schema,
-    tagged,
-    types,
-    util,
-    yamlutil,
-)
+from asdf import config_context, constants, extension, get_config, resolver, schema, tagged, types, util, yamlutil
 from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning
 from asdf.tests import CustomExtension, helpers
 

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -4,13 +4,7 @@ import pytest
 
 from asdf.extension import default_extensions
 from asdf.schema import load_schema
-from asdf.versioning import (
-    AsdfSpec,
-    AsdfVersion,
-    get_version_map,
-    join_tag_version,
-    supported_versions,
-)
+from asdf.versioning import AsdfSpec, AsdfVersion, get_version_map, join_tag_version, supported_versions
 
 
 def test_version_constructor():

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -3,13 +3,7 @@ from collections import OrderedDict
 from functools import lru_cache
 
 from . import util
-from .versioning import (
-    AsdfVersion,
-    default_version,
-    get_version_map,
-    join_tag_version,
-    split_tag_version,
-)
+from .versioning import AsdfVersion, default_version, get_version_map, join_tag_version, split_tag_version
 
 __all__ = ["AsdfTypeIndex"]
 

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,16 @@
+skips: [ B101 ]
+
+exclude_dirs:
+  - .eggs
+  - .git
+  - .pytest_cache
+  - .tox
+  - asdf/commands/tests
+  - asdf/extern
+  - asdf/tags/core/tests
+  - asdf/tests
+  - build
+  - compatibility_tests
+  - dist
+  - docs
+  - __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,21 @@ requires = ["setuptools>=30.3.0", "setuptools_scm", "wheel"]
 
 [tool.black]
 line-length = 120
+exclude = '''
+^/(
+  (
+      \.eggs
+    | \.git
+    | \.pytest_cache
+    | \.tox
+    | asdf/extern
+    | build
+    | dist
+  )/
+)
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 120
+extend_skip_glob = [ "asdf/extern/*" ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,10 +114,18 @@ asdf_schema_ignore_unrecognized_tag = true
 addopts = --color=yes --doctest-rst
 
 [flake8]
-exclude = extern, docs/conf.py, .tox, .eggs
+exclude =
+  .eggs
+  .git
+  .pytest_cache
+  .tox
+  __pycache__
+  asdf/extern
+  build
+  dist
+  docs
 select = F,W,E101,E111,E502,E722,E901,E902
 ignore = W503,W504
-
 
 [coverage:run]
 omit =

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ package_data = {
 }
 
 setup(
-    use_scm_version={"write_to": os.path.join("asdf", "version.py"), "write_to_template": 'version = "{version}"\n'},
+    use_scm_version={
+        "write_to": os.path.join("asdf", "version.py"),
+        "write_to_template": 'version = "{version}"\n',
+    },
     package_data=package_data,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -114,8 +114,9 @@ commands=
 [testenv:bandit]
 deps=
     bandit
+    toml
 commands=
-    bandit -r -x asdf/tests,asdf/commands/tests,asdf/tags/core/tests,asdf/extern asdf
+    bandit -c bandit.yaml -r .
 
 [testenv:codestyle]
 skip_install = true


### PR DESCRIPTION
@WilliamJamieson what do you think of this?  I'm in the habit of running black, flake8, etc manually and would like to continue to do so on occasion.  With these changes I get the same results for this:

```
pre-commit run --all-files
```

vs all these separately:

```
black .
isort .
flake8
bandit -c bandit.yaml -r .
```

As much as possible I had them share configs, but in some cases the excludes get overridden by whatever pre-commit passes to the tool.

I also noticed that isort with the black profile was using a line length of 88.  I changed it to 120 to match black, but that resulted in some reformatting of imports.