### PR TITLE
Update changelog for release 2.12.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.12.1 (unreleased)
+2.12.1 (2022-08-17)
 -------------------
 
 The ASDF Standard is at v1.6.0


### PR DESCRIPTION
Update changelog for hotfix of `jsonschema` issue. See #1172.