### PR TITLE
Add `flake8-errmsg` check to `ruff`

### DIFF
--- a/asdf/_helpers.py
+++ b/asdf/_helpers.py
@@ -6,12 +6,10 @@ def validate_version(version):
     # Account for the possibility of AsdfVersion
     version = str(version)
     if version not in versioning.supported_versions:
-        raise ValueError(
-            "ASDF Standard version {} is not supported by asdf=={}.  "
-            "Available ASDF Standard versions: {}".format(
-                version,
-                asdf_package_version,
-                ", ".join(str(v) for v in versioning.supported_versions),
-            )
+        msg = "ASDF Standard version {} is not supported by asdf=={}.  " "Available ASDF Standard versions: {}".format(
+            version,
+            asdf_package_version,
+            ", ".join(str(v) for v in versioning.supported_versions),
         )
+        raise ValueError(msg)
     return version

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -754,7 +754,8 @@ class AsdfFile:
         try:
             version = versioning.AsdfVersion(parts[1].decode("ascii"))
         except ValueError as err:
-            raise ValueError(f"Unparsable version in ASDF file: {parts[1]}") from err
+            msg = f"Unparsable version in ASDF file: {parts[1]}"
+            raise ValueError(msg) from err
 
         return version
 
@@ -1083,7 +1084,8 @@ class AsdfFile:
 
     def _pre_write(self, fd, all_array_storage, all_array_compression, compression_kwargs=None):
         if all_array_storage not in (None, "internal", "external", "inline"):
-            raise ValueError(f"Invalid value for all_array_storage: '{all_array_storage}'")
+            msg = f"Invalid value for all_array_storage: '{all_array_storage}'"
+            raise ValueError(msg)
 
         self._all_array_storage = all_array_storage
 
@@ -1691,7 +1693,8 @@ class AsdfFile:
 def _check_and_set_mode(fileobj, asdf_mode):
 
     if asdf_mode is not None and asdf_mode not in ["r", "rw"]:
-        raise ValueError(f"Unrecognized asdf mode '{asdf_mode}'. Must be either 'r' or 'rw'")
+        msg = f"Unrecognized asdf mode '{asdf_mode}'. Must be either 'r' or 'rw'"
+        raise ValueError(msg)
 
     if asdf_mode is None:
         if isinstance(fileobj, io.IOBase):
@@ -1723,7 +1726,8 @@ def _handle_deprecated_kwargs(config, kwargs):
             )
             setattr(config, config_property, func(value))
         else:
-            raise TypeError(f"Unexpected keyword argument '{key}'")
+            msg = f"Unexpected keyword argument '{key}'"
+            raise TypeError(msg)
 
 
 def open_asdf(

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -164,7 +164,8 @@ class AsdfFile:
             if self.extensions != tree.extensions:
                 # TODO(eslavich): Why not?  What if that's the goal
                 # of copying the file?
-                raise ValueError("Can not copy AsdfFile and change active extensions")
+                msg = "Can not copy AsdfFile and change active extensions"
+                raise ValueError(msg)
             self._uri = tree.uri
             # Set directly to self._tree (bypassing property), since
             # we can assume the other AsdfFile is already valid.
@@ -380,9 +381,8 @@ class AsdfFile:
             extensions = extensions.extensions
 
         if not isinstance(extensions, list):
-            raise TypeError(
-                "The extensions parameter must be an extension, list of extensions, or instance of AsdfExtensionList"
-            )
+            msg = "The extensions parameter must be an extension, list of extensions, or instance of AsdfExtensionList"
+            raise TypeError(msg)
 
         extensions = [ExtensionProxy.maybe_wrap(e) for e in extensions]
 
@@ -577,7 +577,8 @@ class AsdfFile:
         When set, the tree will be validated against the ASDF schema.
         """
         if self._closed:
-            raise OSError("Cannot access data from closed ASDF file")
+            msg = "Cannot access data from closed ASDF file"
+            raise OSError(msg)
         return self._tree
 
     @tree.setter
@@ -747,7 +748,8 @@ class AsdfFile:
         """
         parts = line.split()
         if len(parts) != 2 or parts[0] != constants.ASDF_MAGIC:
-            raise ValueError("Does not appear to be a ASDF file.")
+            msg = "Does not appear to be a ASDF file."
+            raise ValueError(msg)
 
         try:
             version = versioning.AsdfVersion(parts[1].decode("ascii"))
@@ -771,7 +773,8 @@ class AsdfFile:
         lines = content.splitlines()
         for line in lines:
             if not line.startswith(b"#"):
-                raise ValueError("Invalid content between header and tree")
+                msg = "Invalid content between header and tree"
+                raise ValueError(msg)
             comments.append(line[1:].strip())
 
         return comments
@@ -806,7 +809,8 @@ class AsdfFile:
         """Attempt to populate AsdfFile data from file-like object"""
 
         if strict_extension_check and ignore_missing_extensions:
-            raise ValueError("'strict_extension_check' and 'ignore_missing_extensions' are incompatible options")
+            msg = "'strict_extension_check' and 'ignore_missing_extensions' are incompatible options"
+            raise ValueError(msg)
 
         with config_context() as config:
             _handle_deprecated_kwargs(config, kwargs)
@@ -853,7 +857,8 @@ class AsdfFile:
             elif yaml_token == constants.BLOCK_MAGIC:
                 has_blocks = True
             elif yaml_token != b"":
-                raise OSError("ASDF file appears to contain garbage after header.")
+                msg = "ASDF file appears to contain garbage after header."
+                raise OSError(msg)
 
             if tree is None:
                 # At this point the tree should be tagged, but we want it to be
@@ -960,15 +965,15 @@ class AsdfFile:
                     **kwargs,
                 )
             except ValueError:
-                raise ValueError(
-                    "Input object does not appear to be an ASDF file or a FITS with ASDF extension"
-                ) from None
+                msg = "Input object does not appear to be an ASDF file or a FITS with ASDF extension"
+                raise ValueError(msg) from None
             except ImportError:
-                raise ValueError(
+                msg = (
                     "Input object does not appear to be an ASDF file. Cannot check "
                     "if it is a FITS with ASDF extension because 'astropy' is not "
                     "installed"
-                ) from None
+                )
+                raise ValueError() from None
         elif file_type == util.FileType.ASDF:
             return cls._open_asdf(
                 self,
@@ -982,7 +987,8 @@ class AsdfFile:
                 **kwargs,
             )
         else:
-            raise ValueError("Input object does not appear to be an ASDF file or a FITS with ASDF extension")
+            msg = "Input object does not appear to be an ASDF file or a FITS with ASDF extension"
+            raise ValueError(msg)
 
     @classmethod
     def open(  # noqa: A003
@@ -1184,14 +1190,16 @@ class AsdfFile:
             fd = self._fd
 
             if fd is None:
-                raise ValueError("Can not update, since there is no associated file")
+                msg = "Can not update, since there is no associated file"
+                raise ValueError(msg)
 
             if not fd.writable():
-                raise OSError(
+                msg = (
                     "Can not update, since associated file is read-only. Make "
                     "sure that the AsdfFile was opened with mode='rw' and the "
                     "underlying file handle is writable."
                 )
+                raise OSError(msg)
 
             if version is not None:
                 self.version = version
@@ -1204,7 +1212,8 @@ class AsdfFile:
                 return
 
             if not fd.seekable():
-                raise OSError("Can not update, since associated file is not seekable")
+                msg = "Can not update, since associated file is not seekable"
+                raise OSError(msg)
 
             self.blocks.finish_reading_internal_blocks()
 

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -74,7 +74,8 @@ class BlockManager:
             raise ValueError(f"Unknown array storage type {block.array_storage}")
 
         if block.array_storage == "streamed" and len(self._streamed_blocks) > 1:
-            raise ValueError("Can not add second streaming block")
+            msg = "Can not add second streaming block"
+            raise ValueError(msg)
 
         if block._data is not None:
             self._data_to_block_mapping[id(block._data)] = block
@@ -116,7 +117,8 @@ class BlockManager:
               appears at the end of the file.
         """
         if array_storage not in ["internal", "external", "streamed", "inline"]:
-            raise ValueError("array_storage must be one of 'internal', 'external', 'streamed' or 'inline'")
+            msg = "array_storage must be one of 'internal', 'external', 'streamed' or 'inline'"
+            raise ValueError(msg)
 
         if block.array_storage != array_storage:
             if block in self.blocks:
@@ -209,7 +211,8 @@ class BlockManager:
     def _sort_blocks_by_offset(self):
         def sorter(x):
             if x.offset is None:
-                raise ValueError("Block is missing offset")
+                msg = "Block is missing offset"
+                raise ValueError(msg)
             else:
                 return x.offset
 
@@ -352,7 +355,8 @@ class BlockManager:
 
         for i, block in enumerate(self.external_blocks):
             if uri is None:
-                raise ValueError("Can't write external blocks, since URI of main file is unknown.")
+                msg = "Can't write external blocks, since URI of main file is unknown."
+                raise ValueError(msg)
             subfd = self.get_external_uri(uri, i)
             asdffile = asdf.AsdfFile()
             block = copy.copy(block)
@@ -692,14 +696,16 @@ class BlockManager:
         for i, external_block in enumerate(self.external_blocks):
             if block == external_block:
                 if self._asdffile().uri is None:
-                    raise ValueError("Can't write external blocks, since URI of main file is unknown.")
+                    msg = "Can't write external blocks, since URI of main file is unknown."
+                    raise ValueError(msg)
 
                 parts = list(patched_urllib_parse.urlparse(self._asdffile().uri))
                 path = parts[2]
                 filename = os.path.basename(path)
                 return self.get_external_filename(filename, i)
 
-        raise ValueError("block not found.")
+        msg = "block not found."
+        raise ValueError(msg)
 
     def find_or_create_block_for_array(self, arr, ctx):
         """
@@ -1004,11 +1010,12 @@ class Block:
                 return None
 
             if buff not in (constants.BLOCK_MAGIC, constants.INDEX_HEADER[: len(buff)]):
-                raise ValueError(
+                msg = (
                     "Bad magic number in block. "
                     "This may indicate an internal inconsistency about the "
                     "sizes of the blocks in the file."
                 )
+                raise ValueError(msg)
 
             if buff == constants.INDEX_HEADER[: len(buff)]:
                 return None
@@ -1034,10 +1041,12 @@ class Block:
             raise v  # TODO: hint extension?
 
         if self.input_compression is None and header["used_size"] != header["data_size"]:
-            raise ValueError("used_size and data_size must be equal when no compression is used.")
+            msg = "used_size and data_size must be equal when no compression is used."
+            raise ValueError(msg)
 
         if header["flags"] & constants.BLOCK_FLAG_STREAMED and self.input_compression is not None:
-            raise ValueError("Compression set on a streamed block.")
+            msg = "Compression set on a streamed block."
+            raise ValueError(msg)
 
         if fd.seekable():
             # If the file is seekable, we can delay reading the actual
@@ -1200,7 +1209,8 @@ class Block:
         """
         if self._data is None:
             if self._fd.is_closed():
-                raise OSError("ASDF file has already been closed. " "Can not get the data.")
+                msg = "ASDF file has already been closed. " "Can not get the data."
+                raise OSError(msg)
 
             # Be nice and reset the file position after we're done
             curpos = self._fd.tell()

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -71,7 +71,8 @@ class BlockManager:
             if block not in block_set:
                 block_set.append(block)
         else:
-            raise ValueError(f"Unknown array storage type {block.array_storage}")
+            msg = f"Unknown array storage type {block.array_storage}"
+            raise ValueError(msg)
 
         if block.array_storage == "streamed" and len(self._streamed_blocks) > 1:
             msg = "Can not add second streaming block"
@@ -92,7 +93,8 @@ class BlockManager:
                     if id(block._data) in self._data_to_block_mapping:
                         del self._data_to_block_mapping[id(block._data)]
         else:
-            raise ValueError(f"Unknown array storage type {block.array_storage}")
+            msg = f"Unknown array storage type {block.array_storage}"
+            raise ValueError(msg)
 
     def set_array_storage(self, block, array_storage):
         """
@@ -629,13 +631,15 @@ class BlockManager:
                 if source < len(self._internal_blocks):
                     return self._internal_blocks[source]
             else:
-                raise ValueError(f"Invalid source id {source}")
+                msg = f"Invalid source id {source}"
+                raise ValueError(msg)
 
             # If we have a streamed block or we already know we have
             # no blocks, reading any further isn't going to yield any
             # new blocks.
             if len(self._streamed_blocks) or len(self._internal_blocks) == 0:
-                raise ValueError(f"Block '{source}' not found.")
+                msg = f"Block '{source}' not found."
+                raise ValueError(msg)
 
             # If the desired block hasn't already been read, and the
             # file is seekable, and we have at least one internal
@@ -657,7 +661,8 @@ class BlockManager:
             if source == -1 and last_block.array_storage == "streamed":
                 return last_block
 
-            raise ValueError(f"Block '{source}' not found.")
+            msg = f"Block '{source}' not found."
+            raise ValueError(msg)
 
         elif isinstance(source, str):
             asdffile = self._asdffile().open_external(source)
@@ -669,7 +674,8 @@ class BlockManager:
             block = Block(data=np.array(source), array_storage="inline")
 
         else:
-            raise TypeError(f"Unknown source '{source}'")
+            msg = f"Unknown source '{source}'"
+            raise TypeError(msg)
 
         return block
 
@@ -1026,7 +1032,8 @@ class Block:
         buff = fd.read(2)
         (header_size,) = struct.unpack(b">H", buff)
         if header_size < self._header.size:
-            raise ValueError(f"Header size must be >= {self._header.size}")
+            msg = f"Header size must be >= {self._header.size}"
+            raise ValueError(msg)
 
         buff = fd.read(header_size)
         header = self._header.unpack(buff)
@@ -1094,7 +1101,8 @@ class Block:
             fd.close()
 
         if validate_checksum and not self.validate_checksum():
-            raise ValueError(f"Block at {self._offset} does not match given checksum")
+            msg = f"Block at {self._offset} does not match given checksum"
+            raise ValueError(msg)
 
         return self
 
@@ -1161,7 +1169,8 @@ class Block:
         self.input_compression = self.output_compression
 
         if allocated_size < used_size:
-            raise RuntimeError(f"Block used size {used_size} larger than allocated size {allocated_size}")
+            msg = f"Block used size {used_size} larger than allocated size {allocated_size}"
+            raise RuntimeError(msg)
 
         if self.checksum is not None:
             checksum = self.checksum
@@ -1199,7 +1208,8 @@ class Block:
                     fd.seek(end)
             else:
                 if used_size != data_size:
-                    raise RuntimeError(f"Block used size {used_size} is not equal to the data size {data_size}")
+                    msg = f"Block used size {used_size} is not equal to the data size {data_size}"
+                    raise RuntimeError(msg)
                 fd.write_array(data)
 
     @property

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -135,7 +135,8 @@ class PrintTree:
 
     def __setitem__(self, node_list, visit):
         if not isinstance(node_list, list):
-            raise TypeError("node_list parameter must be an instance of list")
+            msg = "node_list parameter must be an instance of list"
+            raise TypeError(msg)
         current = self.__tree
         for node in ["tree"] + node_list:
             if node not in current["children"]:

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -327,7 +327,8 @@ def parse_yaml_version(content):
     """
     match = re.search(b"^%YAML (.*)$", content, flags=re.MULTILINE)
     if match is None:
-        raise ValueError("YAML version number not found")
+        msg = "YAML version number not found"
+        raise ValueError(msg)
     return match.group(1)
 
 

--- a/asdf/commands/extract.py
+++ b/asdf/commands/extract.py
@@ -43,7 +43,8 @@ def extract_file(input_file, output_file):
     try:
         with asdf.open(input_file) as ih:
             if not isinstance(ih, AsdfInFits):
-                raise RuntimeError(f"Given input file '{input_file}' is not ASDF-in-FITS")
+                msg = f"Given input file '{input_file}' is not ASDF-in-FITS"
+                raise RuntimeError(msg)
 
             with asdf.AsdfFile(ih.tree) as oh:
                 oh.write_to(output_file)

--- a/asdf/commands/tests/test_edit.py
+++ b/asdf/commands/tests/test_edit.py
@@ -95,7 +95,8 @@ def default_mock_input(monkeypatch):
     """
 
     def _input(prompt=None):
-        raise AssertionError(f"Received unexpected request for input: {prompt}")
+        msg = f"Received unexpected request for input: {prompt}"
+        raise AssertionError(msg)
 
     monkeypatch.setattr("builtins.input", _input)
 

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -46,7 +46,8 @@ def validate(compression):
             warnings.warn(f'Found more than one compressor for "{label}"', AsdfWarning)
 
     if compression not in all_labels:
-        raise ValueError(f"Supported compression types are: {all_labels}, not '{compression}'")
+        msg = f"Supported compression types are: {all_labels}, not '{compression}'"
+        raise ValueError(msg)
 
     return compression
 
@@ -212,7 +213,8 @@ def _get_compressor(label):
     elif label == "lz4":
         comp = Lz4Compressor()
     else:
-        raise ValueError(f"Unknown compression type: '{label}'")
+        msg = f"Unknown compression type: '{label}'"
+        raise ValueError(msg)
 
     return comp
 

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -56,11 +56,12 @@ class Lz4Compressor:
         try:
             import lz4.block
         except ImportError as err:
-            raise ImportError(
+            msg = (
                 "lz4 library in not installed in your Python environment, "
                 "therefore the compressed block in this ASDF file "
                 "can not be decompressed."
-            ) from err
+            )
+            raise ImportError(msg) from err
 
         self._api = lz4.block
 
@@ -268,7 +269,8 @@ def decompress(fd, used_size, data_size, compression, config=None):
     len_decoded = decoder.decompress(blocks, out=buffer.data, **config)
 
     if len_decoded != data_size:
-        raise ValueError("Decompressed data wrong size")
+        msg = "Decompressed data wrong size"
+        raise ValueError(msg)
 
     return buffer
 

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -90,7 +90,8 @@ class AsdfConfig:
             be removed.
         """
         if mapping is None and package is None:
-            raise ValueError("Must specify at least one of mapping or package")
+            msg = "Must specify at least one of mapping or package"
+            raise ValueError(msg)
 
         if mapping is not None:
             mapping = ResourceMappingProxy.maybe_wrap(mapping)
@@ -174,7 +175,8 @@ class AsdfConfig:
             be removed.
         """
         if extension is None and package is None:
-            raise ValueError("Must specify at least one of extension or package")
+            msg = "Must specify at least one of extension or package"
+            raise ValueError(msg)
 
         if extension is not None and not isinstance(extension, str):
             extension = ExtensionProxy.maybe_wrap(extension)

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -163,7 +163,8 @@ class ConverterProxy(Converter):
 
     def __init__(self, delegate, extension):
         if not isinstance(delegate, Converter):
-            raise TypeError("Converter must implement the asdf.extension.Converter interface")
+            msg = "Converter must implement the asdf.extension.Converter interface"
+            raise TypeError(msg)
 
         self._delegate = delegate
         self._extension = extension
@@ -178,12 +179,12 @@ class ConverterProxy(Converter):
             if isinstance(tag, str):
                 relevant_tags.update(t.tag_uri for t in extension.tags if uri_match(tag, t.tag_uri))
             else:
-                raise TypeError("Converter property 'tags' must contain str values")
+                msg = "Converter property 'tags' must contain str values"
+                raise TypeError(msg)
 
         if len(relevant_tags) > 1 and not hasattr(delegate, "select_tag"):
-            raise RuntimeError(
-                "Converter handles multiple tags for this extension, but does not implement a select_tag method."
-            )
+            msg = "Converter handles multiple tags for this extension, but does not implement a select_tag method."
+            raise RuntimeError(msg)
 
         self._tags = sorted(relevant_tags)
 
@@ -192,7 +193,8 @@ class ConverterProxy(Converter):
             if isinstance(typ, (str, type)):
                 self._types.append(typ)
             else:
-                raise TypeError("Converter property 'types' must contain str or type values")
+                msg = "Converter property 'types' must contain str or type values"
+                raise TypeError(msg)
 
     @property
     def tags(self):

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -134,7 +134,8 @@ class ExtensionProxy(Extension, AsdfExtension):
 
     def __init__(self, delegate, package_name=None, package_version=None):
         if not isinstance(delegate, (Extension, AsdfExtension)):
-            raise TypeError("Extension must implement the Extension or AsdfExtension interface")
+            msg = "Extension must implement the Extension or AsdfExtension interface"
+            raise TypeError(msg)
 
         self._delegate = delegate
         self._package_name = package_name
@@ -153,7 +154,8 @@ class ExtensionProxy(Extension, AsdfExtension):
             if isinstance(class_name, str):
                 self._legacy_class_names.add(class_name)
             else:
-                raise TypeError("Extension property 'legacy_class_names' must contain str values")
+                msg = "Extension property 'legacy_class_names' must contain str values"
+                raise TypeError(msg)
 
         if self._legacy:
             self._legacy_class_names.add(self._class_name)
@@ -164,7 +166,8 @@ class ExtensionProxy(Extension, AsdfExtension):
         elif value is None:
             self._asdf_standard_requirement = SpecifierSet()
         else:
-            raise TypeError("Extension property 'asdf_standard_requirement' must be str or None")
+            msg = "Extension property 'asdf_standard_requirement' must be str or None"
+            raise TypeError(msg)
 
         self._tags = []
         for tag in getattr(self._delegate, "tags", []):
@@ -173,7 +176,8 @@ class ExtensionProxy(Extension, AsdfExtension):
             elif isinstance(tag, TagDefinition):
                 self._tags.append(tag)
             else:
-                raise TypeError("Extension property 'tags' must contain str or asdf.extension.TagDefinition values")
+                msg = "Extension property 'tags' must contain str or asdf.extension.TagDefinition values"
+                raise TypeError(msg)
 
         self._yaml_tag_handles = getattr(delegate, "yaml_tag_handles", {})
 
@@ -185,9 +189,8 @@ class ExtensionProxy(Extension, AsdfExtension):
         if hasattr(self._delegate, "compressors"):
             for compressor in self._delegate.compressors:
                 if not isinstance(compressor, Compressor):
-                    raise TypeError(
-                        "Extension property 'compressors' must contain instances of asdf.extension.Compressor"
-                    )
+                    msg = "Extension property 'compressors' must contain instances of asdf.extension.Compressor"
+                    raise TypeError(msg)
                 self._compressors.append(compressor)
 
     @property

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -124,9 +124,8 @@ class ExtensionManager:
         try:
             return self._tag_defs_by_tag[tag]
         except KeyError:
-            raise KeyError(
-                f"No support available for YAML tag '{tag}'.  You may need to install a missing extension."
-            ) from None
+            msg = f"No support available for YAML tag '{tag}'.  You may need to install a missing extension."
+            raise KeyError(msg) from None
 
     def get_converter_for_tag(self, tag):
         """
@@ -149,9 +148,8 @@ class ExtensionManager:
         try:
             return self._converters_by_tag[tag]
         except KeyError:
-            raise KeyError(
-                f"No support available for YAML tag '{tag}'.  You may need to install a missing extension."
-            ) from None
+            msg = f"No support available for YAML tag '{tag}'.  You may need to install a missing extension."
+            raise KeyError(msg) from None
 
     def get_converter_for_type(self, typ):
         """
@@ -177,10 +175,11 @@ class ExtensionManager:
             try:
                 return self._converters_by_type[class_name]
             except KeyError:
-                raise KeyError(
+                msg = (
                     f"No support available for Python type '{get_class_name(typ, instance=False)}'.  "
                     "You may need to install or enable an extension."
-                ) from None
+                )
+                raise KeyError(msg) from None
 
 
 def get_cached_extension_manager(extensions):

--- a/asdf/extension/_manifest.py
+++ b/asdf/extension/_manifest.py
@@ -109,5 +109,6 @@ class ManifestExtension(Extension):
                     )
                 )
             else:
-                raise TypeError("Malformed manifest document")
+                msg = "Malformed manifest document"
+                raise TypeError(msg)
         return result

--- a/asdf/extension/_tag.py
+++ b/asdf/extension/_tag.py
@@ -22,7 +22,8 @@ class TagDefinition:
 
     def __init__(self, tag_uri, *, schema_uris=None, title=None, description=None):
         if "*" in tag_uri:
-            raise ValueError("URI patterns are not permitted in TagDefinition")
+            msg = "URI patterns are not permitted in TagDefinition"
+            raise ValueError(msg)
 
         self._tag_uri = tag_uri
 
@@ -70,7 +71,8 @@ class TagDefinition:
         elif len(self._schema_uris) == 1:
             return self._schema_uris[0]
         else:
-            raise RuntimeError("Cannot use TagDefinition.schema_uri when multiple schema URIs are present")
+            msg = "Cannot use TagDefinition.schema_uri when multiple schema URIs are present"
+            raise RuntimeError(msg)
 
     @property
     def schema_uris(self):

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -11,7 +11,8 @@ from . import asdf, block, generic_io, util
 try:
     from astropy.io import fits
 except ImportError as err:
-    raise ImportError("AsdfInFits requires astropy") from err
+    msg = "AsdfInFits requires astropy"
+    raise ImportError(msg) from err
 
 
 ASDF_EXTENSION_NAME = "ASDF"
@@ -85,7 +86,8 @@ class _EmbeddedBlockManager(block.BlockManager):
                         return f"{FITS_SOURCE_PREFIX}{i}"
                     else:
                         return f"{FITS_SOURCE_PREFIX}{hdu.name},{hdu.ver}"
-            raise ValueError("FITS block seems to have been removed")
+            msg = "FITS block seems to have been removed"
+            raise ValueError(msg)
 
         return super().get_source(block)
 
@@ -305,7 +307,8 @@ class AsdfInFits(asdf.AsdfFile):
         self, all_array_storage=None, all_array_compression=None, pad_blocks=False, use_image_hdu=False, **kwargs
     ):
         if self.blocks.streamed_block is not None:
-            raise ValueError("Can not save streamed data to ASDF-in-FITS file.")
+            msg = "Can not save streamed data to ASDF-in-FITS file."
+            raise ValueError(msg)
 
         buff = io.BytesIO()
         super().write_to(
@@ -347,4 +350,5 @@ class AsdfInFits(asdf.AsdfFile):
         self._hdulist.writeto(filename, *args, **kwargs)
 
     def update(self, all_array_storage=None, all_array_compression=None, pad_blocks=False, **kwargs):
-        raise NotImplementedError("In-place update is not currently implemented for ASDF-in-FITS")
+        msg = "In-place update is not currently implemented for ASDF-in-FITS"
+        raise NotImplementedError(msg)

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -74,7 +74,8 @@ class _EmbeddedBlockManager(block.BlockManager):
                     pair = ver
                 return _FitsBlock(self._hdulist[pair])
             else:
-                raise ValueError(f"Can not parse source '{source}'")
+                msg = f"Can not parse source '{source}'"
+                raise ValueError(msg)
 
         return super().get_block(source)
 
@@ -259,7 +260,8 @@ class AsdfInFits(asdf.AsdfFile):
                 # responsible for cleaning up upon close() or __exit__
                 close_hdulist = True
             except OSError as err:
-                raise ValueError(f"Failed to parse given file '{uri}'. Is it FITS?") from err
+                msg = f"Failed to parse given file '{uri}'. Is it FITS?"
+                raise ValueError(msg) from err
 
         self = cls(
             hdulist,

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -68,7 +68,8 @@ def resolve_uri(base, uri):
     resolved = patched_urllib_parse.urljoin(base, uri)
     parsed = patched_urllib_parse.urlparse(resolved)
     if parsed.path != "" and not parsed.path.startswith("/"):
-        raise ValueError("Resolved to relative URL")
+        msg = "Resolved to relative URL"
+        raise ValueError(msg)
     return resolved
 
 
@@ -209,7 +210,8 @@ class GenericFile(metaclass=util.InheritDocstrings):
             sources.
         """
         if not _check_bytes(fd, mode):
-            raise ValueError("File-like object must be opened in binary mode.")
+            msg = "File-like object must be opened in binary mode."
+            raise ValueError(msg)
 
         # can't import at the top level due to circular import
         from .config import get_config
@@ -320,7 +322,8 @@ class GenericFile(metaclass=util.InheritDocstrings):
             Must be 1D contiguous.
         """
         if len(array.shape) != 1 or not array.flags.contiguous:
-            raise ValueError("Requires 1D contiguous array.")
+            msg = "Requires 1D contiguous array."
+            raise ValueError(msg)
 
         self.write(array.data)
 
@@ -342,7 +345,8 @@ class GenericFile(metaclass=util.InheritDocstrings):
             self.seek(cursor, SEEK_SET)
             return content
         else:
-            raise RuntimeError("Non-seekable file")
+            msg = "Non-seekable file"
+            raise RuntimeError(msg)
 
     def seek(self, offset, whence=0):
         """
@@ -744,7 +748,8 @@ class RealFile(RandomAccessFile):
             self.fast_forward(len(arr.data))
         else:
             if len(arr.shape) != 1 or not arr.flags.contiguous:
-                raise ValueError("Requires 1D contiguous array.")
+                msg = "Requires 1D contiguous array."
+                raise ValueError(msg)
 
             self._fd.write(arr.data)
 
@@ -862,7 +867,8 @@ class InputStream(GenericFile):
 
     def fast_forward(self, size):
         if size >= 0 and len(self.read(size)) != size:
-            raise OSError("Read past end of file")
+            msg = "Read past end of file"
+            raise OSError(msg)
 
     def read_into_array(self, size):
         try:
@@ -1014,7 +1020,8 @@ def get_file(init, mode="r", uri=None, close=False):
     ValueError, TypeError, IOError
     """
     if mode not in ("r", "w", "rw"):
-        raise ValueError("mode must be 'r', 'w' or 'rw'")
+        msg = "mode must be 'r', 'w' or 'rw'"
+        raise ValueError(msg)
 
     if init in (sys.__stdout__, sys.__stdin__, sys.__stderr__):
         init = os.fdopen(init.fileno(), init.mode + "b")
@@ -1028,7 +1035,8 @@ def get_file(init, mode="r", uri=None, close=False):
         parsed = patched_urllib_parse.urlparse(str(init))
         if parsed.scheme in ["http", "https"]:
             if "w" in mode:
-                raise ValueError("HTTP connections can not be opened for writing")
+                msg = "HTTP connections can not be opened for writing"
+                raise ValueError(msg)
             return _http_to_temp(init, mode, uri=uri)
         elif parsed.scheme in _local_file_schemes:
             if mode == "rw":
@@ -1054,7 +1062,8 @@ def get_file(init, mode="r", uri=None, close=False):
         return MemoryIO(init, mode, uri=uri)
 
     elif isinstance(init, io.StringIO):
-        raise TypeError("io.StringIO objects are not supported.  Use io.BytesIO instead.")
+        msg = "io.StringIO objects are not supported.  Use io.BytesIO instead."
+        raise TypeError(msg)
 
     elif isinstance(init, io.IOBase):
         if ("r" in mode and not init.readable()) or ("w" in mode and not init.writable()):

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -143,7 +143,8 @@ class _TruncatedReader:
 
         if content == b"":
             if self._exception:
-                raise DelimiterNotFoundError(f"{self._delimiter_name} not found")
+                msg = f"{self._delimiter_name} not found"
+                raise DelimiterNotFoundError(msg)
             self._past_end = True
             return content
 
@@ -157,7 +158,8 @@ class _TruncatedReader:
             self._past_end = True
         elif nbytes is None and self._exception:
             # Read the whole file and didn't find the delimiter
-            raise DelimiterNotFoundError(f"{self._delimiter_name} not found")
+            msg = f"{self._delimiter_name} not found"
+            raise DelimiterNotFoundError(msg)
         else:
             if nbytes:
                 content = content[: nbytes - len(self._initial_content)]
@@ -248,7 +250,8 @@ class GenericFile(metaclass=util.InheritDocstrings):
                 block_size = io.DEFAULT_BUFFER_SIZE
 
         if block_size <= 0:
-            raise ValueError(f"block_size ({block_size}) must be > 0")
+            msg = f"block_size ({block_size}) must be > 0"
+            raise ValueError(msg)
 
         self._blksize = block_size
 
@@ -618,20 +621,23 @@ class GenericFile(metaclass=util.InheritDocstrings):
         -------
         array : np.core.memmap
         """
-        raise NotImplementedError(f"memmapping is not implemented for {self.__class__.__name__}")
+        msg = f"memmapping is not implemented for {self.__class__.__name__}"
+        raise NotImplementedError(msg)
 
     def close_memmap(self):
         """
         Close the memmapped file (if one was mapped with memmap_array)
         """
-        raise NotImplementedError(f"memmapping is not implemented for {self.__class__.__name__}")
+        msg = f"memmapping is not implemented for {self.__class__.__name__}"
+        raise NotImplementedError(msg)
 
     def flush_memmap(self):
         """
         Flush any pending writes to the memmapped file (if one was mapped with
         memmap_array)
         """
-        raise NotImplementedError(f"memmapping is not implemented for {self.__class__.__name__}")
+        msg = f"memmapping is not implemented for {self.__class__.__name__}"
+        raise NotImplementedError(msg)
 
     def read_into_array(self, size):
         """
@@ -1028,7 +1034,8 @@ def get_file(init, mode="r", uri=None, close=False):
 
     if isinstance(init, (GenericFile, GenericWrapper)):
         if mode not in init.mode:
-            raise ValueError(f"File is opened as '{init.mode}', but '{mode}' was requested")
+            msg = f"File is opened as '{init.mode}', but '{mode}' was requested"
+            raise ValueError(msg)
         return GenericWrapper(init)
 
     elif isinstance(init, (str, pathlib.Path)):
@@ -1067,7 +1074,8 @@ def get_file(init, mode="r", uri=None, close=False):
 
     elif isinstance(init, io.IOBase):
         if ("r" in mode and not init.readable()) or ("w" in mode and not init.writable()):
-            raise ValueError(f"File is opened as '{init.mode}', but '{mode}' was requested")
+            msg = f"File is opened as '{init.mode}', but '{mode}' was requested"
+            raise ValueError(msg)
 
         if init.seekable():
             if hasattr(init, "raw"):
@@ -1086,7 +1094,8 @@ def get_file(init, mode="r", uri=None, close=False):
             elif mode == "r":
                 return InputStream(init, mode, uri=uri, close=close)
             else:
-                raise ValueError(f"File '{init}' could not be opened in 'rw' mode")
+                msg = f"File '{init}' could not be opened in 'rw' mode"
+                raise ValueError(msg)
 
     elif mode == "w" and (hasattr(init, "write") and hasattr(init, "seek") and hasattr(init, "tell")):
         return MemoryIO(init, mode, uri=uri)
@@ -1105,4 +1114,5 @@ def get_file(init, mode="r", uri=None, close=False):
     elif mode == "r" and hasattr(init, "read"):
         return InputStream(init, mode, uri=uri, close=close)
 
-    raise ValueError(f"Can't handle '{init}' as a file for mode '{mode}'")
+    msg = f"Can't handle '{init}' as a file for mode '{mode}'"
+    raise ValueError(msg)

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -36,7 +36,8 @@ def resolve_fragment(tree, pointer):
         try:
             tree = tree[part]
         except (TypeError, LookupError) as err:
-            raise ValueError(f"Unresolvable reference: '{pointer}'") from err
+            msg = f"Unresolvable reference: '{pointer}'"
+            raise ValueError(msg) from err
 
     return tree
 
@@ -86,7 +87,8 @@ class Reference(AsdfType):
         try:
             return getattr(self._get_target(), attr)
         except Exception as err:  # noqa: BLE001
-            raise AttributeError(f"No attribute '{attr}'") from err
+            msg = f"No attribute '{attr}'"
+            raise AttributeError(msg) from err
 
     def __getitem__(self, item):
         return self._get_target()[item]

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -167,7 +167,8 @@ def make_reference(asdffile, path):
     target = resolve_fragment(asdffile.tree, path_str)
 
     if asdffile.uri is None:
-        raise ValueError("Can not make a reference to a AsdfFile without an associated URI.")
+        msg = "Can not make a reference to a AsdfFile without an associated URI."
+        raise ValueError(msg)
     base_uri = util.get_base_uri(asdffile.uri)
     uri = base_uri + "#" + path_str
     return Reference(uri, target=target)

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -47,7 +47,8 @@ class Resolver:
         warnings.warn("The 'add_mapping' method is deprecated.", AsdfDeprecationWarning)
 
         if prefix != self._prefix:
-            raise ValueError(f"Prefix '{prefix}' does not match the Resolver prefix '{self._prefix}'")
+            msg = f"Prefix '{prefix}' does not match the Resolver prefix '{self._prefix}'"
+            raise ValueError(msg)
 
         self._mappings = self._mappings + self._validate_mappings(mappings)
 
@@ -83,7 +84,8 @@ class Resolver:
             ):
                 normalized.append(tuple(mapping))
             else:
-                raise ValueError(f"Invalid mapping '{mapping}'")
+                msg = f"Invalid mapping '{mapping}'"
+                raise ValueError(msg)
 
         return tuple(normalized)
 

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -42,7 +42,8 @@ class ResourceMappingProxy(Mapping):
 
     def __init__(self, delegate, package_name=None, package_version=None):
         if not isinstance(delegate, Mapping):
-            raise TypeError("Resource mapping must implement the Mapping interface")
+            msg = "Resource mapping must implement the Mapping interface"
+            raise TypeError(msg)
 
         self._delegate = delegate
         self._package_name = package_name

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -146,7 +146,8 @@ class ResourceManager(Mapping):
 
     def __getitem__(self, uri):
         if uri not in self._mappings_by_uri:
-            raise KeyError(f"Resource unavailable for URI: {uri}")
+            msg = f"Resource unavailable for URI: {uri}"
+            raise KeyError(msg)
 
         content = self._mappings_by_uri[uri][uri]
         if isinstance(content, str):

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -340,7 +340,8 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
 @lru_cache
 def _load_schema(url):
     if url.startswith("http://") or url.startswith("https://") or url.startswith("asdf://"):
-        raise FileNotFoundError(f"Unable to fetch schema from non-file URL: {url}")
+        msg = f"Unable to fetch schema from non-file URL: {url}"
+        raise FileNotFoundError(msg)
 
     with generic_io.get_file(url) as fd:
         if isinstance(url, str) and url.endswith("json"):
@@ -612,7 +613,8 @@ def _validate_large_literals(instance, reading):
                 AsdfWarning,
             )
         else:
-            raise ValidationError(f"Integer value {value} is too large to safely represent as a literal in ASDF")
+            msg = f"Integer value {value} is too large to safely represent as a literal in ASDF"
+            raise ValidationError(msg)
 
     if isinstance(instance, Integral):
         _validate(instance)
@@ -641,7 +643,8 @@ def _validate_mapping_keys(instance, reading):
                     AsdfWarning,
                 )
             else:
-                raise ValidationError(f"Mapping key {key} is not permitted.  Valid types: str, int, bool.")
+                msg = f"Mapping key {key} is not permitted.  Valid types: str, int, bool."
+                raise ValidationError(msg)
 
 
 def validate(instance, ctx=None, schema=None, validators=None, reading=False, *args, **kwargs):

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -159,7 +159,8 @@ class AsdfSearchResult:
             or isinstance(type_, typing.Pattern)
             or isinstance(type_, builtins.type)
         ):
-            raise TypeError("type must be NotSet, str, regular expression, or instance of builtins.type")
+            msg = "type must be NotSet, str, regular expression, or instance of builtins.type"
+            raise TypeError(msg)
 
         # value and key arguments can be anything, but pattern and str have special behavior
 
@@ -250,7 +251,8 @@ class AsdfSearchResult:
         elif len(results) == 1:
             return results[0]
         else:
-            raise RuntimeError("More than one result")
+            msg = "More than one result"
+            raise RuntimeError(msg)
 
     @property
     def path(self):
@@ -268,7 +270,8 @@ class AsdfSearchResult:
         elif len(results) == 1:
             return results[0]
         else:
-            raise RuntimeError("More than one result")
+            msg = "More than one result"
+            raise RuntimeError(msg)
 
     @property
     def nodes(self):
@@ -361,7 +364,8 @@ class AsdfSearchResult:
             else:
                 child = self._node[key]
         else:
-            raise TypeError("This node cannot be indexed")
+            msg = "This node cannot be indexed"
+            raise TypeError(msg)
 
         return AsdfSearchResult(
             self._identifiers + [key],
@@ -430,4 +434,5 @@ def _wrap_filter(filter_):
         elif arity == 2:
             return filter_
         else:
-            raise ValueError("filter must accept 1 or 2 arguments")
+            msg = "filter must accept 1 or 2 arguments"
+            raise ValueError(msg)

--- a/asdf/tagged.py
+++ b/asdf/tagged.py
@@ -138,7 +138,8 @@ def tag_object(tag, instance, ctx=None):
         try:
             instance = yamlutil.custom_tree_to_tagged_tree(instance, ctx)
         except TypeError as err:
-            raise TypeError(f"Don't know how to tag a {type(instance)}") from err
+            msg = f"Don't know how to tag a {type(instance)}"
+            raise TypeError(msg) from err
         instance._tag = tag
     return instance
 

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -50,7 +50,8 @@ class IntegerType(AsdfType):
 
     def __init__(self, value, storage_type="internal"):
         if storage_type not in ["internal", "inline"]:
-            raise ValueError(f"storage_type '{storage_type}' is not a recognized storage type")
+            msg = f"storage_type '{storage_type}' is not a recognized storage type"
+            raise ValueError(msg)
         self._value = value
         self._sign = "-" if value < 0 else "+"
         self._storage = storage_type
@@ -111,7 +112,8 @@ class IntegerType(AsdfType):
         elif isinstance(other, IntegerType):
             return self._value == other._value
         else:
-            raise ValueError(f"Can't compare IntegralType to unknown type: {type(other)}")
+            msg = f"Can't compare IntegralType to unknown type: {type(other)}"
+            raise ValueError(msg)
 
     def __repr__(self):
         return f"IntegerType({self._value})"

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -74,7 +74,8 @@ def asdf_datatype_to_numpy_dtype(datatype, byteorder=None):
             elif isinstance(np_dtype, np.dtype):
                 datatype_list.append(("", np_dtype))
             else:
-                raise RuntimeError("Error parsing asdf datatype")
+                msg = "Error parsing asdf datatype"
+                raise RuntimeError(msg)
         return np.dtype(datatype_list)
     raise ValueError(f"Unknown datatype {datatype}")
 
@@ -143,7 +144,8 @@ def inline_data_asarray(inline, dtype=None):
 
         def find_innermost_match(line, depth=0):
             if not isinstance(line, list) or not len(line):
-                raise ValueError("data can not be converted to structured array")
+                msg = "data can not be converted to structured array"
+                raise ValueError(msg)
             try:
                 np.asarray(tuple(line), dtype=dtype)
             except ValueError:
@@ -232,7 +234,8 @@ class NDArrayType(AsdfType):
                 if (shape[0] == "*" and self._array.shape[1:] != tuple(shape[1:])) or (
                     self._array.shape != tuple(shape)
                 ):
-                    raise ValueError("inline data doesn't match the given shape")
+                    msg = "inline data doesn't match the given shape"
+                    raise ValueError(msg)
 
         self._shape = shape
         self._dtype = dtype
@@ -312,7 +315,8 @@ class NDArrayType(AsdfType):
             return shape
         elif num_stars == 1:
             if shape[0] != "*":
-                raise ValueError("'*' may only be in first entry of shape")
+                msg = "'*' may only be in first entry of shape"
+                raise ValueError(msg)
             if strides is not None:
                 stride = strides[0]
             else:
@@ -385,7 +389,8 @@ class NDArrayType(AsdfType):
             source = node.get("source")
             data = node.get("data")
             if source and data:
-                raise ValueError("Both source and data may not be provided at the same time")
+                msg = "Both source and data may not be provided at the same time"
+                raise ValueError(msg)
             if data:
                 source = data
             shape = node.get("shape", None)
@@ -403,7 +408,8 @@ class NDArrayType(AsdfType):
 
             return cls(source, shape, dtype, offset, strides, "A", mask, ctx)
 
-        raise TypeError("Invalid ndarray description.")
+        msg = "Invalid ndarray description."
+        raise TypeError(msg)
 
     @classmethod
     def reserve_blocks(cls, data, ctx):
@@ -445,12 +451,13 @@ class NDArrayType(AsdfType):
                 or block.data.ctypes.data != data.ctypes.data
                 or block.data.strides != data.strides
             ):
-                raise ValueError(
+                msg = (
                     "ASDF has only limited support for serializing views over arrays stored "
                     "in FITS HDUs.  This error likely means that a slice of such an array "
                     "was found in the ASDF tree.  The slice can be decoupled from the FITS "
                     "array by calling copy() before assigning it to the tree."
                 )
+                raise ValueError(msg)
 
             offset = 0
             strides = None
@@ -513,7 +520,8 @@ class NDArrayType(AsdfType):
             if not new.dtype.fields:
                 # This line is safe because this is actually a piece of test
                 # code, even though it lives in this file:
-                raise AssertionError("arrays not equal")  # noqa: S101
+                msg = "arrays not equal"
+                raise AssertionError(msg)  # noqa: S101
             for a, b in zip(old, new):
                 cls._assert_equality(a, b, func)
         else:
@@ -676,11 +684,13 @@ def validate_datatype(validator, datatype, instance, schema):
             array = inline_data_asarray(instance["data"])
             in_datatype, _ = numpy_dtype_to_asdf_datatype(array.dtype)
         else:
-            raise ValidationError("Not an array")
+            msg = "Not an array"
+            raise ValidationError(msg)
     elif isinstance(instance, (np.ndarray, NDArrayType)):
         in_datatype, _ = numpy_dtype_to_asdf_datatype(instance.dtype)
     else:
-        raise ValidationError("Not an array")
+        msg = "Not an array"
+        raise ValidationError(msg)
 
     if datatype == in_datatype:
         return

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -33,7 +33,8 @@ def asdf_byteorder_to_numpy_byteorder(byteorder):
         return ">"
     elif byteorder == "little":
         return "<"
-    raise ValueError(f"Invalid ASDF byteorder '{byteorder}'")
+    msg = f"Invalid ASDF byteorder '{byteorder}'"
+    raise ValueError(msg)
 
 
 def asdf_datatype_to_numpy_dtype(datatype, byteorder=None):
@@ -56,7 +57,8 @@ def asdf_datatype_to_numpy_dtype(datatype, byteorder=None):
         return np.dtype(datatype)
     elif isinstance(datatype, dict):
         if "datatype" not in datatype:
-            raise ValueError(f"Field entry has no datatype: '{datatype}'")
+            msg = f"Field entry has no datatype: '{datatype}'"
+            raise ValueError(msg)
         name = datatype.get("name", "")
         byteorder = datatype.get("byteorder", byteorder)
         shape = datatype.get("shape")
@@ -77,7 +79,8 @@ def asdf_datatype_to_numpy_dtype(datatype, byteorder=None):
                 msg = "Error parsing asdf datatype"
                 raise RuntimeError(msg)
         return np.dtype(datatype_list)
-    raise ValueError(f"Unknown datatype {datatype}")
+    msg = f"Unknown datatype {datatype}"
+    raise ValueError(msg)
 
 
 def numpy_byteorder_to_asdf_byteorder(byteorder, override=None):
@@ -127,7 +130,8 @@ def numpy_dtype_to_asdf_datatype(dtype, include_byteorder=True, override_byteord
             numpy_byteorder_to_asdf_byteorder(dtype.byteorder, override=override_byteorder),
         )
 
-    raise ValueError(f"Unknown dtype {dtype}")
+    msg = f"Unknown dtype {dtype}"
+    raise ValueError(msg)
 
 
 def inline_data_asarray(inline, dtype=None):
@@ -323,7 +327,8 @@ class NDArrayType(AsdfType):
                 stride = np.product(shape[1:]) * dtype.itemsize
             missing = int(block_size / stride)
             return [missing] + shape[1:]
-        raise ValueError(f"Invalid shape '{shape}'")
+        msg = f"Invalid shape '{shape}'"
+        raise ValueError(msg)
 
     @property
     def block(self):
@@ -376,7 +381,8 @@ class NDArrayType(AsdfType):
         # libraries.
         # See https://github.com/asdf-format/asdf/issues/1015
         if name in ("name", "version", "supported_versions"):
-            raise AttributeError(f"'{self.__class__.name}' object has no attribute '{name}'")
+            msg = f"'{self.__class__.name}' object has no attribute '{name}'"
+            raise AttributeError(msg)
         else:
             return AsdfType.__getattribute__(self, name)
 

--- a/asdf/tests/test_entry_points.py
+++ b/asdf/tests/test_entry_points.py
@@ -39,7 +39,8 @@ def resource_mappings_entry_point_successful():
 
 
 def resource_mappings_entry_point_failing():
-    raise Exception("NOPE")
+    msg = "NOPE"
+    raise Exception(msg)
 
 
 def resource_mappings_entry_point_bad_element():
@@ -103,7 +104,8 @@ def extensions_entry_point_successful():
 
 
 def extensions_entry_point_failing():
-    raise Exception("NOPE")
+    msg = "NOPE"
+    raise Exception(msg)
 
 
 def extensions_entry_point_bad_element():

--- a/asdf/tests/test_helpers.py
+++ b/asdf/tests/test_helpers.py
@@ -15,7 +15,8 @@ def test_conversion_error(tmp_path):
 
         @classmethod
         def from_tree(cls, tree, ctx):
-            raise TypeError("This allows us to test the failure")
+            msg = "This allows us to test the failure"
+            raise TypeError(msg)
 
         @classmethod
         def to_tree(cls, node, ctx):

--- a/asdf/tests/test_info.py
+++ b/asdf/tests/test_info.py
@@ -79,11 +79,13 @@ class ObjectWithInfoSupport:
         for key in kw.keys():
             if re.search("^S_", key):
                 if type(kw[key]) != str:
-                    raise ValueError("S_ pattern object must be a string")
+                    msg = "S_ pattern object must be a string"
+                    raise ValueError(msg)
                 self.patt[key] = kw[key]
             if re.search("^I_", key):
                 if type(kw[key]) != int:
-                    raise ValueError("I_ pattern object must be an int")
+                    msg = "I_ pattern object must be an int"
+                    raise ValueError(msg)
                 self.patt[key] = kw[key]
 
     def __asdf_traverse__(self):

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -1081,11 +1081,10 @@ def test_numpy_scalar_type_validation(numpy_value, valid_types):
                 description = "valid"
             else:
                 description = "invalid"
-            raise AssertionError(
-                "Expected numpy.{} to be {} against jsonschema type '{}'".format(
-                    type(numpy_value).__name__, description, jsonschema_type
-                )
+            msg = "Expected numpy.{} to be {} against jsonschema type '{}'".format(
+                type(numpy_value).__name__, description, jsonschema_type
             )
+            raise AssertionError(msg)
 
     for jsonschema_type in valid_types:
         _assert_validation(jsonschema_type, True)

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -123,11 +123,12 @@ class _TreeModificationContext:
         duration of the context.
         """
         if id(node) in self._pending:
-            raise RuntimeError(
+            msg = (
                 "Unhandled cycle in tree.  This is possibly a bug "
                 "in extension code, which should be yielding "
                 "nodes that may contain reference cycles."
             )
+            raise RuntimeError(msg)
 
         self._pending.add(id(node))
         try:
@@ -185,7 +186,8 @@ class _TreeModificationContext:
             # modified node is being replaced, which is an
             # error because it breaks references within the
             # tree.
-            raise RuntimeError("Node already has an associated result")
+            msg = "Node already has an associated result"
+            raise RuntimeError(msg)
 
         self._map[id(node)] = (node, result)
 
@@ -265,7 +267,8 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
     """
     callback_arity = callback.__code__.co_argcount
     if callback_arity < 1 or callback_arity > 2:
-        raise ValueError("Expected callback to accept one or two arguments")
+        msg = "Expected callback to accept one or two arguments"
+        raise ValueError(msg)
 
     def _handle_generator(result):
         # If the result is a generator, generate one value to

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -219,7 +219,8 @@ class AsdfTypeIndex:
         elif asdftype.name is None:
             yaml_tags = []
         else:
-            raise TypeError("name must be a string, list or None")
+            msg = "name must be a string, list or None"
+            raise TypeError(msg)
 
         for yaml_tag in yaml_tags:
             self._type_by_tag[yaml_tag] = asdftype

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -53,7 +53,8 @@ class _AsdfWriteTypeIndex:
             core_version_map = version_map["core"]
             standard_version_map = version_map["standard"]
         except ValueError as err:
-            raise ValueError(f"Don't know how to write out ASDF version {self._version}") from err
+            msg = f"Don't know how to write out ASDF version {self._version}"
+            raise ValueError(msg) from err
 
         # Process all types defined in the ASDF version map. It is important to
         # make sure that tags that are associated with the core part of the

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -112,7 +112,8 @@ class ExtensionTypeMeta(type):
             elif isinstance(new_cls.name, list):
                 pass
             elif new_cls.name is not None:
-                raise TypeError("name must be string or list")
+                msg = "name must be string or list"
+                raise TypeError(msg)
 
         if hasattr(new_cls, "supported_versions"):
             if not isinstance(new_cls.supported_versions, (list, set)):
@@ -134,7 +135,7 @@ class ExtensionTypeMeta(type):
                     new_attrs["supported_versions"] = set()
                     new_attrs["_latest_version"] = new_cls.version
                     if "__classcell__" in new_attrs:
-                        raise RuntimeError(
+                        msg = (
                             "Subclasses of ExtensionTypeMeta that define "
                             "supported_versions cannot used super() to call "
                             "parent class functions. super() creates a "
@@ -142,6 +143,7 @@ class ExtensionTypeMeta(type):
                             "during creation of versioned siblings. "
                             "See https://github.com/asdf-format/asdf/issues/1245"
                         )
+                        raise RuntimeError(msg)
                     siblings.append(ExtensionTypeMeta.__new__(cls, name, bases, new_attrs))
             setattr(new_cls, "__versioned_siblings", siblings)  # noqa: B010
 

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -38,7 +38,8 @@ def _from_tree_tagged_missing_requirements(cls, tree, ctx):
     # This error will be handled by yamlutil.tagged_tree_to_custom_tree, which
     # will cause a warning to be issued indicating that the tree failed to be
     # converted.
-    raise TypeError(f"{util.human_list(cls.requires)} package{plural} {verb} required to instantiate '{tree._tag}'")
+    msg = f"{util.human_list(cls.requires)} package{plural} {verb} required to instantiate '{tree._tag}'"
+    raise TypeError(msg)
 
 
 class ExtensionTypeMeta(type):

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -195,7 +195,8 @@ class BinaryStruct:
         fields = [0] * len(self._names)
         for key, val in kwargs.items():
             if key not in self._offsets:
-                raise KeyError(f"No header field '{key}'")
+                msg = f"No header field '{key}'"
+                raise KeyError(msg)
             i = self._names.index(key)
             fields[i] = val
         return struct.pack(self._fmt, *fields)
@@ -224,7 +225,8 @@ class BinaryStruct:
         updates = []
         for key, val in kwargs.items():
             if key not in self._offsets:
-                raise KeyError(f"No header field '{key}'")
+                msg = f"No header field '{key}'"
+                raise KeyError(msg)
             updates.append((self._offsets[key], val))
         updates.sort()
 
@@ -369,11 +371,12 @@ def minversion(module, version, inclusive=True):
         except ImportError:
             return False
     else:
-        raise ValueError(
+        msg = (
             "module argument must be an actual imported "
             "module, or the import name of the module; "
             f"got {repr(module)}"
         )
+        raise ValueError(msg)
 
     if module_version is None:
         try:

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -175,23 +175,26 @@ class AsdfLoader(_yaml_base_loader):
         omap = OrderedDict()
         yield omap
         if not isinstance(node, yaml.SequenceNode):
+            msg = "while constructing an ordered map"
             raise yaml.ConstructorError(
-                "while constructing an ordered map",
+                msg,
                 node.start_mark,
                 "expected a sequence, but found %s" % node.id,
                 node.start_mark,
             )
         for subnode in node.value:
             if not isinstance(subnode, yaml.MappingNode):
+                msg = "while constructing an ordered map"
                 raise yaml.ConstructorError(
-                    "while constructing an ordered map",
+                    msg,
                     node.start_mark,
                     f"expected a mapping of length 1, but found {subnode.id}",
                     subnode.start_mark,
                 )
             if len(subnode.value) != 1:
+                msg = "while constructing an ordered map"
                 raise yaml.ConstructorError(
-                    "while constructing an ordered map",
+                    msg,
                     node.start_mark,
                     f"expected a single mapping item, but found {len(subnode.value): %d} items",
                     subnode.start_mark,
@@ -380,7 +383,8 @@ def dump_tree(tree, fd, ctx, tree_finalizer=None, _serialization_context=None):
     # types.  In 3.0, it will be passed as the `ctx` instead of the
     # AsdfFile itself.
     if type(tree) is not AsdfObject:
-        raise TypeError("Root node of ASDF tree must be of type AsdfObject")
+        msg = "Root node of ASDF tree must be of type AsdfObject"
+        raise TypeError(msg)
 
     tags = {"!": STSCI_SCHEMA_TAG_BASE + "/"}
     tree = custom_tree_to_tagged_tree(tree, ctx, _serialization_context=_serialization_context)

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -241,7 +241,8 @@ def custom_tree_to_tagged_tree(tree, ctx, _serialization_context=None):
             tagged_node = tagged.TaggedString(node)
             tagged_node._tag = tag
         else:
-            raise TypeError(f"Converter returned illegal node type: {util.get_class_name(node)}")
+            msg = f"Converter returned illegal node type: {util.get_class_name(node)}"
+            raise TypeError(msg)
 
         _serialization_context._mark_extension_used(converter.extension)
 

--- a/compatibility_tests/common.py
+++ b/compatibility_tests/common.py
@@ -6,11 +6,10 @@ from asdf.versioning import supported_versions
 
 def generate_file(path, version):
     if version not in supported_versions:
-        raise ValueError(
-            "ASDF Standard version {} is not supported by version {} of the asdf library".format(
-                version, asdf.__version__
-            )
+        msg = "ASDF Standard version {} is not supported by version {} of the asdf library".format(
+            version, asdf.__version__
         )
+        raise ValueError(msg)
 
     af = asdf.AsdfFile({"array": np.ones((8, 16))}, version=version)
     af.write_to(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,6 @@ select = [
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
-    "EM102", # Exception must not use an f-string literal, assign to variable first
     "EM103", #Exception must not use a `.format()` string directly, assign to variable first
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,9 +185,14 @@ select = [
     "B", # flake8-bugbear
     "A", # flake8-builtins
     "C4", # flake8-comprehensions
+    "T10", # flake8-debugger
+    "EM", # flake8-errmsg
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
+    "EM101", # Exception must not use a string literal, assign to variable first
+    "EM102", # Exception must not use an f-string literal, assign to variable first
+    "EM103", #Exception must not use a `.format()` string directly, assign to variable first
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,6 @@ select = [
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
-    "EM101", # Exception must not use a string literal, assign to variable first
     "EM102", # Exception must not use an f-string literal, assign to variable first
     "EM103", #Exception must not use a `.format()` string directly, assign to variable first
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,6 @@ select = [
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
-    "EM103", #Exception must not use a `.format()` string directly, assign to variable first
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -176,7 +176,8 @@ class SchemaExample:
             _version = example[1]
             _other = example[3:] if len(example) > 3 else None
         else:
-            raise RuntimeError("Invalid example")
+            msg = "Invalid example"
+            raise RuntimeError(msg)
 
         return cls(_description, _example, _version, _other)
 


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1305.

It enables `ruff` to explicitly checks:
- `flake8-errmsg` 
- flake8-debugger` (no changes required)