### PR TITLE
don't call reserve_blocks on types that have converters

### DIFF
--- a/asdf/block.py
+++ b/asdf/block.py
@@ -556,10 +556,12 @@ class BlockManager:
         reserved_blocks = set()
 
         for node in treeutil.iter_tree(tree):
-            hook = ctx.type_index.get_hook_for_type("reserve_blocks", type(node), ctx.version_string)
-            if hook is not None:
-                for block in hook(node, ctx):
-                    reserved_blocks.add(block)
+            # check that this object will not be handled by a converter
+            if not ctx.extension_manager.handles_type(type(node)):
+                hook = ctx.type_index.get_hook_for_type("reserve_blocks", type(node), ctx.version_string)
+                if hook is not None:
+                    for block in hook(node, ctx):
+                        reserved_blocks.add(block)
 
         for block in list(self.blocks):
             if getattr(block, "_used", 0) == 0 and block not in reserved_blocks:


### PR DESCRIPTION
This PR fixes reserve_blocks to treat objects in the tree (nodes) in a way consistent with
yamlutil.custom_tree_to_tagged_tree. Conversion of nodes in a custom tree will preferentially use Converters if a type/tag is supported by both old style types and new style converters. Reserve blocks always assumed old style types. This resulted in serialization calling old style reserve_blocks and then new style converters for nodes supported by both types and converters.