### PR TITLE
Treat tmpdir as str in _assert_roundtrip_tree

### DIFF
--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -184,7 +184,7 @@ def _assert_roundtrip_tree(
     tree_match_func="assert_equal",
 ):
 
-    fname = str(tmpdir.join("test.asdf"))
+    fname = os.path.join(tmpdir, "test.asdf")
 
     # First, test writing/reading a BytesIO buffer
     buff = io.BytesIO()


### PR DESCRIPTION
With the current implementation, it is impossible to replace tmpdir with tmp_path in astropy test that uses this helper function and then try to pass back tmp_path to this thing as a string.

I don't want to start adding Path support here so this is the simplest thing I can think of.

cc @WilliamJamieson 

ref: https://github.com/astropy/astropy/issues/13787#issuecomment-1292020635