### PR TITLE
Add `flake8-blind-except` check to `ruff`

### DIFF
--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -222,7 +222,7 @@ def edit(path):
             try:
                 new_asdf_version = parse_asdf_version(new_content)
                 new_yaml_version = parse_yaml_version(new_content)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"Error: failed to parse ASDF header: {str(e)}")
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
@@ -260,7 +260,7 @@ def edit(path):
                     return 1
                 elif choice == "c":
                     continue
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print("Error: failed to read updated file as ASDF:")
                 print_exception(e)
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -61,8 +61,8 @@ def _list_entry_points(group, proxy_class):
             for element in elements:
                 try:
                     results.append(proxy_class(element, package_name=package_name, package_version=package_version))
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     _handle_error(e)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             _handle_error(e)
     return results

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -242,7 +242,7 @@ class GenericFile(metaclass=util.InheritDocstrings):
         if block_size == -1:
             try:
                 block_size = os.fstat(self._fd.fileno()).st_blksize
-            except Exception:
+            except Exception:  # noqa: BLE001
                 block_size = io.DEFAULT_BUFFER_SIZE
 
         if block_size <= 0:
@@ -925,7 +925,7 @@ def _http_to_temp(init, mode, uri=None):
     if block_size == -1:
         try:
             block_size = os.fstat(fd.fileno()).st_blksize
-        except Exception:
+        except Exception:  # noqa: BLE001
             block_size = io.DEFAULT_BUFFER_SIZE
 
     try:

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -85,7 +85,7 @@ class Reference(AsdfType):
             return None
         try:
             return getattr(self._get_target(), attr)
-        except Exception:
+        except Exception:  # noqa: BLE001
             raise AttributeError(f"No attribute '{attr}'")
 
     def __getitem__(self, item):

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -101,7 +101,7 @@ class AsdfSearchResult:
                 return result
             else:
                 return False
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     def _get_fully_qualified_type(self, value):

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -475,7 +475,7 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
             try:
                 with generic_io.get_file(schema_location) as f:
                     yaml.safe_load(f.read())
-            except Exception:
+            except Exception:  # noqa: BLE001
                 assert False, (
                     f"{extension_type.__name__} supports tag, {check_type.yaml_tag}, "
                     + f"which resolves to schema at {schema_location}, but "

--- a/asdf/tests/test_reference_files.py
+++ b/asdf/tests/test_reference_files.py
@@ -65,7 +65,7 @@ def test_reference_file(reference_file):
 
     try:
         _compare_trees(name_without_ext, expect_warnings=expect_warnings)
-    except Exception:
+    except Exception:  # noqa: BLE001
         if known_fail:
             pytest.xfail()
         else:

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -358,7 +358,7 @@ def test_version_map_support(version, schema_type, tag):
 
     try:
         load_schema(tag)
-    except Exception:
+    except Exception:  # noqa: BLE001
         assert False, (
             f"ASDF Standard version {version} requires support for "
             + f"{tag}, but the corresponding schema cannot be loaded."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ select = [
     "YTT", # flake8-2020
     # "ANN", # flake8-annotations
     "S", # flake8-bandit
+    "BLE", # flake8-blind-except
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1301.

It enables `ruff` to explicitly check `flake8-blind-except` style checks.