### PR TITLE
More ruff clean-ups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       exclude: "asdf/extern/.*"
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.231'
+  rev: 'v0.0.237'
   hooks:
     - id: ruff
       args: ["--fix"]

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -661,7 +661,7 @@ class BlockManager:
                 return last_block
 
             msg = f"Block '{source}' not found."
-            raise ValueError(msg)  # noqa: TRY004
+            raise ValueError(msg)
 
         if isinstance(source, str):
             asdffile = self._asdffile().open_external(source)

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -87,7 +87,7 @@ class _EmbeddedBlockManager(block.BlockManager):
                     return f"{FITS_SOURCE_PREFIX}{hdu.name},{hdu.ver}"
 
             msg = "FITS block seems to have been removed"
-            raise ValueError(msg)  # noqa: TRY004
+            raise ValueError(msg)
 
         return super().get_source(block)
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -1137,7 +1137,7 @@ def get_file(init, mode="r", uri=None, close=False):
             return InputStream(init, mode, uri=uri, close=close)
 
         msg = f"File '{init}' could not be opened in 'rw' mode"
-        raise ValueError(msg)  # noqa: TRY004
+        raise ValueError(msg)
 
     if mode == "w" and (hasattr(init, "write") and hasattr(init, "seek") and hasattr(init, "tell")):
         return MemoryIO(init, mode, uri=uri)

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -155,25 +155,25 @@ def test_version_and_tuple_inequality():
     assert version <= (2, 1, 0)
     assert version <= (2, 1, 1)
 
-    assert (1, 0, 0) < version
-    assert (1, 0, 1) < version
-    assert (1, 1, 0) < version
-    assert (1, 1, 1) < version
-    assert ((2, 0, 0) < version) is False
-    assert ((2, 0, 0) > version) is False
-    assert (2, 0, 1) > version
-    assert (2, 1, 0) > version
-    assert (2, 1, 1) > version
+    assert (1, 0, 0) < version  # noqa: SIM300
+    assert (1, 0, 1) < version  # noqa: SIM300
+    assert (1, 1, 0) < version  # noqa: SIM300
+    assert (1, 1, 1) < version  # noqa: SIM300
+    assert ((2, 0, 0) < version) is False  # noqa: SIM300
+    assert ((2, 0, 0) > version) is False  # noqa: SIM300
+    assert (2, 0, 1) > version  # noqa: SIM300
+    assert (2, 1, 0) > version  # noqa: SIM300
+    assert (2, 1, 1) > version  # noqa: SIM300
 
-    assert (1, 0, 0) <= version
-    assert (1, 0, 1) <= version
-    assert (1, 1, 0) <= version
-    assert (1, 1, 1) <= version
-    assert (2, 0, 0) <= version
-    assert (2, 0, 0) >= version
-    assert (2, 0, 1) >= version
-    assert (2, 1, 0) >= version
-    assert (2, 1, 1) >= version
+    assert (1, 0, 0) <= version  # noqa: SIM300
+    assert (1, 0, 1) <= version  # noqa: SIM300
+    assert (1, 1, 0) <= version  # noqa: SIM300
+    assert (1, 1, 1) <= version  # noqa: SIM300
+    assert (2, 0, 0) <= version  # noqa: SIM300
+    assert (2, 0, 0) >= version  # noqa: SIM300
+    assert (2, 0, 1) >= version  # noqa: SIM300
+    assert (2, 1, 0) >= version  # noqa: SIM300
+    assert (2, 1, 1) >= version  # noqa: SIM300
 
 
 def test_spec_version_match():
@@ -271,9 +271,9 @@ def test_spec_equal():
     assert "1.3.0" == spec  # noqa: SIM300
 
     assert spec != (1, 1, 0)
-    assert (1, 1, 0) != spec
+    assert (1, 1, 0) != spec  # noqa: SIM300
     assert spec == (1, 3, 0)
-    assert (1, 3, 0) == spec
+    assert (1, 3, 0) == spec  # noqa: SIM300
 
 
 def _standard_versioned_tags():

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -84,7 +84,7 @@ class ExtensionTypeMeta(type):
 
     @property
     def versioned_siblings(cls):
-        return getattr(cls, "__versioned_siblings") or []  # noqa: B009
+        return getattr(cls, "__versioned_siblings") or []
 
     def __new__(cls, name, bases, attrs):
         requires = cls._find_in_bases(attrs, bases, "requires", [])
@@ -147,7 +147,7 @@ class ExtensionTypeMeta(type):
                         )
                         raise RuntimeError(msg)
                     siblings.append(ExtensionTypeMeta.__new__(cls, name, bases, new_attrs))
-            setattr(new_cls, "__versioned_siblings", siblings)  # noqa: B010
+            setattr(new_cls, "__versioned_siblings", siblings)
 
         return new_cls
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,9 @@ extend-ignore = [
     "B905", # Requires python 3.10 (use zip strict)
     "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "PLR2004", # Magic value used in comparison
+    "TRY002", # Create your own exception
+    "TRY301", # Abstract raise to an inner function
+    "TRY400", # Use logging.exception instead of logging.error
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]
 


### PR DESCRIPTION
Ruff has made a few tweaks (some of which I requested in charliermarsh/ruff#2202 and charliermarsh/ruff#2158) to rules we are already enforcing (in particular `SIM300` has been update to detect even more versions of yoda conditions which need to be ignored because we are specifically testing that we can handle those conditions).

This PR cleans up all unnecessary noqa and adds some new `SIM300` noqa. It also ignores:

- `TRY002`
- `TRY301`
- `TRY400`

Which we will address at a later date, per https://github.com/asdf-format/asdf/pull/1329#issuecomment-1405301731.