### PR TITLE
Apply the `flynt` tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,11 +35,11 @@ repos:
       additional_dependencies:
         - tomli
 
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.223'
+- repo: https://github.com/ikamensh/flynt/
+  rev: '0.77'
   hooks:
-    - id: ruff
-      args: ["--fix", "--force-exclude"]
+    - id: flynt
+      exclude: "asdf/extern/.*"
 
 - repo: https://github.com/asottile/pyupgrade
   rev: 'v3.3.1'
@@ -47,6 +47,12 @@ repos:
     - id: pyupgrade
       args: ["--py38-plus"]
       exclude: "asdf/extern/.*"
+
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: 'v0.0.223'
+  hooks:
+    - id: ruff
+      args: ["--fix", "--force-exclude"]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.11.4

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -7,12 +7,10 @@ from asdf.tests import helpers
 
 
 def make_complex_asdf(string):
-    yaml = """
+    yaml = f"""
 a: !core/complex-1.0.0
-  {}
-    """.format(
-        string,
-    )
+  {string}
+    """
 
     return helpers.yaml_to_asdf(yaml)
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -316,17 +316,12 @@ def yaml_to_asdf(yaml_content, yaml_headers=True, standard_version=None):
 
     if yaml_headers:
         buff.write(
-            """#ASDF {}
-#ASDF_STANDARD {}
-%YAML {}
+            f"""#ASDF {file_format_version}
+#ASDF_STANDARD {standard_version}
+%YAML {yaml_version}
 %TAG ! tag:stsci.edu:asdf/
---- !core/asdf-{}
-""".format(
-                file_format_version,
-                standard_version,
-                yaml_version,
-                tree_version,
-            ).encode(
+--- !core/asdf-{tree_version}
+""".encode(
                 "ascii",
             ),
         )

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -294,15 +294,13 @@ def test_reading_extension_metadata():
 
         # Warn when the URI is missing, even if there's
         # a class name match:
-        content = """
+        content = f"""
         history:
           extensions:
             - !core/extension_metadata-1.0.0
               extension_uri: some-missing-URI
-              extension_class: {}
-        """.format(
-            extension_with_uri.class_name,
-        )
+              extension_class: {extension_with_uri.class_name}
+        """
         buff = yaml_to_asdf(content)
         with pytest.warns(AsdfWarning, match=r"URI 'some-missing-URI'"):
             open_asdf(buff)

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -200,14 +200,12 @@ def test_tags_removed_after_load(tmp_path):
 
 
 def test_explicit_tags():
-    yaml = """#ASDF {}
+    yaml = f"""#ASDF {asdf.versioning.default_version}
 %YAML 1.1
 --- !<tag:stsci.edu:asdf/core/asdf-1.0.0>
 foo: !<tag:stsci.edu:asdf/core/ndarray-1.0.0> [1, 2, 3]
 ...
-    """.format(
-        asdf.versioning.default_version,
-    )
+    """
 
     # Check that fully qualified explicit tags work
     buff = helpers.yaml_to_asdf(yaml, yaml_headers=False)

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -181,7 +181,7 @@ class AsdfLoader(_yaml_base_loader):
             raise yaml.ConstructorError(
                 msg,
                 node.start_mark,
-                "expected a sequence, but found %s" % node.id,
+                f"expected a sequence, but found {node.id}",
                 node.start_mark,
             )
         for subnode in node.value:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,9 @@ extend-exclude = ["asdf/extern/*", "docs/*"]
 "asdf/tests/helpers.py" = ["S101"]
 "compatibility_tests/common.py" = ["S101"]
 
+[tool.flynt]
+exclude = ["asdf/extern/*"]
+
 [tool.codespell]
 skip="*.pdf,*.fits,*.asdf,.tox,asdf/extern,build,./tags,.git,docs/_build"
 ignore-words-list="""


### PR DESCRIPTION
[`flynt` ](https://github.com/ikamensh/flynt) is a comprehensive too to update string creation from `%`-style and `.format`-style strings into f-strings. It is more comprehensive than the tools built into `ruff` and `pyupgrade` as a consequence it has found a few straggling older style format strings left in ASDF.

This PR adds a standard configuration for `flynt` and runs the tool on ASDF 