### PR TITLE
always close memmaps with the asdf file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.14.1 (unreleased)
+-------------------
+
+The ASDF Standard is at v1.6.0
+
+- Fix issue #1239, close memmap with asdf file context [#1241]
+
 2.14.0 (2022-11-22)
 -------------------
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -779,11 +779,9 @@ class RealFile(RandomAccessFile):
         return np.fromfile(self._fd, dtype=np.uint8, count=size)
 
     def close(self):
+        self.flush_memmap()
         super().close()
-        if self._close:
-            if hasattr(self, "_mmap") and not self._mmap.closed:
-                self._mmap.flush()
-                self._mmap.close()
+        self.close_memmap()
 
 
 class MemoryIO(RandomAccessFile):


### PR DESCRIPTION
even when reading an already opened file

fixes issue #1239

update changelog

add regression test docstring