### PR TITLE
catch and report useful error with paths with extra leading slash

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ The ASDF Standard is at v1.6.0
 - Add AsdfDeprecationWarning to AsdfFile.blocks [#1336]
 - Document policy for ASDF release cycle including when support for ASDF versions
   end. Also document dependency support policy. [#1323]
+- Throw more useful error when provided with a path containing an
+  extra leading slash [#1354]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -50,6 +50,23 @@ def test_mode_fail(tmp_path):
         generic_io.get_file(path, mode="r+")
 
 
+@pytest.mark.parametrize("mode", ["r", "w", "rw"])
+def test_two_leading_slashes(mode):
+    """
+    Providing a path with two leading slashes '//' will be parsed
+    by urllib as having a netloc (unhandled by generic_io) and
+    an invalid path. This creates an unhelpful error message on
+    write (related to a missing atomic write file) and should be
+    cause beforehand and provided with a more helpful error message
+
+    Regression test for issue:
+    https://github.com/asdf-format/asdf/issues/1353
+    """
+    path = "//bad/two/slashes"
+    with pytest.raises(ValueError, match="Invalid path"):
+        generic_io.get_file(path, mode=mode)
+
+
 def test_open(tmp_path, small_tree):
     from asdf import open
 


### PR DESCRIPTION
providing a path with two leading slashes produces an unhelpful error

fixes #1353