### PR TITLE
Add `pylint` check for `ruff`

### DIFF
--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -229,10 +229,11 @@ class _TreeRenderer:
         prefix = self._make_prefix(info.depth, active_depths, is_tail)
         value = self._render_node_value(info)
 
-        if isinstance(info.parent_node, list) or isinstance(info.parent_node, tuple):
-            line = f"{prefix}[{format_bold(info.identifier)}] {value}"
-        else:
-            line = f"{prefix}{format_bold(info.identifier)} {value}"
+        line = (
+            f"{prefix}[{format_bold(info.identifier)}] {value}"
+            if isinstance(info.parent_node, (list, tuple))
+            else f"{prefix}{format_bold(info.identifier)} {value}"
+        )
 
         if info.info is not None:
             line = line + format_faint(format_italic(" # " + info.info))
@@ -254,7 +255,7 @@ class _TreeRenderer:
         if is_primitive(info.node) and self._show_values:
             return f"({rendered_type}): {info.node}"
 
-        if isinstance(info.node, NDArrayType) or isinstance(info.node, np.ndarray):
+        if isinstance(info.node, (NDArrayType, np.ndarray)):
             return f"({rendered_type}): shape={info.node.shape}, dtype={info.node.dtype.name}"
 
         return f"({rendered_type})"

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -302,7 +302,7 @@ class NodeSchemaInfo:
         preserve_list : bool
             If True, then lists are preserved. Otherwise, they are turned into dicts.
         """
-        if preserve_list and (isinstance(self.node, list) or isinstance(self.node, tuple)) and self.info is None:
+        if preserve_list and isinstance(self.node, (list, tuple)) and self.info is None:
             info = [c_info for child in self.visible_children if len(c_info := child.collect_info(preserve_list)) > 0]
         else:
             info = {

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -351,12 +351,7 @@ class AsdfSearchResult:
         )
 
     def __getitem__(self, key):
-        if (
-            isinstance(self._node, dict)
-            or isinstance(self._node, list)
-            or isinstance(self._node, tuple)
-            or NodeSchemaInfo.traversable(self._node)
-        ):
+        if isinstance(self._node, (dict, list, tuple)) or NodeSchemaInfo.traversable(self._node):
             child = self._node.__asdf_traverse__()[key] if NodeSchemaInfo.traversable(self._node) else self._node[key]
         else:
             msg = "This node cannot be indexed"

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -83,7 +83,7 @@ def test_validate_on_read():
 def test_default_version():
     with asdf.config_context() as config:
         assert config.default_version == asdf.config.DEFAULT_DEFAULT_VERSION
-        assert "1.2.0" != asdf.config.DEFAULT_DEFAULT_VERSION
+        assert asdf.config.DEFAULT_DEFAULT_VERSION != "1.2.0"
         config.default_version = "1.2.0"
         assert config.default_version == "1.2.0"
         with pytest.raises(ValueError):

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -111,25 +111,25 @@ def test_version_and_string_inequality():
     assert version <= "2.1.0"
     assert version <= "2.1.1"
 
-    assert "1.0.0" < version
-    assert "1.0.1" < version
-    assert "1.1.0" < version
-    assert "1.1.1" < version
-    assert ("2.0.0" < version) is False
-    assert ("2.0.0" > version) is False
-    assert "2.0.1" > version
-    assert "2.1.0" > version
-    assert "2.1.1" > version
+    assert "1.0.0" < version  # noqa: PLC2201
+    assert "1.0.1" < version  # noqa: PLC2201
+    assert "1.1.0" < version  # noqa: PLC2201
+    assert "1.1.1" < version  # noqa: PLC2201
+    assert ("2.0.0" < version) is False  # noqa: PLC2201
+    assert ("2.0.0" > version) is False  # noqa: PLC2201
+    assert "2.0.1" > version  # noqa: PLC2201
+    assert "2.1.0" > version  # noqa: PLC2201
+    assert "2.1.1" > version  # noqa: PLC2201
 
-    assert "1.0.0" <= version
-    assert "1.0.1" <= version
-    assert "1.1.0" <= version
-    assert "1.1.1" <= version
-    assert "2.0.0" <= version
-    assert "2.0.0" >= version
-    assert "2.0.1" >= version
-    assert "2.1.0" >= version
-    assert "2.1.1" >= version
+    assert "1.0.0" <= version  # noqa: PLC2201
+    assert "1.0.1" <= version  # noqa: PLC2201
+    assert "1.1.0" <= version  # noqa: PLC2201
+    assert "1.1.1" <= version  # noqa: PLC2201
+    assert "2.0.0" <= version  # noqa: PLC2201
+    assert "2.0.0" >= version  # noqa: PLC2201
+    assert "2.0.1" >= version  # noqa: PLC2201
+    assert "2.1.0" >= version  # noqa: PLC2201
+    assert "2.1.1" >= version  # noqa: PLC2201
 
 
 def test_version_and_tuple_inequality():
@@ -266,9 +266,9 @@ def test_spec_equal():
     assert version1 == spec
 
     assert spec != "1.1.0"
-    assert "1.1.0" != spec
+    assert "1.1.0" != spec  # noqa: PLC2201
     assert spec == "1.3.0"
-    assert "1.3.0" == spec  # noqa: SIM300
+    assert "1.3.0" == spec  # noqa: PLC2201, SIM300
 
     assert spec != (1, 1, 0)
     assert (1, 1, 0) != spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,10 +198,17 @@ select = [
     # "ARG", # flake8-unused-arguments
     # "DTZ", # flake8-datetimez
     "ERA", # eradicate
+    "PD", # pandas-vet
+    "PGH", # pygrep-hooks
+    "PLC", "PLE", "PLR", "PLW", # Pylint
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
+    "PLR1701", # Merge these isinstance calls
+    "PLR2004", # Magic value used in comparison
+    "PLC2201", # Comparison should be variable then constant
+    "PLR0402", # Use from instead of alias
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,6 @@ extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
-    "PLR0402", # Use from instead of alias
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,6 @@ select = [
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
-    "PLR1701", # Merge these isinstance calls
     "PLR2004", # Magic value used in comparison
     "PLC2201", # Comparison should be variable then constant
     "PLR0402", # Use from instead of alias

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,6 @@ extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
-    "PLC2201", # Comparison should be variable then constant
     "PLR0402", # Use from instead of alias
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -182,7 +182,7 @@ class SchemaExample:
 
     @property
     def version(self):
-        import asdf.versioning as versioning
+        from asdf import versioning
 
         if self._version is None:
             return versioning.default_version


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1314.

It enables `ruff` to explicitly checks:
 - `pandas-vet` (no changes)
- `pygrep-hooks` (no changes and feature incomplete with the pre-commit hook)
- `pylint`