### PR TITLE
add custom validator support to extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.15.0 (unreleased)
+-------------------
+
+The ASDF Standard is at v1.6.0
+
+- Allow Extensions to define custom validators  [#1287]
+
 2.14.3 (2022-12-15)
 -------------------
 

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -117,6 +117,22 @@ class Extension(abc.ABC):
         """
         return {}
 
+    @property
+    def validators(self):
+        """
+        Get a dictionary of custom schema keyword validators.
+
+        The dictionary key is the keyword and value a validation function that
+        accepts 4 arguments: validator, value, instance, schema. These functions
+        will be passed to jsonschema as validators during the call to validate.
+
+        See validators https://python-jsonschema.readthedocs.io/en/latest/creating/
+
+        These validators operate in a global scope so careful keyword naming
+        is required to avoid collisions between extensions and with builtin keywords.
+        """
+        return {}
+
 
 class ExtensionProxy(Extension, AsdfExtension):
     """
@@ -369,6 +385,28 @@ class ExtensionProxy(Extension, AsdfExtension):
 
         """
         return self._yaml_tag_handles
+
+    @property
+    def validators(self):
+        """
+        Get a dictionary of custom schema keyword validators.
+
+        The dictionary key is the keyword and value a validation function that
+        accepts 4 arguments: validator, value, instance, schema. These functions
+        will be passed to jsonschema as validators during the call to validate.
+
+        See validators https://python-jsonschema.readthedocs.io/en/latest/creating/
+
+        These validators operate in a global scope so careful keyword naming
+        is required to avoid collisions between extensions and with builtin keywords.
+
+        For legacy extensions wrapped with this proxy, this property will not return
+        any custom validators defined by the types in the extension. Instead, the
+        validators must be accessed through the types.
+        """
+        if hasattr(self.delegate, "validators"):
+            return self.delegate.validators
+        return {}
 
     def __eq__(self, other):
         if isinstance(other, ExtensionProxy):

--- a/asdf/extension/_legacy.py
+++ b/asdf/extension/_legacy.py
@@ -117,12 +117,17 @@ class AsdfExtensionList:
         for extension in extensions:
             tag_mapping.extend(extension.tag_mapping)
             url_mapping.extend(extension.url_mapping)
-            for typ in extension.types:
-                self._type_index.add_type(typ, extension)
-                validators.update(typ.validators)
-                for sibling in typ.versioned_siblings:
-                    self._type_index.add_type(sibling, extension)
-                    validators.update(sibling.validators)
+            if extension.legacy:
+                for typ in extension.types:
+                    self._type_index.add_type(typ, extension)
+                    validators.update(typ.validators)
+                    for sibling in typ.versioned_siblings:
+                        self._type_index.add_type(sibling, extension)
+                        validators.update(sibling.validators)
+            else:
+                # for non-legacy extensions, get validators from the extension
+                # not the types
+                validators.update(extension.validators)
         self._extensions = extensions
         self._tag_mapping = resolver.Resolver(tag_mapping, "tag")
         self._url_mapping = resolver.Resolver(url_mapping, "url")

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -208,6 +208,40 @@ of the object. That method should accept no arguments and return either a
 dict of attributes and their values, or a list if the object itself is
 list-like.
 
+Adding custom validators
+------------------------
+
+An `Extension` may also add new validation keywords to the schema
+language. This can be used to impose restrictions on the
+values in an ASDF file.
+
+To support custom validation keywords, set the "validators"
+member of an `Extension` to a dictionary where the keys are the
+validation keyword names and the values are validation functions.  The
+validation functions are of the same form as the validation functions in the
+underlying `jsonschema` library, and are passed the following arguments:
+
+  - ``validator``: A `jsonschema.Validator` instance.
+
+  - ``value``: The value of the schema keyword.
+
+  - ``instance``: The instance to validate.  This will be made up of
+    basic datatypes as represented in the YAML file (list, dict,
+    number, strings), and not include any object types.
+
+  - ``schema``: The entire schema that applies to instance.  Useful to
+    get other related schema keywords.
+
+The validation function should either return ``None`` if the instance
+is valid or ``yield`` one or more `jsonschema.ValidationError` objects if
+the instance is invalid.
+
+Be warned that custom validators are not restricted to types/yaml from
+the defining extension and instead are applied globally to the entire tree.
+Careful selection of keywords is needed to avoid collisions
+with other extensions and built-in keywords. No checks are made to detect
+collisions.
+
 .. _extending_extensions_installing:
 
 Installing an extension


### PR DESCRIPTION
old style (legacy) extensions allowed for custom validators, functions called when a particular schema keyword was encountered (see CustomType.validators).

This PR introduces a similar feature for new style Extensions where custom validators can be defined in Extension.validators.

The scope of the validators is global (same as legacy validators).

fixes #1012