### PR TITLE
unpin dependency versions in `s390x` build

### DIFF
--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -56,6 +56,6 @@ jobs:
           run: |
             python3 -m venv --system-site-packages tests
             source tests/bin/activate
-            pip3 install --upgrade pip setuptools gwcs==0.9.1 pytest==5.4.3 pytest-doctestplus==0.8.0
+            pip3 install --upgrade pip setuptools gwcs pytest pytest-doctestplus
             pip3 install -e .[all,tests]
             python3 -m pytest --remote-data


### PR DESCRIPTION
fixes issue with `s390x` test failure: https://github.com/asdf-format/asdf/actions/runs/2526970260