### PR TITLE
Add ability to pull information from tagged schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.13.0 (unreleased)
+-------------------
+
+The ASDF Standard is at v1.6.0
+
+- Add ability to pull information from schema about asdf file data, using `schema_data`
+  method. [#1167]
+
 2.12.1 (2022-08-17)
 -------------------
 

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -9,7 +9,7 @@ return what it thinks is suitable for display.
 """
 import numpy as np
 
-from ._node_data import NodeSchemaData
+from ._node_data import NodeSchemaInfo
 from .tags.core.ndarray import NDArrayType
 from .util import is_primitive
 
@@ -43,7 +43,7 @@ def render_tree(
     """
     Render a tree as text with indents showing depth.
     """
-    info = NodeSchemaData.from_root_node("title", identifier, node, refresh_extension_manager=refresh_extension_manager)
+    info = NodeSchemaInfo.from_root_node("title", identifier, node, refresh_extension_manager=refresh_extension_manager)
 
     if len(filters) > 0:
         if not _filter_tree(info, filters):
@@ -244,8 +244,8 @@ class _TreeRenderer:
         else:
             line = f"{prefix}{format_bold(info.identifier)} {value}"
 
-        if info.data is not None:
-            line = line + format_faint(format_italic(" # " + info.data))
+        if info.info is not None:
+            line = line + format_faint(format_italic(" # " + info.info))
         visible_children = info.visible_children
         if len(visible_children) == 0 and len(info.children) > 0:
             line = line + format_italic(" ...")

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -9,7 +9,7 @@ return what it thinks is suitable for display.
 """
 import numpy as np
 
-from ._node_data import NodeSchemaInfo
+from ._node_info import NodeSchemaInfo
 from .tags.core.ndarray import NDArrayType
 from .util import is_primitive
 

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -7,8 +7,6 @@ by the converter mechanism has a __asdf_traverse__() method, then it will
 call that method expecting a dict or list to be returned. The method can
 return what it thinks is suitable for display.
 """
-import re
-
 import numpy as np
 
 from ._node_data import NodeSchemaData
@@ -82,18 +80,6 @@ def format_italic(value):
 
 def _format_code(value, code):
     return f"\x1B[{code}m{value}\x1B[0m"
-
-
-def _get_schema_for_property(schema, attr):
-    subschema = schema.get("properties", {}).get(attr, None)
-    if subschema is not None:
-        return subschema
-    subschema = schema.get("properties", {}).get("patternProperties", None)
-    if subschema:
-        for key in subschema:
-            if re.search(key, attr):
-                return subschema[key]
-    return {}
 
 
 def _filter_tree(info, filters):

--- a/asdf/_node_data.py
+++ b/asdf/_node_data.py
@@ -1,7 +1,6 @@
 import re
-import warnings
+from collections import namedtuple
 
-from .exceptions import AsdfWarning
 from .schema import load_schema
 from .treeutil import get_children
 
@@ -16,6 +15,9 @@ def collect_schema_data(key, node, identifier="root", refresh_extension_manager=
     )
 
     return schema_data.collect_data()
+
+
+SchemaData = namedtuple("SchemaData", ["data", "value"])
 
 
 class NodeSchemaData:
@@ -151,11 +153,6 @@ class NodeSchemaData:
             }
 
             if self.data is not None:
-                data[self.key] = self.data
-
-                if (key := f"{self.key}_data") in data:
-                    warnings.warn("{key} is already a key, file data is not stored under this key", AsdfWarning)
-                else:
-                    data[key] = self.node
+                data[self.key] = SchemaData(self.data, self.node)
 
         return data

--- a/asdf/_node_data.py
+++ b/asdf/_node_data.py
@@ -22,7 +22,50 @@ SchemaInfo = namedtuple("SchemaInfo", ["info", "value"])
 
 class NodeSchemaInfo:
     """
-    Container for a node, and the values of information from a schema
+    Container for keyed information collected from a schema about a node of an ASDF file tree.
+
+        This contains node alongside the parent and child nodes of that node in the ASDF file tree.
+        Effectively this means that each of these "node" objects represents the a subtree of the file tree
+        rooted at the node in question alongside methods to access the underlying schemas for the portions
+        of the ASDF file in question.
+
+    This is used for a variety of general purposes, including:
+    - Providing the long descriptions for nodes as described in the schema.
+    - Assisting in traversing an ASDF file like trees, to search nodes.
+    - Providing a way to pull static information about an ASDF file which has
+      been stored within the schemas for that file.
+
+    Parameters
+    ----------
+    key : str
+        The key for the information to be collected from the underlying schema(s).
+
+    parent : NodeSchemaInfo
+        The parent node of this node. None if this is the root node.
+
+    identifier : str
+        The identifier for this node in the ASDF file tree.
+
+    node : any
+        The value of the node in the ASDF file tree.
+
+    depth : int
+        The depth of this node in the ASDF file tree.
+
+    recursive : bool
+        If this node has already been visited, then this is set to True. Default is False.
+
+    visible : bool
+        If this node will be made visible in the output. Default is True.
+
+    children : list
+        List of the NodeSchemaInfo objects for the children of this node. This is a leaf node if this is empty.
+
+    info : any
+        The information stored in the underlying schema corresponding to the key.
+
+    schema : dict
+        The portion of the underlying schema corresponding to the node.
     """
 
     def __init__(self, key, parent, identifier, node, depth, recursive=False, visible=True):

--- a/asdf/_node_data.py
+++ b/asdf/_node_data.py
@@ -1,0 +1,129 @@
+import re
+
+from .schema import load_schema
+from .treeutil import get_children
+
+
+class NodeSchemaData:
+    """
+    Container for a node, and the values of data from a schema
+    """
+
+    def __init__(self, key, parent, identifier, node, depth, recursive=False, visible=True):
+        self.key = key
+        self.parent = parent
+        self.identifier = identifier
+        self.node = node
+        self.depth = depth
+        self.recursive = recursive
+        self.visible = visible
+        self.children = []
+        self.data = None
+        self.schema = None
+
+    @classmethod
+    def traversable(cls, node):
+        """
+        This method determines if the node is an instance of a class that
+        supports introspection by the info machinery. This determined by
+        the presence of a __asdf_traverse__ method.
+        """
+        return hasattr(node, "__asdf_traverse__")
+
+    @property
+    def visible_children(self):
+        return [c for c in self.children if c.visible]
+
+    @property
+    def parent_node(self):
+        if self.parent is None:
+            return None
+        else:
+            return self.parent.node
+
+    def get_schema_for_property(self, identifier):
+        subschema = self.schema.get("properties", {}).get(identifier, None)
+        if subschema is not None:
+            return subschema
+
+        subschema = self.schema.get("properties", {}).get("patternProperties", None)
+        if subschema:
+            for key in subschema:
+                if re.search(key, identifier):
+                    return subschema[key]
+        return {}
+
+    def extract_schema_data(self, schema):
+        self.schema = schema
+        self.data = schema.get(self.key, None)
+
+    @classmethod
+    def from_root_node(cls, key, root_identifier, root_node, schema=None, refresh_extension_manager=False):
+        """
+        Build a _NodeInfo tree from the given ASDF root node.
+        Intentionally processes the tree in breadth-first order so that recursively
+        referenced nodes are displayed at their shallowest reference point.
+        """
+        from .asdf import AsdfFile, get_config
+        from .extension import ExtensionManager
+
+        af = AsdfFile()
+        if refresh_extension_manager:
+            config = get_config()
+            af._extension_manager = ExtensionManager(config.extensions)
+        extmgr = af.extension_manager
+
+        current_nodes = [(None, root_identifier, root_node)]
+        seen = set()
+        root_data = None
+        current_depth = 0
+        while True:
+            next_nodes = []
+
+            for parent, identifier, node in current_nodes:
+                if (isinstance(node, dict) or isinstance(node, tuple) or cls.traversable(node)) and id(node) in seen:
+                    data = NodeSchemaData(key, parent, identifier, node, current_depth, recursive=True)
+                    parent.children.append(data)
+
+                else:
+                    data = NodeSchemaData(key, parent, identifier, node, current_depth)
+
+                    if root_data is None:
+                        root_data = data
+
+                    if parent is not None:
+                        if parent.schema is not None and not cls.traversable(node):
+                            # Extract subschema if it exists
+                            subschema = parent.get_schema_for_property(identifier)
+                            data.extract_schema_data(subschema)
+
+                        parent.children.append(data)
+
+                    seen.add(id(node))
+
+                    if cls.traversable(node):
+                        tnode = node.__asdf_traverse__()
+                        # Look for a title for the attribute if it is a tagged object
+                        tag = node._tag
+                        tagdef = extmgr.get_tag_definition(tag)
+                        schema_uri = tagdef.schema_uris[0]
+                        schema = load_schema(schema_uri)
+                        data.extract_schema_data(schema)
+
+                    else:
+                        tnode = node
+
+                    if parent is None:
+                        data.schema = schema
+
+                    for child_identifier, child_node in get_children(tnode):
+                        next_nodes.append((data, child_identifier, child_node))
+                        # extract subschema if appropriate
+
+            if len(next_nodes) == 0:
+                break
+
+            current_nodes = next_nodes
+            current_depth += 1
+
+        return root_data

--- a/asdf/_node_data.py
+++ b/asdf/_node_data.py
@@ -5,24 +5,24 @@ from .schema import load_schema
 from .treeutil import get_children
 
 
-def collect_schema_data(key, node, identifier="root", preserve_list=True, refresh_extension_manager=False):
+def collect_schema_info(key, node, identifier="root", preserve_list=True, refresh_extension_manager=False):
     """
-    Collect from the underlying schemas any of the data stored under key.
+    Collect from the underlying schemas any of the info stored under key.
     """
 
-    schema_data = NodeSchemaData.from_root_node(
+    schema_info = NodeSchemaInfo.from_root_node(
         key, identifier, node, refresh_extension_manager=refresh_extension_manager
     )
 
-    return schema_data.collect_data(preserve_list=preserve_list)
+    return schema_info.collect_info(preserve_list=preserve_list)
 
 
-SchemaData = namedtuple("SchemaData", ["data", "value"])
+SchemaInfo = namedtuple("SchemaInfo", ["info", "value"])
 
 
-class NodeSchemaData:
+class NodeSchemaInfo:
     """
-    Container for a node, and the values of data from a schema
+    Container for a node, and the values of information from a schema
     """
 
     def __init__(self, key, parent, identifier, node, depth, recursive=False, visible=True):
@@ -34,7 +34,7 @@ class NodeSchemaData:
         self.recursive = recursive
         self.visible = visible
         self.children = []
-        self.data = None
+        self.info = None
         self.schema = None
 
     @classmethod
@@ -69,14 +69,14 @@ class NodeSchemaData:
                     return subschema[key]
         return {}
 
-    def extract_schema_data(self, schema):
+    def extract_schema_info(self, schema):
         self.schema = schema
-        self.data = schema.get(self.key, None)
+        self.info = schema.get(self.key, None)
 
     @classmethod
     def from_root_node(cls, key, root_identifier, root_node, schema=None, refresh_extension_manager=False):
         """
-        Build a NodeSchemaData tree from the given ASDF root node.
+        Build a NodeSchemaInfo tree from the given ASDF root node.
         Intentionally processes the tree in breadth-first order so that recursively
         referenced nodes are displayed at their shallowest reference point.
         """
@@ -91,29 +91,29 @@ class NodeSchemaData:
 
         current_nodes = [(None, root_identifier, root_node)]
         seen = set()
-        root_data = None
+        root_info = None
         current_depth = 0
         while True:
             next_nodes = []
 
             for parent, identifier, node in current_nodes:
                 if (isinstance(node, dict) or isinstance(node, tuple) or cls.traversable(node)) and id(node) in seen:
-                    data = NodeSchemaData(key, parent, identifier, node, current_depth, recursive=True)
-                    parent.children.append(data)
+                    info = NodeSchemaInfo(key, parent, identifier, node, current_depth, recursive=True)
+                    parent.children.append(info)
 
                 else:
-                    data = NodeSchemaData(key, parent, identifier, node, current_depth)
+                    info = NodeSchemaInfo(key, parent, identifier, node, current_depth)
 
-                    if root_data is None:
-                        root_data = data
+                    if root_info is None:
+                        root_info = info
 
                     if parent is not None:
                         if parent.schema is not None and not cls.traversable(node):
                             # Extract subschema if it exists
                             subschema = parent.get_schema_for_property(identifier)
-                            data.extract_schema_data(subschema)
+                            info.extract_schema_info(subschema)
 
-                        parent.children.append(data)
+                        parent.children.append(info)
 
                     seen.add(id(node))
 
@@ -124,16 +124,16 @@ class NodeSchemaData:
                         tagdef = extmgr.get_tag_definition(tag)
                         schema_uri = tagdef.schema_uris[0]
                         schema = load_schema(schema_uri)
-                        data.extract_schema_data(schema)
+                        info.extract_schema_info(schema)
 
                     else:
                         tnode = node
 
                     if parent is None:
-                        data.schema = schema
+                        info.schema = schema
 
                     for child_identifier, child_node in get_children(tnode):
-                        next_nodes.append((data, child_identifier, child_node))
+                        next_nodes.append((info, child_identifier, child_node))
                         # extract subschema if appropriate
 
             if len(next_nodes) == 0:
@@ -142,11 +142,11 @@ class NodeSchemaData:
             current_nodes = next_nodes
             current_depth += 1
 
-        return root_data
+        return root_info
 
-    def collect_data(self, preserve_list=True):
+    def collect_info(self, preserve_list=True):
         """
-        Collect the data from the NodeSchemaData tree, and return it as nested dict.
+        Collect the information from the NodeSchemaData tree, and return it as nested dict.
 
         Parameters
         ----------
@@ -154,16 +154,16 @@ class NodeSchemaData:
         preserve_list : bool
             If True, then lists are preserved. Otherwise, they are turned into dicts.
         """
-        if preserve_list and (isinstance(self.node, list) or isinstance(self.node, tuple)) and self.data is None:
-            data = [cdata for child in self.visible_children if len(cdata := child.collect_data(preserve_list)) > 0]
+        if preserve_list and (isinstance(self.node, list) or isinstance(self.node, tuple)) and self.info is None:
+            info = [cinfo for child in self.visible_children if len(cinfo := child.collect_info(preserve_list)) > 0]
         else:
-            data = {
-                child.identifier: cdata
+            info = {
+                child.identifier: cinfo
                 for child in self.visible_children
-                if len(cdata := child.collect_data(preserve_list)) > 0
+                if len(cinfo := child.collect_info(preserve_list)) > 0
             }
 
-            if self.data is not None:
-                data[self.key] = SchemaData(self.data, self.node)
+            if self.info is not None:
+                info[self.key] = SchemaInfo(self.info, self.node)
 
-        return data
+        return info

--- a/asdf/_node_data.py
+++ b/asdf/_node_data.py
@@ -4,6 +4,18 @@ from .schema import load_schema
 from .treeutil import get_children
 
 
+def collect_schema_data(key, node, identifier="root", refresh_extension_manager=False):
+    """
+    Collect from the underlying schemas any of the data stored under key.
+    """
+
+    schema_data = NodeSchemaData.from_root_node(
+        key, identifier, node, refresh_extension_manager=refresh_extension_manager
+    )
+
+    return schema_data.to_dict()
+
+
 class NodeSchemaData:
     """
     Container for a node, and the values of data from a schema
@@ -127,3 +139,15 @@ class NodeSchemaData:
             current_depth += 1
 
         return root_data
+
+    def to_dict(self):
+        if (isinstance(self.node, list) or isinstance(self.node, tuple)) and self.data is None:
+            data = [child.to_dict() for child in self.visible_children if len(child.to_dict()) > 0]
+        else:
+            data = {child.identifier: child.to_dict() for child in self.visible_children if len(child.to_dict()) > 0}
+
+            if self.data is not None:
+                data[self.key] = self.data
+                data["value"] = self.node
+
+        return data

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -10,6 +10,7 @@ from jsonschema import ValidationError
 from pkg_resources import parse_version
 
 from . import _display as display
+from . import _node_data as node_data
 from . import _version as version
 from . import block, constants, generic_io, reference, schema, treeutil, util, versioning, yamlutil
 from ._helpers import validate_version
@@ -1504,6 +1505,22 @@ class AsdfFile:
             return self.tree["history"]["entries"]
 
         return []
+
+    def schema_data(self, key, refresh_extension_manager=False):
+        """
+        Get a nested dictionary of the schema data for a given key.
+
+        Parameters
+        ----------
+        key : str
+            The key to look up.
+        refresh_extension_manager : bool
+            If `True`, refresh the extension manager before looking up the
+            key.  This is useful if you want to make sure that the schema
+            data for a given key is up to date.
+        """
+
+        return node_data.collect_schema_data(key, self.tree, refresh_extension_manager=refresh_extension_manager)
 
     def info(
         self,

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -10,7 +10,7 @@ from jsonschema import ValidationError
 from pkg_resources import parse_version
 
 from . import _display as display
-from . import _node_data as node_data
+from . import _node_info as node_info
 from . import _version as version
 from . import block, constants, generic_io, reference, schema, treeutil, util, versioning, yamlutil
 from ._helpers import validate_version
@@ -1522,7 +1522,7 @@ class AsdfFile:
             data for a given key is up to date.
         """
 
-        return node_data.collect_schema_info(
+        return node_info.collect_schema_info(
             key, self.tree, preserve_list=preserve_list, refresh_extension_manager=refresh_extension_manager
         )
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1506,7 +1506,7 @@ class AsdfFile:
 
         return []
 
-    def schema_data(self, key, refresh_extension_manager=False):
+    def schema_data(self, key, preserve_list=True, refresh_extension_manager=False):
         """
         Get a nested dictionary of the schema data for a given key.
 
@@ -1514,13 +1514,17 @@ class AsdfFile:
         ----------
         key : str
             The key to look up.
+        preserve_list : bool
+            If True, then lists are preserved. Otherwise, they are turned into dicts.
         refresh_extension_manager : bool
             If `True`, refresh the extension manager before looking up the
             key.  This is useful if you want to make sure that the schema
             data for a given key is up to date.
         """
 
-        return node_data.collect_schema_data(key, self.tree, refresh_extension_manager=refresh_extension_manager)
+        return node_data.collect_schema_data(
+            key, self.tree, preserve_list=preserve_list, refresh_extension_manager=refresh_extension_manager
+        )
 
     def info(
         self,

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1506,9 +1506,9 @@ class AsdfFile:
 
         return []
 
-    def schema_data(self, key, preserve_list=True, refresh_extension_manager=False):
+    def schema_info(self, key, preserve_list=True, refresh_extension_manager=False):
         """
-        Get a nested dictionary of the schema data for a given key.
+        Get a nested dictionary of the schema information for a given key.
 
         Parameters
         ----------
@@ -1522,7 +1522,7 @@ class AsdfFile:
             data for a given key is up to date.
         """
 
-        return node_data.collect_schema_data(
+        return node_data.collect_schema_info(
             key, self.tree, preserve_list=preserve_list, refresh_extension_manager=refresh_extension_manager
         )
 

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -7,7 +7,7 @@ import re
 import typing
 
 from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES, format_faint, format_italic, render_tree
-from ._node_data import NodeSchemaInfo
+from ._node_info import NodeSchemaInfo
 from .treeutil import get_children, is_container
 from .util import NotSet
 

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -7,7 +7,7 @@ import re
 import typing
 
 from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES, format_faint, format_italic, render_tree
-from ._node_data import NodeSchemaData
+from ._node_data import NodeSchemaInfo
 from .treeutil import get_children, is_container
 from .util import NotSet
 
@@ -328,9 +328,9 @@ class AsdfSearchResult:
             isinstance(self._node, dict)
             or isinstance(self._node, list)
             or isinstance(self._node, tuple)
-            or NodeSchemaData.traversable(self._node)
+            or NodeSchemaInfo.traversable(self._node)
         ):
-            if NodeSchemaData.traversable(self._node):
+            if NodeSchemaInfo.traversable(self._node):
                 child = self._node.__asdf_traverse__()[key]
             else:
                 child = self._node[key]
@@ -363,10 +363,10 @@ def _walk_tree_breadth_first(root_identifiers, root_node, callback):
                 isinstance(node, dict)
                 or isinstance(node, list)
                 or isinstance(node, tuple)
-                or NodeSchemaData.traversable(node)
+                or NodeSchemaInfo.traversable(node)
             ) and id(node) in seen:
                 continue
-            if NodeSchemaData.traversable(node):
+            if NodeSchemaInfo.traversable(node):
                 tnode = node.__asdf_traverse__()
             else:
                 tnode = node

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -6,15 +6,8 @@ import inspect
 import re
 import typing
 
-from ._display import (
-    DEFAULT_MAX_COLS,
-    DEFAULT_MAX_ROWS,
-    DEFAULT_SHOW_VALUES,
-    _NodeInfo,
-    format_faint,
-    format_italic,
-    render_tree,
-)
+from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES, format_faint, format_italic, render_tree
+from ._node_data import NodeSchemaData
 from .treeutil import get_children, is_container
 from .util import NotSet
 
@@ -335,9 +328,9 @@ class AsdfSearchResult:
             isinstance(self._node, dict)
             or isinstance(self._node, list)
             or isinstance(self._node, tuple)
-            or _NodeInfo.supports_info(self._node)
+            or NodeSchemaData.traversable(self._node)
         ):
-            if _NodeInfo.supports_info(self._node):
+            if NodeSchemaData.traversable(self._node):
                 child = self._node.__asdf_traverse__()[key]
             else:
                 child = self._node[key]
@@ -370,10 +363,10 @@ def _walk_tree_breadth_first(root_identifiers, root_node, callback):
                 isinstance(node, dict)
                 or isinstance(node, list)
                 or isinstance(node, tuple)
-                or _NodeInfo.supports_info(node)
+                or NodeSchemaData.traversable(node)
             ) and id(node) in seen:
                 continue
-            if _NodeInfo.supports_info(node):
+            if NodeSchemaData.traversable(node):
                 tnode = node.__asdf_traverse__()
             else:
                 tnode = node

--- a/asdf/tests/test_info.py
+++ b/asdf/tests/test_info.py
@@ -429,6 +429,44 @@ def test_schema_data_support(tmpdir):
         },
     }
 
+    data = af.schema_data("archive_catalog", preserve_list=False, refresh_extension_manager=True)
+    assert data == {
+        "list_of_stuff": {
+            0: {
+                "attributeOne": {
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attributeOne"]}, "v1"),
+                },
+                "attributeTwo": {
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attributeTwo"]}, "v2"),
+                },
+            },
+            1: {
+                "attributeOne": {
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attributeOne"]}, "x1"),
+                },
+                "attributeTwo": {
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attributeTwo"]}, "x2"),
+                },
+            },
+        },
+        "object": {
+            "anyof_attribute": {
+                "attribute1": {
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attribute1"]}, "VAL1"),
+                },
+                "attribute2": {
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attribute2"]}, "VAL2"),
+                },
+            },
+            "clown": {
+                "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.clown"]}, "Bozo"),
+            },
+            "the_meaning_of_life_the_universe_and_everything": {
+                "archive_catalog": ({"datatype": "int", "destination": ["ScienceCommon.silly"]}, 42),
+            },
+        },
+    }
+
 
 def test_info_object_support(capsys, tmpdir):
     manifest_extension(tmpdir)

--- a/asdf/tests/test_info.py
+++ b/asdf/tests/test_info.py
@@ -354,50 +354,40 @@ def test_schema_data_support(tmpdir):
         "list_of_stuff": [
             {
                 "attributeOne": {
-                    "title": "AttributeOne Title",
-                    "title_data": "v1",
+                    "title": ("AttributeOne Title", "v1"),
                 },
                 "attributeTwo": {
-                    "title": "AttributeTwo Title",
-                    "title_data": "v2",
+                    "title": ("AttributeTwo Title", "v2"),
                 },
-                "title": "object with info support 3 title",
-                "title_data": af.tree["list_of_stuff"][0],
+                "title": ("object with info support 3 title", af.tree["list_of_stuff"][0]),
             },
             {
                 "attributeOne": {
-                    "title": "AttributeOne Title",
-                    "title_data": "x1",
+                    "title": ("AttributeOne Title", "x1"),
                 },
                 "attributeTwo": {
-                    "title": "AttributeTwo Title",
-                    "title_data": "x2",
+                    "title": ("AttributeTwo Title", "x2"),
                 },
-                "title": "object with info support 3 title",
-                "title_data": af.tree["list_of_stuff"][1],
+                "title": ("object with info support 3 title", af.tree["list_of_stuff"][1]),
             },
         ],
         "object": {
-            "I_example": {"title": "integer pattern property", "title_data": 1},
-            "S_example": {"title": "string pattern property", "title_data": "beep"},
-            "allof_attribute": {"title": "allOf example attribute", "title_data": "good"},
+            "I_example": {"title": ("integer pattern property", 1)},
+            "S_example": {"title": ("string pattern property", "beep")},
+            "allof_attribute": {"title": ("allOf example attribute", "good")},
             "anyof_attribute": {
                 "attribute1": {
-                    "title": "Attribute1 Title",
-                    "title_data": "VAL1",
+                    "title": ("Attribute1 Title", "VAL1"),
                 },
                 "attribute2": {
-                    "title": "Attribute2 Title",
-                    "title_data": "VAL2",
+                    "title": ("Attribute2 Title", "VAL2"),
                 },
-                "title": "object with info support 2 title",
-                "title_data": af.tree["object"].anyof,
+                "title": ("object with info support 2 title", af.tree["object"].anyof),
             },
-            "clown": {"title": "clown name", "title_data": "Bozo"},
-            "oneof_attribute": {"title": "oneOf example attribute", "title_data": 20},
-            "the_meaning_of_life_the_universe_and_everything": {"title": "Some silly title", "title_data": 42},
-            "title": "object with info support title",
-            "title_data": af.tree["object"],
+            "clown": {"title": ("clown name", "Bozo")},
+            "oneof_attribute": {"title": ("oneOf example attribute", 20)},
+            "the_meaning_of_life_the_universe_and_everything": {"title": ("Some silly title", 42)},
+            "title": ("object with info support title", af.tree["object"]),
         },
     }
 
@@ -406,43 +396,35 @@ def test_schema_data_support(tmpdir):
         "list_of_stuff": [
             {
                 "attributeOne": {
-                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attributeOne"]},
-                    "archive_catalog_data": "v1",
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attributeOne"]}, "v1"),
                 },
                 "attributeTwo": {
-                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attributeTwo"]},
-                    "archive_catalog_data": "v2",
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attributeTwo"]}, "v2"),
                 },
             },
             {
                 "attributeOne": {
-                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attributeOne"]},
-                    "archive_catalog_data": "x1",
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attributeOne"]}, "x1"),
                 },
                 "attributeTwo": {
-                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attributeTwo"]},
-                    "archive_catalog_data": "x2",
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attributeTwo"]}, "x2"),
                 },
             },
         ],
         "object": {
             "anyof_attribute": {
                 "attribute1": {
-                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attribute1"]},
-                    "archive_catalog_data": "VAL1",
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attribute1"]}, "VAL1"),
                 },
                 "attribute2": {
-                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attribute2"]},
-                    "archive_catalog_data": "VAL2",
+                    "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.attribute2"]}, "VAL2"),
                 },
             },
             "clown": {
-                "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.clown"]},
-                "archive_catalog_data": "Bozo",
+                "archive_catalog": ({"datatype": "str", "destination": ["ScienceCommon.clown"]}, "Bozo"),
             },
             "the_meaning_of_life_the_universe_and_everything": {
-                "archive_catalog": {"datatype": "int", "destination": ["ScienceCommon.silly"]},
-                "archive_catalog_data": 42,
+                "archive_catalog": ({"datatype": "int", "destination": ["ScienceCommon.silly"]}, 42),
             },
         },
     }

--- a/asdf/tests/test_info.py
+++ b/asdf/tests/test_info.py
@@ -154,9 +154,15 @@ properties:
   the_meaning_of_life_the_universe_and_everything:
     title: Some silly title
     type: integer
+    archive_catalog:
+        datatype: int
+        destination: [ScienceCommon.silly]
   clown:
     title: clown name
     type: string
+    archive_catalog:
+        datatype: str
+        destination: [ScienceCommon.clown]
   anyof_attribute:
     title: anyOf example attribute
     anyOf:
@@ -205,9 +211,15 @@ properties:
   attribute1:
     title: Attribute1 Title
     type: string
+    archive_catalog:
+        datatype: str
+        destination: [ScienceCommon.attribute1]
   attribute2:
     title: Attribute2 Title
     type: string
+    archive_catalog:
+        datatype: str
+        destination: [ScienceCommon.attribute2]
 ...
 """
 
@@ -223,9 +235,15 @@ properties:
   attributeOne:
     title: AttributeOne Title
     type: string
+    archive_catalog:
+        datatype: str
+        destination: [ScienceCommon.attributeOne]
   attributeTwo:
     title: AttributeTwo Title
     type: string
+    archive_catalog:
+        datatype: str
+        destination: [ScienceCommon.attributeTwo]
 ...
 """
     os.mkdir(tmpdir / "schemas")
@@ -330,56 +348,102 @@ def test_schema_data_support(tmpdir):
     af = asdf.AsdfFile()
     af._extension_manager = ExtensionManager(config.extensions)
     af.tree = create_tree()
-    data = af.schema_data("title", refresh_extension_manager=True)
 
+    data = af.schema_data("title", refresh_extension_manager=True)
     assert data == {
         "list_of_stuff": [
             {
                 "attributeOne": {
                     "title": "AttributeOne Title",
-                    "value": "v1",
+                    "title_data": "v1",
                 },
                 "attributeTwo": {
                     "title": "AttributeTwo Title",
-                    "value": "v2",
+                    "title_data": "v2",
                 },
                 "title": "object with info support 3 title",
-                "value": af.tree["list_of_stuff"][0],
+                "title_data": af.tree["list_of_stuff"][0],
             },
             {
                 "attributeOne": {
                     "title": "AttributeOne Title",
-                    "value": "x1",
+                    "title_data": "x1",
                 },
                 "attributeTwo": {
                     "title": "AttributeTwo Title",
-                    "value": "x2",
+                    "title_data": "x2",
                 },
                 "title": "object with info support 3 title",
-                "value": af.tree["list_of_stuff"][1],
+                "title_data": af.tree["list_of_stuff"][1],
             },
         ],
         "object": {
-            "I_example": {"title": "integer pattern property", "value": 1},
-            "S_example": {"title": "string pattern property", "value": "beep"},
-            "allof_attribute": {"title": "allOf example attribute", "value": "good"},
+            "I_example": {"title": "integer pattern property", "title_data": 1},
+            "S_example": {"title": "string pattern property", "title_data": "beep"},
+            "allof_attribute": {"title": "allOf example attribute", "title_data": "good"},
             "anyof_attribute": {
                 "attribute1": {
                     "title": "Attribute1 Title",
-                    "value": "VAL1",
+                    "title_data": "VAL1",
                 },
                 "attribute2": {
                     "title": "Attribute2 Title",
-                    "value": "VAL2",
+                    "title_data": "VAL2",
                 },
                 "title": "object with info support 2 title",
-                "value": af.tree["object"].anyof,
+                "title_data": af.tree["object"].anyof,
             },
-            "clown": {"title": "clown name", "value": "Bozo"},
-            "oneof_attribute": {"title": "oneOf example attribute", "value": 20},
-            "the_meaning_of_life_the_universe_and_everything": {"title": "Some silly title", "value": 42},
+            "clown": {"title": "clown name", "title_data": "Bozo"},
+            "oneof_attribute": {"title": "oneOf example attribute", "title_data": 20},
+            "the_meaning_of_life_the_universe_and_everything": {"title": "Some silly title", "title_data": 42},
             "title": "object with info support title",
-            "value": af.tree["object"],
+            "title_data": af.tree["object"],
+        },
+    }
+
+    data = af.schema_data("archive_catalog", refresh_extension_manager=True)
+    assert data == {
+        "list_of_stuff": [
+            {
+                "attributeOne": {
+                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attributeOne"]},
+                    "archive_catalog_data": "v1",
+                },
+                "attributeTwo": {
+                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attributeTwo"]},
+                    "archive_catalog_data": "v2",
+                },
+            },
+            {
+                "attributeOne": {
+                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attributeOne"]},
+                    "archive_catalog_data": "x1",
+                },
+                "attributeTwo": {
+                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attributeTwo"]},
+                    "archive_catalog_data": "x2",
+                },
+            },
+        ],
+        "object": {
+            "anyof_attribute": {
+                "attribute1": {
+                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attribute1"]},
+                    "archive_catalog_data": "VAL1",
+                },
+                "attribute2": {
+                    "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.attribute2"]},
+                    "archive_catalog_data": "VAL2",
+                },
+            },
+            "clown": {
+                "archive_catalog": {"datatype": "str", "destination": ["ScienceCommon.clown"]},
+                "archive_catalog_data": "Bozo",
+            },
+            "the_meaning_of_life_the_universe_and_everything": {
+                "archive_catalog": {"datatype": "int", "destination": ["ScienceCommon.silly"]},
+                "archive_catalog_data": 42,
+            },
         },
     }
 

--- a/asdf/tests/test_info.py
+++ b/asdf/tests/test_info.py
@@ -342,15 +342,15 @@ def create_tree():
     }
 
 
-def test_schema_data_support(tmpdir):
+def test_schema_info_support(tmpdir):
     manifest_extension(tmpdir)
     config = asdf.get_config()
     af = asdf.AsdfFile()
     af._extension_manager = ExtensionManager(config.extensions)
     af.tree = create_tree()
 
-    data = af.schema_data("title", refresh_extension_manager=True)
-    assert data == {
+    info = af.schema_info("title", refresh_extension_manager=True)
+    assert info == {
         "list_of_stuff": [
             {
                 "attributeOne": {
@@ -391,8 +391,8 @@ def test_schema_data_support(tmpdir):
         },
     }
 
-    data = af.schema_data("archive_catalog", refresh_extension_manager=True)
-    assert data == {
+    info = af.schema_info("archive_catalog", refresh_extension_manager=True)
+    assert info == {
         "list_of_stuff": [
             {
                 "attributeOne": {
@@ -429,8 +429,8 @@ def test_schema_data_support(tmpdir):
         },
     }
 
-    data = af.schema_data("archive_catalog", preserve_list=False, refresh_extension_manager=True)
-    assert data == {
+    info = af.schema_info("archive_catalog", preserve_list=False, refresh_extension_manager=True)
+    assert info == {
         "list_of_stuff": {
             0: {
                 "attributeOne": {


### PR DESCRIPTION
Adds the ability to search and pull information about fields in an asdf file from the underlying schema files. For example, this enables one to store keywords pertaining to a given asdf object's data entries within the schema(s) defining that object. This however requires that the underlying schemas to all be tagged.