### PR TITLE
Refactor seekable in `GenericFile`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@
 
 - Remove setter for AsdfFile.version. [#1092]
 
+- Refactor "seekable" default for GenericFile from False, to the value provided by
+  the wrapped object. [#1129]
+
 2.11.0 (2022-03-15)
 -------------------
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -651,9 +651,6 @@ class GenericWrapper:
     def __getattr__(self, attr):
         return getattr(self._fd, attr)
 
-    def seekable(self):
-        return False
-
 
 class RandomAccessFile(GenericFile):
     """
@@ -785,6 +782,9 @@ class InputStream(GenericFile):
         super(InputStream, self).__init__(fd, mode, close=close, uri=uri)
         self._fd = fd
         self._buffer = b""
+
+    def seekable(self):
+        return False
 
     def peek(self, size=-1):
         if size < 0:

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -409,7 +409,7 @@ class GenericFile(metaclass=util.InheritDocstrings):
         Returns `True` if the file supports random access (`seek` and
         `tell`).
         """
-        return False
+        return self._fd.seekable()
 
     def can_memmap(self):
         """
@@ -656,9 +656,6 @@ class RandomAccessFile(GenericFile):
     """
     The base class of file types that support random access.
     """
-
-    def seekable(self):
-        return True
 
     def reader_until(
         self, delimiter, readahead_bytes, delimiter_name=None, include=True, initial_content=b"", exception=True

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -651,6 +651,9 @@ class GenericWrapper:
     def __getattr__(self, attr):
         return getattr(self._fd, attr)
 
+    def seekable(self):
+        return False
+
 
 class RandomAccessFile(GenericFile):
     """


### PR DESCRIPTION
The `GenericFile` class (and its subclasses) in asdf is intended to be a wrapper/handler for `io.IOBase` derived python objects, which are what python opens files into. These objects are either "seekable" or not, where in the base python object the `.seekable()` method returns `True` if it is seekable and `False` otherwise. Currently, `GenericFile` and its subclasses default to having `.seekable()` always be `False` even when wrapping python `io` objects which are seekable. This PR changes this behavior so that `GenericFile.seekable()` defaults to the value of `.seekable()` value provided by the underlying python object.