### PR TITLE
catch invalid path parsing for paths with two leading slashes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ The ASDF Standard is at v1.6.0
 - Provide more informative filename when failing to open a file [#1357]
 - Add new plugin type for custom schema validators. [#1328]
 - Add AsdfDeprecationWarning to `~asdf.types.CustomType` [#1359]
+- Throw more useful error when provided with a path containing an
+  extra leading slash [#1356]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -1092,6 +1092,14 @@ def get_file(init, mode="r", uri=None, close=False):
         if parsed.scheme in _local_file_schemes:
             realmode = "r+b" if mode == "rw" else mode + "b"
 
+            # if paths have an extra leading '/' urlparse will
+            # parse them even though they violate rfc8089. This will
+            # lead to errors or writing files to unexpected locations
+            # on non-windows systems
+            if not sys.platform.startswith("win") and parsed.scheme == "" and parsed.netloc != "":
+                msg = f"Invalid path {init}"
+                raise ValueError(msg)
+
             # Windows paths are not URIs, and so they should not be parsed as
             # such. Otherwise, the drive component of the path can get lost.
             # This is not an ideal solution, but we can't use pathlib here

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -59,6 +59,24 @@ def test_missing_directory(tmp_path, mode):
         generic_io.get_file(path, mode=mode)
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="paths with two leading slashes are valid on windows")
+@pytest.mark.parametrize("mode", ["r", "w", "rw"])
+def test_two_leading_slashes(mode):
+    """
+    Providing a path with two leading slashes '//' will be parsed
+    by urllib as having a netloc (unhandled by generic_io) and
+    an invalid path. This creates an unhelpful error message on
+    write (related to a missing atomic write file) and should be
+    cause beforehand and provided with a more helpful error message
+
+    Regression test for issue:
+    https://github.com/asdf-format/asdf/issues/1353
+    """
+    path = "//bad/two/slashes"
+    with pytest.raises(ValueError, match="Invalid path"):
+        generic_io.get_file(path, mode=mode)
+
+
 def test_open(tmp_path, small_tree):
     from asdf import open
 


### PR DESCRIPTION
Providing a path with two leading slashes results in an invalid parsed path. Catch this case and raise an exception reporting the invalid path.

fixes #1353