### PR TITLE
Update ruff config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,14 @@ repos:
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
 
-- repo: https://github.com/asottile/yesqa
-  rev: v1.4.0
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: 'v0.0.170'
   hooks:
-    - id: yesqa
+    - id: ruff
+      args: ["--fix"]
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.0
+  rev: 'v3.3.1'
   hooks:
     - id: pyupgrade
       args: ["--py38-plus"]
@@ -50,15 +51,9 @@ repos:
     - id: black
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.12.1
+  rev: 'v1.12.1'
   hooks:
     - id: blacken-docs
-
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.83
-  hooks:
-    - id: lint
-      args: ["--fix"]
 
 - repo: https://github.com/PyCQA/bandit
   rev: 1.7.4

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -90,7 +90,6 @@ class _EmbeddedBlockManager(block.BlockManager):
         return super().get_source(block)
 
     def find_or_create_block_for_array(self, arr, ctx):
-        from .tags.core import ndarray
 
         base = util.get_array_base(arr)
         for hdu in self._hdulist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,8 +166,3 @@ extend_skip_glob = ["asdf/extern/*", ".eggs/*", ".tox/*"]
 [tool.ruff]
 line-length = 120
 extend-exclude = ["asdf/extern/*", "docs/*"]
-
-[tool.autoflake]
-remove-all-unused-imports = true
-ignore-init-module-imports = true
-remove-unused-variables = true


### PR DESCRIPTION
`ruff` updated its pre-commit API at some point, meaning the `pre-commit.ci` bot was not updating the plugin automatically. In the intervening time `ruff --fix` was improved to remove unnecessary `noqa` flags and fix unused imports (not marked with a `noqa`). Hence

- The removal of the slow `yesqa` job.
- The fix `fits_embed.py`.