### PR TITLE
bump isort to 5.11.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       args: ["--fix"]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.11.5
   hooks:
     - id: isort
 


### PR DESCRIPTION
isort is failing to build in the pre-commit ci

This looks to be related to https://github.com/PyCQA/isort/issues/2079

Bumping to 5.11.5 to see if it builds.