### PR TITLE
Update jsonschema to 4.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
-2.10.2 (unreleased)
+2.11.0 (unreleased)
 -------------------
+
+- Update minimum jsonschema version to 4.0.1. [#1105]
 
 2.10.1 (2022-03-02)
 -------------------

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -401,13 +401,13 @@ def test_defaults():
 
     cls = schema._create_validator(schema.FILL_DEFAULTS)
     validator = cls(s)
-    validator.validate(t, _schema=s)
+    validator.validate(t)
 
     assert t["a"] == 42
 
     cls = schema._create_validator(schema.REMOVE_DEFAULTS)
     validator = cls(s)
-    validator.validate(t, _schema=s)
+    validator.validate(t)
 
     assert t == {}
 
@@ -1070,9 +1070,9 @@ a: !<tag:nowhere.org:custom/doesnt_exist-1.0.0>
 )
 def test_numpy_scalar_type_validation(numpy_value, valid_types):
     def _assert_validation(jsonschema_type, expected_valid):
-        validator = schema.get_validator()
+        validator = schema.get_validator(schema={"type": jsonschema_type})
         try:
-            validator.validate(numpy_value, _schema={"type": jsonschema_type})
+            validator.validate(numpy_value)
         except ValidationError:
             valid = False
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,13 +28,17 @@ setup_requires = setuptools_scm
 install_requires =
     importlib_resources>=3;python_version<"3.9"
     jmespath>=0.6.2
-    jsonschema>=3.0.2,<4
+    jsonschema>=4.0.1
     numpy>=1.10
     packaging>=16.0
     pyyaml>=3.10
     semantic_version>=2.8
     asdf-standard>=1.0.1
     asdf-transform-schemas>=0.2.2
+    # Multiple downstream packages accidentally depend on asdf to
+    # install six.  As a friendly gesture we list six as a dependency
+    # for older Python versions.
+    six;python_version<"3.8"
 
 [options.extras_require]
 all =

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps=
     legacy: gwcs==0.9.1
     legacy: semantic_version==2.8
     legacy: pyyaml==3.13
-    legacy: jsonschema==3.0.2
+    legacy: jsonschema==4.0.1
     legacy: numpy~=1.14.6
     legacy: pytest~=4.6.11
     legacy: astropy~=3.0.0


### PR DESCRIPTION
This updates our minimum jsonschema version to 4.x and makes the changes necessary to use their new API.

Resolves https://github.com/asdf-format/asdf/issues/1104