### PR TITLE
Add `flake8-print` check to `ruff`

### DIFF
--- a/asdf/_convenience.py
+++ b/asdf/_convenience.py
@@ -41,7 +41,7 @@ def info(node_or_path, max_rows=DEFAULT_MAX_ROWS, max_cols=DEFAULT_MAX_COLS, sho
     """
     with _manage_node(node_or_path) as node:
         lines = render_tree(node, max_rows=max_rows, max_cols=max_cols, show_values=show_values, identifier="root")
-        print("\n".join(lines))
+        print("\n".join(lines))  # noqa: T201
 
 
 @contextmanager

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1623,7 +1623,7 @@ class AsdfFile:
             identifier="root",
             refresh_extension_manager=refresh_extension_manager,
         )
-        print("\n".join(lines))
+        print("\n".join(lines))  # noqa: T201
 
     def search(self, key=NotSet, type_=NotSet, value=NotSet, filter_=None):
         """

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -190,7 +190,7 @@ def edit(path):
     # Extract the YAML portion of the original file:
     with generic_io.get_file(path, mode="r") as fd:
         if util.get_file_type(fd) != util.FileType.ASDF:
-            print(f"Error: '{path}' is not an ASDF file.")
+            print(f"Error: '{path}' is not an ASDF file.")  # noqa: T201
             return 1
 
         original_content, available_bytes, contains_blocks = read_yaml(fd)
@@ -216,14 +216,14 @@ def edit(path):
                 new_content = f.read()
 
             if new_content == original_content:
-                print("No changes made to file")
+                print("No changes made to file")  # noqa: T201
                 return 0
 
             try:
                 new_asdf_version = parse_asdf_version(new_content)
                 new_yaml_version = parse_yaml_version(new_content)
             except Exception as e:  # noqa: BLE001
-                print(f"Error: failed to parse ASDF header: {str(e)}")
+                print(f"Error: failed to parse ASDF header: {str(e)}")  # noqa: T201
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
                     return 1
@@ -231,7 +231,7 @@ def edit(path):
                     continue
 
             if new_asdf_version != original_asdf_version or new_yaml_version != original_yaml_version:
-                print("Error: cannot modify ASDF Standard or YAML version using this tool.")
+                print("Error: cannot modify ASDF Standard or YAML version using this tool.")  # noqa: T201
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
                     return 1
@@ -245,7 +245,7 @@ def edit(path):
                 with open_asdf(io.BytesIO(new_content), _force_raw_types=True):
                     pass
             except yaml.YAMLError as e:
-                print("Error: failed to parse updated YAML:")
+                print("Error: failed to parse updated YAML:")  # noqa: T201
                 print_exception(e)
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
@@ -253,7 +253,7 @@ def edit(path):
                 else:
                     continue
             except schema.ValidationError as e:
-                print("Warning: updated ASDF tree failed validation:")
+                print("Warning: updated ASDF tree failed validation:")  # noqa: T201
                 print_exception(e)
                 choice = request_input("(c)ontinue editing, (f)orce update, or (a)bort? ", ["c", "f", "a"])
                 if choice == "a":
@@ -261,7 +261,7 @@ def edit(path):
                 elif choice == "c":
                     continue
             except Exception as e:  # noqa: BLE001
-                print("Error: failed to read updated file as ASDF:")
+                print("Error: failed to read updated file as ASDF:")  # noqa: T201
                 print_exception(e)
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
@@ -287,7 +287,7 @@ def edit(path):
     else:
         # File does not have sufficient space, and binary blocks
         # are present.
-        print("Warning: updated YAML larger than allocated space.  File must be rewritten.")
+        print("Warning: updated YAML larger than allocated space.  File must be rewritten.")  # noqa: T201
         choice = request_input("(c)ontinue or (a)bort? ", ["c", "a"])
         if choice == "a":
             return 1
@@ -340,7 +340,7 @@ def print_exception(e):
     if len(lines) > 20:
         lines = lines[0:20] + ["..."]
     for line in lines:
-        print(f"    {line}")
+        print(f"    {line}")  # noqa: T201
 
 
 def request_input(message, choices):
@@ -360,7 +360,7 @@ def request_input(message, choices):
         if choice in choices:
             return choice
         else:
-            print(f"Invalid choice: {choice}")
+            print(f"Invalid choice: {choice}")  # noqa: T201
 
 
 def open_editor(path):

--- a/asdf/commands/extension.py
+++ b/asdf/commands/extension.py
@@ -63,9 +63,9 @@ def _print_extension_details(ext, tags_only):
             tag_uris.append(typ.make_yaml_tag(typ.name))
 
     if len(tag_uris) > 0:
-        print("tags:")
+        print("tags:")  # noqa: T201
         for tag_uri in sorted(tag_uris):
-            print(f"  - {tag_uri}")
+            print(f"  - {tag_uri}")  # noqa: T201
 
     if not tags_only:
         types = []
@@ -76,14 +76,14 @@ def _print_extension_details(ext, tags_only):
             types.extend(typ.types)
 
         if len(types) > 0:
-            print("types:")
+            print("types:")  # noqa: T201
             for typ in sorted(types, key=_format_type_name):
-                print(f"  - {_format_type_name(typ)}")
+                print(f"  - {_format_type_name(typ)}")  # noqa: T201
 
 
 def find_extensions(summary, tags_only):
     for ext in get_extensions():
-        print(_format_extension(ext))
+        print(_format_extension(ext))  # noqa: T201
         if not summary:
             _print_extension_details(ext, tags_only)
-            print()
+            print()  # noqa: T201

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -288,8 +288,6 @@ def test_mask_roundtrip(tmpdir):
 
         m = tree["masked_array"]
 
-        print(m)
-        print(m.mask)
         assert np.all(m.mask[6:])
         assert len(asdf.blocks) == 2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ select = [
     "EM", # flake8-errmsg
     "ISC", # flake8-implicit-str-concat
     "ICN", # flake8-import-conventions
+    "T20", # flake8-print
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -250,7 +250,7 @@ class AsdfSchemaExampleItem(pytest.Item):
 
                 ff._open_impl(ff, buff, mode="rw")
         except Exception:
-            print(f"Example: {self.example.description}\n From file: {self.filename}")
+            print(f"Example: {self.example.description}\n From file: {self.filename}")  # noqa: T201
             raise
 
         # Just test we can write it out.  A roundtrip test


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1308.

It enables `ruff` to explicitly check `flake8-print` style checks.