### PR TITLE
Added condition for label to run downstream tests as part of PR

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -5,6 +5,17 @@ on:
   schedule:
     # Run every Monday at 6am UTC
     - cron: '0 6 * * 1'
+  pull_request:
+    # We also want this workflow triggered if the `Downstream CI` label is
+    # added or present when PR is updated
+    types:
+      - synchronize
+      - labeled
+  push:
+    branches:
+      - '*.*.x'
+    tags:
+      - '*'
 
 env:
   CRDS_SERVER_URL: https://jwst-crds.stsci.edu
@@ -16,6 +27,7 @@ jobs:
   common:
     name: ${{ matrix.package_name }}@${{ matrix.ref }} unit tests
     runs-on: ubuntu-latest
+    if: (github.repository == 'asdf-format/asdf' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Downstream CI')))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -47,6 +47,11 @@ jobs:
             ref: master
             install_command: pip install -e .[test]
             test_command: pytest
+          - package_name: roman_datamodels
+            repository: spacetelescope/roman_datamodels
+            ref: main
+            install_command: pip install -e .[test]
+            test_command: pytest
           - package_name: specutils
             repository: astropy/specutils
             ref: main


### PR DESCRIPTION
Enables downstream ci to be run on a PR if one adds the `Downstream CI` label.

Closes #1097