### PR TITLE
Add asdf-unit-schemas as dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       coverage: codecov
 
   test:
-    needs: [core, asdf-standard]
+    needs: [core, asdf-schemas]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       cache-path: ~/.cache/pip
@@ -61,7 +61,7 @@ jobs:
         - windows: py39
 
   dev:
-    needs: [core, asdf-standard]
+    needs: [core, asdf-schemas]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       cache-path: ~/.cache/pip
@@ -78,7 +78,7 @@ jobs:
           python-version: 3.11.0-rc.2
 
   compatibility:
-    needs: [core, asdf-standard]
+    needs: [core, asdf-schemas]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       cache-path: ~/.cache/pip
@@ -106,31 +106,50 @@ jobs:
         - linux: prerelease
         - linux: packaged
 
-  asdf-standard:
-    name: Run asdf-standard tests
+  asdf-schemas:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - package_name: asdf-standard
+            repository: asdf-format/asdf-standard
+            ref: master
+            install_command: pip install -e .[test]
+            test_command: pytest
+          - package_name: asdf-transform-schemas
+            repository: asdf-format/asdf-transform-schemas
+            ref: master
+            install_command: pip install -e .[test]
+            test_command: pytest
+          - package_name: asdf-unit-schemas
+            repository: asdf-format/asdf-unit-schemas
+            ref: main
+            install_command: pip install -e .[test]
+            test_command: pytest
     steps:
       - name: Checkout asdf
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          submodules: true
           path: asdf
-      - name: Checkout asdf-standard
+      - name: Checkout ${{ matrix.package_name }}
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: asdf-format/asdf-standard
-          ref: master
-          path: asdf-standard
+          repository: ${{ matrix.repository }}
+          ref: ${{ matrix.ref }}
+          path: target
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - name: Install asdf
         run: cd asdf && pip install .
-      - name: Install asdf-standard
-        run: cd asdf-standard && pip install -e .[test]
+      - name: Install remaining ${{ matrix.package_name }} dependencies
+        run: cd target && ${{ matrix.install_command }}
       - name: Pip Freeze
         run: pip freeze
-      - name: Run asdf-standard tests
-        run: cd asdf-standard && pytest
+      - name: Run ${{ matrix.package_name}} tests
+        run: cd target && ${{ matrix.test_command }}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -97,6 +97,11 @@ jobs:
             ref: main
             install_command: pip install -e .[test]
             test_command: pytest
+          - package_name: asdf-unit-schemas
+            repository: asdf-format/asdf-unit-schemas
+            ref: main
+            install_command: pip install -e .[test]
+            test_command: pytest
           - package_name: asdf-coordinates-schemas
             repository: asdf-format/asdf-coordinates-schemas
             ref: main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 dependencies = [
     'asdf-standard >=1.0.1',
     'asdf-transform-schemas >=0.2.2',
+    'asdf-unit-schmas >= 0.1.0',
     'importlib_resources >=3; python_version <"3.9"',
     'importlib-metadata >=3; python_version <"3.10"',
     'jmespath >=0.6.2',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ git+https://github.com/astropy/asdf-astropy
 git+https://github.com/asdf-format/asdf-coordinates-schemas
 git+https://github.com/asdf-format/asdf-standard
 git+https://github.com/asdf-format/asdf-transform-schemas
+git+https://github.com/asdf-format/asdf-unit-schemas.git
 git+https://github.com/asdf-format/asdf-wcs-schemas
 git+https://github.com/astropy/astropy
 git+https://github.com/spacetelescope/gwcs


### PR DESCRIPTION
Shortly, we will drop `units` from `asdf-standard` in favor of the `asdf-unit-schemas`. For backwards compatibility reasons, we then need to add `asdf-unit-schemas` as a dependency to `asdf`.