### PR TITLE
Release/2.14.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.14.1 (unreleased)
+-------------------
+
+The ASDF Standard is at v1.6.0
+
+- Fix issue #1239, close memmap with asdf file context [#1241]
+
 2.14.0 (2022-11-22)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-2.14.1 (unreleased)
+2.14.1 (2022-11-23)
 -------------------
 
 The ASDF Standard is at v1.6.0

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -779,11 +779,9 @@ class RealFile(RandomAccessFile):
         return np.fromfile(self._fd, dtype=np.uint8, count=size)
 
     def close(self):
+        self.flush_memmap()
         super().close()
-        if self._close:
-            if hasattr(self, "_mmap") and not self._mmap.closed:
-                self._mmap.flush()
-                self._mmap.close()
+        self.close_memmap()
 
 
 class MemoryIO(RandomAccessFile):


### PR DESCRIPTION
Patch release to fix memmaps leaving open files before garbage collection which is causing failures in astropy CI:
https://github.com/astropy/astropy/pull/14035#issuecomment-1325236928