### PR TITLE
Change to tab layout for pyproject.toml vs setup.cfg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ The ASDF Standard is at v1.6.0
 
 - Overhaul of the ASDF documentation to make it more consistent and readable. [#1142, #1152]
 - Update deprecated instances of `abstractproperty` to `abstractmethod` [#1148]
-- Move build configuration into `pyproject.toml` [#1149]
+- Move build configuration into `pyproject.toml` [#1149, #1155]
 
 2.12.0 (2022-06-06)
 -------------------

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -253,18 +253,20 @@ We'll assume that method is located in the module ``asdf_foo_extension.integrati
 Next, in the package's ``pyproject.toml``, define a ``[project.entry-points]`` section (or ``[options.entry_points]`` in
 ``setup.cfg``) that identifies the method as an ``asdf.extensions`` entry point:
 
-.. code-block:: toml
+.. tab:: pyproject.toml
 
-    # pyproject.toml
-    [project.entry-points]
-    'asdf.extensions' = { asdf_foo_extension = 'asdf_foo_extension.integration:get_extensions' }
+    .. code-block:: toml
 
-.. code-block:: ini
+        [project.entry-points]
+        'asdf.extensions' = { asdf_foo_extension = 'asdf_foo_extension.integration:get_extensions' }
 
-    # setup.cfg
-    [options.entry_points]
-    asdf.extensions =
-        asdf_foo_extension = asdf_foo_extension.integration:get_extensions
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [options.entry_points]
+        asdf.extensions =
+            asdf_foo_extension = asdf_foo_extension.integration:get_extensions
 
 After installing the package, the extension should be automatically available in any
 new Python session.

--- a/docs/asdf/extending/legacy.rst
+++ b/docs/asdf/extending/legacy.rst
@@ -881,17 +881,19 @@ containing your schema files to the pytest section of your project's build confi
 (``pyproject.toml`` or ``setup.cfg``). If you do not already have such a file, creating
 one with the following should be sufficient:
 
-.. code:: toml
+.. tab:: pyproject.toml
 
-    # pyproject.toml
-    [tool.pytest.ini_options]
-    asdf_schema_root = 'path/to/schemas another/path/to/schemas'
+    .. code-block:: toml
 
-.. code:: ini
+        [tool.pytest.ini_options]
+        asdf_schema_root = 'path/to/schemas another/path/to/schemas'
 
-    # setup.cfg
-    [tool:pytest]
-    asdf_schema_root = path/to/schemas another/path/to/schemas
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [tool:pytest]
+        asdf_schema_root = path/to/schemas another/path/to/schemas
 
 The schema directory paths should be paths that are relative to the top of the
 package directory **when it is installed**. If this is different from the path

--- a/docs/asdf/extending/resources.rst
+++ b/docs/asdf/extending/resources.rst
@@ -193,17 +193,19 @@ instance:
 Then in ``pyproject.toml``, define an ``[project.entry-points]`` section (or ``[options.entry_points]`` in ``setup.cfg``)
 that identifies the method as an ``asdf.resource_mappings`` entry point:
 
-.. code-block:: toml
+.. tab:: pyproject.toml
 
-    # pyproject.toml
-    [project.entry-points]
-    'asdf.resource_mappings' = { asdf_foo_schemas = 'asdf_foo_schemas.integration:get_resource_mappings' }
+    .. code-block:: toml
 
-.. code-block:: ini
+        [project.entry-points]
+        'asdf.resource_mappings' = { asdf_foo_schemas = 'asdf_foo_schemas.integration:get_resource_mappings' }
 
-    # setup.cfg
-    [options.package_data]
-    * = *.yaml
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [options.package_data]
+        * = *.yaml
 
 After installing the package, it should be possible to load one of our schemas
 in a new session without any additional setup:
@@ -221,17 +223,19 @@ YAML files.  There are multiple ways to accomplish this, but one easy option
 is to add a ``[tool.setuptools.package-data]`` section to ``pyproject.toml`` (or ``[options.package_data]`` in
 ``setup.cfg``) requesting that all files with a ``.yaml`` extension be installed:
 
-.. code-block:: toml
+.. tab:: pyproject.toml
 
-    # pyproject.toml
-    [tool.setuptools.package-data]
-    '*' = ['*.yaml']
+    .. code-block:: toml
 
-.. code-block:: ini
+        [tool.setuptools.package-data]
+        '*' = ['*.yaml']
 
-    # setup.cfg
-    [options.package_data]
-    * = *.yaml
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [options.package_data]
+        * = *.yaml
 
 Entry point performance considerations
 --------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ latex_logo = "_static/logo.pdf"
 man_pages = [("index", project.lower(), project + " Documentation", [author], 1)]
 
 sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname("__file__")), "sphinxext"))
-extensions += ["example", "sphinx_asdf"]
+extensions += ["example", "sphinx_asdf", "sphinx_inline_tabs"]
 
 
 def setup(app):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ docs = [
     'sphinx-asdf',
     'sphinx-astropy',
     'sphinx-rtd-theme',
+    'sphinx-inline-tabs',
     'toml',
 ]
 tests = [


### PR DESCRIPTION
Changes layout for `pyproject.toml` vs `setup.cfg` examples from listing consecutively to placing them on user selectable tabs.