### PR TITLE
Remove pyupgrade use from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,13 +41,6 @@ repos:
     - id: flynt
       exclude: "asdf/extern/.*"
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: 'v3.3.1'
-  hooks:
-    - id: pyupgrade
-      args: ["--py38-plus"]
-      exclude: "asdf/extern/.*"
-
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: 'v0.0.243'
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ line_length = 120
 extend_skip_glob = ["asdf/extern/*", ".eggs/*", ".tox/*"]
 
 [tool.ruff]
+target-version = "py38"
 line-length = 120
 select = ["ALL"]
 extend-ignore = [
@@ -182,7 +183,6 @@ extend-ignore = [
     "DTZ", # flake8-datetimez
     "PTH", # flake8-use-pathlib
     # Individually ignored checks
-    "B905", # Requires python 3.10 (use zip strict)
     "PIE810", # Call `startswith` once with a `tuple`
     "PLR0911", # Too many return statements
     "PLR0912", # Too many branches


### PR DESCRIPTION
All functionality from `pyupgrade` can now be fully replaced by `ruff`, see the completion of https://github.com/charliermarsh/ruff/issues/827.

This PR removes `pyupgrade` and configures `ruff` to take fully advantage of these changes.