### PR TITLE
require numpy < 1.25 for python 3.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 The ASDF Standard is at v1.6.0
 
+- Require numpy<1.25 for python 3.8 [#1327]
 - Discard cache of lazy-loaded block data when it is no longer referenced
   by the tree. [#1280]
 - Add AsdfProvisionalAPIWarning to warn developers of new features that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "jmespath>=0.6.2",
   "jsonschema>=4.0.1",
   "numpy>=1.18",
+  'numpy<1.25,>=1.18; python_version < "3.9"',
   "packaging>=16",
   "pyyaml>=3.10",
   "semantic_version>=2.8",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ git+https://github.com/yaml/pyyaml.git
 git+https://github.com/python-jsonschema/jsonschema
 
 scipy>=0.0.dev0
-numpy>=0.0.dev0
+numpy>=0.0.dev0 ; python_version > "3.8"


### PR DESCRIPTION
Numpy 1.25 is currently being developed and is dropping support for python 3.8.

Fixes #1326