### PR TITLE
Update ruff to v0.0.231

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,10 +49,10 @@ repos:
       exclude: "asdf/extern/.*"
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.223'
+  rev: 'v0.0.231'
   hooks:
     - id: ruff
-      args: ["--fix", "--force-exclude"]
+      args: ["--fix"]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.11.4

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -158,7 +158,7 @@ class _TreeRenderer:
         Select nodes to display, obeying the per-node max_rows value for
         each tree depth.
         """
-        max_rows = (None,) + self._max_rows
+        max_rows = (None, *self._max_rows)
 
         current_infos = [root_info]
         while True:

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -934,10 +934,10 @@ class AsdfFile:
                 ignore_missing_extensions,
                 **kwargs,
             )
-        except Exception as e:
+        except Exception:
             if close_on_fail:
                 generic_file.close()
-            raise e
+            raise
 
     @classmethod
     def _open_generic_file(

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -957,12 +957,23 @@ class AsdfFile:
         file_type = util.get_file_type(generic_file)
 
         if file_type == util.FileType.FITS:
+            # TODO: this feels a bit circular, try to clean up. Also
+            # this introduces another dependency on astropy which may
+            # not be desirable.
             try:
-                # TODO: this feels a bit circular, try to clean up. Also
-                # this introduces another dependency on astropy which may
-                # not be desirable.
+                # Try to import ASDF in FITS
                 from . import fits_embed
 
+            except ImportError:
+                msg = (
+                    "Input object does not appear to be an ASDF file. Cannot check "
+                    "if it is a FITS with ASDF extension because 'astropy' is not "
+                    "installed"
+                )
+                raise ValueError(msg) from None
+
+            try:
+                # Try to open as FITS with ASDF extension
                 return fits_embed.AsdfInFits._open_impl(
                     generic_file,
                     uri=uri,
@@ -978,14 +989,6 @@ class AsdfFile:
             except ValueError:
                 msg = "Input object does not appear to be an ASDF file or a FITS with ASDF extension"
                 raise ValueError(msg) from None
-
-            except ImportError:
-                msg = (
-                    "Input object does not appear to be an ASDF file. Cannot check "
-                    "if it is a FITS with ASDF extension because 'astropy' is not "
-                    "installed"
-                )
-                raise ValueError() from None
 
         if file_type == util.FileType.ASDF:
             return cls._open_asdf(

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -1050,8 +1050,8 @@ class Block:
 
         try:
             self.input_compression = header["compression"]
-        except ValueError as v:
-            raise v  # TODO: hint extension?
+        except ValueError:
+            raise  # TODO: hint extension?
 
         if self.input_compression is None and header["used_size"] != header["data_size"]:
             msg = "used_size and data_size must be equal when no compression is used."

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -661,7 +661,7 @@ class BlockManager:
                 return last_block
 
             msg = f"Block '{source}' not found."
-            raise ValueError(msg)
+            raise ValueError(msg)  # noqa: TRY004
 
         if isinstance(source, str):
             asdffile = self._asdffile().open_external(source)

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -122,7 +122,7 @@ class PrintTree:
         at_end = False
         print_list = []
         current = self.__tree
-        for node in ["tree"] + node_list:
+        for node in ["tree", *node_list]:
             if at_end:
                 print_list.append(node)
             elif node not in current["children"]:
@@ -141,7 +141,7 @@ class PrintTree:
             msg = "node_list parameter must be an instance of list"
             raise TypeError(msg)
         current = self.__tree
-        for node in ["tree"] + node_list:
+        for node in ["tree", *node_list]:
             if node not in current["children"]:
                 current["children"][node] = {"visited": True, "children": {}}
             current = current["children"][node]
@@ -193,7 +193,7 @@ def print_in_tree(diff_ctx, node_list, thing, other, use_marker=False, last_was_
             key = ArrayNode(f"{node_list[-1]}_{i}")
             last_was_list = print_in_tree(
                 diff_ctx,
-                node_list + [key],
+                [*node_list, key],
                 subthing,
                 other,
                 use_marker=True,
@@ -205,7 +205,7 @@ def print_in_tree(diff_ctx, node_list, thing, other, use_marker=False, last_was_
         for key in sorted(thing.keys()):
             last_was_list = print_in_tree(
                 diff_ctx,
-                node_list + [key],
+                [*node_list, key],
                 thing[key],
                 other,
                 use_marker=True,
@@ -238,7 +238,7 @@ def print_dict_diff(diff_ctx, tree, node_list, keys, other):
             nodes = node_list
             key = key
         else:
-            nodes = node_list + [key]
+            nodes = [*node_list, key]
             key = tree[key]
         use_marker = not diff_ctx.minimal
         print_in_tree(diff_ctx, nodes, key, other, use_marker=use_marker)
@@ -289,7 +289,7 @@ def compare_dicts(diff_ctx, dict0, dict1, keys, ignores=None):
     for key in sorted(keys0 & keys1):
         obj0 = dict0[key]
         obj1 = dict1[key]
-        compare_trees(diff_ctx, obj0, obj1, keys=keys + [key])
+        compare_trees(diff_ctx, obj0, obj1, keys=[*keys, key])
     # Display subtree elements existing only in this tree
     print_dict_diff(diff_ctx, dict0, keys, sorted(keys0 - keys1), False)
     # Display subtree elements existing only in that tree
@@ -310,7 +310,7 @@ def compare_trees(diff_ctx, tree0, tree1, keys=None):
     elif isinstance(tree0, list) and isinstance(tree1, list):
         for i, (obj0, obj1) in enumerate(zip(tree0, tree1)):
             key = ArrayNode(f"item_{i}")
-            compare_trees(diff_ctx, obj0, obj1, keys + [key])
+            compare_trees(diff_ctx, obj0, obj1, [*keys, key])
     else:
         compare_objects(diff_ctx, tree0, tree1, keys)
 

--- a/asdf/commands/extract.py
+++ b/asdf/commands/extract.py
@@ -50,7 +50,7 @@ def extract_file(input_file, output_file):
         with asdf.open(input_file) as ih:
             if not isinstance(ih, AsdfInFits):
                 msg = f"Given input file '{input_file}' is not ASDF-in-FITS"
-                raise RuntimeError(msg)
+                raise RuntimeError(msg)  # noqa: TRY004
 
             with asdf.AsdfFile(ih.tree) as oh:
                 oh.write_to(output_file)

--- a/asdf/commands/tests/test_diff.py
+++ b/asdf/commands/tests/test_diff.py
@@ -72,4 +72,4 @@ def test_diff_command():
     filenames = ["frames0.asdf", "frames1.asdf"]
     paths = [get_test_data_path(name) for name in filenames]
 
-    assert main.main_from_args(["diff"] + paths) == 0
+    assert main.main_from_args(["diff", *paths]) == 0

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -87,7 +87,7 @@ class _EmbeddedBlockManager(block.BlockManager):
                     return f"{FITS_SOURCE_PREFIX}{hdu.name},{hdu.ver}"
 
             msg = "FITS block seems to have been removed"
-            raise ValueError(msg)
+            raise ValueError(msg)  # noqa: TRY004
 
         return super().get_source(block)
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -94,7 +94,7 @@ def relative_uri(source, target):
     if relative == ".":
         relative = ""
 
-    return patched_urllib_parse.urlunparse(["", "", relative] + extra)
+    return patched_urllib_parse.urlunparse(["", "", relative, *extra])
 
 
 class _TruncatedReader:

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -608,12 +608,12 @@ class GenericFile(metaclass=util.InheritDocstrings):
         try:
             while reader.read(self.block_size) != b"":
                 pass
-            return True
         except DelimiterNotFoundError as e:
             if exception:
                 raise e
-
             return False
+
+        return True
 
     def fast_forward(self, size):
         """
@@ -986,10 +986,12 @@ def _http_to_temp(init, mode, uri=None):
                 fd.write(chunk)
                 chunk = response.read(block_size)
         fd.seek(0)
-        return RealFile(fd, mode, close=True, uri=uri or init)
+
     except Exception:
         fd.close()
         raise
+
+    return RealFile(fd, mode, close=True, uri=uri or init)
 
 
 def get_uri(file_obj):

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -608,9 +608,10 @@ class GenericFile(metaclass=util.InheritDocstrings):
         try:
             while reader.read(self.block_size) != b"":
                 pass
-        except DelimiterNotFoundError as e:
+        except DelimiterNotFoundError:
             if exception:
-                raise e
+                raise
+
             return False
 
         return True

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -1134,7 +1134,7 @@ def get_file(init, mode="r", uri=None, close=False):
             return InputStream(init, mode, uri=uri, close=close)
 
         msg = f"File '{init}' could not be opened in 'rw' mode"
-        raise ValueError(msg)
+        raise ValueError(msg)  # noqa: TRY004
 
     if mode == "w" and (hasattr(init, "write") and hasattr(init, "seek") and hasattr(init, "tell")):
         return MemoryIO(init, mode, uri=uri)

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -203,7 +203,7 @@ class AsdfSearchResult:
         return AsdfSearchResult(
             self._identifiers,
             self._node,
-            filters=self._filters + [_filter],
+            filters=[*self._filters, _filter],
             parent_node=self._parent_node,
             max_rows=self._max_rows,
             max_cols=self._max_cols,
@@ -358,7 +358,7 @@ class AsdfSearchResult:
             raise TypeError(msg)
 
         return AsdfSearchResult(
-            self._identifiers + [key],
+            [*self._identifiers, key],
             child,
             filters=self._filters,
             parent_node=self._node,
@@ -384,7 +384,7 @@ def _walk_tree_breadth_first(root_identifiers, root_node, callback):
             tnode = node.__asdf_traverse__() if NodeSchemaInfo.traversable(node) else node
             children = get_children(tnode)
             callback(identifiers, parent, node, [c for _, c in children])
-            next_nodes.extend([(identifiers + [i], node, c) for i, c in children])
+            next_nodes.extend([([*identifiers, i], node, c) for i, c in children])
             seen.add(id(node))
 
         if len(next_nodes) == 0:

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -97,13 +97,14 @@ class AsdfSearchResult:
     def _safe_equals(self, a, b):
         try:
             result = a == b
-            if isinstance(result, bool):
-                return result
-
-            return False
 
         except Exception:  # noqa: BLE001
             return False
+
+        if isinstance(result, bool):
+            return result
+
+        return False
 
     def _get_fully_qualified_type(self, value):
         value_type = type(value)

--- a/asdf/stream.py
+++ b/asdf/stream.py
@@ -48,7 +48,7 @@ class Stream(ndarray.NDArrayType):
 
         result = {}
         result["source"] = -1
-        result["shape"] = ["*"] + data._shape
+        result["shape"] = ["*", *data._shape]
         result["datatype"] = data._datatype
         result["byteorder"] = data._byteorder
         if data._strides is not None:

--- a/asdf/tags/core/complex.py
+++ b/asdf/tags/core/complex.py
@@ -7,7 +7,7 @@ from asdf.types import AsdfType
 class ComplexType(AsdfType):
     name = "core/complex"
     version = "1.0.0"
-    types = list(util.iter_subclasses(np.complexfloating)) + [complex]
+    types = [*list(util.iter_subclasses(np.complexfloating)), complex]
 
     @classmethod
     def to_tree(cls, node, ctx):

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -577,9 +577,7 @@ def _make_operation(name):
     return operation
 
 
-classes_to_modify = NDArrayType.__versioned_siblings + [
-    NDArrayType,
-]
+classes_to_modify = [*NDArrayType.__versioned_siblings, NDArrayType]
 for op in [
     "__neg__",
     "__pos__",

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -88,7 +88,7 @@ def asdf_datatype_to_numpy_dtype(datatype, byteorder=None):
 
             else:
                 msg = "Error parsing asdf datatype"
-                raise RuntimeError(msg)
+                raise RuntimeError(msg)  # noqa: TRY004
 
         return np.dtype(datatype_list)
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -379,9 +379,10 @@ class NDArrayType(AsdfType):
         # originates from the call to __repr__ inside the traceback report.
         try:
             self._make_array().__setitem__(*args)
-        except Exception as e:
+        except Exception:
             self._array = None
-            raise e from None
+
+            raise
 
     def __getattribute__(self, name):
         # The presence of these attributes on an NDArrayType instance

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -266,7 +266,7 @@ def test_versioned_writing(monkeypatch):
     monkeypatch.setattr(
         versioning,
         "supported_versions",
-        versioning.supported_versions + [versioning.AsdfVersion("42.0.0")],
+        [*versioning.supported_versions, versioning.AsdfVersion("42.0.0")],
     )
 
     class FancyComplexType(types.CustomType):

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -111,25 +111,25 @@ def test_version_and_string_inequality():
     assert version <= "2.1.0"
     assert version <= "2.1.1"
 
-    assert "1.0.0" < version  # noqa: PLC2201
-    assert "1.0.1" < version  # noqa: PLC2201
-    assert "1.1.0" < version  # noqa: PLC2201
-    assert "1.1.1" < version  # noqa: PLC2201
-    assert ("2.0.0" < version) is False  # noqa: PLC2201
-    assert ("2.0.0" > version) is False  # noqa: PLC2201
-    assert "2.0.1" > version  # noqa: PLC2201
-    assert "2.1.0" > version  # noqa: PLC2201
-    assert "2.1.1" > version  # noqa: PLC2201
+    assert "1.0.0" < version  # noqa: SIM300
+    assert "1.0.1" < version  # noqa: SIM300
+    assert "1.1.0" < version  # noqa: SIM300
+    assert "1.1.1" < version  # noqa: SIM300
+    assert ("2.0.0" < version) is False  # noqa: SIM300
+    assert ("2.0.0" > version) is False  # noqa: SIM300
+    assert "2.0.1" > version  # noqa: SIM300
+    assert "2.1.0" > version  # noqa: SIM300
+    assert "2.1.1" > version  # noqa: SIM300
 
-    assert "1.0.0" <= version  # noqa: PLC2201
-    assert "1.0.1" <= version  # noqa: PLC2201
-    assert "1.1.0" <= version  # noqa: PLC2201
-    assert "1.1.1" <= version  # noqa: PLC2201
-    assert "2.0.0" <= version  # noqa: PLC2201
-    assert "2.0.0" >= version  # noqa: PLC2201
-    assert "2.0.1" >= version  # noqa: PLC2201
-    assert "2.1.0" >= version  # noqa: PLC2201
-    assert "2.1.1" >= version  # noqa: PLC2201
+    assert "1.0.0" <= version  # noqa: SIM300
+    assert "1.0.1" <= version  # noqa: SIM300
+    assert "1.1.0" <= version  # noqa: SIM300
+    assert "1.1.1" <= version  # noqa: SIM300
+    assert "2.0.0" <= version  # noqa: SIM300
+    assert "2.0.0" >= version  # noqa: SIM300
+    assert "2.0.1" >= version  # noqa: SIM300
+    assert "2.1.0" >= version  # noqa: SIM300
+    assert "2.1.1" >= version  # noqa: SIM300
 
 
 def test_version_and_tuple_inequality():
@@ -266,9 +266,9 @@ def test_spec_equal():
     assert version1 == spec
 
     assert spec != "1.1.0"
-    assert "1.1.0" != spec  # noqa: PLC2201
+    assert "1.1.0" != spec  # noqa: SIM300
     assert spec == "1.3.0"
-    assert "1.3.0" == spec  # noqa: PLC2201, SIM300
+    assert "1.3.0" == spec  # noqa: SIM300
 
     assert spec != (1, 1, 0)
     assert (1, 1, 0) != spec

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -372,7 +372,7 @@ def minversion(module, version, inclusive=True):
             return False
     else:
         msg = f"module argument must be an actual imported module, or the import name of the module; got {repr(module)}"
-        raise ValueError(msg)
+        raise ValueError(msg)  # noqa: TRY004
 
     if module_version is None:
         try:

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -98,7 +98,7 @@ def get_base_uri(uri):
     For a given URI, return the part without any fragment.
     """
     parts = patched_urllib_parse.urlparse(uri)
-    return patched_urllib_parse.urlunparse(list(parts[:5]) + [""])
+    return patched_urllib_parse.urlunparse([*list(parts[:5]), ""])
 
 
 def filepath_to_url(path):

--- a/compatibility_tests/assert_file_correct.py
+++ b/compatibility_tests/assert_file_correct.py
@@ -1,3 +1,5 @@
+# noqa: INP001
+
 import argparse
 from pathlib import Path
 

--- a/compatibility_tests/common.py
+++ b/compatibility_tests/common.py
@@ -1,3 +1,5 @@
+# noqa: INP001
+
 import numpy as np
 
 import asdf

--- a/compatibility_tests/generate_file.py
+++ b/compatibility_tests/generate_file.py
@@ -1,3 +1,5 @@
+# noqa: INP001
+
 import argparse
 from pathlib import Path
 

--- a/compatibility_tests/test_file_compatibility.py
+++ b/compatibility_tests/test_file_compatibility.py
@@ -1,3 +1,5 @@
+# noqa: INP001
+
 import json
 import os
 import subprocess

--- a/compatibility_tests/test_file_compatibility.py
+++ b/compatibility_tests/test_file_compatibility.py
@@ -83,7 +83,7 @@ def env_run(env_path, command, *args, **kwargs):
     Run a command on the context of the virtual environment at
     the specified path.
     """
-    return subprocess.run([env_path / "bin" / command] + list(args), **kwargs).returncode == 0
+    return subprocess.run([env_path / "bin" / command, *list(args)], **kwargs).returncode == 0
 
 
 def env_check_output(env_path, command, *args):
@@ -91,7 +91,7 @@ def env_check_output(env_path, command, *args):
     Run a command on the context of the virtual environment at
     the specified path, and return the output.
     """
-    return subprocess.check_output([env_path / "bin" / command] + list(args)).decode("utf-8").strip()
+    return subprocess.check_output([env_path / "bin" / command, *list(args)]).decode("utf-8").strip()
 
 
 def get_supported_versions(env_path):

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+# noqa: INP001
+
 import os
 
 import pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,6 @@ extend-ignore = [
     "PLR2004", # Magic value used in comparison
 
     "TRY201", # Use raise without specifying exception name
-    "INP001", # implicit-namespace-package
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,10 +180,17 @@ extend-ignore = [
     "FBT", # flake8-boolean-trap
     "ARG", # flake8-unused-arguments
     "DTZ", # flake8-datetimez
+    "PTH", # flake8-use-pathlib
     # Individually ignored checks
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
+
+    "RUF005", # unpack-instead-of-concatenating-to-collection-literal
+    "TRY004", # prefer-type-error
+    "TRY300", # try-consider-else
+    "TRY201", # Use raise without specifying exception name
+    "INP001", # implicit-namespace-package
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,6 @@ extend-ignore = [
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
 
-    "TRY004", # prefer-type-error
     "TRY300", # try-consider-else
     "TRY201", # Use raise without specifying exception name
     "INP001", # implicit-namespace-package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,6 @@ extend-ignore = [
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
 
-    "RUF005", # unpack-instead-of-concatenating-to-collection-literal
     "TRY004", # prefer-type-error
     "TRY300", # try-consider-else
     "TRY201", # Use raise without specifying exception name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,6 @@ extend-ignore = [
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
 
-    "TRY300", # try-consider-else
     "TRY201", # Use raise without specifying exception name
     "INP001", # implicit-namespace-package
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,8 +185,6 @@ extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
-
-    "TRY201", # Use raise without specifying exception name
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
We are currently using `ruff v0.0.223` and `ruff v0.0.230` was recently released. It updates and adds new checks. This PR updates ASDF to conform with these ahead of the pre-commit.ci bot attempting to update `ruff`.