### PR TITLE
Add a codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Requests reviews automatically for different parts of ASDF
+
+*    @asdf-format/asdf-maintainers


### PR DESCRIPTION
Adds a codeowners file. This will enable github to automatically assign reviewers for different parts of ASDF.