### PR TITLE
support integer-1.1 and ndarray-1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ The ASDF Standard is at v1.6.0
 The ASDF Standard is at v1.6.0
 
 - Fix issue #1239, close memmap with asdf file context [#1241]
+- Add ndarray-1.1.0 and integer-1.1.0 support [#1250]
 
 2.14.0 (2022-11-22)
 -------------------

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -44,6 +44,7 @@ class IntegerType(AsdfType):
 
     name = "core/integer"
     version = "1.0.0"
+    supported_versions = {"1.0.0", "1.1.0"}
 
     _value_cache = dict()
 
@@ -96,7 +97,7 @@ class IntegerType(AsdfType):
         if tree["sign"] == "-":
             value = -value
 
-        return IntegerType(value)
+        return cls(value)
 
     def __int__(self):
         return int(self._value)

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -298,6 +298,7 @@ def xfail_version_map_support_cases(request):
         ("1.6.0", "tag:stsci.edu:asdf/fits/fits-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/time/time-1.2.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.1.0"),
+        ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/quantity-1.2.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/unit-1.1.0"),
         ("1.5.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -294,12 +294,9 @@ def xfail_version_map_support_cases(request):
     version = request.getfixturevalue("version")
     if (version, tag) in [
         ("1.6.0", "tag:stsci.edu:asdf/core/column-1.1.0"),
-        ("1.6.0", "tag:stsci.edu:asdf/core/integer-1.1.0"),
-        ("1.6.0", "tag:stsci.edu:asdf/core/ndarray-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/core/table-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/fits/fits-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/time/time-1.2.0"),
-        ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/quantity-1.2.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/unit-1.1.0"),

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -133,6 +133,15 @@ class ExtensionTypeMeta(type):
                     new_attrs["version"] = version
                     new_attrs["supported_versions"] = set()
                     new_attrs["_latest_version"] = cls.version
+                    if "__classcell__" in new_attrs:
+                        raise RuntimeError(
+                            "Subclasses of ExtensionTypeMeta that define "
+                            "supported_versions cannot used super() to call "
+                            "parent class functions. super() creates a "
+                            "__classcell__ closure that cannot be duplicated "
+                            "during creation of versioned siblings. "
+                            "See https://github.com/asdf-format/asdf/issues/1245"
+                        )
                     siblings.append(ExtensionTypeMeta.__new__(mcls, name, bases, new_attrs))
             setattr(cls, "__versioned_siblings", siblings)
 


### PR DESCRIPTION
fixes an issue with integer where IntegerType instead of cls was used during class instantiation which resulted in objects being created with the incorrect version. Prior code (that only had one integer version, 1.0) did not suffer from issues because of this bug.

fixes #1245 by removing the use of super in NDArrayType and adding an exception to check for incompatible use of super in classes of type ExtensionTypeMeta.

This should be merged with asdf-standard PR https://github.com/asdf-format/asdf-standard/pull/350