### PR TITLE
Add `flake8-import-conventions` check to `ruff`

### DIFF
--- a/asdf/tests/test_util.py
+++ b/asdf/tests/test_util.py
@@ -102,16 +102,16 @@ def test_get_file_type(content, expected_type):
 
 
 def test_minversion():
-    import numpy
+    import numpy as np
     import yaml
 
     good_versions = ["1.16", "1.16.1", "1.16.0.dev", "1.16dev"]
     bad_versions = ["100000", "100000.2rc1"]
     for version in good_versions:
-        assert util.minversion(numpy, version)
+        assert util.minversion(np, version)
         assert util.minversion("numpy", version)
     for version in bad_versions:
-        assert not util.minversion(numpy, version)
+        assert not util.minversion(np, version)
         assert not util.minversion("numpy", version)
 
     assert util.minversion(yaml, "3.1")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ select = [
     "T10", # flake8-debugger
     "EM", # flake8-errmsg
     "ISC", # flake8-implicit-str-concat
+    "ICN", # flake8-import-conventions
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1307.

It enables `ruff` to explicitly check `flake8-import-conventions` style checks.