### PR TITLE
Update from autoflake8 to autoflake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,10 @@ repos:
       args: ["--py38-plus"]
       exclude: "asdf/extern/.*|docs/.*"
 
-- repo: https://github.com/fsouza/autoflake8
-  rev: v0.4.0
+- repo: https://github.com/PyCQA/autoflake
+  rev: v1.5.3
   hooks:
-  - id: autoflake8
+  -  id: autoflake
 
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1


### PR DESCRIPTION
In https://github.com/asdf-format/asdf-transform-schemas/pull/69#discussion_r967744284, it was pointed out that autoflake8 was recently archived in favor of autoflake. This PR makes the update here.