### PR TITLE
provisionally add block manager to serialization context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ The ASDF Standard is at v1.6.0
 
 - Discard cache of lazy-loaded block data when it is no longer referenced
   by the tree. [#1280]
+- Add AsdfProvisionalAPIWarning to warn developers of new features that
+  may undergo breaking changes but are likely to be included as stable
+  features (without this warning) in a future version of ASDF [#1290]
+- Provisionally add ``block_manager`` to ``SerializationContext`` [#1290]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -15,7 +15,7 @@ from . import _version as version
 from . import block, constants, generic_io, reference, schema, treeutil, util, versioning, yamlutil
 from ._helpers import validate_version
 from .config import config_context, get_config
-from .exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning
+from .exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfProvisionalAPIWarning, AsdfWarning
 from .extension import (
     AsdfExtension,
     AsdfExtensionList,
@@ -1711,7 +1711,7 @@ class AsdfFile:
     # This function is called from within yamlutil methods to create
     # a context when one isn't explicitly passed in.
     def _create_serialization_context(self):
-        return SerializationContext(self.version_string, self.extension_manager, self.uri)
+        return SerializationContext(self.version_string, self.extension_manager, self.uri, self.blocks)
 
 
 def _check_and_set_mode(fileobj, asdf_mode):
@@ -1880,12 +1880,21 @@ class SerializationContext:
     Container for parameters of the current (de)serialization.
     """
 
-    def __init__(self, version, extension_manager, url):
+    def __init__(self, version, extension_manager, url, block_manager):
         self._version = validate_version(version)
         self._extension_manager = extension_manager
         self._url = url
 
         self.__extensions_used = set()
+
+        self._block_manager = block_manager
+
+    @property
+    def block_manager(self):
+        warnings.warn(
+            "The block_manager API within a SerializationContext  is not yet stable", AsdfProvisionalAPIWarning
+        )
+        return self._block_manager
 
     @property
     def url(self):

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1892,7 +1892,8 @@ class SerializationContext:
     @property
     def block_manager(self):
         warnings.warn(
-            "The block_manager API within a SerializationContext  is not yet stable", AsdfProvisionalAPIWarning
+            "The block_manager API within a SerializationContext  is not yet stable",
+            AsdfProvisionalAPIWarning,
         )
         return self._block_manager
 

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -21,3 +21,12 @@ class DelimiterNotFoundError(ValueError):
     Indicates that a delimiter was not found when reading or
     seeking through a file.
     """
+
+
+class AsdfProvisionalAPIWarning(AsdfWarning, FutureWarning):
+    """
+    Used for provisional features where breaking API changes might be
+    introduced at any point (including minor releases). These features
+    are likely to be added in a future ASDF version. However, Use of
+    provisional features is highly discouraged for production code.
+    """

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -217,7 +217,8 @@ def test_block_manager_from_serialization_context():
     ctx = af._create_serialization_context()
     # accessing the block manager should issue a AsdfProvisionalAPIWarning
     with pytest.warns(
-        AsdfProvisionalAPIWarning, match=r"The block_manager API within a SerializationContext  is not yet stable"
+        AsdfProvisionalAPIWarning,
+        match=r"The block_manager API within a SerializationContext  is not yet stable",
     ):
         assert ctx.block_manager == af.blocks
 

--- a/docs/asdf/developer_overview.rst
+++ b/docs/asdf/developer_overview.rst
@@ -72,6 +72,12 @@ Support for ASDF core tags has not yet been moved to the new system.  Doing so
 would be a breaking change for users who subclass that code, so we'll need
 to wait until asdf 3.0 to do that.
 
+Some features working toward this goal are available for testing but will raise
+a ``AsdfProvisionalAPIWarning`` when used. This warning indicates that a feature
+may experience breaking API changes (even for minor ASDF releases) and should
+not be trusted in a production environment. It is likely that features that
+raise this warning will become stable and be added to a future ASDF version.
+
 Some terminology and definitions
 --------------------------------
 


### PR DESCRIPTION
adds AsdfProvisionalAPIWarning and issues this warning during use of block manager from the serialization context

Adding the block manager to the serialization context seemed like a simple and small change to be used to test the warning (and is something we want to the warning for).

Other new features that are candidates for using this warning are:
- #1287
- #1289