### PR TITLE
Update setuptools_scm configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ pip-wheel-metadata
 .DS_Store
 
 # setuptools-scm generated version file
-asdf/version.py
+asdf/_version.py

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
 from jsonschema import ValidationError
 
 from ._convenience import info
+from ._version import version as __version__
 from .asdf import AsdfFile
 from .asdf import open_asdf as open
 from .config import config_context, get_config
@@ -30,4 +31,3 @@ from .stream import Stream
 from .tags.core import IntegerType
 from .tags.core.external_reference import ExternalArrayReference
 from .types import CustomType
-from .version import version as __version__

--- a/asdf/_helpers.py
+++ b/asdf/_helpers.py
@@ -1,5 +1,5 @@
 from . import versioning
-from .version import version as asdf_package_version
+from ._version import version as asdf_package_version
 
 
 def validate_version(version):

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -10,7 +10,8 @@ from jsonschema import ValidationError
 from pkg_resources import parse_version
 
 from . import _display as display
-from . import block, constants, generic_io, reference, schema, treeutil, util, version, versioning, yamlutil
+from . import _version as version
+from . import block, constants, generic_io, reference, schema, treeutil, util, versioning, yamlutil
 from ._helpers import validate_version
 from .config import config_context, get_config
 from .exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning

--- a/asdf/tests/test_entry_points.py
+++ b/asdf/tests/test_entry_points.py
@@ -3,10 +3,10 @@ import pytest
 from pkg_resources import EntryPoint
 
 from asdf import entry_points
+from asdf._version import version as asdf_package_version
 from asdf.exceptions import AsdfWarning
 from asdf.extension import ExtensionProxy
 from asdf.resource import ResourceMappingProxy
-from asdf.version import version as asdf_package_version
 
 
 @pytest.fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools>=30.3.0", "setuptools_scm", "wheel"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "asdf/_version.py"
 
 [tool.black]
 line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import os
 from pathlib import Path
 
 from setuptools import setup
@@ -17,9 +16,5 @@ package_data = {
 }
 
 setup(
-    use_scm_version={
-        "write_to": os.path.join("asdf", "version.py"),
-        "write_to_template": 'version = "{version}"\n',
-    },
     package_data=package_data,
 )


### PR DESCRIPTION
Update usage of `setuptools_scm` to use the `pyproject.toml` file rather than the now depreciated `setup.py` method instead.