### PR TITLE
allow `asdf_schema_skip_tests` and `asdf_schema_xfail_tests` to be list objects under TOML

### DIFF
--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import warnings
 from dataclasses import dataclass
+from typing import Union
 
 import numpy as np
 import pytest
@@ -264,10 +265,13 @@ class AsdfSchemaExampleItem(pytest.Item):
         return self.fspath, 0, ""
 
 
-def _parse_test_list(content):
+def _parse_test_list(content: Union[str, list]) -> dict[str, list]:
     result = {}
 
-    for line in content.split("\n"):
+    if isinstance(content, str):
+        content = content.split("\n")
+
+    for line in content:
         line = line.strip()
         if len(line) > 0:
             parts = line.split("::", 1)

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 import warnings
 from dataclasses import dataclass
-from typing import Union
 
 import numpy as np
 import pytest
@@ -265,7 +264,7 @@ class AsdfSchemaExampleItem(pytest.Item):
         return self.fspath, 0, ""
 
 
-def _parse_test_list(content: Union[str, list]) -> dict[str, list]:
+def _parse_test_list(content):
     result = {}
 
     if isinstance(content, str):


### PR DESCRIPTION
Currently, the values must be in a newline-separated string, so like
```toml
asdf_schema_skip_tests = 'src/rad/resources/schemas/rad_schema-1.0.0.yaml'
```
or
```toml
asdf_schema_skip_tests = """
src/rad/resources/schemas/rad_schema-1.0.0.yaml
src/rad/resources/schemas/second_rad_schema-1.0.0.yaml
"""
```
When configuration is in a list format:
```toml
asdf_schema_skip_tests = [
    'src/rad/resources/schemas/rad_schema-1.0.0.yaml',
    'src/rad/resources/schemas/second_rad_schema-1.0.0.yaml',
]
```
the following error occurs:
https://github.com/spacetelescope/rad/actions/runs/3705663865/jobs/6279862181
```
________________________ ERROR collecting test session _________________________
.tox/py310/lib/python3.10/site-packages/pluggy/_hooks.py:265: in __call__
    return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
.tox/py310/lib/python3.10/site-packages/pluggy/_manager.py:80: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
.tox/py310/lib/python3.10/site-packages/pytest_asdf/plugin.py:303: in pytest_collect_file
    skip_tests = _parse_test_list(parent.config.getini("asdf_schema_skip_tests"))
.tox/py310/lib/python3.10/site-packages/pytest_asdf/plugin.py:270: in _parse_test_list
    for line in content.split("\n"):
E   AttributeError: 'list' object has no attribute 'split'
```
