### PR TITLE
Enable `ALL` `ruff` checks by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,44 +170,20 @@ extend_skip_glob = ["asdf/extern/*", ".eggs/*", ".tox/*"]
 
 [tool.ruff]
 line-length = 120
-select = [
-    "F", # Pyflakes
-    "E", "W", # pycodestyle
-    # "C90", # mccabe complexity
-    "I", # isort
-    # "D", # pydocstyle
-    "UP", # pyupgrade
-    "N", # pep8-naming
-    "YTT", # flake8-2020
-    # "ANN", # flake8-annotations
-    "S", # flake8-bandit
-    "BLE", # flake8-blind-except
-    "B", # flake8-bugbear
-    "A", # flake8-builtins
-    "C4", # flake8-comprehensions
-    "T10", # flake8-debugger
-    "EM", # flake8-errmsg
-    "ISC", # flake8-implicit-str-concat
-    "ICN", # flake8-import-conventions
-    "T20", # flake8-print
-    "PT", # flake8-pytest-style
-    "Q", # flake8-quotes
-    "RET", # flake8-return
-    "SIM", # flake8-simplify
-    "TID", # flake8-tidy-imports
-    # "ARG", # flake8-unused-arguments
-    # "DTZ", # flake8-datetimez
-    "ERA", # eradicate
-    "PD", # pandas-vet
-    "PGH", # pygrep-hooks
-    "PLC", "PLE", "PLR", "PLW", # Pylint
-    "PIE", # flake8-pie
-    "RUF",
-]
+select = ["ALL"]
 extend-ignore = [
+    # Ignored check groups
+    "C90", # mccabe complexity
+    "D", # pydocstyle
+    "ANN", # flake8-annotations
+    "FBT", # flake8-boolean-trap
+    "ARG", # flake8-unused-arguments
+    "DTZ", # flake8-datetimez
+    # Individually ignored checks
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
+    "COM812", # Trailing comma missing
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
This PR enables all `ruff` checks by default. It then turns off checks we cannot (or will now support) at the current time. This is so we can accumulate new `ruff` checks as `ruff` adds them (its under fast development to add new checks all the time).

This will occur when the `pre-commit.ci` bot updates the `.pre-commit-config.yaml` file in a PR each week. We can decide how to fix these "new" checks when they start creating error messages in these new PRs.

This PR is the final part of breaking #1293 into multiple parts and is built off #1317.
 
Closes #1293 