### PR TITLE
Enable CRDS for stdatamodels downstream

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -209,6 +209,11 @@ allowlist_externals=
     git
     bash
 extras=
+setenv=
+    CRDS_SERVER_URL = https://jwst-crds.stsci.edu
+    CRDS_PATH = $HOME/crds_cache
+    CRDS_CLIENT_RETRY_COUNT = 3
+    CRDS_CLIENT_RETRY_DELAY_SECONDS = 20
 commands_pre=
     bash -c "pip freeze -q | grep 'asdf @' > {envtmpdir}/requirements.txt"
     git clone https://github.com/spacetelescope/stdatamodels.git


### PR DESCRIPTION
This should fix the downstream tests for stdatamodels.