### PR TITLE
Temporally Ignore pytest warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ filterwarnings = [
     'ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes',
     'ignore:numpy.ndarray size changed:astropy.utils.exceptions.AstropyWarning',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
+    'ignore:Module already imported so cannot be rewritten:pytest.PytestAssertRewriteWarning'
 ]
 # Configuration for pytest-doctestplus
 text_file_format = 'rst'

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,8 @@ commands=
       -p no:unraisableexception \
       -W ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes \
       -W 'ignore:numpy.ndarray size changed:astropy.utils.exceptions.AstropyWarning' \
-      -W 'ignore:numpy.ndarray size changed:RuntimeWarning'
+      -W 'ignore:numpy.ndarray size changed:RuntimeWarning' \
+      -W 'ignore:Module already imported so cannot be rewritten:pytest.PytestAssertRewriteWarning'
 
 [testenv:packaged]
 # The default tox working directory is in .tox in the source directory.  If we


### PR DESCRIPTION
This ignores the warning discussed in #1168, so that the CI can proceed as normal. The cause of the warning should be found and fixed later.