### PR TITLE
Fix for failing latex build

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -2,9 +2,17 @@ If you use ASDF for work/research presented in a publication (whether directly,
 as a dependency to another package), please cite the Zenodo DOI for the appropriate
 version of ASDF.  The versions (and their BibTeX entries) can be found at:
 
-.. include:: ../../README.rst
-    :start-after: begin-zenodo:
-    :end-before: end-zenodo:
+.. only:: html
+
+    .. include:: ../../README.rst
+        :start-after: begin-zenodo:
+        :end-before: end-zenodo:
+
+.. only:: latex
+
+    .. admonition:: Zenodo DOI
+
+        https://zenodo.org/badge/latestdoi/18112754
 
 We also recommend and encourage you to cite the general ASDF paper:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,11 @@
 ASDF - Advanced Scientific Data Format
 **************************************
 
-.. include:: ../README.rst
-    :start-after: begin-badges:
-    :end-before: end-badges:
+.. only:: html
+
+  .. include:: ../README.rst
+      :start-after: begin-badges:
+      :end-before: end-badges:
 
 `asdf` is a tool for reading and writing Advanced Scientific Data
 Format (ASDF) files.


### PR DESCRIPTION
RTD is failing due to an issue building the latex version of the docs. This PR fixes that bug.

Note the docs builds done as part of the CI do not check if LaTeX is building. This can be checked in by running `make latex` or `make latexpdf` in the `docs` directory of the project.