### PR TITLE
Add `flake8-bugbear` check to `ruff`

### DIFF
--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -36,7 +36,7 @@ def render_tree(
     max_rows=DEFAULT_MAX_ROWS,
     max_cols=DEFAULT_MAX_COLS,
     show_values=DEFAULT_SHOW_VALUES,
-    filters=[],
+    filters=None,
     identifier="root",
     refresh_extension_manager=False,
 ):
@@ -47,7 +47,7 @@ def render_tree(
         key="title",
         node=node,
         identifier=identifier,
-        filters=filters,
+        filters=[] if filters is None else filters,
         refresh_extension_manager=refresh_extension_manager,
     )
     if info is None:

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -20,7 +20,7 @@ def _filter_tree(info, filters):
     return len(info.children) > 0 or all(f(info.node, info.identifier) for f in filters)
 
 
-def create_tree(key, node, identifier="root", filters=[], refresh_extension_manager=False):
+def create_tree(key, node, identifier="root", filters=None, refresh_extension_manager=False):
     """
     Create a `NodeSchemaInfo` tree which can be filtered from a base node.
 
@@ -39,6 +39,7 @@ def create_tree(key, node, identifier="root", filters=[], refresh_extension_mana
         key.  This is useful if you want to make sure that the schema
         data for a given key is up to date.
     """
+    filters = [] if filters is None else filters
 
     schema_info = NodeSchemaInfo.from_root_node(
         key, identifier, node, refresh_extension_manager=refresh_extension_manager
@@ -52,7 +53,7 @@ def create_tree(key, node, identifier="root", filters=[], refresh_extension_mana
 
 
 def collect_schema_info(
-    key, path, node, identifier="root", filters=[], preserve_list=True, refresh_extension_manager=False
+    key, path, node, identifier="root", filters=None, preserve_list=True, refresh_extension_manager=False
 ):
     """
     Collect from the underlying schemas any of the info stored under key, relative to the path
@@ -77,7 +78,11 @@ def collect_schema_info(
     """
 
     schema_info = create_tree(
-        key, node, identifier=identifier, filters=filters, refresh_extension_manager=refresh_extension_manager
+        key,
+        node,
+        identifier=identifier,
+        filters=[] if filters is None else filters,
+        refresh_extension_manager=refresh_extension_manager,
     )
 
     info = schema_info.collect_info(preserve_list=preserve_list)

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -624,7 +624,7 @@ class AsdfFile:
         """
         self._validate(self._tree)
 
-    def make_reference(self, path=[]):
+    def make_reference(self, path=None):
         """
         Make a new reference to a part of this file's tree, that can be
         assigned as a reference to another tree.
@@ -649,7 +649,7 @@ class AsdfFile:
             >>> flat = asdf.open("http://stsci.edu/reference_files/flat.asdf")  # doctest: +SKIP
             >>> ff.tree['flat_field'] = flat.make_reference(['data'])  # doctest: +SKIP
         """
-        return reference.make_reference(self, path)
+        return reference.make_reference(self, [] if path is None else path)
 
     @property
     def blocks(self):

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -751,8 +751,8 @@ class AsdfFile:
 
         try:
             version = versioning.AsdfVersion(parts[1].decode("ascii"))
-        except ValueError:
-            raise ValueError(f"Unparsable version in ASDF file: {parts[1]}")
+        except ValueError as err:
+            raise ValueError(f"Unparsable version in ASDF file: {parts[1]}") from err
 
         return version
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -267,7 +267,7 @@ class BlockManager:
         """
         if not self._internal_blocks:
             return
-        for i, block in enumerate(self._internal_blocks):
+        for block in self._internal_blocks:
             if isinstance(block, UnloadedBlock):
                 block.load()
 

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -218,8 +218,10 @@ def print_in_tree(diff_ctx, node_list, thing, other, use_marker=False, last_was_
     return last_was_list
 
 
-def compare_objects(diff_ctx, obj0, obj1, keys=[]):
+def compare_objects(diff_ctx, obj0, obj1, keys=None):
     """Displays diff of two objects if they are not equal"""
+    keys = [] if keys is None else keys
+
     if obj0 != obj1:
         print_in_tree(diff_ctx, keys, obj0, False, ignore_lwl=True)
         print_in_tree(diff_ctx, keys, obj1, True, ignore_lwl=True)
@@ -273,8 +275,10 @@ def both_are_ndarrays(tree0, tree1):
     return True
 
 
-def compare_dicts(diff_ctx, dict0, dict1, keys, ignores=set()):
+def compare_dicts(diff_ctx, dict0, dict1, keys, ignores=None):
     """Recursively compares two dictionary objects"""
+    ignores = set() if ignores is None else ignores
+
     keys0 = set(dict0.keys()) - ignores
     keys1 = set(dict1.keys()) - ignores
     # Recurse into subtree elements that are shared by both trees
@@ -288,8 +292,10 @@ def compare_dicts(diff_ctx, dict0, dict1, keys, ignores=set()):
     print_dict_diff(diff_ctx, dict1, keys, sorted(keys1 - keys0), True)
 
 
-def compare_trees(diff_ctx, tree0, tree1, keys=[]):
+def compare_trees(diff_ctx, tree0, tree1, keys=None):
     """Recursively traverses two ASDF tree and compares them"""
+    keys = [] if keys is None else keys
+
     if id(tree0) in diff_ctx.ignore_ids and id(tree1) in diff_ctx.ignore_ids:
         return
 

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -354,5 +354,5 @@ def diff(filenames, minimal, iostream=sys.stdout, ignore=None):
 
                 diff_ctx = DiffContext(asdf0, asdf1, iostream, minimal=minimal, ignore_ids=ignore_ids)
                 compare_trees(diff_ctx, asdf0.tree, asdf1.tree)
-    except ValueError as error:
-        raise RuntimeError(str(error))
+    except ValueError as err:
+        raise RuntimeError(str(err)) from err

--- a/asdf/commands/extract.py
+++ b/asdf/commands/extract.py
@@ -48,5 +48,5 @@ def extract_file(input_file, output_file):
             with asdf.AsdfFile(ih.tree) as oh:
                 oh.write_to(output_file)
 
-    except (OSError, ValueError) as error:
-        raise RuntimeError(str(error))
+    except (OSError, ValueError) as err:
+        raise RuntimeError(str(err)) from err

--- a/asdf/commands/main.py
+++ b/asdf/commands/main.py
@@ -43,7 +43,7 @@ def make_argparser():
         commands[str(command)].setup_arguments(subparsers)
         del commands[command]
 
-    for name, command in sorted(commands.items()):
+    for _, command in sorted(commands.items()):
         command.setup_arguments(subparsers)
 
     return parser, subparsers

--- a/asdf/commands/remove_hdu.py
+++ b/asdf/commands/remove_hdu.py
@@ -43,5 +43,5 @@ def remove_hdu(input_file, output_file):
             asdf_hdu = hdulist["ASDF"]
             hdulist.remove(asdf_hdu)
             hdulist.writeto(output_file)
-    except (ValueError, KeyError) as error:
-        raise RuntimeError(str(error))
+    except (ValueError, KeyError) as err:
+        raise RuntimeError(str(err)) from err

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -55,12 +55,12 @@ class Lz4Compressor:
     def __init__(self):
         try:
             import lz4.block
-        except ImportError:
+        except ImportError as err:
             raise ImportError(
                 "lz4 library in not installed in your Python environment, "
                 "therefore the compressed block in this ASDF file "
                 "can not be decompressed."
-            )
+            ) from err
 
         self._api = lz4.block
 

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -47,7 +47,7 @@ def _list_entry_points(group, proxy_class):
 
         def _handle_error(e):
             warnings.warn(
-                f"{group} plugin from package {package_name}=={package_version} failed to load:\n\n"
+                f"{group} plugin from package {package_name}=={package_version} failed to load:\n\n"  # noqa: B023
                 f"{e.__class__.__name__}: {e}",
                 AsdfWarning,
             )

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -10,8 +10,8 @@ from . import asdf, block, generic_io, util
 
 try:
     from astropy.io import fits
-except ImportError:
-    raise ImportError("AsdfInFits requires astropy")
+except ImportError as err:
+    raise ImportError("AsdfInFits requires astropy") from err
 
 
 ASDF_EXTENSION_NAME = "ASDF"
@@ -256,8 +256,8 @@ class AsdfInFits(asdf.AsdfFile):
                 # Since we created this HDUList object, we need to be
                 # responsible for cleaning up upon close() or __exit__
                 close_hdulist = True
-            except OSError:
-                raise ValueError(f"Failed to parse given file '{uri}'. Is it FITS?")
+            except OSError as err:
+                raise ValueError(f"Failed to parse given file '{uri}'. Is it FITS?") from err
 
         self = cls(
             hdulist,

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -35,8 +35,8 @@ def resolve_fragment(tree, pointer):
                 pass
         try:
             tree = tree[part]
-        except (TypeError, LookupError):
-            raise ValueError(f"Unresolvable reference: '{pointer}'")
+        except (TypeError, LookupError) as err:
+            raise ValueError(f"Unresolvable reference: '{pointer}'") from err
 
     return tree
 
@@ -85,8 +85,8 @@ class Reference(AsdfType):
             return None
         try:
             return getattr(self._get_target(), attr)
-        except Exception:  # noqa: BLE001
-            raise AttributeError(f"No attribute '{attr}'")
+        except Exception as err:  # noqa: BLE001
+            raise AttributeError(f"No attribute '{attr}'") from err
 
     def __getitem__(self, item):
         return self._get_target()[item]

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -530,7 +530,7 @@ def _load_schema_cached(url, resolver, resolve_references, resolve_local_refs):
 
 
 def get_validator(
-    schema={},
+    schema=None,
     ctx=None,
     validators=None,
     url_mapping=None,
@@ -592,7 +592,7 @@ def get_validator(
     # test suite!!!).  Instead, we assume that the schemas are valid
     # through the running of the unit tests, not at run time.
     cls = _create_validator(validators=validators, visit_repeat_nodes=_visit_repeat_nodes)
-    return cls(schema, *args, ctx=ctx, serialization_context=_serialization_context, **kwargs)
+    return cls({} if schema is None else schema, *args, ctx=ctx, serialization_context=_serialization_context, **kwargs)
 
 
 def _validate_large_literals(instance, reading):
@@ -644,7 +644,7 @@ def _validate_mapping_keys(instance, reading):
                 raise ValidationError(f"Mapping key {key} is not permitted.  Valid types: str, int, bool.")
 
 
-def validate(instance, ctx=None, schema={}, validators=None, reading=False, *args, **kwargs):
+def validate(instance, ctx=None, schema=None, validators=None, reading=False, *args, **kwargs):
     """
     Validate the given instance (which must be a tagged tree) against
     the appropriate schema.  The schema itself is located using the
@@ -678,7 +678,7 @@ def validate(instance, ctx=None, schema={}, validators=None, reading=False, *arg
 
         ctx = AsdfFile()
 
-    validator = get_validator(schema, ctx, validators, ctx.resolver, *args, **kwargs)
+    validator = get_validator({} if schema is None else schema, ctx, validators, ctx.resolver, *args, **kwargs)
     validator.validate(instance)
 
     additional_validators = [_validate_large_literals]

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -23,7 +23,7 @@ class AsdfSearchResult:
         self,
         identifiers,
         node,
-        filters=[],
+        filters=None,
         parent_node=None,
         max_rows=DEFAULT_MAX_ROWS,
         max_cols=DEFAULT_MAX_COLS,
@@ -31,7 +31,7 @@ class AsdfSearchResult:
     ):
         self._identifiers = identifiers
         self._node = node
-        self._filters = filters
+        self._filters = [] if filters is None else filters
         self._parent_node = parent_node
         self._max_rows = max_rows
         self._max_cols = max_cols

--- a/asdf/tagged.py
+++ b/asdf/tagged.py
@@ -137,8 +137,8 @@ def tag_object(tag, instance, ctx=None):
             ctx = AsdfFile()
         try:
             instance = yamlutil.custom_tree_to_tagged_tree(instance, ctx)
-        except TypeError:
-            raise TypeError(f"Don't know how to tag a {type(instance)}")
+        except TypeError as err:
+            raise TypeError(f"Don't know how to tag a {type(instance)}") from err
         instance._tag = tag
     return instance
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -513,7 +513,7 @@ class NDArrayType(AsdfType):
             if not new.dtype.fields:
                 # This line is safe because this is actually a piece of test
                 # code, even though it lives in this file:
-                assert False, "arrays not equal"  # noqa: S101
+                raise AssertionError("arrays not equal")  # noqa: S101
             for a, b in zip(old, new):
                 cls._assert_equality(a, b, func)
         else:

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -67,7 +67,7 @@ def asdf_datatype_to_numpy_dtype(datatype, byteorder=None):
             return (str(name), datatype, tuple(shape))
     elif isinstance(datatype, list):
         datatype_list = []
-        for i, subdatatype in enumerate(datatype):
+        for subdatatype in datatype:
             np_dtype = asdf_datatype_to_numpy_dtype(subdatatype, byteorder)
             if isinstance(np_dtype, tuple):
                 datatype_list.append(np_dtype)

--- a/asdf/tags/core/tests/test_extension_metadata.py
+++ b/asdf/tags/core/tests/test_extension_metadata.py
@@ -15,7 +15,7 @@ metadata: !core/extension_metadata-1.0.0
     buff = helpers.yaml_to_asdf(yaml)
 
     with asdf.open(buff) as af:
-        af["metadata"].extension_class == "foo.extension.FooExtension"
-        af["metadata"].software["name"] == "FooSoft"
-        af["metadata"].software["version"] == "1.5"
-        af["metadata"]["extension_uri"] == "http://foo.biz/extensions/foo-1.0.0"
+        assert af["metadata"].extension_class == "foo.extension.FooExtension"
+        assert af["metadata"].software["name"] == "FooSoft"
+        assert af["metadata"].software["version"] == "1.5"
+        assert af["metadata"]["extension_uri"] == "http://foo.biz/extensions/foo-1.0.0"

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -438,7 +438,7 @@ def test_masked_array_stay_open_bug(tmpdir):
     p = psutil.Process()
     orig_open = p.open_files()
 
-    for i in range(3):
+    for _ in range(3):
         with asdf.open(tmppath) as f2:
             np.sum(f2.tree["test"])
 
@@ -468,7 +468,7 @@ def test_memmap_stay_open_bug(tmpdir):
     p = psutil.Process()
     orig_open = p.open_files()
 
-    for i in range(3):
+    for _ in range(3):
         with open(tmppath, mode="rb") as fp:
             with asdf.open(fp) as f2:
                 np.sum(f2.tree["test"])

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -477,9 +477,9 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
             try:
                 with generic_io.get_file(schema_location) as f:
                     yaml.safe_load(f.read())
-            except Exception:  # noqa: BLE001
+            except Exception as err:  # noqa: BLE001
                 raise AssertionError(
                     f"{extension_type.__name__} supports tag, {check_type.yaml_tag}, "
                     + f"which resolves to schema at {schema_location}, but "
                     + "schema cannot be read."
-                )
+                ) from err

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -184,11 +184,13 @@ def _assert_roundtrip_tree(
     *,
     asdf_check_func=None,
     raw_yaml_check_func=None,
-    write_options={},
-    init_options={},
+    write_options=None,
+    init_options=None,
     extensions=None,
     tree_match_func="assert_equal",
 ):
+    write_options = {} if write_options is None else write_options
+    init_options = {} if init_options is None else init_options
 
     fname = os.path.join(str(tmp_path), "test.asdf")
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -478,7 +478,7 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
                 with generic_io.get_file(schema_location) as f:
                     yaml.safe_load(f.read())
             except Exception:  # noqa: BLE001
-                assert False, (
+                raise AssertionError(
                     f"{extension_type.__name__} supports tag, {check_type.yaml_tag}, "
                     + f"which resolves to schema at {schema_location}, but "
                     + "schema cannot be read."

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -31,8 +31,9 @@ def _get_sparse_tree():
     return tree
 
 
-def _roundtrip(tmp_path, tree, compression=None, write_options={}, read_options={}):
-    write_options = write_options.copy()
+def _roundtrip(tmp_path, tree, compression=None, write_options=None, read_options=None):
+    read_options = {} if read_options is None else read_options
+    write_options = {} if write_options is None else write_options.copy()
     write_options.update(all_array_compression=compression)
 
     tmpfile = os.path.join(str(tmp_path), "test.asdf")

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -19,7 +19,9 @@ def tree(request):
     return request.param()
 
 
-def _roundtrip(tree, get_write_fd, get_read_fd, write_options={}, read_options={}):
+def _roundtrip(tree, get_write_fd, get_read_fd, write_options=None, read_options=None):
+    write_options = {} if write_options is None else write_options
+    read_options = {} if read_options is None else read_options
 
     # Since we're testing with small arrays, force all arrays to be stored
     # in internal blocks rather than letting some of them be automatically put

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -267,7 +267,7 @@ def test_http_connection(tree, httpserver):
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(list(ff.blocks.internal_blocks)) == 2
         assert isinstance(next(ff.blocks.internal_blocks)._data, np.ndarray)
-        ff.tree["science_data"][0] == 42
+        assert (ff.tree["science_data"] == tree["science_data"]).all()
 
 
 def test_exploded_filesystem(tree, tmp_path):

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -1081,8 +1081,10 @@ def test_numpy_scalar_type_validation(numpy_value, valid_types):
                 description = "valid"
             else:
                 description = "invalid"
-            assert False, "Expected numpy.{} to be {} against jsonschema type '{}'".format(
-                type(numpy_value).__name__, description, jsonschema_type
+            raise AssertionError(
+                "Expected numpy.{} to be {} against jsonschema type '{}'".format(
+                    type(numpy_value).__name__, description, jsonschema_type
+                )
             )
 
     for jsonschema_type in valid_types:

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -358,11 +358,11 @@ def test_version_map_support(version, schema_type, tag):
 
     try:
         load_schema(tag)
-    except Exception:  # noqa: BLE001
+    except Exception as err:  # noqa: BLE001
         raise AssertionError(
             f"ASDF Standard version {version} requires support for "
             + f"{tag}, but the corresponding schema cannot be loaded."
-        )
+        ) from err
 
     extension_type = type_index.from_yaml_tag(ctx, tag)
     assert extension_type is not None, (

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -359,7 +359,7 @@ def test_version_map_support(version, schema_type, tag):
     try:
         load_schema(tag)
     except Exception:  # noqa: BLE001
-        assert False, (
+        raise AssertionError(
             f"ASDF Standard version {version} requires support for "
             + f"{tag}, but the corresponding schema cannot be loaded."
         )

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -52,8 +52,8 @@ class _AsdfWriteTypeIndex:
             version_map = get_version_map(self._version)
             core_version_map = version_map["core"]
             standard_version_map = version_map["standard"]
-        except ValueError:
-            raise ValueError(f"Don't know how to write out ASDF version {self._version}")
+        except ValueError as err:
+            raise ValueError(f"Don't know how to write out ASDF version {self._version}") from err
 
         # Process all types defined in the ASDF version map. It is important to
         # make sure that tags that are associated with the core part of the

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -296,7 +296,7 @@ class AsdfTypeIndex:
             _serialization_context._mark_extension_used(self._extension_by_type[asdftype])
         return asdftype
 
-    @lru_cache(5)
+    @lru_cache(5)  # noqa: B019
     def has_hook(self, hook_name):
         """
         Returns `True` if the given hook name exists on any of the managed

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -81,7 +81,7 @@ class ExtensionTypeMeta(type):
 
     @property
     def versioned_siblings(cls):
-        return getattr(cls, "__versioned_siblings") or []
+        return getattr(cls, "__versioned_siblings") or []  # noqa: B009
 
     def __new__(cls, name, bases, attrs):
         requires = cls._find_in_bases(attrs, bases, "requires", [])
@@ -143,7 +143,7 @@ class ExtensionTypeMeta(type):
                             "See https://github.com/asdf-format/asdf/issues/1245"
                         )
                     siblings.append(ExtensionTypeMeta.__new__(cls, name, bases, new_attrs))
-            setattr(new_cls, "__versioned_siblings", siblings)
+            setattr(new_cls, "__versioned_siblings", siblings)  # noqa: B010
 
         return new_cls
 

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -67,7 +67,7 @@ class ExtensionTypeMeta(type):
             finally:
                 cls._import_cache[modname] = has_module
                 if not has_module:
-                    return False
+                    return False  # noqa: B012
         return True
 
     @classmethod

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -302,8 +302,8 @@ def resolve_name(name):
     for part in parts[cursor:]:
         try:
             ret = getattr(ret, part)
-        except AttributeError:
-            raise ImportError(name)
+        except AttributeError as err:
+            raise ImportError(name) from err
 
     return ret
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ select = [
     "B", # flake8-bugbear
 ]
 extend-ignore = [
-    "B012", # `return` inside finally blocks cause exceptions to be silenced
     "B015", # Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
     "B019", # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
     "B023", # Function definition does not bind loop variable `package_name`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ select = [
     "B", # flake8-bugbear
 ]
 extend-ignore = [
-    "B019", # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
     "B023", # Function definition does not bind loop variable `package_name`
     "B904", # Within an except clause, raise exceptions with raise ... from err or raise ... from None to distinguish them from errors in exception handling
     "B905", # Requires python 3.10 (use zip strict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ select = [
     "B", # flake8-bugbear
 ]
 extend-ignore = [
-    "B023", # Function definition does not bind loop variable `package_name`
     "B904", # Within an except clause, raise exceptions with raise ... from err or raise ... from None to distinguish them from errors in exception handling
     "B905", # Requires python 3.10 (use zip strict)
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ select = [
     "B", # flake8-bugbear
 ]
 extend-ignore = [
-    "B011", # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
     "B012", # `return` inside finally blocks cause exceptions to be silenced
     "B015", # Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
     "B019", # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ select = [
     # "ANN", # flake8-annotations
     "S", # flake8-bandit
     "BLE", # flake8-blind-except
+    "B", # flake8-bugbear
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ select = [
     "B", # flake8-bugbear
 ]
 extend-ignore = [
-    "B015", # Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
     "B019", # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
     "B023", # Function definition does not bind loop variable `package_name`
     "B904", # Within an except clause, raise exceptions with raise ... from err or raise ... from None to distinguish them from errors in exception handling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ select = [
     "B", # flake8-bugbear
 ]
 extend-ignore = [
-    "B006", # Do not use mutable data structures for argument defaults
     "B007", # Loop control variable ... not used within the loop body. If this is intended, start the name with an underscore.
     "B009", # Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
     "B010", # Do not call `setattr` with a constant attribute value. It is not any safer than normal property access

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,19 @@ select = [
     "BLE", # flake8-blind-except
     "B", # flake8-bugbear
 ]
+extend-ignore = [
+    "B006", # Do not use mutable data structures for argument defaults
+    "B007", # Loop control variable ... not used within the loop body. If this is intended, start the name with an underscore.
+    "B009", # Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
+    "B010", # Do not call `setattr` with a constant attribute value. It is not any safer than normal property access
+    "B011", # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
+    "B012", # `return` inside finally blocks cause exceptions to be silenced
+    "B015", # Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
+    "B019", # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
+    "B023", # Function definition does not bind loop variable `package_name`
+    "B904", # Within an except clause, raise exceptions with raise ... from err or raise ... from None to distinguish them from errors in exception handling
+    "B905", # Requires python 3.10 (use zip strict)
+]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,8 +185,6 @@ select = [
     "B", # flake8-bugbear
 ]
 extend-ignore = [
-    "B009", # Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
-    "B010", # Do not call `setattr` with a constant attribute value. It is not any safer than normal property access
     "B011", # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
     "B012", # `return` inside finally blocks cause exceptions to be silenced
     "B015", # Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ select = [
     "B", # flake8-bugbear
 ]
 extend-ignore = [
-    "B007", # Loop control variable ... not used within the loop body. If this is intended, start the name with an underscore.
     "B009", # Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
     "B010", # Do not call `setattr` with a constant attribute value. It is not any safer than normal property access
     "B011", # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ select = [
     "B", # flake8-bugbear
 ]
 extend-ignore = [
-    "B904", # Within an except clause, raise exceptions with raise ... from err or raise ... from None to distinguish them from errors in exception handling
     "B905", # Requires python 3.10 (use zip strict)
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -59,8 +59,8 @@ class AsdfSchemaFile(pytest.File):
         validate_default=True,
         ignore_unrecognized_tag=False,
         ignore_version_mismatch=False,
-        skip_tests=[],
-        xfail_tests=[],
+        skip_tests=None,
+        xfail_tests=None,
         **kwargs,
     ):
 
@@ -83,8 +83,8 @@ class AsdfSchemaFile(pytest.File):
         result.validate_default = validate_default
         result.ignore_unrecognized_tag = ignore_unrecognized_tag
         result.ignore_version_mismatch = ignore_version_mismatch
-        result.skip_tests = skip_tests
-        result.xfail_tests = xfail_tests
+        result.skip_tests = [] if skip_tests is None else skip_tests
+        result.xfail_tests = [] if xfail_tests is None else xfail_tests
 
         return result
 

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -237,7 +237,7 @@ class AsdfSchemaExampleItem(pytest.Item):
         ] = ff2
 
         # Add some dummy blocks so that the ndarray examples work
-        for i in range(3):
+        for _ in range(3):
             b = block.Block(np.zeros((1024 * 1024 * 8), dtype=np.uint8))
             b._used = True
             ff.blocks.add(b)


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1302.

It enables `ruff` to explicitly check `flake8-bugbear` style checks.