### PR TITLE
Add `pep8-naming` check to `ruff`

### DIFF
--- a/asdf/extension/_compressor.py
+++ b/asdf/extension/_compressor.py
@@ -22,9 +22,9 @@ class Compressor(abc.ABC):
     """
 
     @classmethod
-    def __subclasshook__(cls, C):
+    def __subclasshook__(cls, class_):
         if cls is Compressor:
-            return hasattr(C, "label") and (hasattr(C, "compress") or hasattr(C, "decompress"))
+            return hasattr(class_, "label") and (hasattr(class_, "compress") or hasattr(class_, "decompress"))
         return NotImplemented  # pragma: no cover
 
     @property

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -18,13 +18,13 @@ class Converter(abc.ABC):
     """
 
     @classmethod
-    def __subclasshook__(cls, C):
+    def __subclasshook__(cls, class_):
         if cls is Converter:
             return (
-                hasattr(C, "tags")
-                and hasattr(C, "types")
-                and hasattr(C, "to_yaml_tree")
-                and hasattr(C, "from_yaml_tree")
+                hasattr(class_, "tags")
+                and hasattr(class_, "types")
+                and hasattr(class_, "to_yaml_tree")
+                and hasattr(class_, "from_yaml_tree")
             )
         return NotImplemented  # pragma: no cover
 

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -18,9 +18,9 @@ class Extension(abc.ABC):
     """
 
     @classmethod
-    def __subclasshook__(cls, C):
+    def __subclasshook__(cls, class_):
         if cls is Extension:
-            return hasattr(C, "extension_uri")
+            return hasattr(class_, "extension_uri")
         return NotImplemented  # pragma: no cover
 
     @property
@@ -126,7 +126,7 @@ class ExtensionProxy(Extension, AsdfExtension):
     """
 
     @classmethod
-    def maybe_wrap(self, delegate):
+    def maybe_wrap(cls, delegate):
         if isinstance(delegate, ExtensionProxy):
             return delegate
         else:

--- a/asdf/extension/_legacy.py
+++ b/asdf/extension/_legacy.py
@@ -16,9 +16,9 @@ class AsdfExtension(metaclass=abc.ABCMeta):
     """
 
     @classmethod
-    def __subclasshook__(cls, C):
+    def __subclasshook__(cls, class_):
         if cls is AsdfExtension:
-            return hasattr(C, "types") and hasattr(C, "tag_mapping")
+            return hasattr(class_, "types") and hasattr(class_, "tag_mapping")
         return NotImplemented
 
     @property

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -104,7 +104,7 @@ class Reference(AsdfType):
         return item in self._get_target()
 
     @classmethod
-    def to_tree(self, data, ctx):
+    def to_tree(cls, data, ctx):
         if ctx.uri is not None:
             uri = generic_io.relative_uri(ctx.uri, data._uri)
         else:
@@ -112,7 +112,7 @@ class Reference(AsdfType):
         return {"$ref": uri}
 
     @classmethod
-    def validate(self, data):
+    def validate(cls, data):
         pass
 
 

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -34,7 +34,7 @@ class ResourceMappingProxy(Mapping):
     """
 
     @classmethod
-    def maybe_wrap(self, delegate):
+    def maybe_wrap(cls, delegate):
         if isinstance(delegate, ResourceMappingProxy):
             return delegate
         else:

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -91,7 +91,7 @@ def validate_tag(validator, tag_pattern, instance, schema):
         yield ValidationError(f"mismatched tags, wanted '{tag_pattern}', got '{instance_tag}'")
 
 
-def validate_propertyOrder(validator, order, instance, schema):
+def validate_propertyOrder(validator, order, instance, schema):  # noqa: N802
     """
     Stores a value on the `tagged.TaggedDict` instance so that
     properties can be written out in the preferred order.  In that
@@ -109,7 +109,7 @@ def validate_propertyOrder(validator, order, instance, schema):
     instance.property_order = order
 
 
-def validate_flowStyle(validator, flow_style, instance, schema):
+def validate_flowStyle(validator, flow_style, instance, schema):  # noqa: N802
     """
     Sets a flag on the `tagged.TaggedList` or `tagged.TaggedDict`
     object so that the YAML generator knows which style to use to
@@ -263,20 +263,20 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
         }
     )
     id_of = mvalidators.Draft4Validator.ID_OF
-    ASDFValidator = mvalidators.create(
+    ASDFvalidator = mvalidators.create(  # noqa: N806
         meta_schema=meta_schema, validators=validators, type_checker=type_checker, id_of=id_of
     )
 
     def _patch_init(cls):
         original_init = cls.__init__
 
-        def __init__(self, *args, **kwargs):
+        def init(self, *args, **kwargs):
             self.ctx = kwargs.pop("ctx", None)
             self.serialization_context = kwargs.pop("serialization_context", None)
 
             original_init(self, *args, **kwargs)
 
-        cls.__init__ = __init__
+        cls.__init__ = init
 
     def _patch_iter_errors(cls):
         original_iter_errors = cls.iter_errors
@@ -331,10 +331,10 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
 
         cls.iter_errors = iter_errors
 
-    _patch_init(ASDFValidator)
-    _patch_iter_errors(ASDFValidator)
+    _patch_init(ASDFvalidator)
+    _patch_iter_errors(ASDFvalidator)
 
-    return ASDFValidator
+    return ASDFvalidator
 
 
 @lru_cache

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -63,7 +63,7 @@ class ExternalArrayReference(AsdfType):
         return all((uri, target, dtype, shape))
 
     @classmethod
-    def to_tree(self, data, ctx):
+    def to_tree(cls, data, ctx):
         node = {}
         node["fileuri"] = data.fileuri
         node["target"] = data.target

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -557,10 +557,10 @@ class NDArrayType(AsdfType):
 
 
 def _make_operation(name):
-    def __operation__(self, *args):
+    def operation(self, *args):
         return getattr(self._make_array(), name)(*args)
 
-    return __operation__
+    return operation
 
 
 classes_to_modify = NDArrayType.__versioned_siblings + [

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -117,6 +117,7 @@ class FullConverter(MinimumConverter):
 
 
 class MinimalCompressor(Compressor):
+    @staticmethod
     def compress(data):
         return b""
 

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -85,7 +85,7 @@ def fractiontype_factory():
 
 def fractional2dcoordtype_factory():
 
-    FractionType = fractiontype_factory()
+    FractionType = fractiontype_factory()  # noqa: N806
 
     class Fractional2dCoordType(types.CustomType):
         name = "fractional_2d_coord"
@@ -112,7 +112,7 @@ def fractional2dcoordtype_factory():
 
 def test_custom_tag():
 
-    FractionType = fractiontype_factory()
+    FractionType = fractiontype_factory()  # noqa: N806
 
     class FractionExtension(CustomExtension):
         @property

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -80,18 +80,18 @@ class ExtensionTypeMeta(type):
         return default
 
     @property
-    def versioned_siblings(mcls):
-        return getattr(mcls, "__versioned_siblings") or []
+    def versioned_siblings(cls):
+        return getattr(cls, "__versioned_siblings") or []
 
-    def __new__(mcls, name, bases, attrs):
-        requires = mcls._find_in_bases(attrs, bases, "requires", [])
-        if not mcls._has_required_modules(requires):
+    def __new__(cls, name, bases, attrs):
+        requires = cls._find_in_bases(attrs, bases, "requires", [])
+        if not cls._has_required_modules(requires):
             attrs["from_tree_tagged"] = classmethod(_from_tree_tagged_missing_requirements)
             attrs["types"] = []
             attrs["has_required_modules"] = False
         else:
             attrs["has_required_modules"] = True
-            types = mcls._find_in_bases(attrs, bases, "types", [])
+            types = cls._find_in_bases(attrs, bases, "types", [])
             new_types = []
             for typ in types:
                 if isinstance(typ, str):
@@ -99,40 +99,40 @@ class ExtensionTypeMeta(type):
                 new_types.append(typ)
             attrs["types"] = new_types
 
-        cls = super().__new__(mcls, name, bases, attrs)
+        new_cls = super().__new__(cls, name, bases, attrs)
 
-        if hasattr(cls, "version"):
-            if not isinstance(cls.version, (AsdfVersion, AsdfSpec)):
-                cls.version = AsdfVersion(cls.version)
+        if hasattr(new_cls, "version"):
+            if not isinstance(new_cls.version, (AsdfVersion, AsdfSpec)):
+                new_cls.version = AsdfVersion(new_cls.version)
 
-        if hasattr(cls, "name"):
-            if isinstance(cls.name, str):
+        if hasattr(new_cls, "name"):
+            if isinstance(new_cls.name, str):
                 if "yaml_tag" not in attrs:
-                    cls.yaml_tag = cls.make_yaml_tag(cls.name)
-            elif isinstance(cls.name, list):
+                    new_cls.yaml_tag = new_cls.make_yaml_tag(new_cls.name)
+            elif isinstance(new_cls.name, list):
                 pass
-            elif cls.name is not None:
+            elif new_cls.name is not None:
                 raise TypeError("name must be string or list")
 
-        if hasattr(cls, "supported_versions"):
-            if not isinstance(cls.supported_versions, (list, set)):
-                cls.supported_versions = [cls.supported_versions]
+        if hasattr(new_cls, "supported_versions"):
+            if not isinstance(new_cls.supported_versions, (list, set)):
+                new_cls.supported_versions = [new_cls.supported_versions]
             supported_versions = set()
-            for version in cls.supported_versions:
+            for version in new_cls.supported_versions:
                 if not isinstance(version, (AsdfVersion, AsdfSpec)):
                     version = AsdfVersion(version)
                 # This should cause an exception for invalid input
                 supported_versions.add(version)
             # We need to convert back to a list here so that the 'in' operator
             # uses actual comparison instead of hash equality
-            cls.supported_versions = list(supported_versions)
+            new_cls.supported_versions = list(supported_versions)
             siblings = list()
-            for version in cls.supported_versions:
-                if version != cls.version:
+            for version in new_cls.supported_versions:
+                if version != new_cls.version:
                     new_attrs = copy(attrs)
                     new_attrs["version"] = version
                     new_attrs["supported_versions"] = set()
-                    new_attrs["_latest_version"] = cls.version
+                    new_attrs["_latest_version"] = new_cls.version
                     if "__classcell__" in new_attrs:
                         raise RuntimeError(
                             "Subclasses of ExtensionTypeMeta that define "
@@ -142,10 +142,10 @@ class ExtensionTypeMeta(type):
                             "during creation of versioned siblings. "
                             "See https://github.com/asdf-format/asdf/issues/1245"
                         )
-                    siblings.append(ExtensionTypeMeta.__new__(mcls, name, bases, new_attrs))
-            setattr(cls, "__versioned_siblings", siblings)
+                    siblings.append(ExtensionTypeMeta.__new__(cls, name, bases, new_attrs))
+            setattr(new_cls, "__versioned_siblings", siblings)
 
-        return cls
+        return new_cls
 
 
 class AsdfTypeMeta(ExtensionTypeMeta):
@@ -154,14 +154,14 @@ class AsdfTypeMeta(ExtensionTypeMeta):
     `AsdfTypeIndex`.
     """
 
-    def __new__(mcls, name, bases, attrs):
-        cls = super().__new__(mcls, name, bases, attrs)
+    def __new__(cls, name, bases, attrs):
+        new_cls = super().__new__(cls, name, bases, attrs)
         # Classes using this metaclass get added to the list of built-in
         # extensions
         if name != "AsdfType":
-            _all_asdftypes.add(cls)
+            _all_asdftypes.add(new_cls)
 
-        return cls
+        return new_cls
 
 
 class ExtensionType:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,7 @@ select = [
     "I", # isort
     # "D", # pydocstyle
     "UP", # pyupgrade
+    "N", # pep8-naming
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1299.

It enables `ruff` to explicitly check `pep8-naming` style checks.