### PR TITLE
Use ducktyping in generic_io get_file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@
 - Add ``asdf-unit-schemas`` as a dependency, for backwards compatibility. [#1210]
 - Remove stray toplevel packages ``docker`` ``docs`` and ``compatibility_tests`` from wheel [#1214]
 - Close files opened during a failed call to asdf.open [#1221]
+- Modify generic_file for fsspec compatibility [#1226]
 
 2.13.0 (2022-08-19)
 -------------------

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -1034,14 +1034,14 @@ def get_file(init, mode="r", uri=None, close=False):
             raise ValueError(f"File is opened as '{init.mode}', but '{mode}' was requested")
 
         if init.seekable():
-            if isinstance(init, (io.BufferedReader, io.BufferedWriter, io.BufferedRandom)):
+            if hasattr(init, "raw"):
                 init2 = init.raw
             else:
                 init2 = init
-            if isinstance(init2, io.RawIOBase):
-                result = RealFile(init2, mode, uri=uri, close=close)
-            else:
+            if hasattr(init2, "getvalue"):
                 result = MemoryIO(init2, mode, uri=uri)
+            else:
+                result = RealFile(init2, mode, uri=uri, close=close)
             result._secondary_fd = init
             return result
         else:

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -3,6 +3,7 @@ import os
 import sys
 import urllib.request as urllib_request
 
+import fsspec
 import numpy as np
 import pytest
 
@@ -775,3 +776,19 @@ def test_io_subclasses(tmp_path):
     r = f.read(len(ref))
     assert r == ref, (r, ref)
     f.close()
+
+
+def test_fsspec(tmp_path):
+    """
+    Issue #1146 reported errors when opening a fsspec 'file'
+    This is a regression test for the fix in PR #1226
+    """
+    ref = b"01234567890"
+    fn = tmp_path / "test"
+
+    with fsspec.open(fn, mode="bw+") as f:
+        f.write(ref)
+        f.seek(0)
+        gf = generic_io.get_file(f)
+        r = gf.read(len(ref))
+        assert r == ref, (r, ref)

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -739,3 +739,39 @@ def test_blocksize(tree, tmp_path):
         config.io_block_size = 1233  # make sure everything works with a strange blocksize
         with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
             assert ff._fd.block_size == 1233
+
+
+def test_io_subclasses(tmp_path):
+    ref = b"0123456789"
+
+    b = io.BytesIO(b"0123456789")
+    b.seek(0)
+    f = generic_io.get_file(b)
+    r = f.read(len(ref))
+    assert r == ref, (r, ref)
+    f.close()
+
+    b = io.BytesIO(b"0123456789")
+    b.seek(0)
+    br = io.BufferedReader(io.BytesIO(ref))
+    f = generic_io.get_file(b)
+    assert r == ref, (r, ref)
+    f.close()
+
+    b = io.BytesIO(b"")
+    bw = io.BufferedWriter(b)
+    f = generic_io.get_file(bw, mode="w")
+    f.write(ref)
+    b.seek(0)
+    r = b.read(len(ref))
+    assert r == ref, (r, ref)
+    f.close()
+
+    b = io.BytesIO(b"")
+    br = io.BufferedRandom(b)
+    f = generic_io.get_file(br, mode="rw")
+    f.write(ref)
+    f.seek(0)
+    r = f.read(len(ref))
+    assert r == ref, (r, ref)
+    f.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ tests = [
     'pytest-openfiles',
     'psutil',
     'lz4 >=0.10',
+    'fsspec >=2022.8.2',
 ]
 [project.urls]
 'tracker' = 'https://github.com/asdf-format/asdf/issues'


### PR DESCRIPTION
Instead of using isinstance, look for attributes 'raw' and 'getvalue' to determine what generic_io subclass to use. This adds support for fsspec objects.