### PR TITLE
fix saving fortran ndarray issue #1205

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 - Add search support to `~asdf.AsdfFile.schema_info`. [#1187]
 - Add `asdf.search.AsdfSearchResult` support for `~asdf.AsdfFile.schema_info` and
   `~asdf.search.AsdfSearchResult.schema_info` method. [#1197]
+- Use forc ndarray flag to correctly test for fortran array contiguity [#1206]
 
 2.13.0 (2022-08-19)
 -------------------

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -424,7 +424,7 @@ class NDArrayType(AsdfType):
         # is contiguous.  If not, we need to make a copy to avoid
         # writing a nonsense view.
         base = util.get_array_base(data)
-        if not base.flags.contiguous:
+        if not base.flags.forc:
             data = np.ascontiguousarray(data)
             base = util.get_array_base(data)
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -796,7 +796,7 @@ def test_non_contiguous_base_array(tmpdir):
 
 
 def test_fortran_order(tmpdir):
-    array = np.array([[11, 12, 13], [21, 22, 23]], order="F")
+    array = np.array([[11, 12, 13], [21, 22, 23]], order="F", dtype=np.int64)
     tree = dict(data=array)
 
     def check_f_order(t):

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -803,7 +803,11 @@ def test_fortran_order(tmpdir):
         assert t["data"].flags.fortran
         assert np.all(np.isclose(array, t["data"]))
 
-    helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_f_order)
+    def check_raw_yaml(content):
+        tree = yaml.safe_load(re.sub(rb"!core/\S+", b"", content))
+        assert tree["data"]["strides"] == [8, 16]
+
+    helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_f_order, raw_yaml_check_func=check_raw_yaml)
 
 
 def test_readonly(tmpdir):

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -798,7 +798,12 @@ def test_non_contiguous_base_array(tmpdir):
 def test_fortran_order(tmpdir):
     array = np.array([[11, 12, 13], [21, 22, 23]], order="F")
     tree = dict(data=array)
-    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+    def check_f_order(t):
+        assert t["data"].flags.fortran
+        assert np.all(np.isclose(array, t["data"]))
+
+    helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_f_order)
 
 
 def test_readonly(tmpdir):

--- a/asdf/tests/test_array_blocks.py
+++ b/asdf/tests/test_array_blocks.py
@@ -794,3 +794,17 @@ def test_add_block_before_fully_loaded(tmp_path):
         assert_array_equal(af["arr0"], arr0)
         assert_array_equal(af["arr1"], arr1)
         assert_array_equal(af["arr2"], arr2)
+
+
+def test_block_allocation_on_validate():
+    """
+    Verify that no additional block is allocated when a tree
+    containing a fortran ordered array is validated
+
+    See https://github.com/asdf-format/asdf/issues/1205
+    """
+    array = np.array([[11, 12, 13], [21, 22, 23]], order="F")
+    af = asdf.AsdfFile({"array": array})
+    assert len(list(af.blocks.blocks)) == 1
+    af.validate()
+    assert len(list(af.blocks.blocks)) == 1


### PR DESCRIPTION
per eslavich the contiguous array check should check for both f and c order array so modified flags.contiguous to flags.forc

modified ndarray test_fortran_order test to verify fortran ordered on 'roundtrip' write then read