### PR TITLE
deprecate AsdfInFits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ The ASDF Standard is at v1.6.0
 - Add AsdfDeprecationWarning to `~asdf.types.CustomType` [#1359]
 - Throw more useful error when provided with a path containing an
   extra leading slash [#1356]
+- Add AsdfDeprecationWarning to AsdfInFits. Support for reading and
+  writing ASDF in fits files is being moved to `stdatamodels
+  <https://github.com/spacetelescope/stdatamodels>`_. [#1337]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/commands/extract.py
+++ b/asdf/commands/extract.py
@@ -3,7 +3,6 @@ Implementation of command for converting ASDF-in-FITS to standalone ASDF file.
 """
 
 import asdf
-from asdf.fits_embed import AsdfInFits
 
 from .main import Command
 
@@ -45,6 +44,8 @@ class AsdfExtractor(Command):  # pragma: no cover
 
 def extract_file(input_file, output_file):
     """Function for performing extraction from ASDF-in-FITS to pure ASDF."""
+    # local import to avoid issuing Deprecation warning on every use of asdftool
+    from asdf.fits_embed import AsdfInFits
 
     try:
         with asdf.open(input_file) as ih:

--- a/asdf/commands/remove_hdu.py
+++ b/asdf/commands/remove_hdu.py
@@ -39,6 +39,9 @@ class FitsExtractor(Command):  # pragma: no cover
 
 def remove_hdu(input_file, output_file):
     """Function for removing ASDF HDU from ASDF-in-FITS files"""
+    # local import to trigger the deprecation warning since this command
+    # relates to and mentions AsdfInFits
+    from asdf.fits_embed import AsdfInFits  # noqa: F401
 
     try:
         with fits.open(input_file) as hdulist:

--- a/asdf/commands/tests/test_extract.py
+++ b/asdf/commands/tests/test_extract.py
@@ -10,14 +10,9 @@ from asdf.commands import extract
 from asdf.exceptions import AsdfDeprecationWarning
 
 with pytest.warns(AsdfDeprecationWarning, match="AsdfInFits has been deprecated.*"):
-    # asdf.fits_embed is imported here
     if "asdf.fits_embed" in sys.modules:
         del sys.modules["asdf.fits_embed"]
-    # import of asdf.fits_embed is required here to allow for proper removal of
-    # the asdf.fits_embed module (see the above line of code) to trigger the
-    # deprecation warning on import for other tests
     import asdf.fits_embed
-    from asdf.fits_embed import AsdfInFits
 
 from asdf.tests.helpers import assert_tree_match
 
@@ -36,7 +31,7 @@ def test_extract(tmpdir):
     }
 
     asdf_in_fits = str(tmpdir.join("asdf.fits"))
-    with AsdfInFits(hdulist, tree) as aif:
+    with asdf.fits_embed.AsdfInFits(hdulist, tree) as aif:
         aif.write_to(asdf_in_fits)
 
     pure_asdf = str(tmpdir.join("extract.asdf"))
@@ -45,5 +40,5 @@ def test_extract(tmpdir):
     assert os.path.exists(pure_asdf)
 
     with asdf.open(pure_asdf) as af:
-        assert not isinstance(af, AsdfInFits)
+        assert not isinstance(af, asdf.fits_embed.AsdfInFits)
         assert_tree_match(tree, af.tree)

--- a/asdf/commands/tests/test_extract.py
+++ b/asdf/commands/tests/test_extract.py
@@ -13,6 +13,9 @@ with pytest.warns(AsdfDeprecationWarning, match="AsdfInFits has been deprecated.
     # asdf.fits_embed is imported here
     if "asdf.fits_embed" in sys.modules:
         del sys.modules["asdf.fits_embed"]
+    # import of asdf.fits_embed is required here to allow for proper removal of
+    # the asdf.fits_embed module (see the above line of code) to trigger the
+    # deprecation warning on import for other tests
     import asdf.fits_embed
     from asdf.fits_embed import AsdfInFits
 

--- a/asdf/commands/tests/test_extract.py
+++ b/asdf/commands/tests/test_extract.py
@@ -1,11 +1,21 @@
 import os
+import sys
 
 import numpy as np
+import pytest
 from astropy.io.fits import HDUList, ImageHDU
 
 import asdf
 from asdf.commands import extract
-from asdf.fits_embed import AsdfInFits
+from asdf.exceptions import AsdfDeprecationWarning
+
+with pytest.warns(AsdfDeprecationWarning, match="AsdfInFits has been deprecated.*"):
+    # asdf.fits_embed is imported here
+    if "asdf.fits_embed" in sys.modules:
+        del sys.modules["asdf.fits_embed"]
+    import asdf.fits_embed
+    from asdf.fits_embed import AsdfInFits
+
 from asdf.tests.helpers import assert_tree_match
 
 

--- a/asdf/commands/tests/test_remove_hdu.py
+++ b/asdf/commands/tests/test_remove_hdu.py
@@ -11,7 +11,7 @@ from asdf.exceptions import AsdfDeprecationWarning
 with pytest.warns(AsdfDeprecationWarning, match="AsdfInFits has been deprecated.*"):
     if "asdf.fits_embed" in sys.modules:
         del sys.modules["asdf.fits_embed"]
-    from asdf.fits_embed import AsdfInFits
+    import asdf.fits_embed
 
 
 def test_remove_hdu(tmpdir):
@@ -28,7 +28,7 @@ def test_remove_hdu(tmpdir):
     }
 
     asdf_in_fits = str(tmpdir.join("asdf.fits"))
-    with AsdfInFits(hdulist, tree) as aif:
+    with asdf.fits_embed.AsdfInFits(hdulist, tree) as aif:
         aif.write_to(asdf_in_fits)
 
     with fits.open(asdf_in_fits) as hdul:

--- a/asdf/commands/tests/test_remove_hdu.py
+++ b/asdf/commands/tests/test_remove_hdu.py
@@ -1,10 +1,17 @@
 import os
+import sys
 
 import numpy as np
+import pytest
 from astropy.io import fits
 
 from asdf.commands import remove_hdu
-from asdf.fits_embed import AsdfInFits
+from asdf.exceptions import AsdfDeprecationWarning
+
+with pytest.warns(AsdfDeprecationWarning, match="AsdfInFits has been deprecated.*"):
+    if "asdf.fits_embed" in sys.modules:
+        del sys.modules["asdf.fits_embed"]
+    from asdf.fits_embed import AsdfInFits
 
 
 def test_remove_hdu(tmpdir):

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -3,10 +3,12 @@ Utilities for embedded ADSF files in FITS.
 """
 import io
 import re
+import warnings
 
 import numpy as np
 
 from . import asdf, block, generic_io, util
+from .exceptions import AsdfDeprecationWarning
 
 try:
     from astropy.io import fits
@@ -20,6 +22,14 @@ FITS_SOURCE_PREFIX = "fits:"
 
 
 __all__ = ["AsdfInFits"]
+
+warnings.warn(
+    "AsdfInFits has been deprecated and will be removed in "
+    "asdf-3.0. Similar functionality has been added to stdatamodels "
+    "https://github.com/spacetelescope/stdatamodels to load and "
+    "save ASDF in fits files.",
+    AsdfDeprecationWarning,
+)
 
 
 class _FitsBlock:

--- a/asdf/tests/test_deprecated.py
+++ b/asdf/tests/test_deprecated.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from asdf.exceptions import AsdfDeprecationWarning
@@ -9,3 +11,10 @@ def test_custom_type_warning():
 
         class NewCustomType(CustomType):
             pass
+
+
+def test_asdf_in_fits_import_warning():
+    if "asdf.fits_embed" in sys.modules:
+        del sys.modules["asdf.fits_embed"]
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfInFits has been deprecated.*"):
+        import asdf.fits_embed  # noqa: F401

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -1,4 +1,5 @@
 import copy
+import importlib
 import warnings
 
 import numpy as np
@@ -547,3 +548,8 @@ def test_resave_breaks_hdulist_tree_array_link(tmp_path):
         for f in (af1, af2):
             block_bytes = f["ASDF"].data.tobytes().split(b"...")[1].strip()
             assert len(block_bytes) == 0
+
+
+def test_asdf_in_fits_deprecation():
+    with pytest.deprecated_call():
+        importlib.reload(asdf.fits_embed)

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 import numpy as np
 import pytest
@@ -347,8 +348,13 @@ def test_extension_check():
         pass
 
     # Make sure that suppressing the warning works as well
-    with assert_no_warnings(), asdf.open(testfile, ignore_missing_extensions=True):
-        pass
+    with warnings.catch_warnings():
+        # modify the warnings filter to turn warnings into error but append
+        # the new filter so it doesn't override warnings filtered by decorators
+        # or globally
+        warnings.simplefilter("error", append=True)
+        with asdf.open(testfile, ignore_missing_extensions=True):
+            pass
 
     with pytest.raises(RuntimeError), asdf.open(testfile, strict_extension_check=True):
         pass

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -17,7 +17,6 @@ with pytest.warns(AsdfDeprecationWarning, match="AsdfInFits has been deprecated.
     if "asdf.fits_embed" in sys.modules:
         del sys.modules["asdf.fits_embed"]
     import asdf.fits_embed
-    from asdf import fits_embed
 
 from .helpers import assert_no_warnings, assert_tree_match, get_test_data_path, yaml_to_asdf
 
@@ -39,7 +38,7 @@ def create_asdf_in_fits(dtype):
         },
     }
 
-    return fits_embed.AsdfInFits(hdulist, tree)
+    return asdf.fits_embed.AsdfInFits(hdulist, tree)
 
 
 # Testing backwards compatibility ensures that we can continue to read and
@@ -64,7 +63,7 @@ def test_embed_asdf_in_fits_file(tmp_path, backwards_compat, dtype):
         },
     }
 
-    ff = fits_embed.AsdfInFits(hdulist, tree)
+    ff = asdf.fits_embed.AsdfInFits(hdulist, tree)
     ff.write_to(fits_testfile, use_image_hdu=backwards_compat)
 
     with fits.open(fits_testfile) as hdulist2:
@@ -81,7 +80,7 @@ def test_embed_asdf_in_fits_file(tmp_path, backwards_compat, dtype):
         else:
             assert isinstance(asdf_hdu, fits.BinTableHDU)
 
-        with fits_embed.AsdfInFits.open(hdulist2) as ff2:
+        with asdf.fits_embed.AsdfInFits.open(hdulist2) as ff2:
             assert_tree_match(tree, ff2.tree)
 
             ff = asdf.AsdfFile(copy.deepcopy(ff2.tree))
@@ -107,7 +106,7 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmp_path, dtype):
         assert isinstance(asdf_hdu, fits.BinTableHDU)
         assert asdf_hdu.data.tobytes().startswith(b"#ASDF")
 
-        with fits_embed.AsdfInFits.open(hdulist) as ff2:
+        with asdf.fits_embed.AsdfInFits.open(hdulist) as ff2:
             assert_tree_match(asdf_in_fits.tree, ff2.tree)
 
             ff = asdf.AsdfFile(copy.deepcopy(ff2.tree))
@@ -127,12 +126,12 @@ def test_update_in_place(tmp_path, dtype):
     asdf_in_fits.write_to(tempfile)
 
     # Open the file and add data so it needs to be updated
-    with fits_embed.AsdfInFits.open(tempfile) as ff:
+    with asdf.fits_embed.AsdfInFits.open(tempfile) as ff:
         ff.tree["new_stuff"] = "A String"
         ff.update()
 
     # Open the updated file and make sure everything looks okay
-    with fits_embed.AsdfInFits.open(tempfile) as ff:
+    with asdf.fits_embed.AsdfInFits.open(tempfile) as ff:
         assert ff.tree["new_stuff"] == "A String"
         assert_tree_match(ff.tree["model"], asdf_in_fits.tree["model"])
 
@@ -147,12 +146,12 @@ def test_update_and_write_new(tmp_path, dtype):
     asdf_in_fits.write_to(tempfile)
 
     # Open the file and add data so it needs to be updated
-    with fits_embed.AsdfInFits.open(tempfile) as ff:
+    with asdf.fits_embed.AsdfInFits.open(tempfile) as ff:
         ff.tree["new_stuff"] = "A String"
         ff.write_to(newfile)
 
     # Open the updated file and make sure everything looks okay
-    with fits_embed.AsdfInFits.open(newfile) as ff:
+    with asdf.fits_embed.AsdfInFits.open(newfile) as ff:
         assert ff.tree["new_stuff"] == "A String"
         assert_tree_match(ff.tree["model"], asdf_in_fits.tree["model"])
 
@@ -188,7 +187,7 @@ def test_create_in_tree_first(tmp_path, dtype):
     hdulist.append(fits.ImageHDU(tree["model"]["err"]["data"]))
 
     tmpfile = str(tmp_path / "test.fits")
-    with fits_embed.AsdfInFits(hdulist, tree) as ff:
+    with asdf.fits_embed.AsdfInFits(hdulist, tree) as ff:
         ff.write_to(tmpfile)
 
     with asdf.AsdfFile(tree) as ff:
@@ -220,20 +219,20 @@ def test_asdf_in_fits_open(tmp_path, dtype):
     asdf_in_fits.write_to(tmpfile)
 
     # Test opening the file directly from the URI
-    with fits_embed.AsdfInFits.open(tmpfile) as ff:
+    with asdf.fits_embed.AsdfInFits.open(tmpfile) as ff:
         compare_asdfs(asdf_in_fits, ff)
 
     # Test open/close without context handler
-    ff = fits_embed.AsdfInFits.open(tmpfile)
+    ff = asdf.fits_embed.AsdfInFits.open(tmpfile)
     compare_asdfs(asdf_in_fits, ff)
     ff.close()
 
     # Test reading in the file from an already-opened file handle
-    with open(tmpfile, "rb") as handle, fits_embed.AsdfInFits.open(handle) as ff:
+    with open(tmpfile, "rb") as handle, asdf.fits_embed.AsdfInFits.open(handle) as ff:
         compare_asdfs(asdf_in_fits, ff)
 
     # Test opening the file as a FITS file first and passing the HDUList
-    with fits.open(tmpfile) as hdulist, fits_embed.AsdfInFits.open(hdulist) as ff:
+    with fits.open(tmpfile) as hdulist, asdf.fits_embed.AsdfInFits.open(hdulist) as ff:
         compare_asdfs(asdf_in_fits, ff)
 
 
@@ -276,7 +275,7 @@ invalid_software: !core/software-1.0.0
     hdul.append(hdu)
     hdul.writeto(tmpfile)
 
-    for open_method in [asdf.open, fits_embed.AsdfInFits.open]:
+    for open_method in [asdf.open, asdf.fits_embed.AsdfInFits.open]:
         get_config().validate_on_read = True
         with pytest.raises(ValidationError), open_method(tmpfile):
             pass
@@ -300,7 +299,7 @@ def test_bad_fits_input(tmp_path):
 def test_open_gzipped():
     testfile = get_test_data_path("asdf.fits.gz")
 
-    with fits_embed.AsdfInFits.open(testfile) as af:
+    with asdf.fits_embed.AsdfInFits.open(testfile) as af:
         assert af.tree["stuff"].shape == (20, 20)
 
 
@@ -317,14 +316,14 @@ def test_version_mismatch_file():
     with assert_no_warnings(AsdfConversionWarning), asdf.open(testfile) as fits_handle:
         assert fits_handle.tree["a"] == complex(0j)
 
-    with pytest.warns(AsdfConversionWarning, match=r"tag:stsci.edu:asdf/core/complex"), fits_embed.AsdfInFits.open(
+    with pytest.warns(AsdfConversionWarning, match=r"tag:stsci.edu:asdf/core/complex"), asdf.fits_embed.AsdfInFits.open(
         testfile,
         ignore_version_mismatch=False,
     ) as fits_handle:
         assert fits_handle.tree["a"] == complex(0j)
 
     # Make sure warning does not occur when warning is ignored (default)
-    with assert_no_warnings(AsdfConversionWarning), fits_embed.AsdfInFits.open(testfile) as fits_handle:
+    with assert_no_warnings(AsdfConversionWarning), asdf.fits_embed.AsdfInFits.open(testfile) as fits_handle:
         assert fits_handle.tree["a"] == complex(0j)
 
 
@@ -339,7 +338,7 @@ def test_serialize_table(tmp_path):
     hdulist.append(hdu)
 
     tree = {"my_table": hdulist[1].data}
-    with fits_embed.AsdfInFits(hdulist, tree) as ff:
+    with asdf.fits_embed.AsdfInFits(hdulist, tree) as ff:
         ff.write_to(tmpfile)
 
     with asdf.open(tmpfile) as ff:

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -413,6 +413,15 @@ details).
 Saving ASDF in FITS
 ===================
 
+.. warning::
+
+    `~asdf.fits_embed.AsdfInFits` and `~asdf.fits_embed` are deprecated and
+    will be removed from an upcoming version of ASDF. Support for reading
+    and writing ASDF data within a FITS file has moved to the `stdatamodels`
+    package. Please see the the `stdatamodels`
+    :external+stdatamodels:doc:`asdf_in_fits` documentation for information
+    about migrating code from ASDF to `stdatamodels`.
+
 .. note::
 
     This section is about packaging entire ASDF files inside of

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -413,7 +413,7 @@ details).
 Saving ASDF in FITS
 ===================
 
-.. note::
+.. warning::
 
     `~asdf.fits_embed.AsdfInFits` and `~asdf.fits_embed` are deprecated and
     will be removed from an upcoming version of ASDF. Support for reading

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -413,7 +413,7 @@ details).
 Saving ASDF in FITS
 ===================
 
-.. warning::
+.. note::
 
     `~asdf.fits_embed.AsdfInFits` and `~asdf.fits_embed` are deprecated and
     will be removed from an upcoming version of ASDF. Support for reading

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,3 +44,4 @@ nitpicky = True
 # Add intersphinx mappings
 intersphinx_mapping["semantic_version"] = ("https://python-semanticversion.readthedocs.io/en/latest/", None)
 intersphinx_mapping["jsonschema"] = ("https://python-jsonschema.readthedocs.io/en/stable/", None)
+intersphinx_mapping["stdatamodels"] = ("https://stdatamodels.readthedocs.io/en/latest/", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ open_files_ignore = ['test.fits', 'asdf.fits']
 # which pytest trips over during collection:
 filterwarnings = [
     'error',
+    'ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.fits_embed',
     'ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
     'ignore:.*from astropy.io.misc.asdf.*subclasses the deprecated CustomType.*:asdf.exceptions.AsdfDeprecationWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,14 +111,13 @@ open_files_ignore = ['test.fits', 'asdf.fits']
 # which pytest trips over during collection:
 filterwarnings = [
     'error',
-    'ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.fits_embed',
     'ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
     'ignore:.*from astropy.io.misc.asdf.*subclasses the deprecated CustomType.*:asdf.exceptions.AsdfDeprecationWarning',
 ]
 # Configuration for pytest-doctestplus
 text_file_format = 'rst'
-addopts = '--color=yes --doctest-rst'
+addopts = '--color=yes --doctest-rst --ignore=asdf/fits_embed.py'
 
 [tool.coverage.run]
 omit = [

--- a/tox.ini
+++ b/tox.ini
@@ -163,7 +163,8 @@ commands_pre=
     pip install -r {envtmpdir}/requirements.txt
     pip freeze
 commands=
-    pytest specutils
+    pytest specutils \
+        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.fits_embed"
 
 [testenv:gwcs]
 changedir={envtmpdir}


### PR DESCRIPTION
Support to reading and writing ASDF in fits is moving to [stdatamodels](https://github.com/spacetelescope/stdatamodels).

https://github.com/spacetelescope/stdatamodels/pull/110

fixes #1332