### PR TITLE
remove redundant Block.readonly

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -61,7 +61,6 @@ class AsdfFile:
         copy_arrays=False,
         lazy_load=True,
         custom_schema=None,
-        _readonly=False,
     ):
         """
         Parameters
@@ -155,7 +154,7 @@ class AsdfFile:
         self._fd = None
         self._closed = False
         self._external_asdf_by_uri = {}
-        self._blocks = block.BlockManager(self, copy_arrays=copy_arrays, lazy_load=lazy_load, readonly=_readonly)
+        self._blocks = block.BlockManager(self, copy_arrays=copy_arrays, lazy_load=lazy_load)
         self._uri = None
         if tree is None:
             # Bypassing the tree property here, to avoid validating
@@ -1813,13 +1812,10 @@ def open_asdf(
         The new AsdfFile object.
     """
 
-    readonly = False
-
     # For now retain backwards compatibility with the old API behavior,
     # specifically when being called from AsdfFile.open
     if not _compat:
         mode = _check_and_set_mode(fd, mode)
-        readonly = mode == "r" and not copy_arrays
 
     instance = AsdfFile(
         ignore_version_mismatch=ignore_version_mismatch,
@@ -1827,7 +1823,6 @@ def open_asdf(
         copy_arrays=copy_arrays,
         lazy_load=lazy_load,
         custom_schema=custom_schema,
-        _readonly=readonly,
     )
 
     return AsdfFile._open_impl(

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -21,7 +21,7 @@ class BlockManager:
     Manages the `Block`s associated with a ASDF file.
     """
 
-    def __init__(self, asdffile, copy_arrays=False, lazy_load=True, readonly=False):
+    def __init__(self, asdffile, copy_arrays=False, lazy_load=True):
         self._asdffile = weakref.ref(asdffile)
 
         self._internal_blocks = []
@@ -40,7 +40,6 @@ class BlockManager:
         self._validate_checksums = False
         self._memmap = not copy_arrays
         self._lazy_load = lazy_load
-        self._readonly = readonly
         self._internal_blocks_mapped = False
 
     def __len__(self):
@@ -512,9 +511,7 @@ class BlockManager:
         # It seems we're good to go, so instantiate the UnloadedBlock
         # objects
         for offset in offsets[1:-1]:
-            self._internal_blocks.append(
-                UnloadedBlock(fd, offset, memmap=self.memmap, lazy_load=self.lazy_load, readonly=self._readonly)
-            )
+            self._internal_blocks.append(UnloadedBlock(fd, offset, memmap=self.memmap, lazy_load=self.lazy_load))
 
         # We already read the last block in the file -- no need to read it again
         self._internal_blocks.append(block)
@@ -814,7 +811,6 @@ class Block:
         self._should_memmap = memmap
         self._memmapped = False
         self._lazy_load = lazy_load
-        self._readonly = False
 
         self.update_size()
         self._allocated = self._size
@@ -919,10 +915,6 @@ class Block:
     @property
     def checksum(self):
         return self._checksum
-
-    @property
-    def readonly(self):
-        return self._readonly
 
     def _set_checksum(self, checksum):
         if checksum == b"\0" * 16:
@@ -1251,7 +1243,7 @@ class UnloadedBlock:
     requested.
     """
 
-    def __init__(self, fd, offset, memmap=True, lazy_load=True, readonly=False):
+    def __init__(self, fd, offset, memmap=True, lazy_load=True):
         self._fd = fd
         self._offset = offset
         self._data_ref = None
@@ -1264,7 +1256,6 @@ class UnloadedBlock:
         self._should_memmap = memmap
         self._memmapped = False
         self._lazy_load = lazy_load
-        self._readonly = readonly
 
     def __len__(self):
         self.load()

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -264,8 +264,6 @@ class NDArrayType(AsdfType):
 
             self._array = np.ndarray(shape, dtype, block.data, self._offset, self._strides, self._order)
             self._array = self._apply_mask(self._array, self._mask)
-            if block.readonly:
-                self._array.setflags(write=False)
         return self._array
 
     def _apply_mask(self, array, mask):

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -874,9 +874,14 @@ def test_readonly(tmpdir):
     # Opening in read mode (the default) should mean array is readonly
     with asdf.open(tmpfile) as af:
         assert af["data"].flags.writeable is False
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match=r"assignment destination is read-only"):
             af["data"][0] = 41
-            assert str(err) == "assignment destination is read-only"
+
+    # Forcing memmap, the array should still be readonly
+    with asdf.open(tmpfile, copy_arrays=False) as af:
+        assert af["data"].flags.writeable is False
+        with pytest.raises(ValueError, match=r"assignment destination is read-only"):
+            af["data"][0] = 41
 
     # This should be perfectly fine
     with asdf.open(tmpfile, mode="rw") as af:


### PR DESCRIPTION
Block.readonly appears to only be used to unset the write flag during ndarray creation:
https://github.com/asdf-format/asdf/blob/master/asdf/tags/core/ndarray.py#L267-L268

This flag is already set for readonly memmaps (perhaps as a result of #1230) making the Block.readonly flag redundant.

This PR removes the Block.readonly flag and the associated code that sets it and adds to test_readonly to explicitly force memmapping (rather than relying on the defaul).