### PR TITLE
skip testing type versions not in any deployed standard

### DIFF
--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -443,9 +443,7 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
     )
 
     # check the default version
-    types_to_check = [
-        extension_type,
-    ]
+    types_to_check = [extension_type]
 
     # Adding or updating a schema/type version might involve updating multiple
     # packages. This can result in types without schema and schema without types

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -4,7 +4,23 @@ import pytest
 
 from asdf.extension import default_extensions
 from asdf.schema import load_schema
-from asdf.versioning import AsdfSpec, AsdfVersion, get_version_map, join_tag_version, supported_versions
+from asdf.versioning import (
+    AsdfSpec,
+    AsdfVersion,
+    asdf_standard_development_version,
+    default_version,
+    get_version_map,
+    join_tag_version,
+    supported_versions,
+)
+
+
+def test_default_in_supported_versions():
+    assert default_version in supported_versions
+
+
+def test_development_is_not_default():
+    assert default_version != asdf_standard_development_version
 
 
 def test_version_constructor():

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -156,7 +156,12 @@ supported_versions = [
     AsdfVersion("1.6.0"),
 ]
 
+
 default_version = AsdfVersion("1.5.0")
+
+# This is the ASDF Standard version that is currently in development
+# it is possible that breaking changes will be made to this version.
+asdf_standard_development_version = AsdfVersion("1.6.0")
 
 
 # This is the ASDF Standard version at which the format of the history


### PR DESCRIPTION
Modifies _assert_extension_type_correctness to skip checking type versions that are not part of a non-development supported version of the asdf-standard.

Two other tests are added `test_default_in_supported_versions` and `test_development_is_not_default` to catch possible errors where the default is set to a non-supported (or development) version.

As this PR will skip testing completeness (that a type has a schema of the same version) of type versions that are only in development version, it's possible that updating the development version of the asdf-standard will cause test failures if the schema and type versions do not match. Put another way, a PR that advances the asdf-standard development version might reveal and then have to fix these type/schema version issues.

This should allow PR #1250 to pass CI without an asdf-standard release.