### PR TITLE
Turn warnings into errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
       default_python: '3.9'
       envs: |
         - linux: compatibility
-        - linux: warnings
 
   package:
     needs: [test, dev, compatibility]

--- a/asdf/commands/tests/test_diff.py
+++ b/asdf/commands/tests/test_diff.py
@@ -60,7 +60,7 @@ def test_diff_simple_inline_array():
     _assert_diffs_equal(filenames, result_file, minimal=False)
 
 
-@pytest.mark.filterwarnings("ignore::astropy.io.fits.verify.VerifyWarning")
+@pytest.mark.filterwarnings("ignore:unclosed file .*")
 def test_file_not_found():
     # Try to open files that exist but are not valid asdf
     filenames = ["frames.diff", "blocks.diff"]

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -166,6 +166,7 @@ def test_asdf_file_version_requirement():
             af = AsdfFile(version="1.4.0", extensions=[extension_with_requirement])
 
 
+@pytest.mark.filterwarnings("ignore:unclosed file .*")
 def test_open_asdf_extensions(tmp_path):
     extension = TestExtension(extension_uri="asdf://somewhere.org/extensions/foo-1.0")
 

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -291,7 +291,7 @@ def test_open_gzipped():
         assert af.tree["stuff"].shape == (20, 20)
 
 
-@pytest.mark.filterwarnings("ignore::astropy.io.fits.verify.VerifyWarning")
+@pytest.mark.filterwarnings("ignore:unclosed file .*")
 def test_bad_input(tmp_path):
     """Make sure these functions behave properly with bad input"""
     text_file = str(tmp_path / "test.txt")

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -361,6 +361,12 @@ def test_unicode_open(tmp_path, small_tree):
 
 
 @pytest.mark.filterwarnings("ignore:unclosed file .*")
+def test_open_stdout():
+    """Test ability to open/write stdout as an output stream"""
+    with generic_io.get_file(sys.__stdout__, "w"):
+        pass
+
+
 def test_invalid_obj(tmp_path):
     with pytest.raises(ValueError):
         generic_io.get_file(42)
@@ -383,9 +389,6 @@ def test_invalid_obj(tmp_path):
     with open(path, "rb") as fd:
         with pytest.raises(ValueError):
             generic_io.get_file(fd, "w")
-
-    with generic_io.get_file(sys.__stdout__, "w"):
-        pass
 
 
 def test_nonseekable_file(tmp_path):

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -360,6 +360,7 @@ def test_unicode_open(tmp_path, small_tree):
                 pass
 
 
+@pytest.mark.filterwarnings("ignore:unclosed file .*")
 def test_invalid_obj(tmp_path):
     with pytest.raises(ValueError):
         generic_io.get_file(42)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,7 @@ open_files_ignore = ['test.fits', 'asdf.fits']
 filterwarnings = [
     'error',
     'ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes',
-    'ignore:numpy.ndarray size changed:astropy.utils.exceptions.AstropyWarning',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
-    'ignore:Module already imported so cannot be rewritten:pytest.PytestAssertRewriteWarning'
 ]
 # Configuration for pytest-doctestplus
 text_file_format = 'rst'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ open_files_ignore = ['test.fits', 'asdf.fits']
 # The asdf.asdftypes module emits a warning on import,
 # which pytest trips over during collection:
 filterwarnings = [
+    'error',
     'ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes',
     'ignore:numpy.ndarray size changed:astropy.utils.exceptions.AstropyWarning',
     'ignore:numpy.ndarray size changed:RuntimeWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,26 +92,6 @@ filterwarnings = [
 ]
 # Configuration for pytest-doctestplus
 text_file_format = 'rst'
-# Account for both the astropy test runner case and the native pytest case
-asdf_schema_root = 'asdf-standard/schemas asdf/schemas'
-asdf_schema_skip_tests = """
-    stsci.edu/asdf/asdf-schema-1.0.0.yaml
-    stsci.edu/asdf/transform/domain-1.0.0.yaml
-    stsci.edu/asdf/wcs/celestial_frame-1.0.0.yaml
-    stsci.edu/asdf/wcs/celestial_frame-1.1.0.yaml
-    stsci.edu/asdf/wcs/frame-1.0.0.yaml
-    stsci.edu/asdf/wcs/frame-1.1.0.yaml
-    stsci.edu/asdf/wcs/spectral_frame-1.1.0.yaml
-    stsci.edu/asdf/wcs/step-1.1.0.yaml
-    stsci.edu/asdf/wcs/step-1.2.0.yaml
-    stsci.edu/asdf/wcs/wcs-1.1.0.yaml
-    stsci.edu/asdf/wcs/wcs-1.2.0.yaml
-    stsci.edu/yaml-schema/draft-01.yaml
-"""
-asdf_schema_xfail_tests = 'stsci.edu/asdf/core/ndarray-1.0.0.yaml::test_example_2'
-# Enable the schema tests by default
-asdf_schema_tests_enabled = 'true'
-asdf_schema_ignore_unrecognized_tag = 'true'
 addopts = '--color=yes --doctest-rst'
 
 [tool.coverage.run]

--- a/tox.ini
+++ b/tox.ini
@@ -37,16 +37,6 @@ install_command= python -m pip install --no-cache-dir {opts} {packages}
 [testenv:prerelease]
 pip_pre= true
 
-[testenv:warnings]
-commands=
-    pip freeze
-    pytest --remote-data -W error \
-      -p no:unraisableexception \
-      -W ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes \
-      -W 'ignore:numpy.ndarray size changed:astropy.utils.exceptions.AstropyWarning' \
-      -W 'ignore:numpy.ndarray size changed:RuntimeWarning' \
-      -W 'ignore:Module already imported so cannot be rewritten:pytest.PytestAssertRewriteWarning'
-
 [testenv:packaged]
 # The default tox working directory is in .tox in the source directory.  If we
 # execute pytest from there, it will discover tox.ini in the source directory


### PR DESCRIPTION
Turns all warnings into errors and cleans up pytest config