### PR TITLE
Remove AsdfFile.extension_manager, AsdfFile.extension_list, and AsdfFile.version setter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,11 @@
 
 - Remove extensions argument from AsdfFile class and open functions. [#1062]
 
+- Remove ExtensionManager and ExtensionList from AsdfFile instance and store
+  in AsdfConfig instead. [#1092]
+
+- Remove setter for AsdfFile.version. [#1092]
+
 2.10.2 (unreleased)
 -------------------
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -559,7 +559,9 @@ class BlockManager:
         reserved_blocks = set()
 
         for node in treeutil.iter_tree(tree):
-            hook = ctx.type_index.get_hook_for_type("reserve_blocks", type(node), ctx.version_string)
+            hook = get_config().extension_list.type_index.get_hook_for_type(
+                "reserve_blocks", type(node), ctx.version_string
+            )
             if hook is not None:
                 for block in hook(node, ctx):
                     reserved_blocks.add(block)

--- a/asdf/commands/tags.py
+++ b/asdf/commands/tags.py
@@ -5,7 +5,8 @@ Implementation of command for displaying available tags in asdf
 
 import sys
 
-from .. import AsdfFile
+from asdf import get_config
+
 from .main import Command
 
 __all__ = ["list_tags"]
@@ -45,13 +46,14 @@ def _format_type(typ):
 
 def list_tags(display_classes=False, iostream=sys.stdout):
     """Function to list tags"""
-    af = AsdfFile()
+    extension_manager = get_config().get_extension_manager(get_config().default_version)
+    type_index = get_config().extension_list.type_index
 
     tag_pairs = []
-    for tag in af.extension_manager._converters_by_tag:
-        tag_pairs.append((tag, af.extension_manager.get_converter_for_tag(tag).types))
-    for tag in af.type_index._type_by_tag:
-        tag_pairs.append((tag, [af.type_index._type_by_tag[tag]]))
+    for tag in extension_manager._converters_by_tag:
+        tag_pairs.append((tag, extension_manager.get_converter_for_tag(tag).types))
+    for tag in type_index._type_by_tag:
+        tag_pairs.append((tag, [type_index._type_by_tag[tag]]))
 
     for tag, types in sorted(tag_pairs, key=lambda pair: pair[0]):
         string = str(tag)

--- a/asdf/commands/tests/test_tags.py
+++ b/asdf/commands/tests/test_tags.py
@@ -2,7 +2,8 @@ import io
 
 import pytest
 
-from ... import AsdfFile
+from asdf import get_config
+
 from .. import list_tags
 
 
@@ -18,8 +19,10 @@ def test_all_tags_present():
     iostream.seek(0)
     tags = {line.strip() for line in iostream.readlines()}
 
-    af = AsdfFile()
-    for tag in af.type_index._type_by_tag:
+    type_index = get_config().extension_list.type_index
+    extension_manager = get_config().get_extension_manager(get_config().default_version)
+
+    for tag in type_index._type_by_tag:
         assert tag in tags
-    for tag in af.extension_manager._converters_by_tag:
+    for tag in extension_manager._converters_by_tag:
         assert tag in tags

--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -10,10 +10,9 @@ from ._legacy import (
     AsdfExtensionList,
     BuiltinExtension,
     default_extensions,
-    get_cached_asdf_extension_list,
     get_default_resolver,
 )
-from ._manager import ExtensionManager, get_cached_extension_manager
+from ._manager import ExtensionManager
 from ._manifest import ManifestExtension
 from ._tag import TagDefinition
 from ._validator import Validator
@@ -24,7 +23,6 @@ __all__ = [
     "ExtensionProxy",
     "ManifestExtension",
     "ExtensionManager",
-    "get_cached_extension_manager",
     "TagDefinition",
     "Converter",
     "ConverterProxy",
@@ -36,5 +34,4 @@ __all__ = [
     "BuiltinExtension",
     "default_extensions",
     "get_default_resolver",
-    "get_cached_asdf_extension_list",
 ]

--- a/asdf/extension/_legacy.py
+++ b/asdf/extension/_legacy.py
@@ -1,5 +1,4 @@
 import abc
-from functools import lru_cache
 
 from .. import resolver, types
 from ..type_index import AsdfTypeIndex
@@ -150,39 +149,6 @@ class AsdfExtensionList:
         return self._validators
 
 
-def get_cached_asdf_extension_list(extensions):
-    """
-    Get a previously created AsdfExtensionList for the specified
-    extensions, or create and cache one if necessary.  Building
-    the type index is expensive, so it helps performance to reuse
-    the index when possible.
-
-    Parameters
-    ----------
-    extensions : list of asdf.extension.AsdfExtension
-
-    Returns
-    -------
-    asdf.extension.AsdfExtensionList
-    """
-    from ._extension import ExtensionProxy
-
-    # The tuple makes the extensions hashable so that we
-    # can pass them to the lru_cache method.  The ExtensionProxy
-    # overrides __hash__ to return the hashed object id of the wrapped
-    # extension, so this will method will only return the same
-    # AsdfExtensionList if the list contains identical extension
-    # instances in identical order.
-    extensions = tuple(ExtensionProxy.maybe_wrap(e) for e in extensions)
-
-    return _get_cached_asdf_extension_list(extensions)
-
-
-@lru_cache()
-def _get_cached_asdf_extension_list(extensions):
-    return AsdfExtensionList(extensions)
-
-
 # A kludge in asdf.util.get_class_name allows this class to retain
 # its original name, despite being moved from extension.py to
 # this file.
@@ -215,7 +181,9 @@ class _DefaultExtensions:
 
     @property
     def extension_list(self):
-        return get_cached_asdf_extension_list(self.extensions)
+        from ..config import get_config
+
+        return get_config().extension_list
 
     @property
     def package_metadata(self):

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -1,5 +1,3 @@
-from functools import lru_cache
-
 from ..tagged import Tagged
 from ..util import get_class_name, uri_match
 from ._extension import ExtensionProxy
@@ -192,39 +190,6 @@ class ExtensionManager:
     @property
     def validator_manager(self):
         return self._validator_manager
-
-
-def get_cached_extension_manager(extensions):
-    """
-    Get a previously created ExtensionManager for the specified
-    extensions, or create and cache one if necessary.  Building
-    the manager is expensive, so it helps performance to reuse
-    it when possible.
-
-    Parameters
-    ----------
-    extensions : list of asdf.extension.AsdfExtension or asdf.extension.Extension
-
-    Returns
-    -------
-    asdf.extension.ExtensionManager
-    """
-    from ._extension import ExtensionProxy
-
-    # The tuple makes the extensions hashable so that we
-    # can pass them to the lru_cache method.  The ExtensionProxy
-    # overrides __hash__ to return the hashed object id of the wrapped
-    # extension, so this will method will only return the same
-    # ExtensionManager if the list contains identical extension
-    # instances in identical order.
-    extensions = tuple(ExtensionProxy.maybe_wrap(e) for e in extensions)
-
-    return _get_cached_extension_manager(extensions)
-
-
-@lru_cache()
-def _get_cached_extension_manager(extensions):
-    return ExtensionManager(extensions)
 
 
 class ValidatorManager:

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -22,6 +22,7 @@ except ImportError:
 import yaml
 
 import asdf
+from asdf import get_config
 from asdf.core import AsdfObject
 
 from .. import generic_io, versioning
@@ -29,7 +30,6 @@ from ..asdf import AsdfFile, get_asdf_library_info
 from ..block import Block
 from ..constants import YAML_TAG_PREFIX
 from ..exceptions import AsdfConversionWarning
-from ..extension import default_extensions
 from ..resolver import Resolver, ResolverChain
 from ..versioning import AsdfVersion, get_version_map
 from .httpserver import RangeHTTPServer
@@ -92,10 +92,11 @@ def assert_tree_match(old_tree, new_tree, ctx=None, funcname="assert_equal", ign
     ignore_keys = set(ignore_keys)
 
     if ctx is None:
-        version_string = str(versioning.default_version)
-        ctx = default_extensions.extension_list
+        version_string = get_config().default_version
     else:
         version_string = ctx.version_string
+
+    ctx = get_config().extension_list
 
     def recurse(old, new):
         if id(old) in seen or id(new) in seen:

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -317,28 +317,28 @@ def test_extension_version_check(installed, extension, warns):
         config.add_extension(proxy)
         af = asdf.AsdfFile()
 
-    af._fname = "test.asdf"
+        af._fname = "test.asdf"
 
-    tree = {
-        "history": {
-            "extensions": [
-                asdf.core.ExtensionMetadata(
-                    extension_class="asdf.tests.test_api.FooExtension",
-                    software=asdf.core.Software(name="foo", version=extension),
-                ),
-            ]
+        tree = {
+            "history": {
+                "extensions": [
+                    asdf.core.ExtensionMetadata(
+                        extension_class="asdf.tests.test_api.FooExtension",
+                        software=asdf.core.Software(name="foo", version=extension),
+                    ),
+                ]
+            }
         }
-    }
 
-    if warns:
-        with pytest.warns(AsdfWarning, match="File 'test.asdf' was created with"):
+        if warns:
+            with pytest.warns(AsdfWarning, match="File 'test.asdf' was created with"):
+                af._check_extensions(tree)
+
+            with pytest.raises(RuntimeError) as err:
+                af._check_extensions(tree, strict=True)
+            err.match("^File 'test.asdf' was created with")
+        else:
             af._check_extensions(tree)
-
-        with pytest.raises(RuntimeError) as err:
-            af._check_extensions(tree, strict=True)
-        err.match("^File 'test.asdf' was created with")
-    else:
-        af._check_extensions(tree)
 
 
 @pytest.mark.parametrize(

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -3,7 +3,7 @@ import pytest
 from asdf import config_context, get_config
 from asdf.asdf import AsdfFile, SerializationContext, open_asdf
 from asdf.exceptions import AsdfWarning
-from asdf.extension import ExtensionManager, ExtensionProxy
+from asdf.extension import ExtensionProxy
 from asdf.tests.helpers import assert_no_warnings, yaml_to_asdf
 from asdf.versioning import AsdfVersion
 
@@ -74,34 +74,10 @@ def test_asdf_file_version():
         with pytest.raises(ValueError):
             AsdfFile(version=AsdfVersion("0.5.4"))
 
-        af = AsdfFile()
-
-        af.version = "1.3.0"
-        assert af.version == AsdfVersion("1.3.0")
-        assert af.version_string == "1.3.0"
-
-        af.version = AsdfVersion("1.4.0")
-        assert af.version == AsdfVersion("1.4.0")
-        assert af.version_string == "1.4.0"
-
-        with pytest.raises(ValueError):
-            af.version = "0.5.4"
-
-        with pytest.raises(ValueError):
-            af.version = AsdfVersion("2.5.4")
-
-        af.version = "1.0.0"
-        assert af.version_map["tags"]["tag:stsci.edu:asdf/core/asdf"] == "1.0.0"
-
-        af.version = "1.2.0"
-        assert af.version_map["tags"]["tag:stsci.edu:asdf/core/asdf"] == "1.1.0"
-
 
 def test_serialization_context():
-    extension_manager = ExtensionManager([])
-    context = SerializationContext("1.4.0", extension_manager, "file://test.asdf")
+    context = SerializationContext("1.4.0", "file://test.asdf")
     assert context.version == "1.4.0"
-    assert context.extension_manager is extension_manager
     assert context._extensions_used == set()
 
     extension = get_config().extensions[0]
@@ -118,7 +94,7 @@ def test_serialization_context():
         context._mark_extension_used(object())
 
     with pytest.raises(ValueError):
-        SerializationContext("0.5.4", extension_manager, None)
+        SerializationContext("0.5.4", None)
 
 
 def test_reading_extension_metadata():

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -15,8 +15,6 @@ from asdf.extension import (
     ManifestExtension,
     TagDefinition,
     Validator,
-    get_cached_asdf_extension_list,
-    get_cached_extension_manager,
 )
 from asdf.tests.helpers import assert_extension_correctness
 from asdf.types import CustomType
@@ -437,13 +435,6 @@ def test_extension_manager():
         manager.get_converter_for_type(object)
 
 
-def test_get_cached_extension_manager():
-    extension = MinimumExtension()
-    extension_manager = get_cached_extension_manager([extension])
-    assert get_cached_extension_manager([extension]) is extension_manager
-    assert get_cached_extension_manager([MinimumExtension()]) is not extension_manager
-
-
 def test_tag_definition():
     tag_def = TagDefinition(
         "asdf://somewhere.org/extensions/foo/tags/foo-1.0",
@@ -597,13 +588,6 @@ def test_converter_proxy():
     # Should fail because types must instances of type:
     with pytest.raises(TypeError):
         ConverterProxy(MinimumConverter(types=[object()]), extension)
-
-
-def test_get_cached_asdf_extension_list():
-    extension = LegacyExtension()
-    extension_list = get_cached_asdf_extension_list([extension])
-    assert get_cached_asdf_extension_list([extension]) is extension_list
-    assert get_cached_asdf_extension_list([LegacyExtension()]) is not extension_list
 
 
 def test_manifest_extension():

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -253,16 +253,6 @@ def test_schema_caching():
     assert s1 is not s2
 
 
-def test_asdf_file_resolver_hashing():
-    # Confirm that resolvers from distinct AsdfFile instances
-    # hash to the same value (this allows schema caching to function).
-    a1 = asdf.AsdfFile()
-    a2 = asdf.AsdfFile()
-
-    assert hash(a1.resolver) == hash(a2.resolver)
-    assert a1.resolver == a2.resolver
-
-
 def test_load_schema_from_resource_mapping():
     content = """
 id: http://somewhere.org/schemas/razmataz-1.0.0


### PR DESCRIPTION
Now that user extensions are gone, we can move ExtensionManager to AsdfConfig instead of keeping a reference on each AsdfFile.  This simplifies the code vs passing around those instances, and saves users from having to instantiate an AsdfFile to get ahold of ExtensionManager.

I'm also dropping the AsdfFile.version setter in this PR, which mainly existed to reset the AsdfFile's extension variables.  I don't think it's safe to change the version of an open AsdfFile anyway (instead users should call write_to or maybe update).