### PR TITLE
Add `pyupgrade` check to `ruff`

### DIFF
--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -122,8 +122,12 @@ def test_named_tuple_typing(tmp_path):
     Ensure that we are able to serialize a typing.NamedTuple.
     """
 
-    nt = NamedTuple("TestNamedTuple2", (("one", int), ("two", int), ("three", int)))
-    tree = {"val": nt(1, 2, 3)}
+    class NT(NamedTuple):
+        one: int
+        two: int
+        three: int
+
+    tree = {"val": NT(1, 2, 3)}
 
     run_tuple_test(tree, tmp_path)
 
@@ -141,9 +145,12 @@ def test_named_tuple_collections_recursive(tmp_path):
 
 
 def test_named_tuple_typing_recursive(tmp_path):
-    nt = NamedTuple("TestNamedTuple4", (("one", int), ("two", int), ("three", np.ndarray)))
+    class NT(NamedTuple):
+        one: int
+        two: int
+        three: np.ndarray
 
-    tree = {"val": nt(1, 2, np.ones(3))}
+    tree = {"val": NT(1, 2, np.ones(3))}
 
     def check_asdf(asdf):
         assert (asdf.tree["val"][2] == np.ones(3)).all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,10 @@ extend_skip_glob = ["asdf/extern/*", ".eggs/*", ".tox/*"]
 
 [tool.ruff]
 line-length = 120
+select = [
+    "F", # Pyflakes
+    "E", "W", # pycodestyle
+]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,8 @@ select = [
     "E", "W", # pycodestyle
     # "C90", # mccabe complexity
     "I", # isort
+    # "D", # pydocstyle
+    "UP", # pyupgrade
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,8 @@ line-length = 120
 select = [
     "F", # Pyflakes
     "E", "W", # pycodestyle
+    # "C90", # mccabe complexity
+    "I", # isort
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts.

It enables `ruff` to explicitly check:

- `Pyflakes` (a `ruff` default)
- `pycodestyle` (also a `ruff default)
- `isort` (we were running `isort` as a standalone tool)
- `pyupgrade` (we were running parts of `pyupgrade` standalone, this runs all those checks and found some extra things to change)