### PR TITLE
Add support for ndarray 1.1 and fix issue #1245

### DIFF
--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -567,6 +567,9 @@ def _make_operation(name):
     return __operation__
 
 
+classes_to_modify = NDArrayType.__versioned_siblings + [
+    NDArrayType,
+]
 for op in [
     "__neg__",
     "__pos__",
@@ -631,7 +634,8 @@ for op in [
     "__delitem__",
     "__contains__",
 ]:
-    setattr(NDArrayType, op, _make_operation(op))
+    [setattr(cls, op, _make_operation(op)) for cls in classes_to_modify]
+del classes_to_modify
 
 
 def _get_ndim(instance):

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -215,6 +215,7 @@ class NDArrayType(AsdfType):
     name = "core/ndarray"
     version = "1.0.0"
     types = [np.ndarray, ma.MaskedArray]
+    supported_versions = {"1.1.0", "1.0.0"}
 
     def __init__(self, source, shape, dtype, offset, strides, order, mask, asdffile):
         self._asdffile = asdffile

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -373,10 +373,12 @@ class NDArrayType(AsdfType):
         # can cause problems when the array is passed to other
         # libraries.
         # See https://github.com/asdf-format/asdf/issues/1015
-        if name in ("name", "version"):
+        if name in ("name", "version", "supported_versions"):
             raise AttributeError(f"'{self.__class__.name}' object has no attribute '{name}'")
         else:
-            return super().__getattribute__(name)
+            # do not use super as it conflicts with ExtensionTypeMeta
+            # See https://github.com/asdf-format/asdf/issues/1245
+            return AsdfType.__getattribute__(self, name)
 
     @classmethod
     def from_tree(cls, node, ctx):

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -133,6 +133,14 @@ class ExtensionTypeMeta(type):
                     new_attrs["version"] = version
                     new_attrs["supported_versions"] = set()
                     new_attrs["_latest_version"] = cls.version
+                    if "__classcell__" in new_attrs:
+                        raise RuntimeError(
+                            "Subclasses of ExtensionTypeMeta that define supported_versions "
+                            "cannot used super() to call parent class functions. super() "
+                            "creates a __classcell__ closure that cannot be duplicated "
+                            "during creation of versioned siblings. "
+                            "See https://github.com/asdf-format/asdf/issues/1245"
+                        )
                     siblings.append(ExtensionTypeMeta.__new__(mcls, name, bases, new_attrs))
             setattr(cls, "__versioned_siblings", siblings)
 


### PR DESCRIPTION
This PR fixes #1245 by removing the use of super in NDArrayType and adding an exception to check for incompatible use of super in classes of type ExtensionTypeMeta.

One test is failing locally:
```python
FAILED asdf/tests/test_extension.py::test_builtin_extension - AssertionError: NDArrayType supports tag, tag:stsci.edu:asdf/core/ndarray-1...
```
due to the missing schema added in this PR: https://github.com/asdf-format/asdf-standard/pull/350 As that PR is failing due to missing support added in this PR there appears to be no way to have either pass prior to merging without skipping tests.

Additional changes to asdf will be required to fully support https://github.com/asdf-format/asdf-standard/pull/350 including an update to add supported_versions to IntegerType. This should be left as a draft until a full set of PRs is ready.