### PR TITLE
Add support of schema_info for AsdfSearchResult as "path"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Update citation. [#1184]
 - Add search support to `~asdf.AsdfFile.schema_info`. [#1187]
+- Add `asdf.search.AsdfSearchResult` support for `~asdf.AsdfFile.schema_info` and
+  `~asdf.search.AsdfSearchResult.schema_info` method. [#1197]
 
 2.13.0 (2022-08-19)
 -------------------

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -51,7 +51,7 @@ def render_tree(
         refresh_extension_manager=refresh_extension_manager,
     )
     if info is None:
-        info = []
+        return []
 
     renderer = _TreeRenderer(
         max_rows,

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -9,7 +9,7 @@ return what it thinks is suitable for display.
 """
 import numpy as np
 
-from ._node_info import NodeSchemaInfo
+from ._node_info import create_tree
 from .tags.core.ndarray import NDArrayType
 from .util import is_primitive
 
@@ -43,11 +43,15 @@ def render_tree(
     """
     Render a tree as text with indents showing depth.
     """
-    info = NodeSchemaInfo.from_root_node("title", identifier, node, refresh_extension_manager=refresh_extension_manager)
-
-    if len(filters) > 0:
-        if not _filter_tree(info, filters):
-            return []
+    info = create_tree(
+        key="title",
+        node=node,
+        identifier=identifier,
+        filters=filters,
+        refresh_extension_manager=refresh_extension_manager,
+    )
+    if info is None:
+        info = []
 
     renderer = _TreeRenderer(
         max_rows,
@@ -80,20 +84,6 @@ def format_italic(value):
 
 def _format_code(value, code):
     return f"\x1B[{code}m{value}\x1B[0m"
-
-
-def _filter_tree(info, filters):
-    """
-    Remove nodes from the tree that get caught in the filters.
-    Mutates the tree.
-    """
-    filtered_children = []
-    for child in info.children:
-        if _filter_tree(child, filters):
-            filtered_children.append(child)
-    info.children = filtered_children
-
-    return len(info.children) > 0 or all(f(info.node, info.identifier) for f in filters)
 
 
 class _TreeRenderer:

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -7,7 +7,8 @@ from .treeutil import get_children
 
 def _filter_tree(info, filters):
     """
-    Remove nodes from the tree that get caught in the filters.
+    Keep nodes in tree which pass the all of the filters.
+
     Mutates the tree.
     """
     filtered_children = []

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -20,6 +20,24 @@ def _filter_tree(info, filters):
 
 
 def create_tree(key, node, identifier="root", filters=[], refresh_extension_manager=False):
+    """
+    Create a `NodeSchemaInfo` tree which can be filtered from a base node.
+
+    Parameters
+    ----------
+    key : str
+        The key to look up.
+    node : dict
+        The asdf tree to search.
+    filters : list of functions
+        A list of functions that take a node and identifier and return True if the node should be included in the tree.
+    preserve_list : bool
+        If True, then lists are preserved. Otherwise, they are turned into dicts.
+    refresh_extension_manager : bool
+        If `True`, refresh the extension manager before looking up the
+        key.  This is useful if you want to make sure that the schema
+        data for a given key is up to date.
+    """
 
     schema_info = NodeSchemaInfo.from_root_node(
         key, identifier, node, refresh_extension_manager=refresh_extension_manager

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1515,8 +1515,9 @@ class AsdfFile:
         key : str
             The key to look up.
             Default: "description"
-        path : str
-            A dot-separated path to the parameter to find the key information on.
+        path : str or asdf.search.AsdfSearchResult
+            A dot-separated path to the parameter to find the key information on or
+            an `asdf.search.AsdfSearchResult` object.
             Default = None (full dictionary).
         preserve_list : bool
             If True, then lists are preserved. Otherwise, they are turned into dicts.
@@ -1526,9 +1527,14 @@ class AsdfFile:
             data for a given key is up to date.
         """
 
-        return node_info.collect_schema_info(
-            key, path, self.tree, preserve_list=preserve_list, refresh_extension_manager=refresh_extension_manager
-        )
+        if isinstance(path, AsdfSearchResult):
+            return path.schema_info(
+                key, preserve_list=preserve_list, refresh_extension_manager=refresh_extension_manager
+            )
+        else:
+            return node_info.collect_schema_info(
+                key, path, self.tree, preserve_list=preserve_list, refresh_extension_manager=refresh_extension_manager
+            )
 
     def info(
         self,

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -341,7 +341,12 @@ class AsdfSearchResult:
         """
 
         return collect_schema_info(
-            key, None, self._node, preserve_list=preserve_list, refresh_extension_manager=refresh_extension_manager
+            key,
+            None,
+            self._node,
+            filters=self._filters,
+            preserve_list=preserve_list,
+            refresh_extension_manager=refresh_extension_manager,
         )
 
     def __getitem__(self, key):

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -7,7 +7,7 @@ import re
 import typing
 
 from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES, format_faint, format_italic, render_tree
-from ._node_info import NodeSchemaInfo
+from ._node_info import NodeSchemaInfo, collect_schema_info
 from .treeutil import get_children, is_container
 from .util import NotSet
 
@@ -322,6 +322,27 @@ class AsdfSearchResult:
             return format_faint(format_italic("No results found."))
         else:
             return "\n".join(lines)
+
+    def schema_info(self, key="description", preserve_list=True, refresh_extension_manager=False):
+        """
+        Get a nested dictionary of the schema information for a given key, relative to this search result.
+
+        Parameters
+        ----------
+        key : str
+            The key to look up.
+            Default: "description"
+        preserve_list : bool
+            If True, then lists are preserved. Otherwise, they are turned into dicts.
+        refresh_extension_manager : bool
+            If `True`, refresh the extension manager before looking up the
+            key.  This is useful if you want to make sure that the schema
+            data for a given key is up to date.
+        """
+
+        return collect_schema_info(
+            key, None, self._node, preserve_list=preserve_list, refresh_extension_manager=refresh_extension_manager
+        )
 
     def __getitem__(self, key):
         if (

--- a/asdf/tests/test_info.py
+++ b/asdf/tests/test_info.py
@@ -567,6 +567,17 @@ def test_schema_info_support(tmpdir):
         },
     }
 
+    # Test using a search result
+    search = af.search("clown")
+    assert af.schema_info("description", search, refresh_extension_manager=True) == {
+        "object": {
+            "clown": {
+                "description": ("clown description", "Bozo"),
+            },
+            "description": ("object with info support description", af.tree["object"]),
+        },
+    }
+
 
 def test_info_object_support(capsys, tmpdir):
     manifest_extension(tmpdir)

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -754,8 +754,8 @@ the information from the schema requested together with the value stored in the
 ASDF file itself.
 
 One needs to provide a ``key``, which corresponds the to the keyword the information
-is stored under inside the schema, by default this is ``description``. Moreover,
-one can also provide a ``path`` which is a dot-separated string of the keys in the
+is stored under inside the schema, by default this is ``description``. One can also
+provide a ``path`` in the form of a dot-separated string of the keys in the
 ASDF file that lead to the value(s) of interest. For example:
 
 .. code:: pycon
@@ -763,3 +763,17 @@ ASDF file that lead to the value(s) of interest. For example:
     >>> af.schema_info("archive_catalog", "foo.bar")  # doctest: +SKIP
     {'thing1': {'archive_catalog': 'Thing 1 Archive catalog information'},
      'thing2': {'archive_catalog': 'Thing 2 Archive catalog information'}}
+
+Or one can provide a ``path`` as an `asdf.search.AsdfSearchResult` object:
+
+.. code:: pycon
+
+    >>> af.schema_info("archive_catalog", af.search("bar"))  # doctest: +SKIP
+    {'thing1': {'archive_catalog': 'Thing 1 Archive catalog information'},
+     'thing2': {'archive_catalog': 'Thing 2 Archive catalog information'}}
+
+
+.. note::
+    The there is also the `asdf.search.AsdfSearchResult.schema_info` method,
+    which can be directly called on an `asdf.search.AsdfSearchResult` object.
+    instead of having to pass the search through `AsdfFile.schema_info`.


### PR DESCRIPTION
Adds support for using a `AsdfSearchResult` as the `path` argument to a `schema_info` call on `AsdfFile` and a `schema_info` method on an `AsdfSearchResult`.

Fixes #558