### PR TITLE
Add `flake8-pie` check for `ruff`

### DIFF
--- a/asdf/extension/_compressor.py
+++ b/asdf/extension/_compressor.py
@@ -38,7 +38,6 @@ class Compressor(abc.ABC):
         label : bytes
             The compression label
         """
-        pass  # pragma: no cover
 
     def compress(self, data, **kwargs):
         """

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -41,7 +41,6 @@ class Converter(abc.ABC):
         iterable of str
             Tag URIs or URI patterns.
         """
-        pass  # pragma: no cover
 
     @property
     @abc.abstractmethod
@@ -55,7 +54,6 @@ class Converter(abc.ABC):
         iterable of str or type
             If str, the fully qualified class name of the type.
         """
-        pass  # pragma: no cover
 
     def select_tag(self, obj, tags, ctx):
         """
@@ -119,7 +117,6 @@ class Converter(abc.ABC):
         dict or list or str
             The YAML node representation of the object.
         """
-        pass  # pragma: no cover
 
     @abc.abstractmethod
     def from_yaml_tree(self, node, tag, ctx):
@@ -152,7 +149,6 @@ class Converter(abc.ABC):
             An instance of one of the types listed in the `types` property,
             or a generator that yields such an instance.
         """
-        pass  # pragma: no cover
 
 
 class ConverterProxy(Converter):

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -36,7 +36,6 @@ class Extension(abc.ABC):
         -------
         str
         """
-        pass  # pragma: no cover
 
     @property
     def legacy_class_names(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,6 @@ extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
-    "PIE790", # Unnecessary `pass` statement
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,11 +201,13 @@ select = [
     "PD", # pandas-vet
     "PGH", # pygrep-hooks
     "PLC", "PLE", "PLR", "PLW", # Pylint
+    "PIE", # flake8-pie
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
+    "PIE790", # Unnecessary `pass` statement
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1315.

It enables `ruff` to explicitly checks `flake8-pie` style.