### PR TITLE
Bug/memmap and pad blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ The ASDF Standard is at v1.6.0
 The ASDF Standard is at v1.6.0
 
 - Fix issue #1256, where ``enum`` could not be used on tagged objects. [#1257]
+- Fix issue #1268, where update could fail to clear memmaps for some files [#1269]
 
 2.14.1 (2022-11-23)
 -------------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1257,6 +1257,11 @@ class AsdfFile:
                 # close memmaps so they will regenerate
                 if fd.can_memmap():
                     fd.close_memmap()
+                    # also clean any memmapped blocks
+                    for b in self.blocks._internal_blocks:
+                        if b._memmapped:
+                            b._memmapped = False
+                            b._data = None
 
     def write_to(
         self,


### PR DESCRIPTION
Updated test_block_data_change to fill a hole in the test suite that failed to test for the circumstances that lead to a segfault in issue #1268. Updated update to clear memmaps held by blocks.