### PR TITLE
Feature/whole file memmap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@
 - Close files opened during a failed call to asdf.open [#1221]
 - Modify generic_file for fsspec compatibility [#1226]
 - Add fsspec http filesystem support [#1228]
+- Memmap whole file instead of each array [#1230]
 
 2.13.0 (2022-08-19)
 -------------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1211,8 +1211,8 @@ class AsdfFile:
             self.blocks.finish_reading_internal_blocks()
 
             # flush all pending memmap writes
-            if hasattr(fd, "_mmap"):
-                fd._mmap.flush()
+            if fd.can_memmap():
+                fd.flush_memmap()
 
             self._pre_write(fd, all_array_storage, all_array_compression, compression_kwargs=compression_kwargs)
 
@@ -1224,11 +1224,9 @@ class AsdfFile:
                     # write out in a serial fashion.
                     self._serial_write(fd, pad_blocks, include_block_index)
                     fd.truncate()
-                    # if we have memmapped data close the memmap so it will
-                    # regenerate
-                    if hasattr(fd, "_mmap"):
-                        fd._mmap.close()
-                        del fd._mmap
+                    # close memmaps so they will regenerate
+                    if fd.can_memmap():
+                        fd.close_memmap()
                     return
 
                 # Estimate how big the tree will be on disk by writing the
@@ -1252,11 +1250,9 @@ class AsdfFile:
                     # write out in a serial fashion.
                     self._serial_write(fd, pad_blocks, include_block_index)
                     fd.truncate()
-                    # if we have memmapped data close the memmap so it will
-                    # regenerate
-                    if hasattr(fd, "_mmap"):
-                        fd._mmap.close()
-                        del fd._mmap
+                    # close memmaps so they will regenerate
+                    if fd.can_memmap():
+                        fd.close_memmap()
                     return
 
                 fd.seek(0)
@@ -1264,11 +1260,9 @@ class AsdfFile:
                 fd.flush()
             finally:
                 self._post_write(fd)
-            # if we have memmapped data close the memmap so it will
-            # regenerate
-            if hasattr(fd, "_mmap"):
-                fd._mmap.close()
-                del fd._mmap
+            # close memmaps so they will regenerate
+            if fd.can_memmap():
+                fd.close_memmap()
 
     def write_to(
         self,

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1224,9 +1224,6 @@ class AsdfFile:
                     # write out in a serial fashion.
                     self._serial_write(fd, pad_blocks, include_block_index)
                     fd.truncate()
-                    # close memmaps so they will regenerate
-                    if fd.can_memmap():
-                        fd.close_memmap()
                     return
 
                 # Estimate how big the tree will be on disk by writing the
@@ -1250,9 +1247,6 @@ class AsdfFile:
                     # write out in a serial fashion.
                     self._serial_write(fd, pad_blocks, include_block_index)
                     fd.truncate()
-                    # close memmaps so they will regenerate
-                    if fd.can_memmap():
-                        fd.close_memmap()
                     return
 
                 fd.seek(0)
@@ -1260,9 +1254,9 @@ class AsdfFile:
                 fd.flush()
             finally:
                 self._post_write(fd)
-            # close memmaps so they will regenerate
-            if fd.can_memmap():
-                fd.close_memmap()
+                # close memmaps so they will regenerate
+                if fd.can_memmap():
+                    fd.close_memmap()
 
     def write_to(
         self,

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -12,7 +12,6 @@ import yaml
 
 from . import compression as mcompression
 from . import constants, generic_io, treeutil, util, yamlutil
-from .compat.numpycompat import NUMPY_LT_1_7
 from .config import get_config
 from .util import patched_urllib_parse
 
@@ -1224,16 +1223,6 @@ class Block:
         return self._data
 
     def close(self):
-        if self._memmapped and self._data is not None:
-            if NUMPY_LT_1_7:  # pragma: no cover
-                try:
-                    self._data.flush()
-                except ValueError:
-                    pass
-            else:
-                self._data.flush()
-            if self._data._mmap is not None:
-                self._data._mmap.close()
         self._data = None
 
 

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -144,6 +144,9 @@ def write_edited_yaml_larger(path, new_content, version):
                 blocks.write_block_index(fd, ctx)
                 blocks.close()
 
+            # the file needs to be closed here to release all memmaps
+            original_fd.close()
+
         # Swap in the new version of the file atomically:
         shutil.copy(temp_file.name, path)
     finally:

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -741,7 +741,7 @@ class RealFile(RandomAccessFile):
     def memmap_array(self, offset, size):
         if not hasattr(self, "_mmap"):
             if "w" in self._mode:
-                acc = mmap.ACCESS_READ | mmap.ACCESS_WRITE
+                acc = mmap.ACCESS_WRITE
                 self._fd.seek(0, 2)
                 flen = self._fd.tell()
                 nb = size + offset

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -743,13 +743,14 @@ class RealFile(RandomAccessFile):
             loc = self._fd.tell()
             if "w" in self._mode:
                 acc = mmap.ACCESS_WRITE
-                self._fd.seek(0, 2)
-                flen = self._fd.tell()
-                nb = size + offset
-                if nb > flen:
-                    self._fd.seek(nb - 1, 0)
-                    self._fd.write(b"\0")
-                    self._fd.flush()
+                # self._fd.seek(0, 2)
+                # flen = self._fd.tell()
+                # nb = size + offset
+                # import pdb; pdb.set_trace()
+                # if nb > flen:
+                #     self._fd.seek(nb - 1, 0)
+                #     self._fd.write(b"\0")
+                #     self._fd.flush()
             else:
                 acc = mmap.ACCESS_READ
             self._fd.seek(0, 2)

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -614,20 +614,20 @@ class GenericFile(metaclass=util.InheritDocstrings):
         -------
         array : np.core.memmap
         """
-        raise NotImplementedError()
+        raise NotImplementedError(f"memmapping is not implemented for {self.__class__.__name__}")
 
     def close_memmap(self):
         """
         Close the memmapped file (if one was mapped with memmap_array)
         """
-        raise NotImplementedError()
+        raise NotImplementedError(f"memmapping is not implemented for {self.__class__.__name__}")
 
     def flush_memmap(self):
         """
         Flush any pending writes to the memmapped file (if one was mapped with
         memmap_array)
         """
-        raise NotImplementedError()
+        raise NotImplementedError(f"memmapping is not implemented for {self.__class__.__name__}")
 
     def read_into_array(self, size):
         """

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -1,3 +1,4 @@
+import mmap
 import sys
 
 import numpy as np
@@ -248,7 +249,7 @@ class NDArrayType(AsdfType):
         # memory mapping.
         if self._array is not None:
             base = util.get_array_base(self._array)
-            if isinstance(base, np.memmap) and base._mmap is not None and base._mmap.closed:
+            if isinstance(base, np.memmap) and isinstance(base.base, mmap.mmap) and base.base.closed:
                 self._array = None
 
         if self._array is None:

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -810,6 +810,27 @@ def test_fortran_order(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_f_order, raw_yaml_check_func=check_raw_yaml)
 
 
+def test_memmap_write(tmpdir):
+    tmpfile = str(tmpdir.join("data.asdf"))
+    tree = dict(data=np.zeros(100))
+
+    with asdf.AsdfFile(tree) as af:
+        # Make sure we're actually writing to an internal array for this test
+        af.write_to(tmpfile, all_array_storage="internal")
+
+    with asdf.open(tmpfile, mode="rw", copy_arrays=False) as af:
+        data = af["data"]
+        assert data.flags.writeable is True
+        data[0] = 42
+        assert data[0] == 42
+
+    with asdf.open(tmpfile, mode="rw", copy_arrays=False) as af:
+        assert af["data"][0] == 42
+
+    with asdf.open(tmpfile, mode="r", copy_arrays=False) as af:
+        assert af["data"][0] == 42
+
+
 def test_readonly(tmpdir):
 
     tmpfile = str(tmpdir.join("data.asdf"))

--- a/asdf/tests/test_array_blocks.py
+++ b/asdf/tests/test_array_blocks.py
@@ -354,6 +354,7 @@ def test_update_replace_all_arrays(tmp_path):
     ff.write_to(testpath, pad_blocks=True)
 
     with asdf.open(testpath, mode="rw") as ff:
+        assert_array_equal(ff.tree["my_array"], np.ones((64, 64)) * 1)
         ff.tree["my_array"] = np.ones((64, 64)) * 2
         ff.update()
 


### PR DESCRIPTION
Instead of memmaping each array (which consumes one open file descriptor per array) this PR will memmap the entire file (when enabled) and provide the mmap.mmap to each array.

This has the added benefit of greatly increasing open speed for files with a large number of arrays. For example the current jwst ifupost nirspec reference file has 240 arrays. With this PR (on my machine) open takes ~1.5 seconds compared to ~7 without this PR.

~I'm opening this as draft to run the downstream tests.~