### PR TITLE
Bug/ndarray schema with test skip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 The ASDF Standard is at v1.6.0
 
 - Fix issue #1239, close memmap with asdf file context [#1241]
+- Add ndarray-1.10 and integer-1.1.0 support [#1255]
 
 2.14.0 (2022-11-22)
 -------------------

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -44,6 +44,7 @@ class IntegerType(AsdfType):
 
     name = "core/integer"
     version = "1.0.0"
+    supported_versions = {"1.0.0", "1.1.0"}
 
     _value_cache = dict()
 
@@ -96,7 +97,7 @@ class IntegerType(AsdfType):
         if tree["sign"] == "-":
             value = -value
 
-        return IntegerType(value)
+        return cls(value)
 
     def __int__(self):
         return int(self._value)

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -31,7 +31,13 @@ from ..exceptions import AsdfConversionWarning
 from ..extension import default_extensions
 from ..resolver import Resolver, ResolverChain
 from ..tags.core import AsdfObject
-from ..versioning import AsdfVersion, get_version_map
+from ..versioning import (
+    AsdfVersion,
+    asdf_standard_development_version,
+    get_version_map,
+    split_tag_version,
+    supported_versions,
+)
 from .httpserver import RangeHTTPServer
 
 try:
@@ -436,7 +442,27 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
         extension_type.__name__
     )
 
-    for check_type in extension_type.versioned_siblings + [extension_type]:
+    # check the default version
+    types_to_check = [extension_type]
+
+    # Adding or updating a schema/type version might involve updating multiple
+    # packages. This can result in types without schema and schema without types
+    # for the development version of the asdf-standard. To account for this,
+    # don't include versioned siblings of types with versions that are not
+    # in one of the asdf-standard versions in supported_versions (excluding the
+    # current development version).
+    asdf_standard_versions = supported_versions.copy()
+    if asdf_standard_development_version in asdf_standard_versions:
+        asdf_standard_versions.remove(asdf_standard_development_version)
+    for sibling in extension_type.versioned_siblings:
+        tag_base, version = split_tag_version(sibling.yaml_tag)
+        for asdf_standard_version in asdf_standard_versions:
+            vm = get_version_map(asdf_standard_version)
+            if tag_base in vm["tags"] and AsdfVersion(vm["tags"][tag_base]) == version:
+                types_to_check.append(sibling)
+                break
+
+    for check_type in types_to_check:
         schema_location = resolver(check_type.yaml_tag)
 
         assert schema_location is not None, (

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -4,7 +4,23 @@ import pytest
 
 from asdf.extension import default_extensions
 from asdf.schema import load_schema
-from asdf.versioning import AsdfSpec, AsdfVersion, get_version_map, join_tag_version, supported_versions
+from asdf.versioning import (
+    AsdfSpec,
+    AsdfVersion,
+    asdf_standard_development_version,
+    default_version,
+    get_version_map,
+    join_tag_version,
+    supported_versions,
+)
+
+
+def test_default_in_supported_versions():
+    assert default_version in supported_versions
+
+
+def test_development_is_not_default():
+    assert default_version != asdf_standard_development_version
 
 
 def test_version_constructor():

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -298,6 +298,7 @@ def xfail_version_map_support_cases(request):
         ("1.6.0", "tag:stsci.edu:asdf/fits/fits-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/time/time-1.2.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.1.0"),
+        ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/quantity-1.2.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/unit-1.1.0"),
         ("1.5.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -294,12 +294,9 @@ def xfail_version_map_support_cases(request):
     version = request.getfixturevalue("version")
     if (version, tag) in [
         ("1.6.0", "tag:stsci.edu:asdf/core/column-1.1.0"),
-        ("1.6.0", "tag:stsci.edu:asdf/core/integer-1.1.0"),
-        ("1.6.0", "tag:stsci.edu:asdf/core/ndarray-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/core/table-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/fits/fits-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/time/time-1.2.0"),
-        ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.0.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/defunit-1.1.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/quantity-1.2.0"),
         ("1.6.0", "tag:stsci.edu:asdf/unit/unit-1.1.0"),

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -133,6 +133,15 @@ class ExtensionTypeMeta(type):
                     new_attrs["version"] = version
                     new_attrs["supported_versions"] = set()
                     new_attrs["_latest_version"] = cls.version
+                    if "__classcell__" in new_attrs:
+                        raise RuntimeError(
+                            "Subclasses of ExtensionTypeMeta that define "
+                            "supported_versions cannot used super() to call "
+                            "parent class functions. super() creates a "
+                            "__classcell__ closure that cannot be duplicated "
+                            "during creation of versioned siblings. "
+                            "See https://github.com/asdf-format/asdf/issues/1245"
+                        )
                     siblings.append(ExtensionTypeMeta.__new__(mcls, name, bases, new_attrs))
             setattr(cls, "__versioned_siblings", siblings)
 

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -156,7 +156,12 @@ supported_versions = [
     AsdfVersion("1.6.0"),
 ]
 
+
 default_version = AsdfVersion("1.5.0")
+
+# This is the ASDF Standard version that is currently in development
+# it is possible that breaking changes will be made to this version.
+asdf_standard_development_version = AsdfVersion("1.6.0")
 
 
 # This is the ASDF Standard version at which the format of the history


### PR DESCRIPTION
This PR merges #1250 and #1253

It may be cleaner to merge #1253 then rebase and merge #1250 however the CI here should tell us if the test changes in #1253 are sufficient to allow #1250 CI to pass. I'm leaving this as a draft until we sort out which option to take.

From #1250:

fixes an issue with integer where IntegerType instead of cls was used during class instantiation which resulted in objects being created with the incorrect version. Prior code (that only had one integer version, 1.0) did not suffer from issues because of this bug.

fixes https://github.com/asdf-format/asdf/issues/1245 by removing the use of super in NDArrayType and adding an exception to check for incompatible use of super in classes of type ExtensionTypeMeta.

From #1253:

Modifies _assert_extension_type_correctness to skip checking type versions that are not part of a non-development supported version of the asdf-standard.

Two other tests are added test_default_in_supported_versions and test_development_is_not_default to catch possible errors where the default is set to a non-supported (or development) version.

As this PR will skip testing completeness (that a type has a schema of the same version) of type versions that are only in development version, it's possible that updating the development version of the asdf-standard will cause test failures if the schema and type versions do not match. Put another way, a PR that advances the asdf-standard development version might reveal and then have to fix these type/schema version issues.