### PR TITLE
Enable `ruff` specific checks

### DIFF
--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -366,7 +366,7 @@ class GenericFile(metaclass=util.InheritDocstrings):
             SEEK_SET or 0 (absolute file positioning); other values
             are SEEK_CUR or 1 (seek relative to the current
             position) and SEEK_END or 2 (seek relative to the
-            file’s end).
+            file`s end).
         """
         result = self._fd.seek(offset, whence)
         self.tell()

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -527,7 +527,7 @@ class NDArrayType(AsdfType):
                 # This line is safe because this is actually a piece of test
                 # code, even though it lives in this file:
                 msg = "arrays not equal"
-                raise AssertionError(msg)  # noqa: S101
+                raise AssertionError(msg)
             for a, b in zip(old, new):
                 cls._assert_equality(a, b, func)
         else:

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -326,7 +326,10 @@ def test_mask_nan():
 
 
 def test_string(tmpdir):
-    tree = {"ascii": np.array([b"foo", b"bar", b"baz"]), "unicode": np.array(["სამეცნიერო", "данные", "வடிவம்"])}
+    tree = {
+        "ascii": np.array([b"foo", b"bar", b"baz"]),
+        "unicode": np.array(["სამეცნიერო", "данные", "வடிவம்"]),  # noqa: RUF001
+    }
 
     helpers.assert_roundtrip_tree(tree, tmpdir)
 

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -243,7 +243,7 @@ def test_asdf_open(tmp_path, dtype):
         compare_asdfs(asdf_in_fits, ff)
 
     # Test open/close without context handler
-    ff = asdf_open(tmpfile)  # noqa: SIM115
+    ff = asdf_open(tmpfile)
     compare_asdfs(asdf_in_fits, ff)
     ff.close()
 

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -45,16 +45,16 @@ def test_unicode_write(tmp_path):
     characters, not as escape sequences
     """
 
-    tree = {"ɐʇɐp‾ǝpoɔıun": 42, "ascii_only": "this is ascii"}
+    tree = {"ɐʇɐp‾ǝpoɔıun": 42, "ascii_only": "this is ascii"}  # noqa: RUF001
 
     def check_asdf(asdf):
-        assert "ɐʇɐp‾ǝpoɔıun" in asdf.tree
+        assert "ɐʇɐp‾ǝpoɔıun" in asdf.tree  # noqa: RUF001
         assert isinstance(asdf.tree["ascii_only"], str)
 
     def check_raw_yaml(content):
         # Ensure that unicode is written out as UTF-8 without escape
         # sequences
-        assert "ɐʇɐp‾ǝpoɔıun".encode() in content
+        assert "ɐʇɐp‾ǝpoɔıun".encode() in content  # noqa: RUF001
         # Ensure that the unicode "tag" is not used
         assert b"unicode" not in content
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,6 @@ extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
-    "RUF002", # Docstring contains ambiguous unicode character '’' (did you mean '`'?)
     "RUF100", # Unused `noqa` directive
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,6 @@ extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
-    "RUF100", # Unused `noqa` directive
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,6 @@ extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
-    "RUF001", # String contains ambiguous unicode character
     "RUF002", # Docstring contains ambiguous unicode character '’' (did you mean '`'?)
     "RUF100", # Unused `noqa` directive
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,11 +202,15 @@ select = [
     "PGH", # pygrep-hooks
     "PLC", "PLE", "PLR", "PLW", # Pylint
     "PIE", # flake8-pie
+    "RUF",
 ]
 extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
+    "RUF001", # String contains ambiguous unicode character
+    "RUF002", # Docstring contains ambiguous unicode character '’' (did you mean '`'?)
+    "RUF100", # Unused `noqa` directive
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
This PR is part of breaking #1293 into multiple parts and is built off #1316.

It enables `ruff` to run its unique set of checks.