### PR TITLE
Add `eradicate` check for `ruff`

### DIFF
--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -285,7 +285,6 @@ class NDArrayType(AsdfType):
             # memmapped mask array is freed properly when the masked
             # array goes away.
             array = ma.array(array, mask=mask.view())
-            # assert util.get_array_base(array.mask) is util.get_array_base(mask)
             return array
 
         if np.isscalar(mask):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,9 @@ select = [
     "RET", # flake8-return
     "SIM", # flake8-simplify
     "TID", # flake8-tidy-imports
+    # "ARG", # flake8-unused-arguments
+    # "DTZ", # flake8-datetimez
+    "ERA", # eradicate
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1313.

It enables `ruff` to explicitly check `eradicate` style checks.