### PR TITLE
Start using codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,14 @@ repos:
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.2
+  hooks:
+    - id: codespell
+      args: ["--write-changes"]
+      additional_dependencies:
+        - tomli
+
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: 'v0.0.170'
   hooks:

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -191,7 +191,7 @@ class _TreeRenderer:
 
         is_tail indicates if the child is the last of the children,
         needed to indicate the proper connecting character in the tree
-        display. Likewise, active_depths is used to track which preceeding
+        display. Likewise, active_depths is used to track which preceding
         depths are incomplete thus need continuing lines preceding in
         the tree display.
         """

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -754,7 +754,7 @@ class AsdfFile:
         try:
             version = versioning.AsdfVersion(parts[1].decode("ascii"))
         except ValueError:
-            raise ValueError(f"Unparseable version in ASDF file: {parts[1]}")
+            raise ValueError(f"Unparsable version in ASDF file: {parts[1]}")
 
         return version
 
@@ -947,7 +947,7 @@ class AsdfFile:
             try:
                 # TODO: this feels a bit circular, try to clean up. Also
                 # this introduces another dependency on astropy which may
-                # not be desireable.
+                # not be desirable.
                 from . import fits_embed
 
                 return fits_embed.AsdfInFits._open_impl(

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -757,7 +757,7 @@ class BlockManager:
 
     def get_output_compressions(self):
         """
-        Get the list of unqiue compressions used on blocks.
+        Get the list of unique compressions used on blocks.
         """
         return list({b.output_compression for b in self.blocks})
 
@@ -820,7 +820,7 @@ class Block:
         self._allocated = self._size
 
     def __repr__(self):
-        return "<Block {} off: {} alc: {} siz: {}>".format(
+        return "<Block {} off: {} alc: {} size: {}>".format(
             self._array_storage[:3], self._offset, self._allocated, self._size
         )
 
@@ -904,7 +904,7 @@ class Block:
     @property
     def output_compression_kwargs(self):
         """
-        The configuration options to the Compressor constructur
+        The configuration options to the Compressor constructor
         used to write the block.
         :return:
         """

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -436,7 +436,7 @@ class NDArrayType(AsdfType):
         block = ctx.blocks.find_or_create_block_for_array(data, ctx)
 
         if block.array_storage == "fits":
-            # Views over arrays stored in FITS files have some idiosyncracies.
+            # Views over arrays stored in FITS files have some idiosyncrasies.
             # astropy.io.fits always writes arrays C-contiguous with big-endian
             # byte order, whereas asdf preserves the "contiguousity" and byte order
             # of the base array.

--- a/asdf/tags/core/tests/test_external_reference.py
+++ b/asdf/tags/core/tests/test_external_reference.py
@@ -3,7 +3,7 @@ from asdf.tests import helpers
 
 
 def test_roundtrip_external_array(tmpdir):
-    ref = ExternalArrayReference("./nonexistant.fits", 1, "np.float64", (100, 100))
+    ref = ExternalArrayReference("./nonexistent.fits", 1, "np.float64", (100, 100))
 
     tree = {"nothere": ref}
 

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -229,7 +229,7 @@ def test_extension_proxy():
     with pytest.raises(TypeError):
         ExtensionProxy(FullExtension(compressors=[object()]))
 
-    # Unparseable ASDF Standard requirement:
+    # Unparsable ASDF Standard requirement:
     with pytest.raises(ValueError):
         ExtensionProxy(FullExtension(asdf_standard_requirement="asdf-standard >= 1.4.0"))
 

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -356,7 +356,7 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
                 result._tag = node._tag
         except TypeError:
             # The derived class signature is different, so simply store the
-            # list representing the contents. Currently this is primarly
+            # list representing the contents. Currently this is primarily
             # intended to handle namedtuple and NamedTuple instances.
             if not ignore_implicit_conversion:
                 warnings.warn(f"Failed to serialize instance of {type(node)}, converting to list instead", AsdfWarning)
@@ -384,7 +384,7 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
             # to the same object id.
             return _context[node]
 
-        # Inform the context that we're going to start modifing
+        # Inform the context that we're going to start modifying
         # this node.
         with _context.pending(node):
             # Take note of the "id" field, in case we're modifying

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -363,7 +363,7 @@ class ExtensionType:
         compatible.
 
         Child classes can override this method to affect how version
-        compatiblity for this type is determined.
+        compatibility for this type is determined.
 
         Parameters
         ----------

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -100,7 +100,7 @@ see :ref:`config_options_array_inline_threshold`.
 Saving external arrays
 ----------------------
 
-ASDF files may also be saved in "exploded form", which creats multiple files
+ASDF files may also be saved in "exploded form", which creates multiple files
 corresponding to the following data items:
 
 - One ASDF file containing only the header and tree.

--- a/docs/asdf/developer_overview.rst
+++ b/docs/asdf/developer_overview.rst
@@ -191,7 +191,7 @@ When an ``AsdfFile`` class is instantiated, one thing that happens on the
 retrieves the extensions from the global config and selects those that
 are compatible with the ``AsdfFile``'s ASDF Standard version.  It returns the
 resulting list, which is assigned to the ``_plugin_extensions`` variable.  The
-term "plugin extensions" constrasts with "user extensions" which are additional
+term "plugin extensions" contrasts with "user extensions" which are additional
 extensions provided by the user as an argument to ``AsdfFile.__init__``.
 
 The extension lists are used by ``AsdfFile`` to create the file's ``ExtensionList``
@@ -298,7 +298,7 @@ tagged_tree is then returned to the ``af`` instance (still running the
 (This is the major reason that the tree isn't  directly converted to an object
 tree since jsonschema would not be able to use the  final object tree for
 validation, besides issues relate to the fact that things that don't validate
-may not be convertable to the designated object.)
+may not be convertible to the designated object.)
 
 The validate machinery is a bit confusing since there are essentially two basic
 approaches to how validation is done. One type of validation is for validation

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -659,7 +659,7 @@ a child node of the current tree root:
 Regular expression searches
 ---------------------------
 
-Any string argument to search is interpeted as a regular expression.  For example,
+Any string argument to search is interpreted as a regular expression.  For example,
 we can search for nodes whose keys start with a particular string:
 
 .. code:: pycon

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,3 +166,6 @@ extend_skip_glob = ["asdf/extern/*", ".eggs/*", ".tox/*"]
 [tool.ruff]
 line-length = 120
 extend-exclude = ["asdf/extern/*", "docs/*"]
+
+[tool.codespell]
+skip="*.pdf,*.fits,*.asdf,.tox,asdf/extern,build,tags,.git,docs/_build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ line-length = 120
 extend-exclude = ["asdf/extern/*", "docs/*"]
 
 [tool.codespell]
-skip="*.pdf,*.fits,*.asdf,.tox,asdf/extern,build,tags,.git,docs/_build"
+skip="*.pdf,*.fits,*.asdf,.tox,asdf/extern,build,./tags,.git,docs/_build"
 ignore-words-list="""
 fo,
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,3 +169,6 @@ extend-exclude = ["asdf/extern/*", "docs/*"]
 
 [tool.codespell]
 skip="*.pdf,*.fits,*.asdf,.tox,asdf/extern,build,tags,.git,docs/_build"
+ignore-words-list="""
+fo,
+"""


### PR DESCRIPTION
Inspired by astropy/astropy#13982 and astropy/astropy#13985, this PR adds [codespell](https://github.com/codespell-project/codespell) as another build style tool to ASDF. codespell should autofix (via pre-commit) any common spelling issues in ASDF and its docs (if a word is being incorrectly fixed, simply add it to the `ignore-words-list` in the `pyproject.toml` file.