### PR TITLE
Update pre-commit with yesqa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
 
+- repo: https://github.com/asottile/yesqa
+  rev: v1.4.0
+  hooks:
+    - id: yesqa
+
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.1.0
   hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import tomli
-from sphinx_asdf.conf import *  # noqa: F403, F401
+from sphinx_asdf.conf import *  # noqa: F403
 
 try:
     from importlib.metadata import distribution


### PR DESCRIPTION
Enable [`yesqa` ](https://github.com/asottile/yesqa) as part of pre-commit.

`yesqa` checks that `# noqa` codes apply and orders the `# noqa` codes.