### PR TITLE
Add `flake8-tidy-imports` check for `ruff`

### DIFF
--- a/asdf/commands/defragment.py
+++ b/asdf/commands/defragment.py
@@ -3,8 +3,8 @@ Defragment command.
 """
 
 import asdf
+from asdf import AsdfFile
 
-from .. import AsdfFile
 from .main import Command
 
 __all__ = ["defragment"]

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -30,10 +30,10 @@ except ImportError:
         RESET = ""
 
 import asdf
+from asdf.tagged import Tagged
+from asdf.tags.core.ndarray import NDArrayType
+from asdf.util import human_list
 
-from ..tagged import Tagged
-from ..tags.core.ndarray import NDArrayType
-from ..util import human_list
 from .main import Command
 
 __all__ = ["diff"]

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -15,9 +15,10 @@ import tempfile
 
 import yaml
 
-from .. import constants, generic_io, schema, util
-from ..asdf import AsdfFile, open_asdf
-from ..block import BlockManager
+from asdf import constants, generic_io, schema, util
+from asdf.asdf import AsdfFile, open_asdf
+from asdf.block import BlockManager
+
 from .main import Command
 
 __all__ = ["edit"]

--- a/asdf/commands/exploded.py
+++ b/asdf/commands/exploded.py
@@ -6,8 +6,8 @@ Contains commands for dealing with exploded and imploded forms.
 import os
 
 import asdf
+from asdf import AsdfFile
 
-from .. import AsdfFile
 from .main import Command
 
 __all__ = ["implode", "explode"]

--- a/asdf/commands/extension.py
+++ b/asdf/commands/extension.py
@@ -1,7 +1,8 @@
 """
 Implementation of command for reporting information about installed extensions.
 """
-from ..entry_points import get_extensions
+from asdf.entry_points import get_extensions
+
 from .main import Command
 
 __all__ = ["find_extensions"]

--- a/asdf/commands/info.py
+++ b/asdf/commands/info.py
@@ -2,7 +2,8 @@
 Commands for displaying summaries of ASDF trees
 """
 
-from .. import _convenience as convenience
+from asdf import _convenience as convenience
+
 from .main import Command
 
 __all__ = ["info"]

--- a/asdf/commands/main.py
+++ b/asdf/commands/main.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 
-from .. import util
+from asdf import util
 
 # This list is ordered in order of average workflow
 command_order = ["Explode", "Implode"]

--- a/asdf/commands/tags.py
+++ b/asdf/commands/tags.py
@@ -5,7 +5,8 @@ Implementation of command for displaying available tags in asdf
 
 import sys
 
-from .. import AsdfFile
+from asdf import AsdfFile
+
 from .main import Command
 
 __all__ = ["list_tags"]

--- a/asdf/commands/tests/test_exploded.py
+++ b/asdf/commands/tests/test_exploded.py
@@ -5,8 +5,7 @@ import numpy as np
 import asdf
 from asdf import AsdfFile
 from asdf.commands import main
-
-from ...tests.helpers import assert_tree_match, get_file_sizes
+from asdf.tests.helpers import assert_tree_match, get_file_sizes
 
 
 def test_explode_then_implode(tmpdir):

--- a/asdf/commands/tests/test_extension.py
+++ b/asdf/commands/tests/test_extension.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .. import find_extensions
+from asdf.commands import find_extensions
 
 
 @pytest.mark.parametrize("summary", [True, False])

--- a/asdf/commands/tests/test_extract.py
+++ b/asdf/commands/tests/test_extract.py
@@ -4,10 +4,9 @@ import numpy as np
 from astropy.io.fits import HDUList, ImageHDU
 
 import asdf
+from asdf.commands import extract
 from asdf.fits_embed import AsdfInFits
 from asdf.tests.helpers import assert_tree_match
-
-from .. import extract
 
 
 def test_extract(tmpdir):

--- a/asdf/commands/tests/test_info.py
+++ b/asdf/commands/tests/test_info.py
@@ -2,8 +2,9 @@ from functools import partial
 
 import pytest
 
-from ...tests import helpers
-from .. import main
+from asdf.commands import main
+from asdf.tests import helpers
+
 from . import data as test_data
 
 get_test_data_path = partial(helpers.get_test_data_path, module=test_data)

--- a/asdf/commands/tests/test_main.py
+++ b/asdf/commands/tests/test_main.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .. import main
+from asdf.commands import main
 
 
 def test_help():

--- a/asdf/commands/tests/test_remove_hdu.py
+++ b/asdf/commands/tests/test_remove_hdu.py
@@ -3,9 +3,8 @@ import os
 import numpy as np
 from astropy.io import fits
 
+from asdf.commands import remove_hdu
 from asdf.fits_embed import AsdfInFits
-
-from .. import remove_hdu
 
 
 def test_remove_hdu(tmpdir):

--- a/asdf/commands/tests/test_tags.py
+++ b/asdf/commands/tests/test_tags.py
@@ -2,8 +2,8 @@ import io
 
 import pytest
 
-from ... import AsdfFile
-from .. import list_tags
+from asdf import AsdfFile
+from asdf.commands import list_tags
 
 
 @pytest.mark.parametrize("display_classes", [True, False])

--- a/asdf/commands/tests/test_to_yaml.py
+++ b/asdf/commands/tests/test_to_yaml.py
@@ -3,10 +3,9 @@ import os
 import numpy as np
 
 import asdf
-
-from ... import AsdfFile
-from ...tests.helpers import assert_tree_match, get_file_sizes
-from .. import main
+from asdf import AsdfFile
+from asdf.commands import main
+from asdf.tests.helpers import assert_tree_match, get_file_sizes
 
 
 def test_to_yaml(tmpdir):

--- a/asdf/commands/to_yaml.py
+++ b/asdf/commands/to_yaml.py
@@ -6,8 +6,8 @@ Contains commands for dealing with exploded and imploded forms.
 import os
 
 import asdf
+from asdf import AsdfFile
 
-from .. import AsdfFile
 from .main import Command
 
 __all__ = ["to_yaml"]

--- a/asdf/compat/numpycompat.py
+++ b/asdf/compat/numpycompat.py
@@ -1,4 +1,4 @@
-from ..util import minversion
+from asdf.util import minversion
 
 __all__ = ["NUMPY_LT_1_7", "NUMPY_LT_1_14"]
 

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -4,7 +4,7 @@ types.  Will eventually replace the `asdf.types` module.
 """
 import abc
 
-from ..util import get_class_name, uri_match
+from asdf.util import get_class_name, uri_match
 
 
 class Converter(abc.ABC):

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -2,7 +2,8 @@ import abc
 
 from packaging.specifiers import SpecifierSet
 
-from ..util import get_class_name
+from asdf.util import get_class_name
+
 from ._compressor import Compressor
 from ._converter import ConverterProxy
 from ._legacy import AsdfExtension

--- a/asdf/extension/_legacy.py
+++ b/asdf/extension/_legacy.py
@@ -2,9 +2,9 @@ import abc
 import warnings
 from functools import lru_cache
 
-from .. import resolver, types
-from ..exceptions import AsdfDeprecationWarning
-from ..type_index import AsdfTypeIndex
+from asdf import resolver, types
+from asdf.exceptions import AsdfDeprecationWarning
+from asdf.type_index import AsdfTypeIndex
 
 __all__ = ["AsdfExtension"]
 
@@ -221,7 +221,7 @@ class BuiltinExtension:
 class _DefaultExtensions:
     @property
     def extensions(self):
-        from ..config import get_config
+        from asdf.config import get_config
 
         return [e for e in get_config().extensions if e.legacy]
 
@@ -237,7 +237,7 @@ class _DefaultExtensions:
 
     def reset(self):
         """This will be used primarily for testing purposes."""
-        from ..config import get_config
+        from asdf.config import get_config
 
         get_config().reset_extensions()
 

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 
-from ..util import get_class_name
+from asdf.util import get_class_name
+
 from ._extension import ExtensionProxy
 
 

--- a/asdf/extension/_manifest.py
+++ b/asdf/extension/_manifest.py
@@ -38,7 +38,7 @@ class ManifestExtension(Extension):
 
         See the class docstring for details on keyword parameters.
         """
-        from ..config import get_config
+        from asdf.config import get_config
 
         manifest = yaml.safe_load(get_config().resource_manager[manifest_uri])
         return cls(manifest, **kwargs)

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -1,4 +1,5 @@
-from ...types import AsdfType
+from asdf.types import AsdfType
+
 from .complex import ComplexType
 from .constant import ConstantType
 from .external_reference import ExternalArrayReference

--- a/asdf/tags/core/complex.py
+++ b/asdf/tags/core/complex.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from ... import util
-from ...types import AsdfType
+from asdf import util
+from asdf.types import AsdfType
 
 
 class ComplexType(AsdfType):

--- a/asdf/tags/core/constant.py
+++ b/asdf/tags/core/constant.py
@@ -1,4 +1,4 @@
-from ...types import AsdfType
+from asdf.types import AsdfType
 
 
 class Constant:

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -1,4 +1,4 @@
-from ...types import AsdfType
+from asdf.types import AsdfType
 
 
 class ExternalArrayReference(AsdfType):

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -2,7 +2,7 @@ from numbers import Integral
 
 import numpy as np
 
-from ...types import AsdfType
+from asdf.types import AsdfType
 
 
 class IntegerType(AsdfType):

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -5,8 +5,8 @@ import numpy as np
 from jsonschema import ValidationError
 from numpy import ma
 
-from ... import util
-from ...types import AsdfType
+from asdf import util
+from asdf.types import AsdfType
 
 _datatype_names = {
     "int8": "i1",

--- a/asdf/tests/__init__.py
+++ b/asdf/tests/__init__.py
@@ -4,7 +4,8 @@ This packages contains affiliated package tests.
 
 import numpy as np
 
-from .. import CustomType, util
+from asdf import CustomType, util
+
 from .helpers import get_test_data_path
 
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -22,22 +22,22 @@ except ImportError:
 import yaml
 
 import asdf
-
-from .. import generic_io, versioning
-from ..asdf import AsdfFile, get_asdf_library_info
-from ..block import Block
-from ..constants import YAML_TAG_PREFIX
-from ..exceptions import AsdfConversionWarning
-from ..extension import default_extensions
-from ..resolver import Resolver, ResolverChain
-from ..tags.core import AsdfObject
-from ..versioning import (
+from asdf import generic_io, versioning
+from asdf.asdf import AsdfFile, get_asdf_library_info
+from asdf.block import Block
+from asdf.constants import YAML_TAG_PREFIX
+from asdf.exceptions import AsdfConversionWarning
+from asdf.extension import default_extensions
+from asdf.resolver import Resolver, ResolverChain
+from asdf.tags.core import AsdfObject
+from asdf.versioning import (
     AsdfVersion,
     asdf_standard_development_version,
     get_version_map,
     split_tag_version,
     supported_versions,
 )
+
 from .httpserver import RangeHTTPServer
 
 try:

--- a/asdf/tests/httpserver.py
+++ b/asdf/tests/httpserver.py
@@ -6,7 +6,7 @@ import socketserver
 import tempfile
 import threading
 
-from ..extern.RangeHTTPServer import RangeHTTPRequestHandler
+from asdf.extern.RangeHTTPServer import RangeHTTPRequestHandler
 
 __all__ = ["HTTPServer", "RangeHTTPServer"]
 

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -8,8 +8,7 @@ import pytest
 import asdf
 from asdf import compression, config_context, generic_io
 from asdf.extension import Compressor, Extension
-
-from ..tests import helpers
+from asdf.tests import helpers
 
 
 def _get_large_tree():

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -51,7 +51,7 @@ def test_mode_fail(tmp_path):
 
 
 def test_open(tmp_path, small_tree):
-    from .. import open
+    from asdf import open
 
     path = os.path.join(str(tmp_path), "test.asdf")
 

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -242,7 +242,7 @@ flow_thing:
 
 
 def test_versioned_writing(monkeypatch):
-    from ..tags.core.complex import ComplexType
+    from asdf.tags.core.complex import ComplexType
 
     # Create a bogus version map
     monkeypatch.setitem(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,6 @@ select = [
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
-    "TID252", # Relative imports from parent modules are banned
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,10 +194,12 @@ select = [
     "Q", # flake8-quotes
     "RET", # flake8-return
     "SIM", # flake8-simplify
+    "TID", # flake8-tidy-imports
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
+    "TID252", # Relative imports from parent modules are banned
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1312.

It enables `ruff` to explicitly check `flake8-tidy-imports` style checks.