### PR TITLE
skip tests to prep for asdf-standard 1.6 update

### DIFF
--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -277,9 +277,14 @@ def xfail_version_map_support_cases(request):
     tag = request.getfixturevalue("tag")
     version = request.getfixturevalue("version")
     if (version, tag) in [
+        ("1.6.0", "tag:stsci.edu:asdf/core/column-1.1.0"),
+        ("1.6.0", "tag:stsci.edu:asdf/core/table-1.1.0"),
+        ("1.6.0", "tag:stsci.edu:asdf/fits/fits-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/time/time-1.2.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
+        ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/quantity-1.2.0"),
+        ("1.6.0", "tag:stsci.edu:asdf/unit/unit-1.1.0"),
         ("1.5.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
         ("1.4.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
         ("1.4.0", "tag:stsci.edu:asdf/wcs/celestial_frame-1.1.0"),


### PR DESCRIPTION
This should skip the tests failing for asdf-standard PR https://github.com/asdf-format/asdf-standard/pull/350
due to missing converters which will be added in asdf PR https://github.com/asdf-format/asdf/pull/1250