### PR TITLE
Add `flake8-comprehensions` check to `ruff`

### DIFF
--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -413,11 +413,11 @@ class AsdfFile:
             return
 
         if "history" not in self.tree:
-            self.tree["history"] = dict(extensions=[])
+            self.tree["history"] = {"extensions": []}
         # Support clients who are still using the old history format
         elif isinstance(self.tree["history"], list):
             histlist = self.tree["history"]
-            self.tree["history"] = dict(entries=histlist, extensions=[])
+            self.tree["history"] = {"entries": histlist, "extensions": []}
             warnings.warn(
                 "The ASDF history format has changed in order to "
                 "support metadata about extensions. History entries "
@@ -1499,7 +1499,7 @@ class AsdfFile:
 
         if self.version >= versioning.NEW_HISTORY_FORMAT_MIN_VERSION:
             if "history" not in self.tree:
-                self.tree["history"] = dict(entries=[])
+                self.tree["history"] = {"entries": []}
             elif "entries" not in self.tree["history"]:
                 self.tree["history"]["entries"] = []
 

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -113,7 +113,7 @@ class PrintTree:
     """
 
     def __init__(self):
-        self.__tree = dict(visited=False, children=dict())
+        self.__tree = {"visited": False, "children": {}}
 
     def get_print_list(self, node_list):
         at_end = False
@@ -139,7 +139,7 @@ class PrintTree:
         current = self.__tree
         for node in ["tree"] + node_list:
             if node not in current["children"]:
-                current["children"][node] = dict(visited=True, children=dict())
+                current["children"][node] = {"visited": True, "children": {}}
             current = current["children"][node]
 
 

--- a/asdf/commands/tests/test_extract.py
+++ b/asdf/commands/tests/test_extract.py
@@ -19,7 +19,7 @@ def test_extract(tmpdir):
     tree = {
         "some_words": "These are some words",
         "nested": {"a": 100, "b": 42},
-        "list": [x for x in range(10)],
+        "list": list(range(10)),
         "image": image.data,
     }
 

--- a/asdf/commands/tests/test_remove_hdu.py
+++ b/asdf/commands/tests/test_remove_hdu.py
@@ -17,7 +17,7 @@ def test_remove_hdu(tmpdir):
     tree = {
         "some_words": "These are some words",
         "nested": {"a": 100, "b": 42},
-        "list": [x for x in range(10)],
+        "list": list(range(10)),
         "image": image.data,
     }
 

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -46,7 +46,7 @@ class IntegerType(AsdfType):
     version = "1.0.0"
     supported_versions = {"1.0.0", "1.1.0"}
 
-    _value_cache = dict()
+    _value_cache = {}
 
     def __init__(self, value, storage_type="internal"):
         if storage_type not in ["internal", "inline"]:
@@ -59,7 +59,7 @@ class IntegerType(AsdfType):
     def to_tree(cls, node, ctx):
 
         if ctx not in cls._value_cache:
-            cls._value_cache[ctx] = dict()
+            cls._value_cache[ctx] = {}
 
         abs_value = int(np.abs(node._value))
 
@@ -78,7 +78,7 @@ class IntegerType(AsdfType):
             if node._storage == "internal":
                 cls._value_cache[ctx][abs_value] = array
 
-        tree = dict()
+        tree = {}
         ctx.set_array_storage(array, node._storage)
         tree["words"] = array
         tree["sign"] = node._sign

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -243,7 +243,7 @@ def test_metadata_with_custom_extension(tmpdir):
 
     # If we use the extension but we don't serialize any types that require it,
     # no metadata about this extension should be added to the file
-    tree2 = {"x": [x for x in range(10)]}
+    tree2 = {"x": list(range(10))}
     tmpfile2 = str(tmpdir.join("no_extension.asdf"))
     with asdf.AsdfFile(tree2, extensions=FractionExtension()) as ff:
         ff.write_to(tmpfile2)

--- a/asdf/tags/core/tests/test_integer.py
+++ b/asdf/tags/core/tests/test_integer.py
@@ -28,7 +28,7 @@ def test_integer_value(tmpdir, value, sign):
         value = -value
 
     integer = IntegerType(value)
-    tree = dict(integer=integer)
+    tree = {"integer": integer}
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
@@ -37,13 +37,13 @@ def test_integer_storage(tmpdir, inline):
 
     tmpfile = str(tmpdir.join("integer.asdf"))
 
-    kwargs = dict()
+    kwargs = {}
     if inline:
         kwargs["storage_type"] = "inline"
 
     random.seed(0)
     value = random.getrandbits(1000)
-    tree = dict(integer=IntegerType(value, **kwargs))
+    tree = {"integer": IntegerType(value, **kwargs)}
 
     with asdf.AsdfFile(tree) as af:
         af.write_to(tmpfile)
@@ -66,7 +66,7 @@ def test_integer_storage_duplication(tmpdir):
 
     random.seed(0)
     value = random.getrandbits(1000)
-    tree = dict(integer1=IntegerType(value), integer2=IntegerType(value))
+    tree = {"integer1": IntegerType(value), "integer2": IntegerType(value)}
 
     with asdf.AsdfFile(tree) as af:
         af.write_to(tmpfile)

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -828,7 +828,7 @@ def test_non_contiguous_base_array(tmpdir):
 
 def test_fortran_order(tmpdir):
     array = np.array([[11, 12, 13], [21, 22, 23]], order="F", dtype=np.int64)
-    tree = dict(data=array)
+    tree = {"data": array}
 
     def check_f_order(t):
         assert t["data"].flags.fortran
@@ -843,7 +843,7 @@ def test_fortran_order(tmpdir):
 
 def test_memmap_write(tmpdir):
     tmpfile = str(tmpdir.join("data.asdf"))
-    tree = dict(data=np.zeros(100))
+    tree = {"data": np.zeros(100)}
 
     with asdf.AsdfFile(tree) as af:
         # Make sure we're actually writing to an internal array for this test
@@ -865,7 +865,7 @@ def test_memmap_write(tmpdir):
 def test_readonly(tmpdir):
 
     tmpfile = str(tmpdir.join("data.asdf"))
-    tree = dict(data=np.ndarray(100))
+    tree = {"data": np.ndarray(100)}
 
     with asdf.AsdfFile(tree) as af:
         # Make sure we're actually writing to an internal array for this test
@@ -896,7 +896,7 @@ def test_readonly(tmpdir):
 
 def test_readonly_inline(tmpdir):
     tmpfile = str(tmpdir.join("data.asdf"))
-    tree = dict(data=np.ndarray(100))
+    tree = {"data": np.ndarray(100)}
 
     with asdf.AsdfFile(tree) as af:
         af.write_to(tmpfile, all_array_storage="inline")

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -40,7 +40,7 @@ def test_no_warning_nan_array(tmp_path):
     https://github.com/asdf-format/asdf/pull/557
     """
 
-    tree = dict(array=np.array([1, 2, np.nan]))
+    tree = {"array": np.array([1, 2, np.nan])}
 
     with assert_no_warnings():
         assert_roundtrip_tree(tree, tmp_path)
@@ -50,7 +50,7 @@ def test_warning_deprecated_open(tmp_path):
 
     tmpfile = str(tmp_path / "foo.asdf")
 
-    tree = dict(foo=42, bar="hello")
+    tree = {"foo": 42, "bar": "hello"}
     with asdf.AsdfFile(tree) as af:
         af.write_to(tmpfile)
 
@@ -67,7 +67,7 @@ def test_open_readonly(tmp_path):
 
     tmpfile = str(tmp_path / "readonly.asdf")
 
-    tree = dict(foo=42, bar="hello", baz=np.arange(20))
+    tree = {"foo": 42, "bar": "hello", "baz": np.arange(20)}
     with asdf.AsdfFile(tree) as af:
         af.write_to(tmpfile, all_array_storage="internal")
 

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -178,7 +178,7 @@ def test_set_array_compression(tmp_path):
     zlib_data = np.array([x for x in range(1000)])
     bzp2_data = np.array([x for x in range(1000)])
 
-    tree = dict(zlib_data=zlib_data, bzp2_data=bzp2_data)
+    tree = {"zlib_data": zlib_data, "bzp2_data": bzp2_data}
     with asdf.AsdfFile(tree) as af_out:
         af_out.set_array_compression(zlib_data, "zlib", level=1)
         af_out.set_array_compression(bzp2_data, "bzp2", compresslevel=9000)
@@ -196,7 +196,7 @@ def test_nonnative_endian_compression(tmp_path):
     ledata = np.arange(1000, dtype="<i8")
     bedata = np.arange(1000, dtype=">i8")
 
-    _roundtrip(tmp_path, dict(ledata=ledata, bedata=bedata), "lz4")
+    _roundtrip(tmp_path, {"ledata": ledata, "bedata": bedata}, "lz4")
 
 
 class LzmaCompressor(Compressor):
@@ -235,8 +235,8 @@ def test_compression_with_extension(tmp_path):
         config.add_extension(LzmaExtension())
 
         with pytest.raises(lzma.LZMAError):
-            _roundtrip(tmp_path, tree, "lzma", write_options=dict(compression_kwargs={"preset": 9000}))
-        fn = _roundtrip(tmp_path, tree, "lzma", write_options=dict(compression_kwargs={"preset": 6}))
+            _roundtrip(tmp_path, tree, "lzma", write_options={"compression_kwargs": {"preset": 9000}})
+        fn = _roundtrip(tmp_path, tree, "lzma", write_options={"compression_kwargs": {"preset": 6}})
 
         hist = {
             "extension_class": "asdf.tests.test_compression.LzmaExtension",

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -175,8 +175,8 @@ def test_set_array_compression(tmp_path):
 
     tmpfile = os.path.join(str(tmp_path), "compressed.asdf")
 
-    zlib_data = np.array([x for x in range(1000)])
-    bzp2_data = np.array([x for x in range(1000)])
+    zlib_data = np.array(list(range(1000)))
+    bzp2_data = np.array(list(range(1000)))
 
     tree = {"zlib_data": zlib_data, "bzp2_data": bzp2_data}
     with asdf.AsdfFile(tree) as af_out:

--- a/asdf/tests/test_helpers.py
+++ b/asdf/tests/test_helpers.py
@@ -19,7 +19,7 @@ def test_conversion_error(tmp_path):
 
         @classmethod
         def to_tree(cls, node, ctx):
-            return dict(a=node.a, b=node.b)
+            return {"a": node.a, "b": node.b}
 
         def __eq__(self, other):
             return self.a == other.a and self.b == other.b
@@ -38,7 +38,7 @@ def test_conversion_error(tmp_path):
             return []
 
     foo = FooType(10, "hello")
-    tree = dict(foo=foo)
+    tree = {"foo": foo}
 
     with pytest.raises(AsdfConversionWarning):
         with pytest.warns(AsdfWarning, match=r"Unable to locate schema file"):

--- a/asdf/tests/test_info.py
+++ b/asdf/tests/test_info.py
@@ -11,7 +11,13 @@ from asdf.resource import DirectoryResourceMapping
 
 
 def test_info_module(capsys, tmp_path):
-    tree = dict(foo=42, bar="hello", baz=np.arange(20), nested={"woo": "hoo", "yee": "haw"}, long_line="a" * 100)
+    tree = {
+        "foo": 42,
+        "bar": "hello",
+        "baz": np.arange(20),
+        "nested": {"woo": "hoo", "yee": "haw"},
+        "long_line": "a" * 100,
+    }
     af = asdf.AsdfFile(tree)
 
     def _assert_correct_info(node_or_path):
@@ -627,7 +633,7 @@ def test_recursive_info_object_support(capsys, tmp_path):
 
     recursive_obj = RecursiveObjectWithInfoSupport()
     recursive_obj.recursive = recursive_obj
-    tree = dict(random=3.14159, rtest=recursive_obj)
+    tree = {"random": 3.14159, "rtest": recursive_obj}
     af = asdf.AsdfFile(tree)
     af.info(refresh_extension_manager=True)
     captured = capsys.readouterr()
@@ -635,7 +641,7 @@ def test_recursive_info_object_support(capsys, tmp_path):
 
 
 def test_search():
-    tree = dict(foo=42, bar="hello", baz=np.arange(20))
+    tree = {"foo": 42, "bar": "hello", "baz": np.arange(20)}
     af = asdf.AsdfFile(tree)
 
     result = af.search("foo")

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -742,15 +742,15 @@ def test_nested_array():
         },
     }
 
-    good = dict(stuff=[[1, "hello", 2], [4, "world", 9.7]])
+    good = {"stuff": [[1, "hello", 2], [4, "world", 9.7]]}
     schema.validate(good, schema=s)
 
     bads = [
-        dict(stuff=[[1, 2, 3]]),
-        dict(stuff=[12, "dldl"]),
-        dict(stuff=[[12, "dldl"]]),
-        dict(stuff=[[1, "hello", 2], [4, 5]]),
-        dict(stuff=[[1, "hello", 2], [4, 5, 6]]),
+        {"stuff": [[1, 2, 3]]},
+        {"stuff": [12, "dldl"]},
+        {"stuff": [[12, "dldl"]]},
+        {"stuff": [[1, "hello", 2], [4, 5]]},
+        {"stuff": [[1, "hello", 2], [4, 5, 6]]},
     ]
 
     for b in bads:
@@ -782,15 +782,15 @@ properties:
     schema_tree = schema.load_schema(str(schema_path))
     schema.check_schema(schema_tree)
 
-    good = dict(stuff=[[1, "hello", 2], [4, "world", 9.7]])
+    good = {"stuff": [[1, "hello", 2], [4, "world", 9.7]]}
     schema.validate(good, schema=schema_tree)
 
     bads = [
-        dict(stuff=[[1, 2, 3]]),
-        dict(stuff=[12, "dldl"]),
-        dict(stuff=[[12, "dldl"]]),
-        dict(stuff=[[1, "hello", 2], [4, 5]]),
-        dict(stuff=[[1, "hello", 2], [4, 5, 6]]),
+        {"stuff": [[1, 2, 3]]},
+        {"stuff": [12, "dldl"]},
+        {"stuff": [[12, "dldl"]]},
+        {"stuff": [[1, "hello", 2], [4, 5]]},
+        {"stuff": [[1, "hello", 2], [4, 5, 6]]},
     ]
 
     for b in bads:

--- a/asdf/tests/test_search.py
+++ b/asdf/tests/test_search.py
@@ -192,7 +192,7 @@ def test_recursive_tree():
 
 
 def test_search():
-    tree = dict(foo=42, bar="hello", baz=np.arange(20))
+    tree = {"foo": 42, "bar": "hello", "baz": np.arange(20)}
     af = AsdfFile(tree)
 
     result = af.search("foo")

--- a/asdf/tests/test_treeutil.py
+++ b/asdf/tests/test_treeutil.py
@@ -19,7 +19,7 @@ def test_get_children():
 
 
 def test_is_container():
-    for value in [[], {}, tuple()]:
+    for value in [[], {}, ()]:
         assert treeutil.is_container(value) is True
 
     for value in ["foo", 12, 13.9827]:

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -420,7 +420,7 @@ def test_newer_tag():
 
         @classmethod
         def to_tree(cls, data, ctx):
-            return dict(c=data.c, d=data.d)
+            return {"c": data.c, "d": data.d}
 
     class CustomFlowExtension(CustomExtension):
         @property
@@ -532,9 +532,9 @@ def test_supported_versions():
         @classmethod
         def to_tree(cls, data, ctx):
             if cls.version == "1.0.0":
-                return dict(a=data.c, b=data.d)
+                return {"a": data.c, "b": data.d}
             else:
-                return dict(c=data.c, d=data.d)
+                return {"c": data.c, "d": data.d}
 
     class CustomFlowExtension(CustomExtension):
         @property
@@ -610,7 +610,7 @@ def test_tag_without_schema(tmp_path):
 
         @classmethod
         def to_tree(cls, node, ctx):
-            return dict(a=node.a, b=node.b)
+            return {"a": node.a, "b": node.b}
 
         def __eq__(self, other):
             return self.a == other.a and self.b == other.b
@@ -629,7 +629,7 @@ def test_tag_without_schema(tmp_path):
             return []
 
     foo = FooType("hello", 42)
-    tree = dict(foo=foo)
+    tree = {"foo": foo}
 
     with pytest.warns(AsdfWarning, match=r"Unable to locate schema file"):
         with asdf.AsdfFile(tree, extensions=FooExtension()) as af:

--- a/asdf/tests/test_util.py
+++ b/asdf/tests/test_util.py
@@ -10,7 +10,7 @@ def test_is_primitive():
     for value in [None, "foo", 1, 1.39, 1 + 1j, True]:
         assert util.is_primitive(value) is True
 
-    for value in [[], tuple(), {}, set()]:
+    for value in [[], (), {}, set()]:
         assert util.is_primitive(value) is False
 
 

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -86,7 +86,7 @@ def run_tuple_test(tree, tmp_path):
         assert b"tuple" not in content
 
     # Ignore these warnings for the tests that don't actually test the warning
-    init_options = dict(ignore_implicit_conversion=True)
+    init_options = {"ignore_implicit_conversion": True}
 
     helpers.assert_roundtrip_tree(
         tree, tmp_path, asdf_check_func=check_asdf, raw_yaml_check_func=check_raw_yaml, init_options=init_options
@@ -140,7 +140,7 @@ def test_named_tuple_collections_recursive(tmp_path):
     def check_asdf(asdf):
         assert (asdf.tree["val"][2] == np.ones(3)).all()
 
-    init_options = dict(ignore_implicit_conversion=True)
+    init_options = {"ignore_implicit_conversion": True}
     helpers.assert_roundtrip_tree(tree, tmp_path, asdf_check_func=check_asdf, init_options=init_options)
 
 
@@ -155,7 +155,7 @@ def test_named_tuple_typing_recursive(tmp_path):
     def check_asdf(asdf):
         assert (asdf.tree["val"][2] == np.ones(3)).all()
 
-    init_options = dict(ignore_implicit_conversion=True)
+    init_options = {"ignore_implicit_conversion": True}
     helpers.assert_roundtrip_tree(tree, tmp_path, asdf_check_func=check_asdf, init_options=init_options)
 
 

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -126,7 +126,7 @@ class ExtensionTypeMeta(type):
             # We need to convert back to a list here so that the 'in' operator
             # uses actual comparison instead of hash equality
             new_cls.supported_versions = list(supported_versions)
-            siblings = list()
+            siblings = []
             for version in new_cls.supported_versions:
                 if version != new_cls.version:
                     new_attrs = copy(attrs)

--- a/compatibility_tests/test_file_compatibility.py
+++ b/compatibility_tests/test_file_compatibility.py
@@ -165,7 +165,7 @@ def test_file_compatibility(asdf_version, env_path, tmpdir):
     # versions support.
     current_supported_versions = set(asdf.versioning.supported_versions)
     old_supported_versions = set(get_supported_versions(env_path))
-    standard_versions = [v for v in current_supported_versions.intersection(old_supported_versions)]
+    standard_versions = list(current_supported_versions.intersection(old_supported_versions))
 
     # Confirm that this test isn't giving us a false sense of security.
     assert len(standard_versions) > 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ select = [
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
-    "C408", # Unnecessary `dict` call (rewrite as a literal)
     "C416", # Unnecessary `list` comprehension (rewrite using `list()`)
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ select = [
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
-    "C416", # Unnecessary `list` comprehension (rewrite using `list()`)
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,9 +184,12 @@ select = [
     "BLE", # flake8-blind-except
     "B", # flake8-bugbear
     "A", # flake8-builtins
+    "C4", # flake8-comprehensions
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
+    "C408", # Unnecessary `dict` call (rewrite as a literal)
+    "C416", # Unnecessary `list` comprehension (rewrite using `list()`)
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1304.

It enables `ruff` to explicitly check `flake8-comprehensions` style checks.