### PR TITLE
Use `--open-files`, `--run-slow`, and `--remote-data` flags for astropy downstream

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -136,7 +136,7 @@ commands_pre=
     pip install -r {envtmpdir}/requirements.txt
     pip freeze
 commands=
-    pytest astropy/astropy/io/misc/asdf
+    pytest astropy/astropy/io/misc/asdf --open-files --run-slow --remote-data
 
 [testenv:asdf-astropy]
 changedir={envtmpdir}


### PR DESCRIPTION
Fixes #1244, by adding the appropriate flags to the `tox` environment for `astropy` downstream testing