### PR TITLE
Pin pytest to < 7.1 for Windows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ docs =
 tests =
     # Necessary for Windows until https://github.com/pytest-dev/pytest/issues/9765
     # is resolved:
-    pytest<7.1;sys_platform=="win32"
+    pytest!=7.1.0;sys_platform=="win32"
     pytest;sys_platform!="win32"
     astropy
     gwcs

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,10 @@ docs =
     matplotlib
     docutils
 tests =
-    pytest
+    # Necessary for Windows until https://github.com/pytest-dev/pytest/issues/9765
+    # is resolved:
+    pytest<7.1;sys_platform=="win32"
+    pytest;sys_platform!="win32"
     astropy
     gwcs
     pytest-doctestplus


### PR DESCRIPTION
Until https://github.com/pytest-dev/pytest/issues/9765 is resolved, our Windows CI job will fail with pytest 7.1.