### PR TITLE
use pytest to parametrize test_version_map_support

### DIFF
--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -279,6 +279,7 @@ def xfail_version_map_support_cases(request):
     if (version, tag) in [
         ("1.6.0", "tag:stsci.edu:asdf/time/time-1.2.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
+        ("1.6.0", "tag:stsci.edu:asdf/unit/quantity-1.2.0"),
         ("1.5.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
         ("1.4.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
         ("1.4.0", "tag:stsci.edu:asdf/wcs/celestial_frame-1.1.0"),


### PR DESCRIPTION
Allow for more fine-grained control over explicit tag/extension version match failures.

test_version_map_support checks for explicit tag/extension matches. All tags currently not supported in legacy extensions fail these matches which required xfailing all checks with standard tags: https://github.com/asdf-format/asdf/blob/05d5001b27766b01688f8bd4b6e01d92445e1e3c/asdf/tests/test_versioning.py#L269-L271

As astropy.io.misc.asdf supports some of the core tags (time, unit, etc) but is a deprecated extension any updates to the schema for these tags will result in core tag test failures in test_version_map_support. This PR will allow xfailing just those tags supported outside of asdf and allow for continued testing of other core tags.