### PR TITLE
Add fsspec http support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@
 - Remove stray toplevel packages ``docker`` ``docs`` and ``compatibility_tests`` from wheel [#1214]
 - Close files opened during a failed call to asdf.open [#1221]
 - Modify generic_file for fsspec compatibility [#1226]
+- Add fsspec http filesystem support [#1228]
 
 2.13.0 (2022-08-19)
 -------------------

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -218,7 +218,6 @@ class GenericFile(metaclass=util.InheritDocstrings):
         self._fd = fd
         self._mode = mode
         self._close = close
-        self._size = None
         self._uri = uri
 
         self.block_size = get_config().io_block_size
@@ -722,9 +721,7 @@ class RealFile(RandomAccessFile):
     def __init__(self, fd, mode, close=False, uri=None):
         super().__init__(fd, mode, close=close, uri=uri)
 
-        stat = os.fstat(fd.fileno())
-        self._size = stat.st_size
-        if uri is None and isinstance(fd.name, str):
+        if uri is None and hasattr(fd, "name") and isinstance(fd.name, str):
             self._uri = util.filepath_to_url(os.path.abspath(fd.name))
 
     def write_array(self, arr):
@@ -761,10 +758,6 @@ class MemoryIO(RandomAccessFile):
 
     def __init__(self, fd, mode, uri=None):
         super().__init__(fd, mode, uri=uri)
-        tell = fd.tell()
-        fd.seek(0, 2)
-        self._size = fd.tell()
-        fd.seek(tell, 0)
 
     def read_into_array(self, size):
         buf = self._fd.getvalue()

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 import fsspec
@@ -395,10 +396,28 @@ def test_fsspec(tmp_path):
     This is a regression test for the fix in PR #1226
     """
     tree = {"a": 1}
-    af = AsdfFile({"a": 1})
+    af = AsdfFile(tree)
     fn = tmp_path / "test.asdf"
     af.write_to(fn)
 
+    with fsspec.open(fn) as f:
+        af = open_asdf(f)
+        assert_tree_match(tree, af.tree)
+
+
+@pytest.mark.remote_data
+def test_fsspec_http(httpserver):
+    """
+    Issue #1146 reported errors when opening a fsspec url (using the http
+    filesystem)
+    This is a regression test for the fix in PR #1228
+    """
+    tree = {"a": 1}
+    af = AsdfFile(tree)
+    path = os.path.join(httpserver.tmpdir, "test")
+    af.write_to(path)
+
+    fn = httpserver.url + "test"
     with fsspec.open(fn) as f:
         af = open_asdf(f)
         assert_tree_match(tree, af.tree)

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -797,8 +797,9 @@ def test_fsspec(tmp_path):
 @pytest.mark.remote_data
 def test_fsspec_http(httpserver):
     """
-    Issue #1146 reported errors when opening a fsspec 'file'
-    This is a regression test for the fix in PR #1226
+    Issue #1146 reported errors when opening a fsspec url (using the http
+    filesystem)
+    This is a regression test for the fix in PR #1228
     """
     ref = b"01234567890"
     path = os.path.join(httpserver.tmpdir, "test")

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -792,3 +792,22 @@ def test_fsspec(tmp_path):
         gf = generic_io.get_file(f)
         r = gf.read(len(ref))
         assert r == ref, (r, ref)
+
+
+@pytest.mark.remote_data
+def test_fsspec_http(httpserver):
+    """
+    Issue #1146 reported errors when opening a fsspec 'file'
+    This is a regression test for the fix in PR #1226
+    """
+    ref = b"01234567890"
+    path = os.path.join(httpserver.tmpdir, "test")
+
+    with open(path, "wb") as f:
+        f.write(ref)
+
+    fn = httpserver.url + "test"
+    with fsspec.open(fn) as f:
+        gf = generic_io.get_file(f)
+        r = gf.read(len(ref))
+        assert r == ref, (r, ref)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ tests = [
     'pytest-openfiles',
     'psutil',
     'lz4 >=0.10',
-    'fsspec >=2022.8.2',
+    'fsspec[http] >=2022.8.2',
 ]
 [project.urls]
 'tracker' = 'https://github.com/asdf-format/asdf/issues'


### PR DESCRIPTION
Opening an http filesystem file using fsspec returns an object that is incompatible with generic_io. The fsspec object, when treated like a generic_io.RealFile, fails on both the _size and name/uri calculations.

[generic_io.GenericFile._size](https://github.com/asdf-format/asdf/blob/989cd955420ae717dff763c152be3cc21343d244/asdf/generic_io.py#L221) does not appear to be used so this PR removes it from all GenericFile classes.

[fd.name](https://github.com/asdf-format/asdf/blob/989cd955420ae717dff763c152be3cc21343d244/asdf/generic_io.py#L727) is used to calculate the uri (when not otherwise supplied). fsspec http files do not have a name so a different method of defining uri (such as providing one at the time of opening) will need to be used when a uri is necessary. This PR adds a `hasattr` check for name to avoid an exception during creation of the RealFile.