### PR TITLE
add AsdfDeprecationWarning to AsdfFile.blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ The ASDF Standard is at v1.6.0
 - Add AsdfProvisionalAPIWarning to warn developers of new features that
   may undergo breaking changes but are likely to be included as stable
   features (without this warning) in a future version of ASDF [#1295]
+- Add AsdfDeprecationWarning to AsdfFile.blocks [#1336]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -362,7 +362,7 @@ class BlockManager:
             asdffile = asdf.AsdfFile()
             block = copy.copy(block)
             block._array_storage = "internal"
-            asdffile.blocks.add(block)
+            asdffile._blocks.add(block)
             block._used = True
             asdffile.write_to(subfd, pad_blocks=pad_blocks)
 
@@ -667,7 +667,7 @@ class BlockManager:
 
         if isinstance(source, str):
             asdffile = self._asdffile().open_external(source)
-            block = asdffile.blocks._internal_blocks[0]
+            block = asdffile._blocks._internal_blocks[0]
             self.set_array_storage(block, "external")
 
         # Handle the case of inline data

--- a/asdf/commands/tests/test_defragment.py
+++ b/asdf/commands/tests/test_defragment.py
@@ -23,7 +23,7 @@ def _test_defragment(tmpdir, codec):
     out_path = os.path.join(str(tmpdir), "original.defragment.asdf")
     ff = AsdfFile(tree)
     ff.write_to(path)
-    assert len(ff.blocks) == 2
+    assert len(ff._blocks) == 2
 
     result = main.main_from_args(["defragment", path, "-o", out_path, "-c", codec])
 
@@ -38,7 +38,7 @@ def _test_defragment(tmpdir, codec):
 
     with asdf.open(os.path.join(str(tmpdir), "original.defragment.asdf")) as ff:
         assert_tree_match(ff.tree, tree)
-        assert len(list(ff.blocks.internal_blocks)) == 2
+        assert len(list(ff._blocks.internal_blocks)) == 2
 
 
 def test_defragment_zlib(tmpdir):

--- a/asdf/commands/tests/test_exploded.py
+++ b/asdf/commands/tests/test_exploded.py
@@ -24,7 +24,7 @@ def test_explode_then_implode(tmpdir):
     # in internal blocks rather than letting some of them be automatically put
     # inline.
     ff.write_to(path, all_array_storage="internal")
-    assert len(ff.blocks) == 2
+    assert len(ff._blocks) == 2
 
     result = main.main_from_args(["explode", path])
 
@@ -47,7 +47,7 @@ def test_explode_then_implode(tmpdir):
 
     with asdf.open(str(tmpdir.join("original_exploded_all.asdf"))) as af:
         assert_tree_match(af.tree, tree)
-        assert len(af.blocks) == 2
+        assert len(af._blocks) == 2
 
 
 def test_file_not_found(tmpdir):

--- a/asdf/commands/tests/test_to_yaml.py
+++ b/asdf/commands/tests/test_to_yaml.py
@@ -21,7 +21,7 @@ def test_to_yaml(tmpdir):
     path = os.path.join(str(tmpdir), "original.asdf")
     ff = AsdfFile(tree)
     ff.write_to(path)
-    assert len(ff.blocks) == 2
+    assert len(ff._blocks) == 2
 
     result = main.main_from_args(["to_yaml", path])
 
@@ -34,4 +34,4 @@ def test_to_yaml(tmpdir):
 
     with asdf.open(os.path.join(str(tmpdir), "original.yaml")) as ff:
         assert_tree_match(ff.tree, tree)
-        assert len(list(ff.blocks.internal_blocks)) == 0
+        assert len(list(ff._blocks.internal_blocks)) == 0

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -312,7 +312,7 @@ class AsdfInFits(asdf.AsdfFile):
         use_image_hdu=False,
         **kwargs,
     ):
-        if self.blocks.streamed_block is not None:
+        if self._blocks.streamed_block is not None:
             msg = "Can not save streamed data to ASDF-in-FITS file."
             raise ValueError(msg)
 

--- a/asdf/stream.py
+++ b/asdf/stream.py
@@ -36,7 +36,7 @@ class Stream(ndarray.NDArrayType):
     @classmethod
     def reserve_blocks(cls, data, ctx):
         if isinstance(data, Stream):
-            yield ctx.blocks.get_streamed_block()
+            yield ctx._blocks.get_streamed_block()
 
     @classmethod
     def from_tree(cls, data, ctx):
@@ -44,7 +44,7 @@ class Stream(ndarray.NDArrayType):
 
     @classmethod
     def to_tree(cls, data, ctx):
-        ctx.blocks.get_streamed_block()
+        ctx._blocks.get_streamed_block()
 
         result = {}
         result["source"] = -1

--- a/asdf/tags/core/tests/test_integer.py
+++ b/asdf/tags/core/tests/test_integer.py
@@ -67,7 +67,7 @@ def test_integer_storage_duplication(tmpdir):
 
     with asdf.AsdfFile(tree) as af:
         af.write_to(tmpfile)
-        assert len(af.blocks) == 1
+        assert len(af._blocks) == 1
 
     with asdf.open(tmpfile, _force_raw_types=True) as rf:
         assert rf.tree["integer1"]["words"]["source"] == 0

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -64,8 +64,8 @@ def test_sharing(tmpdir):
 
         assert tree["science_data"].ctypes.data == tree["skipping"].ctypes.data
 
-        assert len(list(asdf.blocks.internal_blocks)) == 1
-        assert next(asdf.blocks.internal_blocks)._size == 80
+        assert len(list(asdf._blocks.internal_blocks)) == 1
+        assert next(asdf._blocks.internal_blocks)._size == 80
 
         if "w" in asdf._mode:
             tree["science_data"][0] = 42
@@ -135,7 +135,7 @@ def test_dont_load_data():
         str(ff.tree["science_data"])
         repr(ff.tree)
 
-        for block in ff.blocks.internal_blocks:
+        for block in ff._blocks.internal_blocks:
             assert block._data is None
 
 
@@ -172,7 +172,7 @@ def test_array_inline_threshold_recursive(tmpdir):
     tree = {"test": aff}
 
     def check_asdf(asdf):
-        assert len(list(asdf.blocks.internal_blocks)) == 0
+        assert len(list(asdf._blocks.internal_blocks)) == 0
 
     with asdf.config_context() as config:
         config.array_inline_threshold = 100
@@ -253,13 +253,13 @@ def test_inline():
     buff = io.BytesIO()
 
     ff = asdf.AsdfFile(tree)
-    ff.blocks.set_array_storage(ff.blocks[tree["science_data"]], "inline")
+    ff._blocks.set_array_storage(ff._blocks[tree["science_data"]], "inline")
     ff.write_to(buff)
 
     buff.seek(0)
     with asdf.open(buff, mode="rw") as ff:
         helpers.assert_tree_match(tree, ff.tree)
-        assert len(list(ff.blocks.internal_blocks)) == 0
+        assert len(list(ff._blocks.internal_blocks)) == 0
         buff = io.BytesIO()
         ff.write_to(buff)
 
@@ -285,7 +285,7 @@ def test_mask_roundtrip(tmpdir):
         m = tree["masked_array"]
 
         assert np.all(m.mask[6:])
-        assert len(asdf.blocks) == 2
+        assert len(asdf._blocks) == 2
 
     helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf)
 
@@ -415,7 +415,7 @@ def test_inline_masked_array(tmpdir):
     f.write_to(testfile)
 
     with asdf.open(testfile) as f2:
-        assert len(list(f2.blocks.internal_blocks)) == 0
+        assert len(list(f2._blocks.internal_blocks)) == 0
         assert_array_equal(f.tree["test"], f2.tree["test"])
 
     with open(testfile, "rb") as fd:

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -263,7 +263,7 @@ def _assert_roundtrip_tree(
         buff.seek(0)
         ff = asdf.open(buff, extensions=extensions, copy_arrays=True, lazy_load=False)
         # Ensure that all the blocks are loaded
-        for block in ff.blocks._internal_blocks:
+        for block in ff._blocks._internal_blocks:
             assert isinstance(block, Block)
             assert block._data is not None
     # The underlying file is closed at this time and everything should still work
@@ -274,7 +274,7 @@ def _assert_roundtrip_tree(
     # Now repeat with copy_arrays=False and a real file to test mmap()
     AsdfFile(tree, extensions=extensions, **init_options).write_to(fname, **write_options)
     with asdf.open(fname, mode="rw", extensions=extensions, copy_arrays=False, lazy_load=False) as ff:
-        for block in ff.blocks._internal_blocks:
+        for block in ff._blocks._internal_blocks:
             assert isinstance(block, Block)
             assert block._data is not None
         assert_tree_match(tree, ff.tree, ff, funcname=tree_match_func)

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -368,26 +368,26 @@ def test_auto_inline(tmp_path):
     with asdf.AsdfFile(tree) as af:
         # By default blocks are written internal.
         af.write_to(outfile)
-        assert len(list(af.blocks.inline_blocks)) == 0
-        assert len(list(af.blocks.internal_blocks)) == 2
+        assert len(list(af._blocks.inline_blocks)) == 0
+        assert len(list(af._blocks.internal_blocks)) == 2
 
         af.write_to(outfile, auto_inline=10)
-        assert len(list(af.blocks.inline_blocks)) == 1
-        assert len(list(af.blocks.internal_blocks)) == 1
+        assert len(list(af._blocks.inline_blocks)) == 1
+        assert len(list(af._blocks.internal_blocks)) == 1
 
         # The previous write modified the small array block's storage
         # to inline, and a subsequent write should maintain that setting.
         af.write_to(outfile)
-        assert len(list(af.blocks.inline_blocks)) == 1
-        assert len(list(af.blocks.internal_blocks)) == 1
+        assert len(list(af._blocks.inline_blocks)) == 1
+        assert len(list(af._blocks.internal_blocks)) == 1
 
         af.write_to(outfile, auto_inline=7)
-        assert len(list(af.blocks.inline_blocks)) == 1
-        assert len(list(af.blocks.internal_blocks)) == 1
+        assert len(list(af._blocks.inline_blocks)) == 1
+        assert len(list(af._blocks.internal_blocks)) == 1
 
         af.write_to(outfile, auto_inline=5)
-        assert len(list(af.blocks.inline_blocks)) == 0
-        assert len(list(af.blocks.internal_blocks)) == 2
+        assert len(list(af._blocks.inline_blocks)) == 0
+        assert len(list(af._blocks.internal_blocks)) == 2
 
 
 @pytest.mark.parametrize(
@@ -410,8 +410,8 @@ def test_array_inline_threshold(array_inline_threshold, inline_blocks, internal_
 
         with asdf.AsdfFile(tree) as af:
             af.write_to(file_path)
-            assert len(list(af.blocks.inline_blocks)) == inline_blocks
-            assert len(list(af.blocks.internal_blocks)) == internal_blocks
+            assert len(list(af._blocks.inline_blocks)) == inline_blocks
+            assert len(list(af._blocks.internal_blocks)) == internal_blocks
 
 
 @pytest.mark.parametrize(
@@ -433,8 +433,8 @@ def test_array_inline_threshold_masked_array(array_inline_threshold, inline_bloc
 
         with asdf.AsdfFile(tree) as af:
             af.write_to(file_path)
-            assert len(list(af.blocks.inline_blocks)) == inline_blocks
-            assert len(list(af.blocks.internal_blocks)) == internal_blocks
+            assert len(list(af._blocks.inline_blocks)) == inline_blocks
+            assert len(list(af._blocks.internal_blocks)) == internal_blocks
 
 
 @pytest.mark.parametrize(
@@ -455,8 +455,8 @@ def test_array_inline_threshold_string_array(array_inline_threshold, inline_bloc
 
         with asdf.AsdfFile(tree) as af:
             af.write_to(file_path)
-            assert len(list(af.blocks.inline_blocks)) == inline_blocks
-            assert len(list(af.blocks.internal_blocks)) == internal_blocks
+            assert len(list(af._blocks.inline_blocks)) == inline_blocks
+            assert len(list(af._blocks.internal_blocks)) == internal_blocks
 
 
 def test_resolver_deprecations():

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -417,3 +417,9 @@ def test_fsspec_http(httpserver):
     with fsspec.open(fn) as f:
         af = open_asdf(f)
         assert_tree_match(tree, af.tree)
+
+
+def test_blocks_deprecated():
+    af = AsdfFile()
+    with pytest.deprecated_call():
+        af.blocks

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -179,6 +179,7 @@ def test_set_array_compression(tmp_path):
             af_out.write_to(tmpfile)
         af_out.set_array_compression(bzp2_data, "bzp2", compresslevel=9)
         af_out.write_to(tmpfile)
+        assert af_out.get_array_compression_kwargs(bzp2_data)["compresslevel"] == 9
 
     with asdf.open(tmpfile) as af_in:
         assert af_in.get_array_compression(af_in.tree["zlib_data"]) == "zlib"

--- a/asdf/tests/test_file_format.py
+++ b/asdf/tests/test_file_format.py
@@ -90,18 +90,18 @@ XXXXXXXX
 
     buff = io.BytesIO(content)
     with asdf.open(buff) as ff:
-        assert len(ff.blocks) == 0
+        assert len(ff._blocks) == 0
 
     buff.seek(0)
     fd = generic_io.InputStream(buff, "r")
     with asdf.open(fd) as ff:
-        assert len(ff.blocks) == 0
+        assert len(ff._blocks) == 0
 
     with open(path, "wb") as fd:
         fd.write(content)
 
     with open(path, "rb") as fd, asdf.open(fd) as ff:
-        assert len(ff.blocks) == 0
+        assert len(ff._blocks) == 0
 
 
 def test_invalid_source(small_tree):
@@ -115,22 +115,22 @@ def test_invalid_source(small_tree):
 
     buff.seek(0)
     with asdf.open(buff) as ff2:
-        ff2.blocks.get_block(0)
+        ff2._blocks.get_block(0)
 
         with pytest.raises(ValueError):
-            ff2.blocks.get_block(2)
+            ff2._blocks.get_block(2)
 
         with pytest.raises(IOError):
-            ff2.blocks.get_block("http://ABadUrl.verybad/test.asdf")
+            ff2._blocks.get_block("http://ABadUrl.verybad/test.asdf")
 
         with pytest.raises(TypeError):
-            ff2.blocks.get_block(42.0)
+            ff2._blocks.get_block(42.0)
 
         with pytest.raises(ValueError):
-            ff2.blocks.get_source(42.0)
+            ff2._blocks.get_source(42.0)
 
-        block = ff2.blocks.get_block(0)
-        assert ff2.blocks.get_source(block) == 0
+        block = ff2._blocks.get_block(0)
+        assert ff2._blocks.get_source(block) == 0
 
 
 def test_empty_file():
@@ -139,14 +139,14 @@ def test_empty_file():
 
     with asdf.open(buff) as ff:
         assert ff.tree == {}
-        assert len(ff.blocks) == 0
+        assert len(ff._blocks) == 0
 
     buff = io.BytesIO(b"#ASDF 1.0.0\n#ASDF_STANDARD 1.0.0")
     buff.seek(0)
 
     with asdf.open(buff) as ff:
         assert ff.tree == {}
-        assert len(ff.blocks) == 0
+        assert len(ff._blocks) == 0
 
 
 @pytest.mark.filterwarnings("ignore::astropy.io.fits.verify.VerifyWarning")

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -388,7 +388,7 @@ def test_dangling_file_handle(tmp_path):
     ctx = asdf.AsdfFile()
     gc.collect()
 
-    ctx.blocks.find_or_create_block_for_array(hdul[0].data, ctx)
+    ctx._blocks.find_or_create_block_for_array(hdul[0].data, ctx)
     gc.collect()
 
     hdul.close()

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -83,9 +83,9 @@ def test_path(tree, tmp_path):
         return f
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
-        assert len(list(ff.blocks.internal_blocks)) == 2
-        next(ff.blocks.internal_blocks).data
-        assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)
+        assert len(list(ff._blocks.internal_blocks)) == 2
+        next(ff._blocks.internal_blocks).data
+        assert isinstance(next(ff._blocks.internal_blocks)._data, np.core.memmap)
 
 
 def test_open2(tree, tmp_path):
@@ -107,8 +107,8 @@ def test_open2(tree, tmp_path):
         return f
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
-        assert len(list(ff.blocks.internal_blocks)) == 2
-        assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)
+        assert len(list(ff._blocks.internal_blocks)) == 2
+        assert isinstance(next(ff._blocks.internal_blocks)._data, np.core.memmap)
 
 
 def test_open_fail(tmp_path):
@@ -163,8 +163,8 @@ def test_io_open(tree, tmp_path):
         return f
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
-        assert len(list(ff.blocks.internal_blocks)) == 2
-        assert isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)
+        assert len(list(ff._blocks.internal_blocks)) == 2
+        assert isinstance(next(ff._blocks.internal_blocks)._data, np.core.memmap)
         ff.tree["science_data"][0] = 42
 
 
@@ -199,9 +199,9 @@ def test_bytes_io(tree):
         return f
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
-        assert len(list(ff.blocks.internal_blocks)) == 2
-        assert not isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)
-        assert isinstance(next(ff.blocks.internal_blocks)._data, np.ndarray)
+        assert len(list(ff._blocks.internal_blocks)) == 2
+        assert not isinstance(next(ff._blocks.internal_blocks)._data, np.core.memmap)
+        assert isinstance(next(ff._blocks.internal_blocks)._data, np.ndarray)
         ff.tree["science_data"][0] = 42
 
 
@@ -216,9 +216,9 @@ def test_streams(tree):
         return generic_io.InputStream(buff, "rw")
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
-        assert len(ff.blocks) == 2
-        assert not isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)
-        assert isinstance(next(ff.blocks.internal_blocks)._data, np.ndarray)
+        assert len(ff._blocks) == 2
+        assert not isinstance(next(ff._blocks.internal_blocks)._data, np.core.memmap)
+        assert isinstance(next(ff._blocks.internal_blocks)._data, np.ndarray)
         ff.tree["science_data"][0] = 42
 
 
@@ -245,9 +245,9 @@ def test_urlopen(tree, httpserver):
         return generic_io.get_file(urllib_request.urlopen(httpserver.url + "test.asdf"))
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
-        assert len(list(ff.blocks.internal_blocks)) == 2
-        assert not isinstance(next(ff.blocks.internal_blocks)._data, np.core.memmap)
-        assert isinstance(next(ff.blocks.internal_blocks)._data, np.ndarray)
+        assert len(list(ff._blocks.internal_blocks)) == 2
+        assert not isinstance(next(ff._blocks.internal_blocks)._data, np.core.memmap)
+        assert isinstance(next(ff._blocks.internal_blocks)._data, np.ndarray)
 
 
 @pytest.mark.remote_data()
@@ -267,8 +267,8 @@ def test_http_connection(tree, httpserver):
         return fd
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
-        assert len(list(ff.blocks.internal_blocks)) == 2
-        assert isinstance(next(ff.blocks.internal_blocks)._data, np.ndarray)
+        assert len(list(ff._blocks.internal_blocks)) == 2
+        assert isinstance(next(ff._blocks.internal_blocks)._data, np.ndarray)
         assert (ff.tree["science_data"] == tree["science_data"]).all()
 
 
@@ -282,8 +282,8 @@ def test_exploded_filesystem(tree, tmp_path):
         return generic_io.get_file(path, mode="r")
 
     with _roundtrip(tree, get_write_fd, get_read_fd, write_options={"all_array_storage": "external"}) as ff:
-        assert len(list(ff.blocks.internal_blocks)) == 0
-        assert len(list(ff.blocks.external_blocks)) == 2
+        assert len(list(ff._blocks.internal_blocks)) == 0
+        assert len(list(ff._blocks.external_blocks)) == 2
 
 
 def test_exploded_filesystem_fail(tree, tmp_path):
@@ -317,8 +317,8 @@ def test_exploded_http(tree, httpserver):
         return generic_io.get_file(httpserver.url + "test.asdf")
 
     with _roundtrip(tree, get_write_fd, get_read_fd, write_options={"all_array_storage": "external"}) as ff:
-        assert len(list(ff.blocks.internal_blocks)) == 0
-        assert len(list(ff.blocks.external_blocks)) == 2
+        assert len(list(ff._blocks.internal_blocks)) == 0
+        assert len(list(ff._blocks.external_blocks)) == 2
 
 
 def test_exploded_stream_write(small_tree):

--- a/asdf/tests/test_stream.py
+++ b/asdf/tests/test_stream.py
@@ -22,7 +22,7 @@ def test_stream():
     buff.seek(0)
 
     with asdf.open(buff) as ff:
-        assert len(ff.blocks) == 1
+        assert len(ff._blocks) == 1
         assert ff.tree["stream"].shape == (100, 6, 2)
         for i, row in enumerate(ff.tree["stream"]):
             assert np.all(row == i)
@@ -43,7 +43,7 @@ def test_stream_write_nothing():
     buff.seek(0)
 
     with asdf.open(buff) as ff:
-        assert len(ff.blocks) == 1
+        assert len(ff._blocks) == 1
         assert ff.tree["stream"].shape == (0, 6, 2)
 
 
@@ -64,7 +64,7 @@ def test_stream_twice():
     buff.seek(0)
 
     ff = asdf.open(buff)
-    assert len(ff.blocks) == 1
+    assert len(ff._blocks) == 1
     assert ff.tree["stream"].shape == (100, 6, 2)
     assert ff.tree["stream2"].shape == (50, 12, 2)
 
@@ -85,10 +85,10 @@ def test_stream_with_nonstream():
     buff.seek(0)
 
     with asdf.open(buff) as ff:
-        assert len(ff.blocks) == 1
+        assert len(ff._blocks) == 1
         assert_array_equal(ff.tree["nonstream"], np.array([1, 2, 3, 4], np.int64))
         assert ff.tree["stream"].shape == (100, 6, 2)
-        assert len(ff.blocks) == 2
+        assert len(ff._blocks) == 2
         for i, row in enumerate(ff.tree["stream"]):
             assert np.all(row == i)
 
@@ -109,10 +109,10 @@ def test_stream_real_file(tmp_path):
             fd.write(np.array([i] * 12, np.float64).tobytes())
 
     with asdf.open(path) as ff:
-        assert len(ff.blocks) == 1
+        assert len(ff._blocks) == 1
         assert_array_equal(ff.tree["nonstream"], np.array([1, 2, 3, 4], np.int64))
         assert ff.tree["stream"].shape == (100, 6, 2)
-        assert len(ff.blocks) == 2
+        assert len(ff._blocks) == 2
         for i, row in enumerate(ff.tree["stream"]):
             assert np.all(row == i)
 
@@ -131,7 +131,7 @@ def test_stream_to_stream():
     buff.seek(0)
 
     with asdf.open(generic_io.InputStream(buff, "r")) as ff:
-        assert len(ff.blocks) == 2
+        assert len(ff._blocks) == 2
         assert_array_equal(ff.tree["nonstream"], np.array([1, 2, 3, 4], np.int64))
         assert ff.tree["stream"].shape == (100, 6, 2)
         for i, row in enumerate(ff.tree["stream"]):

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -244,7 +244,7 @@ class AsdfSchemaExampleItem(pytest.Item):
         for _ in range(3):
             b = block.Block(np.zeros((1024 * 1024 * 8), dtype=np.uint8))
             b._used = True
-            ff.blocks.add(b)
+            ff._blocks.add(b)
         b._array_storage = "streamed"
 
         try:

--- a/tox.ini
+++ b/tox.ini
@@ -136,7 +136,7 @@ commands_pre=
     pip install -r {envtmpdir}/requirements.txt
     pip freeze
 commands=
-    pytest astropy/astropy/io/misc/asdf --open-files --run-slow --remote-data
+    pytest astropy/astropy/io/misc/asdf --open-files --run-slow --remote-data -W "ignore:The property AsdfFile.blocks has been deprecated:asdf.exceptions.AsdfDeprecationWarning:asdf.asdf:661"
 
 [testenv:asdf-astropy]
 changedir={envtmpdir}


### PR DESCRIPTION
Public use of the block manager will be removed in ASDF 3.0 to allow for major changes to it's API. It is currently used by the legacy extensions (also removed in ASDF 3.0). The new converters do not currently have block storage access.

To provide a sense for possible breaking changes to the block manager and block storage access, the current experimental branch that adds block storage access to converters passes all block manager calls through the serialization context:
https://github.com/asdf-format/asdf/commit/4f6215608431f9f9e563fda9dc79d22c87a930bf
Adding block storage access to the converter is scheduled for ASDF 3.0 and the API and implementation details are not yet finalized.

Fixes issue #1335