### PR TITLE
Fix handling of NDArrayType during block to fits hdu matching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@
 - Modify generic_file for fsspec compatibility [#1226]
 - Add fsspec http filesystem support [#1228]
 - Memmap whole file instead of each array [#1230]
+- Fix issue #1232 where array data was duplicated during resaving of a fits file [#1234]
 
 2.13.0 (2022-08-19)
 -------------------

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -92,13 +92,12 @@ class _EmbeddedBlockManager(block.BlockManager):
     def find_or_create_block_for_array(self, arr, ctx):
         from .tags.core import ndarray
 
-        if not isinstance(arr, ndarray.NDArrayType):
-            base = util.get_array_base(arr)
-            for hdu in self._hdulist:
-                if hdu.data is None:
-                    continue
-                if base is util.get_array_base(hdu.data):
-                    return _FitsBlock(hdu)
+        base = util.get_array_base(arr)
+        for hdu in self._hdulist:
+            if hdu.data is None:
+                continue
+            if base is util.get_array_base(hdu.data):
+                return _FitsBlock(hdu)
 
         return super().find_or_create_block_for_array(arr, ctx)
 

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -464,6 +464,16 @@ def test_array_view_compatible_dtype(tmp_path):
 
 
 def test_hdu_link_independence(tmp_path):
+    """
+    As links between arrays and hdu items are made during
+    saving, it's possible that if this goes wrong links
+    might be made between multiple arrays and a single hdu.
+    In this case, modifying one array will change memory
+    shared with another array. This test creates a file
+    with multiple arrays, writes it to a fits file,
+    reads it back in and then modifies the contents of
+    each array to check for this possible errort.
+    """
     asdf_in_fits = create_asdf_in_fits("f4")
     # set all arrays to same values
     asdf_in_fits["model"]["sci"]["data"][:] = 0

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -482,8 +482,8 @@ def test_hdu_link_independence(tmp_path):
         aif["model"]["err"]["data"][:] = 3
 
         assert np.all(aif["model"]["sci"]["data"] == 1)
-        assert np.all(aif["model"]["dq"]["data"] == 1)
-        assert np.all(aif["model"]["err"]["data"] == 1)
+        assert np.all(aif["model"]["dq"]["data"] == 2)
+        assert np.all(aif["model"]["err"]["data"] == 3)
 
 
 def test_array_view_different_layout(tmp_path):

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -463,6 +463,29 @@ def test_array_view_compatible_dtype(tmp_path):
             af.write_to(file_path)
 
 
+def test_hdu_link_independence(tmp_path):
+    asdf_in_fits = create_asdf_in_fits("f4")
+    # set all arrays to same values
+    asdf_in_fits["model"]["sci"]["data"][:] = 0
+    asdf_in_fits["model"]["dq"]["data"][:] = 0
+    asdf_in_fits["model"]["err"]["data"][:] = 0
+
+    fn0 = tmp_path / "test0.fits"
+
+    # write out the asdf in fits file
+    asdf_in_fits.write_to(str(fn0))
+
+    with asdf.open(fn0, mode="r") as aif:
+        # assign new values
+        aif["model"]["sci"]["data"][:] = 1
+        aif["model"]["dq"]["data"][:] = 2
+        aif["model"]["err"]["data"][:] = 3
+
+        assert np.all(aif["model"]["sci"]["data"] == 1)
+        assert np.all(aif["model"]["dq"]["data"] == 1)
+        assert np.all(aif["model"]["err"]["data"] == 1)
+
+
 def test_array_view_different_layout(tmp_path):
     """
     A view over the FITS array with a different memory layout

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -85,8 +85,10 @@ def get_array_base(arr):
     For a given Numpy array, finds the base array that "owns" the
     actual data.
     """
+    from .tags.core import ndarray
+
     base = arr
-    while isinstance(base.base, np.ndarray):
+    while isinstance(base.base, (np.ndarray, ndarray.NDArrayType)):
         base = base.base
     return base
 


### PR DESCRIPTION
Fixes #1232 

When an asdf tree containing arrays is read from a fits file, the arrays are created as NDArrayType objects (instead of ndarray). If this tree was resaved to a fits file the NDArrayType was mishandled during matching arrays to hdu items which resulted in duplicate storage of array data in hdu items and internal blocks.

This PR adds a few tests for this issue and fixes the handling of NDArrayType to allow for accurate matching between hdu items and arrays to avoid data duplication.