### PR TITLE
fix usages of backticks for inline code in docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ The ASDF Standard is at v1.6.0
 
 - Overhaul of the ASDF documentation to make it more consistent and readable. [#1142]
 - Update deprecated instances of ``abstractproperty`` to ``abstractmethod`` [#1148]
+- Fix instances of inline code in docs [#1151]
 
 2.12.0 (2022-06-06)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 The ASDF Standard is at v1.6.0
 
 - Overhaul of the ASDF documentation to make it more consistent and readable. [#1142]
-- Update deprecated instances of `abstractproperty` to `abstractmethod` [#1148]
+- Update deprecated instances of ``abstractproperty`` to ``abstractmethod`` [#1148]
 
 2.12.0 (2022-06-06)
 -------------------
@@ -521,7 +521,7 @@ The ASDF Standard is at v1.3.0
 - Make sure extension metadata is written even when constructing the ASDF tree
   on-the-fly. [#549]
 
-- Fix large integer validation when storing `numpy` integer literals in the
+- Fix large integer validation when storing ``numpy`` integer literals in the
   tree. [#553]
 
 - Fix bug that caused subclass of external type to be serialized by the wrong

--- a/README.rst
+++ b/README.rst
@@ -75,9 +75,9 @@ Creating a file
 
 .. _begin-create-file-text:
 
-We're going to store several `numpy` arrays and other data to an ASDF file. We
-do this by creating a "tree", which is simply a `dict`, and we provide it as
-input to the constructor of `AsdfFile`:
+We're going to store several ``numpy`` arrays and other data to an ASDF file. We
+do this by creating a "tree", which is simply a ``dict``, and we provide it as
+input to the constructor of ``AsdfFile``:
 
 .. code:: python
 
@@ -171,8 +171,8 @@ Reading a file
 
 .. _begin-read-file-text:
 
-To read an existing ASDF file, we simply use the top-level `open` function of
-the `asdf` package:
+To read an existing ASDF file, we simply use the top-level ``open`` function of
+the ``asdf`` package:
 
 .. code:: python
 
@@ -180,7 +180,7 @@ the `asdf` package:
 
     af = asdf.open('example.asdf')
 
-The `open` function also works as a context handler:
+The ``open`` function also works as a context handler:
 
 .. code:: python
 
@@ -215,7 +215,7 @@ To get a quick overview of the data stored in the file, use the top-level
     ├─random (NDArrayType): shape=(100,), dtype=float64
     └─sequence (NDArrayType): shape=(100,), dtype=int64
 
-The `AsdfFile` behaves like a Python `dict`, and nodes are accessed like
+The ``AsdfFile`` behaves like a Python ``dict``, and nodes are accessed like
 any other dictionary entry:
 
 .. code:: python
@@ -248,7 +248,7 @@ Array data remains unloaded until it is explicitly accessed:
 
 By default, uncompressed data blocks are memory mapped for efficient
 access. Memory mapping can be disabled by using the ``copy_arrays``
-option of `open` when reading:
+option of ``open`` when reading:
 
 .. code:: python
 

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -6,7 +6,7 @@ Saving arrays
 Beyond the basic data types of dictionaries, lists, strings and numbers, the
 most important thing ASDF can save is arrays.  It's as simple as putting a
 :mod:`numpy` array somewhere in the tree.  Here, we save an 8x8 array of random
-floating-point numbers (using `numpy.random.rand`).  Note that the resulting
+floating-point numbers (using ``numpy.random.rand``).  Note that the resulting
 YAML output contains information about the structure (size and data type) of
 the array, but the actual array content is in a binary block.
 
@@ -58,7 +58,7 @@ Saving inline arrays
 
 For small arrays, you may not care about the efficiency of a binary
 representation and just want to save the array contents directly in the YAML
-tree.  The `~asdf.AsdfFile.set_array_storage` method can be used to set the
+tree.  The ``~asdf.AsdfFile.set_array_storage`` method can be used to set the
 storage type of the associated data. The allowed values are ``internal``,
 ``external``, and ``inline``.
 
@@ -84,7 +84,7 @@ storage type of the associated data. The allowed values are ``internal``,
 .. asdf:: test.asdf
 
 Alternatively, it is possible to use the ``all_array_storage`` parameter of
-`AsdfFile.write_to` and `AsdfFile.update` to control the storage
+`AsdfFile.write_to` and ``AsdfFile.update`` to control the storage
 format of all arrays in the file.
 
 .. code::
@@ -158,9 +158,9 @@ implicitly determined to include all of the remaining contents of the
 file.  By definition, it must be the last block in the file.
 
 To use streaming, rather than including a Numpy array object in the
-tree, you include a `asdf.Stream` object which sets up the structure
+tree, you include a ``asdf.Stream`` object which sets up the structure
 of the streamed data, but will not write out the actual content.  The
-file handle's `write` method is then used to manually write out the
+file handle's ``write`` method is then used to manually write out the
 binary data.
 
 .. runcode::
@@ -265,7 +265,7 @@ different compression algorithm when writing the file out again.
 Memory mapping
 --------------
 
-By default, all internal array data is memory mapped using `numpy.memmap`. This
+By default, all internal array data is memory mapped using ``numpy.memmap``. This
 allows for the efficient use of memory even when reading files with very large
 arrays. The use of memory mapping means that the following usage pattern is not
 permitted:
@@ -279,11 +279,11 @@ permitted:
 
     af.tree
 
-Specifically, if an ASDF file has been opened using a `with` context, it is not
+Specifically, if an ASDF file has been opened using a ``with`` context, it is not
 possible to access the file contents outside of the scope of that context,
 because any memory mapped arrays will no longer be available.
 
 It may sometimes be useful to copy array data into memory instead of using
-memory maps. This can be controlled by passing the `copy_arrays` parameter to
-either the `AsdfFile` constructor or `asdf.open`. By default,
+memory maps. This can be controlled by passing the ``copy_arrays`` parameter to
+either the ``AsdfFile`` constructor or ``asdf.open``. By default,
 `copy_arrays=False`.

--- a/docs/asdf/asdf_tool.rst
+++ b/docs/asdf/asdf_tool.rst
@@ -19,7 +19,7 @@ useful operations:
   - ``edit``: Edit the YAML portion of an ASDF file.
 
   - ``remove-hdu``: Remove ASDF extension from ASDF-in-FITS file (requires
-    `astropy`, see :ref:`asdf-in-fits`).
+    ``astropy``, see :ref:`asdf-in-fits`).
 
   - ``info``: Print a rendering of an ASDF tree.
 

--- a/docs/asdf/config.rst
+++ b/docs/asdf/config.rst
@@ -4,16 +4,16 @@
 Configuration
 =============
 
-Version 2.8 of this library introduced a new mechanism, `AsdfConfig`, for setting
+Version 2.8 of this library introduced a new mechanism, ``AsdfConfig``, for setting
 global configuration options.  Currently available options are limited, but we expect
 to eventually move many of the ``AsdfFile.__init__`` and ``AsdfFile.write_to``
-keyword arguments to `AsdfConfig`.
+keyword arguments to ``AsdfConfig``.
 
 AsdfConfig and you
 ==================
 
-The `AsdfConfig` class provides properties that can be adjusted to change the
-behavior of the `asdf` library for all files.  For example, to disable schema validation
+The ``AsdfConfig`` class provides properties that can be adjusted to change the
+behavior of the ``asdf`` library for all files.  For example, to disable schema validation
 on read:
 
 .. code-block:: python
@@ -21,13 +21,13 @@ on read:
     >>> import asdf
     >>> asdf.get_config().validate_on_read = False # doctest: +SKIP
 
-This will prevent validation on any subsequent call to `~asdf.open`.
+This will prevent validation on any subsequent call to ``~asdf.open``.
 
 Obtaining an AsdfConfig instance
 --------------------------------
 
-There are two methods available that give access to an `AsdfConfig` instance:
-`~asdf.get_config` and `~asdf.config_context`.  The former simply returns
+There are two methods available that give access to an ``AsdfConfig`` instance:
+`~asdf.get_config` and ``~asdf.config_context``.  The former simply returns
 the currently active config:
 
 .. code-block:: python
@@ -42,9 +42,9 @@ the currently active config:
       validate_on_read: True
     >
 
-The latter method, `~asdf.config_context`, returns a context manager that
+The latter method, ``~asdf.config_context``, returns a context manager that
 yields a copy of the currently active config.  The copy is also returned by
-subsequent calls to `~asdf.get_config`, but only until the context manager exits.
+subsequent calls to ``~asdf.get_config``, but only until the context manager exits.
 This allows for short-lived configuration changes that do not impact other code:
 
 .. code-block:: python
@@ -73,9 +73,9 @@ This allows for short-lived configuration changes that do not impact other code:
 Special note to library maintainers
 -----------------------------------
 
-Libraries that use `asdf` are encouraged to only modify `AsdfConfig` within a
-surrounding call to `~asdf.config_context`.  The downstream library will then
-be able to customize `asdf`'s behavior without impacting other libraries or
+Libraries that use ``asdf`` are encouraged to only modify ``AsdfConfig`` within a
+surrounding call to ``~asdf.config_context``.  The downstream library will then
+be able to customize ``asdf``'s behavior without impacting other libraries or
 clobbering changes made by the user.
 
 Config options
@@ -116,7 +116,7 @@ legacy_fill_schema_defaults
 Flag that controls filling default values from schemas for older versions of
 the ASDF Standard.  This library used to remove nodes from the tree whose
 values matched the default property in the schema.  That behavior was changed
-in `asdf` 2.8, but in order to read files produced by older versions of the library,
+in ``asdf`` 2.8, but in order to read files produced by older versions of the library,
 default values must still be filled from the schema for ASDF Standard <= 1.5.0.
 
 Set to False to disable filling default values from the schema for these
@@ -137,7 +137,7 @@ Additional AsdfConfig features
 ==============================
 
 `AsdfConfig` also provides methods for adding and removing plugins at runtime.
-For example, the `AsdfConfig.add_resource_mapping` method can be used to register
+For example, the ``AsdfConfig.add_resource_mapping`` method can be used to register
 a schema, which can then be used to validate a file:
 
 .. code-block:: python
@@ -165,4 +165,4 @@ a schema, which can then be used to validate a file:
     >>> af["foo"] = "bar"
     >>> af.validate()
 
-See the `AsdfConfig` API documentation for more detail.
+See the ``AsdfConfig`` API documentation for more detail.

--- a/docs/asdf/extending/compressors.rst
+++ b/docs/asdf/extending/compressors.rst
@@ -6,12 +6,12 @@
 Binary block compressors
 ========================
 
-The `Compressor` interface provides an implementation of a compression algorithm
-that can be used to transform binary blocks in an `~asdf.AsdfFile`.  Each
+The ``Compressor`` interface provides an implementation of a compression algorithm
+that can be used to transform binary blocks in an ``~asdf.AsdfFile``.  Each
 Compressor must provide a 4-byte compression code that identifies the algorithm.
 Once the Compressor is installed as part of an Extension plugin, this code
-will be available to users as an argument to `~asdf.AsdfFile.set_array_compression` and
-the ``all_array_compression`` argument to `~asdf.AsdfFile.write_to` and
+will be available to users as an argument to ``~asdf.AsdfFile.set_array_compression`` and
+the ``all_array_compression`` argument to ``~asdf.AsdfFile.write_to`` and
 `~asdf.AsdfFile.update`.
 
 See :ref:`extending_extensions_compressors` for details on including
@@ -30,8 +30,8 @@ the block's data.
 
 `Compressor.compress` - The method that transforms the block's bytes
 before they are written to an ASDF file.  The positional argument
-is a `memoryview` object which is guaranteed to be 1D and contiguous.
-Compressors must be prepared to handle `memoryview.itemsize` > 1.
+is a ``memoryview`` object which is guaranteed to be 1D and contiguous.
+Compressors must be prepared to handle ``memoryview.itemsize`` > 1.
 Any keyword arguments are passed through from the user and may be used
 to tune the compression algorithm.  ``compress`` methods have no return
 value and instead are expected to yield bytes-like values until the
@@ -39,7 +39,7 @@ input data has been fully compressed.
 
 `Compressor.decompress` - The method that transforms the block's bytes
 after they are read from an ASDF file.  The first positional argument
-is an `~collections.abc.Iterable` of bytes-like objects that each
+is an ``~collections.abc.Iterable`` of bytes-like objects that each
 contain a chunk of the compressed input data.  The second positional
 argument is a pre-allocated output array where the decompressed
 bytes should be written.  The method is expected to return the
@@ -48,13 +48,13 @@ number of bytes written to the output array.
 Entry point performance considerations
 ======================================
 
-For the good of `asdf` users everywhere, it's important that entry point
+For the good of ``asdf`` users everywhere, it's important that entry point
 methods load as quickly as possible.  All extensions must be loaded before
 reading an ASDF file, and therefore all compressors are created as well.  Any
 compressor module or ``__init__`` method that lingers will introduce a delay
-to the initial call to `asdf.open`.  For that reason, we recommend that compressor
+to the initial call to ``asdf.open``.  For that reason, we recommend that compressor
 authors minimize the number of imports that occur in the module containing the
 Compressor implementation, and defer imports of compression libraries to inside
-the `Comrpessor.compress` and `Compressor.decompress` methods.  This will
+the ``Comrpessor.compress`` and ``Compressor.decompress`` methods.  This will
 prevent the library from ever being imported when reading ASDF files that
 do not utilize the Compressor's algorithm.

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -6,7 +6,7 @@
 Converters
 ==========
 
-The `~asdf.extension.Converter` interface defines a mapping between
+The ``~asdf.extension.Converter`` interface defines a mapping between
 tagged objects in the ASDF tree and their corresponding Python object(s).
 Typically a Converter will map one YAML tag to one Python type, but
 the interface also supports many-to-one and many-to-many mappings.  A
@@ -22,22 +22,22 @@ two required methods:
 
 `Converter.tags` - a list of tag URIs or URI patterns handled by the converter.
 Patterns may include the wildcard character `*`, which matches any sequence of
-characters up to a `/`, or `**`, which matches any sequence of characters.
-The `~asdf.util.uri_match` method can be used to test URI patterns.
+characters up to a ``/``, or `**`, which matches any sequence of characters.
+The ``~asdf.util.uri_match`` method can be used to test URI patterns.
 
 `Converter.types` - a list of Python types or fully-qualified Python type names handled
 by the converter.  Note that a string name must reflect the actual location of the
 class's implementation and not just a module where it is imported for convenience.
 For example, if class ``Foo`` is implemented in ``example_package.foo.Foo`` but
 imported as ``example_package.Foo`` for convenience, it is the former name that
-must be used.  The `~asdf.util.get_class_name` method will return the name that
+must be used.  The ``~asdf.util.get_class_name`` method will return the name that
 `asdf` expects.
 
 The string type name is recommended over a type object for performance reasons,
 see :ref:`extending_converters_performance`.
 
 `Converter.to_yaml_tree` - a method that accepts a complex Python object and returns
-a simple node object (typically a `dict`) suitable for serialization to YAML.  The
+a simple node object (typically a ``dict``) suitable for serialization to YAML.  The
 node is permitted to contain nested complex objects; these will in turn
 be passed to other ``to_yaml_tree`` methods in other Converters.
 
@@ -114,7 +114,7 @@ around it and install that extension:
 
     asdf.get_config().add_extension(ShapesExtension())
 
-Now we can include a Rectangle object in an `~asdf.asdf.AsdfFile` tree
+Now we can include a Rectangle object in an ``~asdf.asdf.AsdfFile`` tree
 and write out a file:
 
 .. code-block:: python
@@ -250,7 +250,7 @@ But upon deserialization, we notice a problem:
 
     assert reconstituted_f1.inverse.inverse is asdf.treeutil.PendingValue
 
-The presence of `~asdf.treeutil.PendingValue` is asdf's way of telling us
+The presence of ``~asdf.treeutil.PendingValue`` is asdf's way of telling us
 that the value corresponding to the key ``inverse`` was not fully deserialized
 at the time that we retrieved it.  We can handle this situation by making our
 ``from_yaml_tree`` a generator function:
@@ -287,11 +287,11 @@ With this modification we can successfully deserialize our ASDF file:
 Entry point performance considerations
 ======================================
 
-For the good of `asdf` users everywhere, it's important that entry point
+For the good of ``asdf`` users everywhere, it's important that entry point
 methods load as quickly as possible.  All extensions must be loaded before
 reading an ASDF file, and therefore all converters are created as well.  Any
 converter module or ``__init__`` method that lingers will introduce a delay
-to the initial call to `asdf.open`.  For that reason, we recommend that converter
+to the initial call to ``asdf.open``.  For that reason, we recommend that converter
 authors minimize the number of imports that occur in the module containing the
 Converter implementation, and defer imports of serializable types to within the
 ``from_yaml_tree`` method.  This will prevent the type from ever being imported

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -23,7 +23,7 @@ Every extension to ASDF must be uniquely identified by a URI; this URI is
 written to the file's metadata when the extension is used and allows
 software to determine if the necessary extensions are installed when the file
 is read.  An ASDF extension implementation intended for use with this library
-must, at a minimum, implement the `Extension` interface and
+must, at a minimum, implement the ``Extension`` interface and
 provide its URI as a property:
 
 .. code-block:: python
@@ -42,7 +42,7 @@ Additional tags
 ---------------
 
 In order to implement support for additional YAML tags, an Extension subclass
-must provide both a list of relevant tags and a list of `Converter`
+must provide both a list of relevant tags and a list of ``Converter``
 instances that translate objects with those tags to and from YAML.  These lists
 are provided in the ``tags`` and ``converters`` properties, respectively:
 
@@ -64,7 +64,7 @@ detail in :ref:`extending_converters`.
 The Extension implemented above will happily convert between ``foo-1.0.0``
 tagged YAML objects and the appropriate Python representation, but it will
 not perform any schema validation.  In order to associate the tag with
-a schema, we'll need to provide a `TagDefinition` object
+a schema, we'll need to provide a ``TagDefinition`` object
 instead of just a string:
 
 .. code-block:: python
@@ -89,7 +89,7 @@ instead of just a string:
 Additional block compressors
 ----------------------------
 
-Binary block compressors implement the `Compressor` interface
+Binary block compressors implement the ``Compressor`` interface
 and are included in an extension via the ``compressors`` property:
 
 .. code-block:: python
@@ -186,7 +186,7 @@ an additional list of class names that previously identified the extension:
 
 .. _exposing_extension_object_internals:
 
-Making converted object's contents visible to `info` and `search`
+Making converted object's contents visible to ``info`` and ``search``
 -----------------------------------------------------------------
 
 If the object produced by the extension supports a class method
@@ -200,9 +200,9 @@ list-like.
 Installing an extension
 =======================
 
-Once an extension is implemented, it must be installed so that the `asdf`
+Once an extension is implemented, it must be installed so that the ``asdf``
 library knows to use it.  There are two options for installing an extension:
-manually per session using `~asdf.config.AsdfConfig`, or automatically
+manually per session using ``~asdf.config.AsdfConfig``, or automatically
 for every session using the ``asdf.extensions`` entry point
 
 .. _extending_extensions_installing_asdf_config:
@@ -232,7 +232,7 @@ for the duration of the current Python session.
 Installing extensions via entry points
 --------------------------------------
 
-The `asdf` package also offers an entry point for installing extensions
+The ``asdf`` package also offers an entry point for installing extensions
 This registers a package's extensions automatically on package install
 without requiring calls to the AsdfConfig method.  The entry point is
 called ``asdf.extensions`` and expects to receive a method that returns
@@ -266,13 +266,13 @@ new Python session.
 Entry point performance considerations
 --------------------------------------
 
-For the good of `asdf` users everywhere, it's important that entry point
+For the good of ``asdf`` users everywhere, it's important that entry point
 methods load as quickly as possible.  All extensions must be loaded before
 reading an ASDF file, so any entry point method that lingers will introduce a delay
-to the initial call to `asdf.open`.  For that reason, we recommend that extension
+to the initial call to ``asdf.open``.  For that reason, we recommend that extension
 authors minimize the number of imports that occur in the module containing
 the entry point method, particularly imports of modules outside of the
-Python standard library or `asdf` itself.
+Python standard library or ``asdf`` itself.
 
 .. _extending_extensions_manifest:
 
@@ -284,7 +284,7 @@ that includes information such as the extension URI, list of tags, ASDF Standard
 requirement, etc.  Instructions on writing a manifest can be found in
 :ref:`extending_manifests`, but once written, we'll still need a Python Extension (big 'E')
 whose content mirrors the manifest. Rather than duplicate that information in Python code,
-we recommend use of the `ManifestExtension` class, which reads a manifest
+we recommend use of the ``ManifestExtension`` class, which reads a manifest
 and maps its content to the appropriate Extension interface properties.
 
 Assuming the manifest is installed as a resource (see :ref:`extending_resources`), an extension
@@ -336,7 +336,7 @@ loaded:
     def get_extensions():
         return [EXTENSION]
 
-When the module is imported, ``ManifestExtension.from_uri`` asks the `asdf` library to load
+When the module is imported, ``ManifestExtension.from_uri`` asks the ``asdf`` library to load
 all available resources so that it can retrieve the manifest content.  But loading the resources
 requires importing this module to get at the ``get_resource_mappings`` method, so now we're stuck!
 
@@ -349,5 +349,5 @@ The solution is to instantiate the ManifestExtension inside of its entry point m
             ManifestExtension.from_uri("asdf://example.com/example-project/manifests/foo-1.0.0")
         ]
 
-This is not as inefficient as it might seem, since the `asdf` library only calls the method once
+This is not as inefficient as it might seem, since the ``asdf`` library only calls the method once
 and reuses a cached result thereafter.

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -187,7 +187,7 @@ an additional list of class names that previously identified the extension:
 .. _exposing_extension_object_internals:
 
 Making converted object's contents visible to ``info`` and ``search``
------------------------------------------------------------------
+---------------------------------------------------------------------
 
 If the object produced by the extension supports a class method
 `.__asdf_traverse__` then it can be used by those tools to expose the contents

--- a/docs/asdf/extending/legacy.rst
+++ b/docs/asdf/extending/legacy.rst
@@ -5,9 +5,9 @@
 Deprecated extension API
 ========================
 
-This page documents the original `asdf` extension API, which has been
+This page documents the original ``asdf`` extension API, which has been
 deprecated in favor of :ref:`extending_extensions`.  Since support
-for the deprecated API will be removed in `asdf` 3.0, we recommend that
+for the deprecated API will be removed in ``asdf`` 3.0, we recommend that
 all new extensions be implemented with the new API.
 
 Extensions provide a way for ASDF to represent complex types that are not
@@ -20,13 +20,13 @@ Supporting new types in ASDF is easy. Three components are required:
 
 1. A YAML Schema file for each new type.
 
-2. A tag class (inheriting from `asdf.CustomType`) corresponding to each new
-   custom type. The class must override `~asdf.CustomType.to_tree` and
-   `~asdf.CustomType.from_tree` from `asdf.CustomType` in order to define how
+2. A tag class (inheriting from ``asdf.CustomType``) corresponding to each new
+   custom type. The class must override ``~asdf.CustomType.to_tree`` and
+   ``~asdf.CustomType.from_tree`` from ``asdf.CustomType`` in order to define how
    ASDF serializes and deserializes the custom type.
 
 3. A Python class to define an "extension" to ASDF, which is a set of related
-   types. This class must implement the `asdf.AsdfExtension` abstract base
+   types. This class must implement the ``asdf.AsdfExtension`` abstract base
    class. In general, a third-party library that defines multiple custom types
    can group them all in the same extension.
 
@@ -45,7 +45,7 @@ An Example
 ----------
 
 As an example, we will write an extension for ASDF that allows us to represent
-Python's standard `fractions.Fraction` class for representing rational numbers.
+Python's standard ``fractions.Fraction`` class for representing rational numbers.
 We will call our new ASDF type ``fraction``.
 
 First, the YAML Schema, defining the type as a pair of integers:
@@ -67,7 +67,7 @@ First, the YAML Schema, defining the type as a pair of integers:
     ...
 
 Then, the Python implementation of the tag class and extension class. See the
-`asdf.CustomType` and `asdf.AsdfExtension` documentation for more information:
+`asdf.CustomType` and ``asdf.AsdfExtension`` documentation for more information:
 
 .. runcode:: hidden
 
@@ -116,20 +116,20 @@ Then, the Python implementation of the tag class and extension class. See the
                      util.filepath_to_url(os.path.dirname(__file__))
                      + '/{url_suffix}.yaml')]
 
-Note that the method `~asdf.CustomType.to_tree` of the tag class
-``FractionType`` defines how the library converts `fractions.Fraction` into a
+Note that the method ``~asdf.CustomType.to_tree`` of the tag class
+``FractionType`` defines how the library converts ``fractions.Fraction`` into a
 tree that can be stored by ASDF. Conversely, the method
 `~asdf.CustomType.from_tree` defines how the library reads a serialized
 representation of the object and converts it back into an instance of
 `fractions.Fraction`.
 
-Note that the values of the `~asdf.CustomType.name`,
-`~asdf.CustomType.organization`, `~asdf.CustomType.standard`, and
+Note that the values of the ``~asdf.CustomType.name``,
+`~asdf.CustomType.organization`, ``~asdf.CustomType.standard``, and
 `~asdf.CustomType.version` fields are all reflected in the ``id`` and ``tag``
 definitions in the schema.
 
-Note also that the base of the ``tag`` value (up to the `name` and `version`
-components) is reflected in `~asdf.AsdfExtension.tag_mapping` property of the
+Note also that the base of the ``tag`` value (up to the ``name`` and ``version``
+components) is reflected in ``~asdf.AsdfExtension.tag_mapping`` property of the
 `FractionExtension` type, which is used to map tags to URLs. The
 `~asdf.AsdfExtension.url_mapping` is used to map URLs (of the same form as the
 ``id`` field in the schema) to the actual location of a schema file.
@@ -150,34 +150,34 @@ Defining custom types
 ---------------------
 
 In the example above, we showed how to create an extension that is capable of
-serializing `fractions.Fraction`. The custom tag type that we created was
-defined as a subclass of `asdf.CustomType`.
+serializing ``fractions.Fraction``. The custom tag type that we created was
+defined as a subclass of ``asdf.CustomType``.
 
 Custom type attributes
 **********************
 
-We overrode the following attributes of `~asdf.CustomType` in order to define
+We overrode the following attributes of ``~asdf.CustomType`` in order to define
 `FractionType` (each bullet is also a link to the API documentation):
 
-* `~asdf.CustomType.name`
-* `~asdf.CustomType.organization`
-* `~asdf.CustomType.version`
-* `~asdf.CustomType.standard`
-* `~asdf.CustomType.types`
+* ``~asdf.CustomType.name``
+* ``~asdf.CustomType.organization``
+* ``~asdf.CustomType.version``
+* ``~asdf.CustomType.standard``
+* ``~asdf.CustomType.types``
 
 Each of these attributes is important, and each is described in more detail in
 the linked API documentation.
 
-The choice of `~asdf.CustomType.name` should be descriptive of the custom type
-that is being serialized. The choice of `~asdf.CustomType.organization`, and
+The choice of ``~asdf.CustomType.name`` should be descriptive of the custom type
+that is being serialized. The choice of ``~asdf.CustomType.organization``, and
 `~asdf.CustomType.standard` is fairly arbitrary, but also important. Custom
 types that are provided by the same package should be grouped into the same
-`~asdf.CustomType.standard` and `~asdf.CustomType.organization`.
+`~asdf.CustomType.standard` and ``~asdf.CustomType.organization``.
 
-These three values, along with the `~asdf.CustomType.version`, are used to
+These three values, along with the ``~asdf.CustomType.version``, are used to
 define the YAML tag that will mark the serialized type in ASDF files. In our
 example, the tag becomes ``tag:nowhere.org:custom/fraction-1.0.0``. The tag
-is important when defining the `asdf.AsdfExtension` subclass.
+is important when defining the ``asdf.AsdfExtension`` subclass.
 
 Critically, these values must all be reflected in the associated schema.
 
@@ -185,24 +185,24 @@ Custom type methods
 *******************
 
 In addition to the attributes mentioned above, we also overrode the following
-methods of `~asdf.CustomType` (each bullet is also a link to the API
+methods of ``~asdf.CustomType`` (each bullet is also a link to the API
 documentation):
 
-* `~asdf.CustomType.to_tree`
-* `~asdf.CustomType.from_tree`
+* ``~asdf.CustomType.to_tree``
+* ``~asdf.CustomType.from_tree``
 
-The `~asdf.CustomType.to_tree` method defines how an instance of a custom data
+The ``~asdf.CustomType.to_tree`` method defines how an instance of a custom data
 type is converted into data structures that represent a YAML tree that can be
 serialized to a file.
 
-The `~asdf.CustomType.from_tree` method defines how a YAML tree can be
+The ``~asdf.CustomType.from_tree`` method defines how a YAML tree can be
 converted back into an instance of the original custom data type.
 
-In the example above, we used a `list` to contain the important attributes of
+In the example above, we used a ``list`` to contain the important attributes of
 `fractions.Fraction`. However, this choice is fairly arbitrary, as long as it
-is consistent between the way that `~asdf.CustomType.to_tree` and
+is consistent between the way that ``~asdf.CustomType.to_tree`` and
 `~asdf.CustomType.from_tree` are defined. For example, we could have also
-chosen to use a `dict`:
+chosen to use a ``dict``:
 
 .. runcode::
 
@@ -263,8 +263,8 @@ Serializing more complex types
 
 Sometimes the custom types that we wish to represent in ASDF themselves have
 attributes which are also custom types. As a somewhat contrived example,
-consider a 2D cartesian coordinate that uses `fraction.Fraction` to represent
-each of the components. We will call this type `Fractional2DCoordinate`.
+consider a 2D cartesian coordinate that uses ``fraction.Fraction`` to represent
+each of the components. We will call this type ``Fractional2DCoordinate``.
 
 First we need to define a schema to represent this new type::
 
@@ -326,14 +326,14 @@ We also need to define the custom tag type that corresponds to our new type:
             return coord
 
 In previous versions of this library, it was necessary for our
-`Fractional2DCoordinateType` class to call `~asdf.yamlutil` functions
+`Fractional2DCoordinateType` class to call ``~asdf.yamlutil`` functions
 explicitly to convert the ``x`` and ``y`` components to and from
 their tree representations.  Now, the library will automatically
-convert nested custom types before calling `~asdf.CustomType.from_tree`,
-and after receiving the result from `~asdf.CustomType.to_tree`.
+convert nested custom types before calling ``~asdf.CustomType.from_tree``,
+and after receiving the result from ``~asdf.CustomType.to_tree``.
 
-Since `Fractional2DCoordinateType` shares the same
-`~asdf.CustomType.organization` and `~asdf.CustomType.standard` as
+Since ``Fractional2DCoordinateType`` shares the same
+`~asdf.CustomType.organization` and ``~asdf.CustomType.standard`` as
 `FractionType`, it can be added to the same extension class:
 
 .. runcode::
@@ -370,7 +370,7 @@ Now we can use this extension to create an ASDF file:
 .. asdf:: coord.asdf ignore_unrecognized_tag
 
 Note that in the resulting ASDF file, the ``x`` and ``y`` components of
-our new `fraction_2d_coord` type are tagged as `fraction-1.0.0`.
+our new ``fraction_2d_coord`` type are tagged as `fraction-1.0.0`.
 
 Serializing reference cycles
 ****************************
@@ -407,7 +407,7 @@ so you might wish to construct your objects in the following way:
 Which creates an "infinite loop" between the two fractions.  An ordinary
 `~asdf.CustomType` wouldn't be able to deserialize this, since each object
 requires that the other be deserialized first!  Let's see what happens
-when we define our `~asdf.CustomType.from_tree` method in a naive way:
+when we define our ``~asdf.CustomType.from_tree`` method in a naive way:
 
 .. runcode::
 
@@ -457,7 +457,7 @@ But upon deserialization, we notice a problem:
 
     assert reconstituted_f1.inverse.inverse is asdf.treeutil.PendingValue
 
-The presence of `~asdf.treeutil.PendingValue` is `asdf`'s way of telling you
+The presence of ``~asdf.treeutil.PendingValue`` is ``asdf``'s way of telling you
 that the value corresponding to the key ``inverse`` was not fully deserialized
 at the time that you retrieved it.  We can handle this situation by making our
 `~asdf.CustomType.from_tree` a generator function:
@@ -488,13 +488,13 @@ at the time that you retrieved it.  We can handle this situation by making our
             yield result
             result.inverse = tree["inverse"]
 
-The generator version of `~asdf.CustomType.from_tree` yields the partially constructed
+The generator version of ``~asdf.CustomType.from_tree`` yields the partially constructed
 `FractionWithInverse` object before setting its inverse property.  This allows
-asdf to proceed to constructing the inverse `FractionWithInverse` object,
-and resume the original `~asdf.CustomType.from_tree` execution only when the inverse
+asdf to proceed to constructing the inverse ``FractionWithInverse`` object,
+and resume the original ``~asdf.CustomType.from_tree`` execution only when the inverse
 is actually available.
 
-With this new version of `~asdf.CustomType.from_tree`, we can successfully deserialize
+With this new version of ``~asdf.CustomType.from_tree``, we can successfully deserialize
 our ASDF file:
 
 .. runcode:: hidden
@@ -629,14 +629,14 @@ versions of Person:
 We need to update our tag class implementation as well. However, we need to be
 careful. We still want to be able to read version 1.0.0 of our schema and be
 able to convert it to the newer version of ``Person`` objects. To accomplish
-this, we will make use of the `~asdf.CustomType.supported_versions` attribute
+this, we will make use of the ``~asdf.CustomType.supported_versions`` attribute
 for our tag class. This will allow us to declare explicit support for the
 schema versions our tag class implements.
 
-Under the hood, `asdf` creates multiple copies of our ``PersonType`` tag class,
-each with a different `~asdf.CustomType.version` attribute corresponding to one
+Under the hood, ``asdf`` creates multiple copies of our ``PersonType`` tag class,
+each with a different ``~asdf.CustomType.version`` attribute corresponding to one
 of the supported versions. This means that in our new tag class implementation,
-we can condition our `~asdf.CustomType.from_tree` implementation on the value
+we can condition our ``~asdf.CustomType.from_tree`` implementation on the value
 of ``version`` to determine which schema version should be used when reading:
 
 .. code-block:: python
@@ -673,13 +673,13 @@ the older version of the schema.
 Handling subclasses
 *******************
 
-By default, if a custom type is serialized by an `asdf` tag class, then all
+By default, if a custom type is serialized by an ``asdf`` tag class, then all
 subclasses of that type can also be serialized. However, no attributes that are
 specific to the subclass will be stored in the file. When reading the file, an
 instance of the base custom type will be returned instead of the subclass that
 was written.
 
-To properly handle subclasses of custom types already recognized by `asdf`, it is
+To properly handle subclasses of custom types already recognized by ``asdf``, it is
 necessary to implement a separate tag class that is specific to the subclass to
 be serialized.
 
@@ -690,13 +690,13 @@ this feature was dropped as it produced files that were not portable.
 Creating custom schemas
 -----------------------
 
-All custom types to be serialized by `asdf` require custom schemas. The best
+All custom types to be serialized by ``asdf`` require custom schemas. The best
 resource for creating ASDF schemas can be found in the :ref:`ASDF Standard
 <asdf-standard:asdf-schemas>` documentation.
 
 In most cases, ASDF schemas will be included as part of a packaged software
 distribution. In these cases, it is important for the
-`~asdf.AsdfExtension.url_mapping` of the corresponding `~asdf.AsdfExtension`
+`~asdf.AsdfExtension.url_mapping` of the corresponding ``~asdf.AsdfExtension``
 extension class to map the schema URL to an actual location on disk. However,
 it is possible for schemas to be hosted online as well, in which case the URL
 mapping can map (perhaps trivially) to an actual network location. See
@@ -714,13 +714,13 @@ language. This can be used to impose type-specific restrictions on the
 values in an ASDF file.  This feature is used internally so a schema
 can specify the required datatype of an array.
 
-To support custom validation keywords, set the `~asdf.CustomType.validators`
-member of a `~asdf.CustomType` subclass to a dictionary where the keys are the
+To support custom validation keywords, set the ``~asdf.CustomType.validators``
+member of a ``~asdf.CustomType`` subclass to a dictionary where the keys are the
 validation keyword name and the values are validation functions.  The
 validation functions are of the same form as the validation functions in the
 underlying ``jsonschema`` library, and are passed the following arguments:
 
-  - ``validator``: A `jsonschema.Validator` instance.
+  - ``validator``: A ``jsonschema.Validator`` instance.
 
   - ``value``: The value of the schema keyword.
 
@@ -732,7 +732,7 @@ underlying ``jsonschema`` library, and are passed the following arguments:
     get other related schema keywords.
 
 The validation function should either return ``None`` if the instance
-is valid or ``yield`` one or more `asdf.ValidationError` objects if
+is valid or ``yield`` one or more ``asdf.ValidationError`` objects if
 the instance is invalid.
 
 To continue the example from above, for the ``FractionType`` say we
@@ -757,19 +757,19 @@ asserts that the corresponding fraction is in simplified form:
 Defining custom extension classes
 ---------------------------------
 
-Extension classes are the mechanism that `asdf` uses to register custom tag types
+Extension classes are the mechanism that ``asdf`` uses to register custom tag types
 so that they can be used when processing ASDF files. Packages that define their
 own custom tag types must also define extensions in order for those types to be
 used.
 
-All extension classes must implement the `asdf.AsdfExtension` abstract base
+All extension classes must implement the ``asdf.AsdfExtension`` abstract base
 class. A custom extension will override each of the following properties of
 `AsdfExtension` (the text in each bullet is also a link to the corresponding
 documentation):
 
-* `~asdf.AsdfExtension.types`
-* `~asdf.AsdfExtension.tag_mapping`
-* `~asdf.AsdfExtension.url_mapping`
+* ``~asdf.AsdfExtension.types``
+* ``~asdf.AsdfExtension.tag_mapping``
+* ``~asdf.AsdfExtension.url_mapping``
 
 .. _packaging_extensions:
 
@@ -777,18 +777,18 @@ Overriding built-in extensions
 ******************************
 
 It is possible for externally defined extensions to override tag types that are
-provided by `asdf`'s built-in extension. For example, maybe an external package
-wants to provide a different implementation of `~asdf.tags.core.NDArrayType`.
+provided by ``asdf``'s built-in extension. For example, maybe an external package
+wants to provide a different implementation of ``~asdf.tags.core.NDArrayType``.
 In this case, the external package does not need to provide custom schemas
 since the schema for the type to be overridden is already provided as part of
 the ASDF standard.
 
-Instead, the extension class may inherit from `asdf`'s
+Instead, the extension class may inherit from ``asdf``'s
 `~asdf.extension.BuiltinExtension` and simply override the
 `~asdf.AsdfExtension.types` property to indicate the type that is being
-overridden.  Doing this preserves the `~asdf.AsdfExtension.tag_mapping` and
-`~asdf.AsdfExtension.url_mapping` that is used by the `BuiltinExtension`, which
-allows the schemas that are packaged by `asdf` to be located.
+overridden.  Doing this preserves the ``~asdf.AsdfExtension.tag_mapping`` and
+`~asdf.AsdfExtension.url_mapping` that is used by the ``BuiltinExtension``, which
+allows the schemas that are packaged by ``asdf`` to be located.
 
 `asdf` will give precedence to the type that is provided by the external
 extension, effectively overriding the corresponding type in the built-in
@@ -803,21 +803,21 @@ Packaging schemas
 
 If a package provides custom schemas, the schema files must be installed as
 part of that package distribution. In general, schema files must be installed
-into a subdirectory of the package distribution. The `asdf` extension class must
-supply a `~asdf.AsdfExtension.url_mapping` that maps to the installed location
+into a subdirectory of the package distribution. The ``asdf`` extension class must
+supply a ``~asdf.AsdfExtension.url_mapping`` that maps to the installed location
 of the schemas. See :ref:`defining_extensions` for more details.
 
 Registering entry points
 ************************
 
 Packages that provide their own ASDF extensions can (and should!) install them
-so that they are automatically detectable by the `asdf` Python package. This is
-accomplished using Python's `setuptools` entry points. Entry points are
-registered in a package's `setup.py` file.
+so that they are automatically detectable by the ``asdf`` Python package. This is
+accomplished using Python's ``setuptools`` entry points. Entry points are
+registered in a package's ``setup.py`` file.
 
-Consider a package that provides an extension class `MyPackageExtension` in the
-submodule `mypackage.asdf.extensions`. We need to register this class as an
-extension entry point that `asdf` will recognize. First, we create a dictionary:
+Consider a package that provides an extension class ``MyPackageExtension`` in the
+submodule ``mypackage.asdf.extensions``. We need to register this class as an
+extension entry point that ``asdf`` will recognize. First, we create a dictionary:
 
 .. code:: python
 
@@ -826,7 +826,7 @@ extension entry point that `asdf` will recognize. First, we create a dictionary:
         'mypackage = mypackage.asdf.extensions:MyPackageExtension'
     ]
 
-The key used in the `entry_points` dictionary must be ``'asdf_extensions'``.
+The key used in the ``entry_points`` dictionary must be ``'asdf_extensions'``.
 The value must be an array of one or more strings, each with the following
 format:
 
@@ -837,9 +837,9 @@ the package and the extension. In most cases the package itself name will
 suffice.
 
 Note that depending on individual package requirements, there may be other
-entries in the `entry_points` dictionary.
+entries in the ``entry_points`` dictionary.
 
-The entry points must be passed to the call to `setuptools.setup`:
+The entry points must be passed to the call to ``setuptools.setup``:
 
 .. code:: python
 
@@ -860,7 +860,7 @@ When running ``python setup.py install`` or ``python setup.py develop`` on this
 package, the entry points will be registered automatically. This allows the
 `asdf` package to recognize the extensions without any user intervention. Users
 of your package that wish to read ASDF files using types that you have
-registered will not need to use any extension explicitly. Instead, `asdf` will
+registered will not need to use any extension explicitly. Instead, ``asdf`` will
 automatically recognize the types you have registered and will process them
 appropriately. See :ref:`other_packages` for more information on using
 extensions.
@@ -870,12 +870,12 @@ extensions.
 Testing custom schemas
 ----------------------
 
-Packages that provide their own schemas can test them using `asdf`'s
+Packages that provide their own schemas can test them using ``asdf``'s
 :ref:`pytest <pytest:toc>` plugin for schema testing.
 Schemas are tested for overall validity, and any examples given within the
 schemas are also tested.
 
-The schema tester plugin is automatically registered when the `asdf` package is
+The schema tester plugin is automatically registered when the ``asdf`` package is
 installed. In order to enable testing, it is necessary to add the directory
 containing your schema files to the pytest section of your project's
 `setup.cfg` file. If you do not already have such a file, creating a
@@ -889,24 +889,24 @@ containing your schema files to the pytest section of your project's
 The schema directory paths should be paths that are relative to the top of the
 package directory **when it is installed**. If this is different from the path
 in the source directory, then both paths can be used to facilitate in-place
-testing (see `asdf`'s own `setup.cfg` for an example of this).
+testing (see ``asdf``'s own ``setup.cfg`` for an example of this).
 
 .. note::
 
-   Older versions of `asdf` (prior to 2.4.0) required the plugin to be registered
-   in your project's `conftest.py` file. As of 2.4.0, the plugin is now
+   Older versions of ``asdf`` (prior to 2.4.0) required the plugin to be registered
+   in your project's ``conftest.py`` file. As of 2.4.0, the plugin is now
    registered automatically and so this line should be removed from your
-   `conftest.py` file, unless you need to retain compatibility with older
-   versions of `asdf`.
+   ``conftest.py`` file, unless you need to retain compatibility with older
+   versions of ``asdf``.
 
 The ``asdf_schema_skip_names`` configuration variable can be used to skip
 schema files that live within one of the ``asdf_schema_root`` directories but
 should not be tested. The names should be given as simple base file names
-(without directory paths or extensions). Again, see `asdf`'s own `setup.cfg` file
+(without directory paths or extensions). Again, see ``asdf``'s own ``setup.cfg`` file
 for an example.
 
 The schema tests do **not** run by default. In order to enable the tests by
 default for your package, add ``asdf_schema_tests_enabled = true`` to the
-``[tool:pytest]`` section of your `setup.cfg` file. If you do not wish to
+``[tool:pytest]`` section of your ``setup.cfg`` file. If you do not wish to
 enable the schema tests by default, you can add the ``--asdf-tests`` option to
 the ``pytest`` command line to enable tests on a per-run basis.

--- a/docs/asdf/extending/manifests.rst
+++ b/docs/asdf/extending/manifests.rst
@@ -10,7 +10,7 @@ ASDF extensions that are intended to be implemented by ASDF libraries
 in multiple languages, so that other implementers do not need to go
 spelunking through Python code to discover the tags and schemas that
 are included in the extension.  This library provides support for
-automatically populating a `~asdf.extension.Extension` object from
+automatically populating a ``~asdf.extension.Extension`` object from
 a manifest; see :ref:`extending_extensions_manifest` for more information.
 
 Anatomy of a manifest
@@ -42,7 +42,7 @@ with one tag and schema:
     id: asdf://example.com/example-project/manifests/example-1.0.0
 
 The ``id`` property contains the URI that uniquely identifies our manifest.  This
-URI is how we'll refer to the manifest document's content when using the `asdf`
+URI is how we'll refer to the manifest document's content when using the ``asdf``
 library.
 
 .. code-block:: yaml

--- a/docs/asdf/extending/resources.rst
+++ b/docs/asdf/extending/resources.rst
@@ -7,23 +7,23 @@ Resources and resource mappings
 ===============================
 
 In the terminology of this library, a "resource" is a sequence of bytes associated
-with a URI.  Currently the two types of resources recognized by `asdf` are schemas
+with a URI.  Currently the two types of resources recognized by ``asdf`` are schemas
 and extension manifests.  Both of these are YAML documents whose associated URI
 is expected to match the ``id`` property of the document.
 
-A "resource mapping" is an `asdf` plugin that provides access to
+A "resource mapping" is an ``asdf`` plugin that provides access to
 the content for a URI.  These plugins must implement the
-`~collections.abc.Mapping` interface (a simple `dict` qualifies) and map
-`str` URI keys to `bytes` values.  Resource mappings are installed into
-the `asdf` library via one of two routes: the `AsdfConfig.add_resource_mapping <asdf.config.AsdfConfig.add_resource_mapping>`
+`~collections.abc.Mapping` interface (a simple ``dict`` qualifies) and map
+`str` URI keys to ``bytes`` values.  Resource mappings are installed into
+the ``asdf`` library via one of two routes: the `AsdfConfig.add_resource_mapping <asdf.config.AsdfConfig.add_resource_mapping>`
 method or the ``asdf.resource_mappings`` entry point.
 
 Installing resources via AsdfConfig
 ===================================
 
-The simplest way to isntall a resource into `asdf` is to add it at runtime using the
+The simplest way to isntall a resource into ``asdf`` is to add it at runtime using the
 `AsdfConfig.add_resource_mapping <asdf.config.AsdfConfig.add_resource_mapping>` method.
-For example, the following code istalls a schema for use with the `asdf.AsdfFile`
+For example, the following code istalls a schema for use with the ``asdf.AsdfFile``
 custom_schema argument:
 
 .. code-block:: python
@@ -58,9 +58,9 @@ The DirectoryResourceMapping class
 ==================================
 
 But what if we don't want to store our schemas in variables in the code?
-Storing resources in a directory tree is a common use case, so `asdf` provides
-a `~collections.abc.Mapping` implementation that reads schema content from
-a filesystem.  This is the `DirectoryResourceMapping` class.
+Storing resources in a directory tree is a common use case, so ``asdf`` provides
+a ``~collections.abc.Mapping`` implementation that reads schema content from
+a filesystem.  This is the ``DirectoryResourceMapping`` class.
 
 Consider these three schemas:
 
@@ -88,15 +88,15 @@ which are arranged in the following directory structure::
         └─ baz-8.1.1.yaml
 
 Our goal is to install all schemas in the directory tree so that they
-are available for use with `asdf`.  The `DirectoryResourceMapping` class
+are available for use with ``asdf``.  The ``DirectoryResourceMapping`` class
 can do that for us, but we need to show it how to construct the schema URIs
 from the file paths *without reading the id property from the files*.  This
 requirement is a performance consideration; not all resources are used
-in every session, and if `asdf` were to read and parse all available files
-when plugins are loaded, the first call to `asdf.open` would be
+in every session, and if ``asdf`` were to read and parse all available files
+when plugins are loaded, the first call to ``asdf.open`` would be
 intolerably slow.
 
-We should configure `DirectoryResourceMapping` like this:
+We should configure ``DirectoryResourceMapping`` like this:
 
 .. code-block:: python
 
@@ -121,7 +121,7 @@ searching for schemas, ``filename_pattern`` is a glob pattern chosen to exclude
 our README file, and ``stem_filename`` causes the class to drop the ``.yaml`` suffix
 when constructing URIs.
 
-We can test that our configuration is correct by asking `asdf` to read
+We can test that our configuration is correct by asking ``asdf`` to read
 and parse one of the schemas:
 
 .. code-block:: python
@@ -137,11 +137,11 @@ and parse one of the schemas:
 Installing resources via entry points
 =====================================
 
-The `asdf` package also offers an entry point for installing resource
+The ``asdf`` package also offers an entry point for installing resource
 mapping plugins.  This installs a package's resources automatically
 without requiring calls to the AsdfConfig method.  The entry point is
 called ``asdf.resource_mappings`` and expects to receive
-a method that returns a list of `~abc.collections.Mapping` instances.
+a method that returns a list of ``~abc.collections.Mapping`` instances.
 
 For example, let's say we're creating a package named ``asdf-foo-schemas``
 that provides the same schemas described in the previous section.  Our
@@ -164,7 +164,7 @@ directory structure might look something like this::
                 └─ baz-8.1.1.yaml
 
 In ``integration.py``, we'll define the entry point method
-and have it return a list with a single element, our `DirectoryResourceMapping`
+and have it return a list with a single element, our ``DirectoryResourceMapping``
 instance:
 
 .. code-block:: python
@@ -222,13 +222,13 @@ that all files with a ``.yaml`` extension be installed:
 Entry point performance considerations
 --------------------------------------
 
-For the good of `asdf` users everywhere, it's important that entry point
+For the good of ``asdf`` users everywhere, it's important that entry point
 methods load as quickly as possible.  All resource URIs must be loaded
 before reading an ASDF file, so any entry point method that lingers
-will introduce a delay to the initial call to `asdf.open`.  For that reason,
+will introduce a delay to the initial call to ``asdf.open``.  For that reason,
 we recommend to minimize the number of imports that occur in the module
 containing the entry point method, particularly imports of modules outside
-of the Python standard library or `asdf` itself.  When resources are stored
+of the Python standard library or ``asdf`` itself.  When resources are stored
 in a filesystem, it's also helpful to delay reading a file until its URI
 is actually requested, which may not occur in a given session.  The
 DirectoryResourceMapping class is implemented with this behavior.

--- a/docs/asdf/extending/schemas.rst
+++ b/docs/asdf/extending/schemas.rst
@@ -113,7 +113,7 @@ not have an impact on the validation process.
 
 This line invokes the ``type`` validator to check the data type of the
 top-level value.  We're asserting that the type must be a YAML mapping,
-which in Python is represented as a `dict`.
+which in Python is represented as a ``dict``.
 
 .. code-block:: yaml
     :lineno-start: 12
@@ -199,7 +199,7 @@ Finally, the YAML document end indicator indicates the end of the schema.
 Checking schema syntax
 ======================
 
-The `~asdf.schema.check_schema` function performs basic syntax checks on a schema and
+The ``~asdf.schema.check_schema`` function performs basic syntax checks on a schema and
 will raise an error if it discovers a problem.  It does not currently accept URIs and
 requires that the schema already be loaded into Python objects.  If the schema is already
 registered with the asdf library as a resource (see :ref:`extending_resources`), it can
@@ -226,7 +226,7 @@ Testing validation
 ==================
 
 Getting a schema to validate as intended can be a tricky business, so it's helpful
-to test validation against some example objects as you go along.  The `~asdf.schema.validate`
+to test validation against some example objects as you go along.  The ``~asdf.schema.validate``
 function will validate a Python object against a schema:
 
 .. code-block:: python

--- a/docs/asdf/extending/uris.rst
+++ b/docs/asdf/extending/uris.rst
@@ -35,7 +35,7 @@ downside that users expect to be able to retrieve the document contents from tha
 The asdf:// URI scheme
 ======================
 
-To counter the problem of URIs vs URLs, `asdf` 2.8 introduced support for the ``asdf://`` URI
+To counter the problem of URIs vs URLs, ``asdf`` 2.8 introduced support for the ``asdf://`` URI
 scheme.  These URIs are constructed just like ``http://`` or ``https://`` URIs, but the ASDF-specific
 scheme makes clear that the content cannot be fetched from a webserver.
 
@@ -50,7 +50,7 @@ Schemas
 -------
 
 Schemas are expected to include an ``id`` property that contains the URI that identifies them.
-That URI is used when referring to the schema in calls to `asdf` library functions.
+That URI is used when referring to the schema in calls to ``asdf`` library functions.
 We recommend the following pattern for schema URIs:
 
 ``asdf://<domain>/<project>/schemas/<name>-<version>``
@@ -84,7 +84,7 @@ Manifests
 
 Manifest documents are language-independent definitions of extensions to ASDF and
 include an ``id`` property that contains the URI that identifies them.  That URI is
-used when referring to the manifest in calls to `asdf` library functions.  We
+used when referring to the manifest in calls to ``asdf`` library functions.  We
 recommend the following pattern for manifest URIs:
 
 ``asdf://<domain>/<project>/manifests/<name>-<version>``

--- a/docs/asdf/extending/use_cases.rst
+++ b/docs/asdf/extending/use_cases.rst
@@ -12,9 +12,9 @@ to get the job done.
 Validate an ASDF tree against a schema
 ======================================
 
-The `asdf` library already validates individual tagged objects within the tree,
+The ``asdf`` library already validates individual tagged objects within the tree,
 but what if we want to validate the structure of the tree itself?  Such
-"document schemas" can be associated with an `~asdf.AsdfFile` using the
+"document schemas" can be associated with an ``~asdf.AsdfFile`` using the
 ``custom_schema`` argument, but this argument accepts a URI and the asdf
 library needs to know how to access the schema content associated with that
 URI.
@@ -22,8 +22,8 @@ URI.
 1. Designate a URI for the schema.  See :ref:`extending_uris_entities_schemas` for
    recommendations on schema URI structure.
 2. Write the schema.  See :ref:`extending_schemas` if you're new to authoring schemas.
-3. Install the schema as an `asdf` library resource.  See :ref:`extending_resources`
-   for an overview of resources in `asdf` and options for installing them.
+3. Install the schema as an ``asdf`` library resource.  See :ref:`extending_resources`
+   for an overview of resources in ``asdf`` and options for installing them.
 
 Serialize a new type
 ====================
@@ -46,19 +46,19 @@ into the file and back again:
 2. Select a tag URI that will signify the type in YAML.  See :ref:`extending_uris_entities_tags`
    for recommendations on tag URI structure.
 
-3. Implement a `~asdf.extension.Converter` class that converts the type to
+3. Implement a ``~asdf.extension.Converter`` class that converts the type to
    YAML-serializable objects and back again.  See :ref:`extending_converters`
    for a discussion of the Converter interface.
 
-4. Implement an `~asdf.extension.Extension` class which is the vehicle
+4. Implement an ``~asdf.extension.Extension`` class which is the vehicle
    for plugging our converter into the asdf library.  See :ref:`extending_extensions`
    for a discussion of the Extension interface.
 
 5. Install the extension.  There are multiple ways to do this, but the path
-   of least resistance is to install the extension at runtime using `~asdf.config.AsdfConfig`.
+   of least resistance is to install the extension at runtime using ``~asdf.config.AsdfConfig``.
    See :ref:`extending_extensions_installing_asdf_config`.
 
-Now instances of our type can be added to an `~asdf.AsdfFile`'s tree and
+Now instances of our type can be added to an ``~asdf.AsdfFile``'s tree and
 serialized to an ASDF file.
 
 For sharing with other Python users
@@ -66,10 +66,10 @@ For sharing with other Python users
 
 Now say our files are getting out into the world and into the hands of
 other Python users.  We'll want to build an installable package
-around our code and use the `asdf` library's entry points to make our
+around our code and use the ``asdf`` library's entry points to make our
 extension more convenient to use.  We should also think about adding
 a schema that validates our tagged objects, so if someone manually edits
-a file and makes a mistake, we get a clear error when `asdf` opens the file.
+a file and makes a mistake, we get a clear error when ``asdf`` opens the file.
 
 1. Identify the Python type to serialize.  We'll need to know the fully-qualified
    name of the type (module path + class name).
@@ -83,19 +83,19 @@ a file and makes a mistake, we get a clear error when `asdf` opens the file.
 4. Write the schema that will validate the tagged object.  See :ref:`extending_schemas`
    if you're new to authoring schemas.
 
-5. Make the schema installable as an `asdf` library resource.  See :ref:`extending_resources`
-   for an overview of resources in `asdf` and :ref:`extending_resources_entry_points` for
+5. Make the schema installable as an ``asdf`` library resource.  See :ref:`extending_resources`
+   for an overview of resources in ``asdf`` and :ref:`extending_resources_entry_points` for
    information on installing resources via an entry point.
 
-6. Implement a `~asdf.extension.Converter` class that converts the type to
+6. Implement a ``~asdf.extension.Converter`` class that converts the type to
    YAML-serializable objects and back again.  See :ref:`extending_converters`
    for a discussion of the Converter interface.  Refer to the schema to ensure
    that the Converter is writing YAML objects correctly.
 
-7. Implement an `~asdf.extension.Extension` class which is the vehicle
-   for plugging our converter into the `asdf` library.  See :ref:`extending_extensions`
+7. Implement an ``~asdf.extension.Extension`` class which is the vehicle
+   for plugging our converter into the ``asdf`` library.  See :ref:`extending_extensions`
    for a discussion of the Extension interface.  We'll need to associate the schema
-   URI with the tag URI in our tag's `~asdf.extension.TagDefinition` object.
+   URI with the tag URI in our tag's ``~asdf.extension.TagDefinition`` object.
 
 8. Install the extension via an entry point.  See :ref:`extending_extensions_installing_entry_points`.
 
@@ -127,17 +127,17 @@ called an extension manifest that defines the extension in a language-independen
    we're including in our extension.  See :ref:`extending_manifests` for information
    on the manifest format.
 
-5. Make the schema and manifest installable as `asdf` library resources.  See
-   :ref:`extending_resources` for an overview of resources in `asdf` and
+5. Make the schema and manifest installable as ``asdf`` library resources.  See
+   :ref:`extending_resources` for an overview of resources in ``asdf`` and
    :ref:`extending_resources_entry_points` for information on installing resources
    via an entry point.
 
-6. Implement a `~asdf.extension.Converter` class that converts the type to
+6. Implement a ``~asdf.extension.Converter`` class that converts the type to
    YAML-serializable objects and back again.  See :ref:`extending_converters`
    for a discussion of the Converter interface.  Refer to the schema to ensure
    that the Converter is writing YAML objects correctly.
 
-7. Use `asdf.extension.ManifestExtension.from_uri` to populate an extension with the Converter
+7. Use ``asdf.extension.ManifestExtension.from_uri`` to populate an extension with the Converter
    and information from the manifest document.  See :ref:`extending_extensions_manifest` for
    instructions on using ManifestExtension.
 
@@ -151,17 +151,17 @@ Support a new block compressor
 ==============================
 
 In order to support a new compression algorithm for ASDF binary blocks,
-we need to implement the `~asdf.extension.Compressor` interface and install
+we need to implement the ``~asdf.extension.Compressor`` interface and install
 that in an extension.
 
 1. Select a 4-byte compression code that will signify the compression algorithm.
 
-1. Implement a `~asdf.extension.Compressor` class that associates the 4-byte code with
+1. Implement a ``~asdf.extension.Compressor`` class that associates the 4-byte code with
    compression and decompression methods.  See :ref:`extending_compressors` for a discussion
    of the Compressor interface.
 
-2. Implement an `~asdf.extension.Extension` class which is the vehicle
-   for plugging our compressor into the `asdf` library.  See :ref:`extending_extensions`
+2. Implement an ``~asdf.extension.Extension`` class which is the vehicle
+   for plugging our compressor into the ``asdf`` library.  See :ref:`extending_extensions`
    for a discussion of the Extension interface.
 
 3. Install the extension via one of the two available methods.  See
@@ -169,4 +169,4 @@ that in an extension.
 
 Now the compression algorithm will be available for both reading and writing ASDF files.
 Users writing files will simply need to specify the new 4-byte compression code when making calls
-to `asdf.AsdfFile.set_array_compression`.
+to ``asdf.AsdfFile.set_array_compression``.

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -27,16 +27,16 @@ and reading trees, see :ref:`overview`.
    Attempting to store a larger value as a YAML literal will result in a validation
    error.
 
-   For arbitrary precision integer support, see `IntegerType`.
+   For arbitrary precision integer support, see ``IntegerType``.
 
    Integers and floats of up to 64 bits can be stored inside of :mod:`numpy`
    arrays (see below).
 
 
-One of the key features of `asdf` is its ability to serialize :mod:`numpy`
+One of the key features of ``asdf`` is its ability to serialize :mod:`numpy`
 arrays. This is discussed in detail in :ref:`array-data`.
 
-While the core `asdf` package supports serialization of basic data types and
+While the core ``asdf`` package supports serialization of basic data types and
 Numpy arrays, its true power comes from its ability to be extended to support
 serialization of a wide range of custom data types. Details on using ASDF
 extensions can be found in :ref:`using_extensions`. Details on creating custom
@@ -94,8 +94,8 @@ Schema validation
 Schema validation is used to determine whether an ASDF file is well formed. All
 ASDF files must conform to the schemas defined by the :ref:`ASDF Standard
 <asdf-standard:asdf-standard>`. Schema validation occurs
-when reading ASDF files (using `asdf.open`), and also when writing them out
-(using `AsdfFile.write_to` or `AsdfFile.update`).
+when reading ASDF files (using ``asdf.open``), and also when writing them out
+(using ``AsdfFile.write_to`` or ``AsdfFile.update``).
 
 Schema validation also plays a role when using custom extensions (see
 :ref:`using_extensions` and :ref:`extending_extensions`). Extensions must provide schemas
@@ -159,7 +159,7 @@ a top-level ``metadata`` property that contains information about the time the
 image was taken and the resolution of the image.
 
 In order to use this schema for a secondary validation pass, we pass the
-`custom_schema` argument to either `asdf.open` or the `AsdfFile` constructor.
+`custom_schema` argument to either ``asdf.open`` or the ``AsdfFile`` constructor.
 Assume that the schema file lives in ``image_schema.yaml``, and we wish to
 open a file called ``image.asdf``. We would open the file with the following
 code:
@@ -216,8 +216,8 @@ In general, forward compatibility with newer versions of the ASDF Standard and
 ASDF file format is not supported by the software.
 
 When creating new ASDF files, it is possible to control the version of the file
-format that is used. This can be specified by passing the `version` argument to
-either the `AsdfFile` constructor when the file object is created, or to the
+format that is used. This can be specified by passing the ``version`` argument to
+either the ``AsdfFile`` constructor when the file object is created, or to the
 `AsdfFile.write_to` method when it is written. By default, the latest version
 of the file format will be used. Note that this option has no effect on the
 versions of tags from custom extensions.
@@ -230,7 +230,7 @@ Tree References
 
 ASDF files may reference items in the tree in other ASDF files.  The
 syntax used in the file for this is called "JSON Pointer", but users
-of `asdf` can largely ignore that.
+of ``asdf`` can largely ignore that.
 
 First, we'll create a ASDF file with a couple of arrays in it:
 
@@ -270,7 +270,7 @@ to the target file.
 
 .. asdf:: source.asdf
 
-Calling `~asdf.AsdfFile.find_references` will look up all of the
+Calling ``~asdf.AsdfFile.find_references`` will look up all of the
 references so they can be used as if they were local to the tree.  It
 doesn't actually move any of the data, and keeps the references as
 references.
@@ -281,7 +281,7 @@ references.
        ff.find_references()
        assert ff.tree['my_ref_b'].shape == (10,)
 
-On the other hand, calling `~asdf.AsdfFile.resolve_references`
+On the other hand, calling ``~asdf.AsdfFile.resolve_references``
 places all of the referenced content directly in the tree, so when we
 write it out again, all of the external references are gone, with the
 literal content in its place.
@@ -296,14 +296,14 @@ literal content in its place.
 
 A similar feature provided by YAML, anchors and aliases, also provides
 a way to support references within the same file.  These are supported
-by `asdf`, however the JSON Pointer approach is generally favored because:
+by ``asdf``, however the JSON Pointer approach is generally favored because:
 
    - It is possible to reference elements in another file
 
    - Elements are referenced by location in the tree, not an
      identifier, therefore, everything can be referenced.
 
-Anchors and aliases are handled automatically by `asdf` when the
+Anchors and aliases are handled automatically by ``asdf`` when the
 data structure is recursive.  For example here is a dictionary that is
 included twice in the same tree:
 
@@ -340,7 +340,7 @@ are required:
   cases the name will be a path relative to the ASDF file itself, or a URI
   for a network resource.
 * The data type of the array data. This is a string representing any valid
-  `numpy.dtype`.
+  ``numpy.dtype``.
 * The shape of the data array. This is a tuple representing the dimensions of
   the array data.
 * The array data ``target``. This is either an integer or a string that
@@ -370,7 +370,7 @@ about:
 .. asdf:: external_array.asdf
 
 When reading a file containing external references, the user is responsible for
-using the information in the `ExternalArrayReference` type to open the external
+using the information in the ``ExternalArrayReference`` type to open the external
 file and retrieve the associated array data.
 
 Saving history entries
@@ -379,9 +379,9 @@ Saving history entries
 `asdf` has a convenience method for notating the history of transformations
 that have been performed on a file.
 
-Given a `~asdf.AsdfFile` object, call `~asdf.AsdfFile.add_history_entry`, given
+Given a ``~asdf.AsdfFile`` object, call ``~asdf.AsdfFile.add_history_entry``, given
 a description of the change and optionally a description of the software (i.e.
-your software, not `asdf`) that performed the operation.
+your software, not ``asdf``) that performed the operation.
 
 .. runcode::
 
@@ -418,13 +418,13 @@ Saving ASDF in FITS
     This section is about packaging entire ASDF files inside of
     `FITS data format <https://en.wikipedia.org/wiki/FITS>`_ files. This is
     probably only of interest to astronomers. Making use of this feature
-    requires the `astropy` package to be installed.
+    requires the ``astropy`` package to be installed.
 
 Sometimes you may need to store the structured data supported by ASDF inside of
 a FITS file in order to be compatible with legacy tools that support only FITS.
 
-First, create an `~astropy.io.fits.HDUList` object using `astropy.io.fits`.
-Here, we are building an `~astropy.io.fits.HDUList` from scratch, but it could
+First, create an ``~astropy.io.fits.HDUList`` object using ``astropy.io.fits``.
+Here, we are building an ``~astropy.io.fits.HDUList`` from scratch, but it could
 also have been loaded from an existing file.
 
 We will create a FITS file that has two image extensions, SCI and DQ
@@ -439,7 +439,7 @@ respectively.
     hdulist.append(fits.ImageHDU(np.arange(512, dtype=float), name='DQ'))
 
 Next we make a tree structure out of the data in the FITS file.  Importantly,
-we use the *same* array references in the FITS `~astropy.io.fits.HDUList` and
+we use the *same* array references in the FITS ``~astropy.io.fits.HDUList`` and
 store them in the tree. By doing this, ASDF will automatically refer to the
 data in the regular FITS extensions.
 
@@ -456,8 +456,8 @@ data in the regular FITS extensions.
         }
     }
 
-Now we take both the FITS `~astropy.io.fits.HDUList` and the ASDF tree and
-create an `AsdfInFits` object.
+Now we take both the FITS ``~astropy.io.fits.HDUList`` and the ASDF tree and
+create an ``AsdfInFits`` object.
 
 .. runcode::
 
@@ -480,9 +480,9 @@ indicate that the data comes from a FITS extension:
 
 .. asdf:: content.asdf
 
-To load an ASDF-in-FITS file, simply open it using `asdf.open`. The returned
-value will be an `AsdfInFits` object, which can be used in the same way as any
-other `AsdfFile` object.
+To load an ASDF-in-FITS file, simply open it using ``asdf.open``. The returned
+value will be an ``AsdfInFits`` object, which can be used in the same way as any
+other ``AsdfFile`` object.
 
 .. runcode::
 
@@ -497,7 +497,7 @@ other `AsdfFile` object.
 Rendering ASDF trees
 ====================
 
-The `asdf.info` function prints a representation of an ASDF
+The ``asdf.info`` function prints a representation of an ASDF
 tree to stdout.  For example:
 
 .. code:: python
@@ -515,9 +515,9 @@ tree to stdout.  For example:
       └─example_key (str): example value
 
 The first argument may be a ``str`` or ``pathlib.Path`` filesystem path,
-or an `AsdfFile` or sub-node of an ASDF tree.
+or an ``AsdfFile`` or sub-node of an ASDF tree.
 
-By default, `asdf.info` limits the number of lines, and line length,
+By default, ``asdf.info`` limits the number of lines, and line length,
 of the displayed tree.  The ``max_rows`` parameter controls the number of
 lines, and ``max_cols`` controls the line length.  Set either to ``None`` to
 disable that limit.
@@ -538,26 +538,26 @@ FITS header comments are used.
     >>> asdf.info('file.asdf', max_rows=(None, 5)) # doctest: +SKIP
     ...
 
-The `AsdfFile.info` method behaves similarly to `asdf.info`, rendering
-the tree of the associated `AsdfFile`.
+The ``AsdfFile.info`` method behaves similarly to ``asdf.info``, rendering
+the tree of the associated ``AsdfFile``.
 
-Normally `asdf.info` will not show the contents of asdf nodes turned
+Normally ``asdf.info`` will not show the contents of asdf nodes turned
 into Python custom objects, but if that object supports a special
 method, you may see the contents of such objects.
 See :ref:`exposing_extension_object_internals` for how
-to implement such support for `asdf.info` and `asdf.search`.
+to implement such support for ``asdf.info`` and ``asdf.search``.
 
 Searching the ASDF tree
 =======================
 
-The `AsdfFile` search interface provides a way to interactively discover the
+The ``AsdfFile`` search interface provides a way to interactively discover the
 locations and values of nodes within the ASDF tree.  We can search for
 nodes by key/index, type, or value.
 
 Basic usage
 -----------
 
-Initiate a search by calling `AsdfFile.search` on an open file:
+Initiate a search by calling ``AsdfFile.search`` on an open file:
 
 .. code:: python
 
@@ -580,9 +580,9 @@ Initiate a search by calling `AsdfFile.search` on an open file:
 
 .. currentmodule:: asdf.search
 
-The search returns an `AsdfSearchResult` object that displays in
+The search returns an ``AsdfSearchResult`` object that displays in
 the Python console as a rendered tree.  For single-node search
-results, the `AsdfSearchResult.path` property contains the Python code required to
+results, the ``AsdfSearchResult.path`` property contains the Python code required to
 reference that node directly:
 
 .. code:: python
@@ -590,14 +590,14 @@ reference that node directly:
     >>> af.search('example').path # doctest: +SKIP
     "root['data']['example_key']"
 
-While the `AsdfSearchResult.node` property contains the actual value of the node:
+While the ``AsdfSearchResult.node`` property contains the actual value of the node:
 
 .. code:: python
 
    >>> af.search('example').node # doctest: +SKIP
    'example value'
 
-For searches with multiple matching nodes, use the `AsdfSearchResult.paths` and `AsdfSearchResult.nodes`
+For searches with multiple matching nodes, use the ``AsdfSearchResult.paths`` and ``AsdfSearchResult.nodes``
 properties instead:
 
 .. code:: python
@@ -607,7 +607,7 @@ properties instead:
     >>> af.search('duplicate_key').nodes # doctest: +SKIP
     ["value 1", "value 2"]
 
-To replace matching nodes with a new value, use the `AsdfSearchResult.replace` method:
+To replace matching nodes with a new value, use the ``AsdfSearchResult.replace`` method:
 
 .. code:: python
 
@@ -617,7 +617,7 @@ To replace matching nodes with a new value, use the `AsdfSearchResult.replace` m
 
 .. currentmodule:: asdf
 
-The first argument to `AsdfFile.search` searches by dict key or list/tuple index.  We can
+The first argument to ``AsdfFile.search`` searches by dict key or list/tuple index.  We can
 also search by type, value, or any combination thereof:
 
 .. code:: python
@@ -633,7 +633,7 @@ also search by type, value, or any combination thereof:
 Chaining searches
 -----------------
 
-The return value of `AsdfFile.search`, `asdf.search.AsdfSearchResult`, has its own search method,
+The return value of ``AsdfFile.search``, ``asdf.search.AsdfSearchResult``, has its own search method,
 so it's possible to chain searches together.  This is useful when you need
 to see intermediate results before deciding how to further narrow the search.
 
@@ -715,9 +715,9 @@ Formatting search results
 
 .. currentmodule:: asdf.search
 
-The `AsdfSearchResult` object displays its content as a rendered tree with
+The ``AsdfSearchResult`` object displays its content as a rendered tree with
 reasonable defaults for maximum number of lines and columns displayed.  To
-change those values, we call `AsdfSearchResult.format`:
+change those values, we call ``AsdfSearchResult.format``:
 
 .. code:: python
 
@@ -726,7 +726,7 @@ change those values, we call `AsdfSearchResult.format`:
     >>> af.search(type=float).format(max_rows=None) # Show all matching rows # doctest: +SKIP
     ...
 
-Like `AsdfSearchResult.search`, calls to format may be chained:
+Like ``AsdfSearchResult.search``, calls to format may be chained:
 
 .. code:: python
 

--- a/docs/asdf/install.rst
+++ b/docs/asdf/install.rst
@@ -4,15 +4,15 @@
 Installation
 ************
 
-There are several different ways to install the `asdf` package. Each is
+There are several different ways to install the ``asdf`` package. Each is
 described in detail below.
 
 Requirements
 ============
 
-The `asdf` package has several dependencies which are listed in the project's
+The ``asdf`` package has several dependencies which are listed in the project's
 setup.cfg file.  All dependencies are available on pypi and will be automatically
-installed along with `asdf`.
+installed along with ``asdf``.
 
 Support for units, time, and transform tags requires an implementation of these
 types.  One recommended option is the `astropy <https://www.astropy.org/>`__ package.
@@ -35,11 +35,11 @@ the `conda-forge <https://conda-forge.org/>`__ channel. It is also available
 through the `astroconda <https://astroconda.readthedocs.io/en/latest/>`__
 channel.
 
-To install `asdf` within an existing conda environment::
+To install ``asdf`` within an existing conda environment::
 
     $ conda install -c conda-forge asdf
 
-To create a new conda environment and install `asdf`::
+To create a new conda environment and install ``asdf``::
 
     $ conda create -n new-env-name -c conda-forge python asdf
 

--- a/docs/asdf/using_extensions.rst
+++ b/docs/asdf/using_extensions.rst
@@ -3,18 +3,18 @@
 The built-in extension
 ----------------------
 
-The ability to serialize the following types is provided by `asdf`'s built-in
+The ability to serialize the following types is provided by ``asdf``'s built-in
 extension:
 
-* `dict`
-* `list`
-* `str`
-* `int`
-* `float`
-* `complex`
-* `numpy.ndarray`
+* ``dict``
+* ``list``
+* ``str``
+* ``int``
+* ``float``
+* ``complex``
+* ``numpy.ndarray``
 
-The built-in extension is packaged with `asdf` and is automatically used when
+The built-in extension is packaged with ``asdf`` and is automatically used when
 reading and writing files. Users can not control the use of the built-in
 extension and in general they need not concern themselves with the details of
 its implementation. However, it is useful to be aware that the built-in
@@ -30,7 +30,7 @@ In order for a particular custom type to be serialized, a special class called
 a "converter" must be implemented. Each converter defines how the corresponding
 custom type will be serialized and deserialized. More details on how converters
 are implemented can be found in :ref:`extending_converters`. Users should never
-have to refer to converter implementations directly; they simply enable `asdf` to
+have to refer to converter implementations directly; they simply enable ``asdf`` to
 recognize and process custom types.
 
 In addition to converters, each custom type may have a corresponding schema,
@@ -45,9 +45,9 @@ implementation) changes.
 Extensions
 ----------
 
-In order for the converters and schemas to be used by `asdf`, they must be
+In order for the converters and schemas to be used by ``asdf``, they must be
 packaged into an **extension** class. In general, the details of extensions are
-irrelevant to users of `asdf`. However, users need to be aware of extensions in
+irrelevant to users of ``asdf``. However, users need to be aware of extensions in
 the following two scenarios:
 
 * when storing custom data types to files to be written
@@ -70,7 +70,7 @@ for custom types and extensions, see :ref:`extending_extensions`.
 Reading files with custom types
 *******************************
 
-The `asdf` software is capable of reading files that contain custom data types
+The ``asdf`` software is capable of reading files that contain custom data types
 even if the extension that was used to create the file is not present. However,
 the extension is required in order to properly deserialize the original type.
 
@@ -96,7 +96,7 @@ Custom types, extensions, and versioning
 ----------------------------------------
 
 Tags and schemas that follow best practices are versioned. This allows changes
-to tags and schemas to be recorded, and it allows `asdf` to define behavior with
+to tags and schemas to be recorded, and it allows ``asdf`` to define behavior with
 respect to version compatibility.
 
 Tag and schema versions may change for several reasons. One common reason is to
@@ -110,7 +110,7 @@ encouraged to maintain backwards compatibility with all older tag versions.
 Reading files
 *************
 
-When `asdf` encounters a tagged object in a file, it will compare the URI of
+When ``asdf`` encounters a tagged object in a file, it will compare the URI of
 the tag in the file with the list of tags handled by available converters.
 The first matching converter will be selected to deserialize the object.  If
 no such converters exist, the library will emit a warning and the object will
@@ -118,31 +118,31 @@ be presented to the user in its primitive form.
 
 If multiple converters are present that both handle the same tag, the first
 found by the library will be used.  Users may disable a converter by removing
-its extension with the `~asdf.config.AsdfConfig.remove_extension` method.
+its extension with the ``~asdf.config.AsdfConfig.remove_extension`` method.
 
 Writing files
 *************
 
-When writing a object to a file, `asdf` compares the object's type to the list
+When writing a object to a file, ``asdf`` compares the object's type to the list
 of types handled by available converters.  The first matching converter will
 be selected to serialize the object.  If no such converters exist, the library
 will raise an error.
 
 If multiple converters are present that both handle the same type, the first
 found by the library will be used.  Users may disable a converter by removing
-its extension with the `~asdf.config.AsdfConfig.remove_extension` method.
+its extension with the ``~asdf.config.AsdfConfig.remove_extension`` method.
 
 .. _other_packages:
 
 Extensions from other packages
 ------------------------------
 
-Some external packages may define extensions that allow `asdf` to recognize some
+Some external packages may define extensions that allow ``asdf`` to recognize some
 or all of the types that are defined by that package. Such packages may install
 the extension class as part of the package itself (details for developers can
 be found in :ref:`extending_extensions_installing_entry_points`).
 
-If the package installs its extension, then `asdf` will automatically detect the
+If the package installs its extension, then ``asdf`` will automatically detect the
 extension and use it when processing any files. No specific action is required
 by the user in order to successfully read and write custom types defined by
 the extension for that particular package.
@@ -169,7 +169,7 @@ Sometimes no packaged extensions are provided for the types you wish to
 serialize. In this case, it is necessary to explicitly install any necessary
 extension classes when reading and writing files that contain custom types.
 
-The config object returned from `asdf.get_config` offers an `~asdf.config.AsdfConfig.add_extension`
+The config object returned from ``asdf.get_config`` offers an ``~asdf.config.AsdfConfig.add_extension``
 method that can be used to install an extension for the remainder of the current
 Python session.
 
@@ -193,7 +193,7 @@ any package, we will need to manually install it:
     af.write_to('custom.asdf')
 
 Note that the extension class must actually be instantiated when it is passed
-to `~asdf.config.AsdfConfig.add_extension`.
+to ``~asdf.config.AsdfConfig.add_extension``.
 
 To read the file (in a new session) we again need to install the extension first:
 
@@ -214,10 +214,10 @@ were used to create the file will be added to the file itself.  This includes
 the extension's URI, which uniquely identifies a particular version of the
 extension.
 
-When reading files with extension metadata, `asdf` can check whether the required
+When reading files with extension metadata, ``asdf`` can check whether the required
 extensions are present before processing the file. If a required extension is
-not present, `asdf` will issue a warning.
+not present, ``asdf`` will issue a warning.
 
 It is possible to turn these warnings into errors by using the
-`strict_extension_check` parameter of `asdf.open`. If this parameter is set to
+`strict_extension_check` parameter of ``asdf.open``. If this parameter is set to
 `True`, then opening the file will fail if any of the required extensions are missing.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,7 +88,7 @@ See also
 - The :ref:`Advanced Scientific Data Format (ASDF) standard
   <asdf-standard:asdf-standard>`.
 
-- `asdf` Python package distribution on `pypi <https://pypi.org/project/asdf/>`_
+- ``asdf`` Python package distribution on `pypi <https://pypi.org/project/asdf/>`_
 
 Changes
 =======


### PR DESCRIPTION
changed usage of ` `` ` (italic in RST) to ` ```` ` (inline code in RST)
```sed
s/ `([\w.-~]+)`([^_])/ ``\1``\2/g
``` 