### PR TITLE
Unpin jsonschema, fix default validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@
 - Use forc ndarray flag to correctly test for fortran array contiguity [#1206]
 - Unpin ``jsonschema`` version and fix ``jsonschema`` deprecation warnings. [#1185]
 - Replace ``pkg_resources`` with ``importlib.metadata``. [#1199]
+- Unpin jsonschema, fix default validation for jsonschema 4.10+ [#1203]
 
 2.13.0 (2022-08-19)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@
 - Use forc ndarray flag to correctly test for fortran array contiguity [#1206]
 - Unpin ``jsonschema`` version and fix ``jsonschema`` deprecation warnings. [#1185]
 - Replace ``pkg_resources`` with ``importlib.metadata``. [#1199]
-- Unpin jsonschema, fix default validation for jsonschema 4.10+ [#1203]
+- Fix default validation for jsonschema 4.10+ [#1203]
 
 2.13.0 (2022-08-19)
 -------------------

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from functools import lru_cache
 from numbers import Integral
+from operator import methodcaller
 
 import numpy as np
 import yaml
@@ -749,6 +750,14 @@ def check_schema(schema, validate_default=True):
 
         validators.update({"default": _validate_default})
 
+        def applicable_validators(schema):
+            items = list(schema.items())
+            items.append(("default", ""))
+            return items
+
+    else:
+        applicable_validators = methodcaller("items")
+
     meta_schema_id = schema.get("$schema", YAML_SCHEMA_METASCHEMA_ID)
     meta_schema = _load_schema_cached(meta_schema_id, extension.get_default_resolver(), False, False)
 
@@ -759,6 +768,7 @@ def check_schema(schema, validate_default=True):
         validators=validators,
         type_checker=mvalidators.Draft4Validator.TYPE_CHECKER,
         id_of=mvalidators.Draft4Validator.ID_OF,
+        applicable_validators=applicable_validators,
     )
     validator = cls(meta_schema, resolver=resolver)
     validator.validate(schema)

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -410,7 +410,6 @@ def test_defaults():
     assert t == {}
 
 
-@pytest.mark.xfail(reason="This will be fixed by #1203")
 def test_default_check_in_schema():
     s = {"type": "object", "properties": {"a": {"type": "integer", "default": "foo"}}}
 
@@ -420,7 +419,6 @@ def test_default_check_in_schema():
     schema.check_schema(s, validate_default=False)
 
 
-@pytest.mark.xfail(reason="This will be fixed by #1203")
 def test_check_complex_default():
     default_software = tagged.TaggedDict({"name": "asdf", "version": "2.7.0"}, "tag:stsci.edu/asdf/core/software-1.0.0")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-wcs-schemas
 git+https://github.com/astropy/astropy
 git+https://github.com/spacetelescope/gwcs
-git+https://github.com/yaml/pyyaml.git
+git+https://github.com/python-jsonschema/jsonschema
 
 scipy>=0.0.dev0
 numpy>=0.0.dev0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ git+https://github.com/asdf-format/asdf-wcs-schemas
 git+https://github.com/astropy/astropy
 git+https://github.com/spacetelescope/gwcs
 git+https://github.com/yaml/pyyaml.git
-git+https://github.com/python-jsonschema/jsonschema
 
 scipy>=0.0.dev0
 numpy>=0.0.dev0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-wcs-schemas
 git+https://github.com/astropy/astropy
 git+https://github.com/spacetelescope/gwcs
+git+https://github.com/yaml/pyyaml.git
 git+https://github.com/python-jsonschema/jsonschema
 
 scipy>=0.0.dev0


### PR DESCRIPTION
Add custom default validator to 'applicable_validators' argument to jsonschema.validators.create

Tested locally with jsonschema 4.16

This is work towards fixing #1172

One test is still failing locally (a doctest in docs/asdf/config.rst) but I wanted to trigger the CI and discuss the changes so far.

closes #1177