### PR TITLE
Support for examples speciflying asdf-standard version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,9 @@
-2.11.2
-------
+2.11.2 (unreleased)
+-------------------
 
 - Added ability to display title as a comment in using the
   ``info()`` functionality. [#1138]
+- Add ability to set asdf-standard version for schema example items. [#1143]
 
 2.11.1 (2022-04-15)
 -------------------

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -2,12 +2,11 @@ import io
 import os
 import pathlib
 import warnings
+from dataclasses import dataclass
 
 import numpy as np
 import pytest
 import yaml
-
-from dataclasses import dataclass
 
 # Avoid all imports of asdf at this level in order to avoid circular imports
 
@@ -188,7 +187,7 @@ class SchemaExample:
 
         if self._version is None:
             return versioning.default_version
-        
+
         version = self._version.lower().split("asdf-standard-")[1]
         return versioning.AsdfVersion(version)
 


### PR DESCRIPTION
Adds ability to set asdf-standard for an example item in a schema example test, this is part of the fix for astropy/asdf-astropy#82.

The bug is actually that the pytest plugin always assumes the example is written under the default asdf-standard. This is incorrect in the reported bug because `time-1.0.0` only appears in asdf-standard 1.0.0, so the asdf-astropy extension never gets loaded, causing a fall back to the astropy extension.