### PR TITLE
Bugfix for `enum` bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.14.2 (unreleased)
+-------------------
+
+The ASDF Standard is at v1.6.0
+
+- Fix issue #1256, where ``enum`` could not be used on tagged objects. [#1257]
+
 2.14.1 (2022-11-23)
 -------------------
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -150,6 +150,17 @@ def validate_type(validator, types, instance, schema):
     return mvalidators.Draft4Validator.VALIDATORS["type"](validator, types, instance, schema)
 
 
+def validate_enum(validator, enums, instance, schema):
+    """
+    `asdf.tagged.Tagged` objects will fail in the default enum validator
+    """
+
+    if isinstance(instance, tagged.Tagged):
+        instance = instance.base
+
+    yield from mvalidators.Draft4Validator.VALIDATORS["enum"](validator, enums, instance, schema)
+
+
 YAML_VALIDATORS = util.HashableDict(mvalidators.Draft4Validator.VALIDATORS.copy())
 YAML_VALIDATORS.update(
     {
@@ -158,6 +169,7 @@ YAML_VALIDATORS.update(
         "flowStyle": validate_flowStyle,
         "style": validate_style,
         "type": validate_type,
+        "enum": validate_enum,
     }
 )
 

--- a/asdf/tagged.py
+++ b/asdf/tagged.py
@@ -40,11 +40,21 @@ class Tagged:
     with it.
     """
 
+    _base_type = None
+
+    @property
+    def base(self):
+        """Convert to base type"""
+
+        return self._base_type(self)
+
 
 class TaggedDict(Tagged, UserDict, dict):
     """
     A Python dict with a tag attached.
     """
+
+    _base_type = dict
 
     flow_style = None
     property_order = None
@@ -72,6 +82,8 @@ class TaggedList(Tagged, UserList, list):
     A Python list with a tag attached.
     """
 
+    _base_type = list
+
     flow_style = None
 
     def __init__(self, data=None, tag=None):
@@ -96,6 +108,8 @@ class TaggedString(Tagged, UserString, str):
     """
     A Python string with a tag attached.
     """
+
+    _base_type = str
 
     style = None
 


### PR DESCRIPTION
In spacetelescope/rad#155, a bug with using `enum` was reported. It of course had an unhelpful error message. The details of the bug's cause and possible resolution are detailed in issue #1256. This PR fixes #1256 by implemented one of possible paths (path 3) for resolution and adds regression tests for this behavior.