### PR TITLE
Discard cache of lazy-loaded block data when it is no longer referenced by the tree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.15.0 (unreleased)
+-------------------
+
+The ASDF Standard is at v1.6.0
+
+- Discard cache of lazy-loaded block data when it is no longer referenced
+  by the tree. [#1280]
+
 2.14.3 (2022-12-15)
 -------------------
 

--- a/asdf/tests/test_array_blocks.py
+++ b/asdf/tests/test_array_blocks.py
@@ -1,3 +1,4 @@
+import gc
 import io
 import os
 
@@ -828,3 +829,23 @@ def test_block_allocation_on_validate():
     assert len(list(af.blocks.blocks)) == 1
     af.validate()
     assert len(list(af.blocks.blocks)) == 1
+
+
+def test_block_data_caching(tmp_path):
+    file_path = tmp_path / "test.asdf"
+
+    array = np.arange(200)
+    af = asdf.AsdfFile({"array": array})
+    af.write_to(file_path)
+
+    with asdf.open(file_path, lazy_load=True, copy_arrays=True) as af:
+        original_id = id(af.blocks.get_block(0).data)
+        # If the tree still contains a reference to the data,
+        # the Block's cache should return the same object.
+        assert id(af.blocks.get_block(0).data) == original_id
+        af["array"] = None
+        gc.collect()
+        # If the data no longer exists in the tree (or anywhere else),
+        # the Block should discard its cached reference and
+        # re-read the data from disk.
+        assert id(af.blocks.get_block(0).data) != original_id


### PR DESCRIPTION
This wraps the Block class's `_data` reference in a weakref when reading in lazy_load=True and copy_arrays=False mode.  There isn't any benefit when reading ndarray but this will allow us to process large chunked arrays without memory mapping.