### PR TITLE
remove uses of asdf metaschema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.14.2 (unreleased)
+-------------------
+
+The ASDF Standard is at v1.6.0
+
+- Remove uses of asdf-schema-1.0.0 metaschema [#1249]
+
 2.14.1 (2022-11-23)
 -------------------
 

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -65,7 +65,7 @@ def test_load_schema(tmp_path):
     schema_def = """
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/nugatory/nugatory-1.0.0"
 tag: "tag:stsci.edu:asdf/nugatory/nugatory-1.0.0"
 
@@ -88,7 +88,7 @@ def test_load_schema_with_full_tag(tmp_path):
     schema_def = """
 %YAML 1.1
 ---
-$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/nugatory/nugatory-1.0.0"
 tag: "tag:stsci.edu:asdf/nugatory/nugatory-1.0.0"
 
@@ -112,7 +112,7 @@ def test_load_schema_with_tag_address(tmp_path):
 %YAML 1.1
 %TAG !asdf! tag:stsci.edu:asdf/
 ---
-$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/nugatory/nugatory-1.0.0"
 tag: "tag:stsci.edu:asdf/nugatory/nugatory-1.0.0"
 
@@ -136,7 +136,7 @@ def test_load_schema_with_file_url(tmp_path):
 %YAML 1.1
 %TAG !asdf! tag:stsci.edu:asdf/
 ---
-$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/nugatory/nugatory-1.0.0"
 tag: "tag:stsci.edu:asdf/nugatory/nugatory-1.0.0"
 
@@ -160,7 +160,7 @@ required: [foobar]
 def test_load_schema_with_asdf_uri_scheme():
     subschema_content = """%YAML 1.1
 ---
-$schema: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: asdf://somewhere.org/schemas/bar
 
 bar:
@@ -169,7 +169,7 @@ bar:
 """
     content = """%YAML 1.1
 ---
-$schema: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: asdf://somewhere.org/schemas/foo
 
 definitions:
@@ -207,7 +207,7 @@ def test_load_schema_with_stsci_id():
     """
     subschema_content = """%YAML 1.1
 ---
-$schema: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: http://stsci.edu/schemas/bar
 
 bar:
@@ -216,7 +216,7 @@ bar:
 """
     content = """%YAML 1.1
 ---
-$schema: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: http://stsci.edu/schemas/foo
 
 definitions:
@@ -1116,7 +1116,7 @@ def test_validator_visit_repeat_nodes():
 def test_tag_validator():
     content = """%YAML 1.1
 ---
-$schema: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: asdf://somewhere.org/schemas/foo
 tag: asdf://somewhere.org/tags/foo
 ...
@@ -1132,7 +1132,7 @@ tag: asdf://somewhere.org/tags/foo
 
     content = """%YAML 1.1
 ---
-$schema: http://stsci.edu/schemas/asdf/asdf-schema-1.0.0
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: asdf://somewhere.org/schemas/bar
 tag: asdf://somewhere.org/tags/bar-*
 ...

--- a/docs/asdf/extending/schemas.rst
+++ b/docs/asdf/extending/schemas.rst
@@ -79,10 +79,6 @@ a *metaschema*.  ASDF comes with three built-in metaschemas:
   Includes everything in JSON Schema Draft 4, plus additional YAML-specific
   validators including ``tag`` and ``propertyOrder``.
 
-- ``http://stsci.edu/schemas/asdf/asdf-schema-1.0.0`` - The ASDF Schema metaschema.
-  Includes everything in YAML Schema, plus additional ASDF-specific validators
-  that check ndarray properties.
-
 Our schema makes use of the ``tag`` validator, so we're specifying the YAML Schema
 URI here.
 


### PR DESCRIPTION
The asdf metaschema: https://github.com/asdf-format/asdf-standard/blob/master/resources/schemas/stsci.edu/asdf/asdf-schema-1.0.0.yaml
appears to only be used in a few tests and is no longer used in the ndarray schema. Modifying the tests to use the other included metaschema: https://github.com/asdf-format/asdf-standard/blob/master/resources/schemas/stsci.edu/yaml-schema/draft-01.yaml
does not result in any test failures (locally). Removal of the asdf metaschema (which contains a reference to the ndarray schema version 1.0 which contains a bug) will simplify the fix for ndarray schema bug: https://github.com/asdf-format/asdf-standard/issues/345