### PR TITLE
provide more informative error message for failed open

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ The ASDF Standard is at v1.6.0
   end. Also document dependency support policy. [#1323]
 - Update lower pins on ``numpy`` (per release policy), ``packaging``, and ``pyyaml`` to
   ones that we can successfully build and test against. [#1360]
+- Provide more informative filename when failing to open a file [#1357]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -1101,9 +1101,20 @@ def get_file(init, mode="r", uri=None, close=False):
                 if sys.platform.startswith("win") and parsed.scheme in string.ascii_letters
                 else url2pathname(parsed.path)
             )
-            fd = atomicfile.atomic_open(realpath, realmode) if mode == "w" else open(realpath, realmode)  # noqa: SIM115
+            try:
+                fd = (
+                    atomicfile.atomic_open(realpath, realmode)
+                    if mode == "w"
+                    else open(realpath, realmode)  # noqa: SIM115
+                )
 
-            fd = fd.__enter__()
+                fd = fd.__enter__()
+            except FileNotFoundError as e:
+                # atomic_open will create an Exception with an odd looking path
+                # overwrite the error message to make it more informative
+                e.filename = realpath
+                raise e  # noqa: TRY201
+
             return RealFile(fd, mode, close=True, uri=uri)
 
     if isinstance(init, io.BytesIO):

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -50,6 +50,13 @@ def test_mode_fail(tmp_path):
         generic_io.get_file(path, mode="r+")
 
 
+@pytest.mark.parametrize("mode", ["r", "w", "rw"])
+def test_missing_directory(tmp_path, mode):
+    path = tmp_path / "missing" / "test.asdf"
+    with pytest.raises(FileNotFoundError, match=f".*: '{path}'$"):
+        generic_io.get_file(path, mode=mode)
+
+
 def test_open(tmp_path, small_tree):
     from asdf import open
 

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -1,5 +1,6 @@
 import io
 import os
+import re
 import sys
 import urllib.request as urllib_request
 
@@ -52,8 +53,8 @@ def test_mode_fail(tmp_path):
 
 @pytest.mark.parametrize("mode", ["r", "w", "rw"])
 def test_missing_directory(tmp_path, mode):
-    path = tmp_path / "missing" / "test.asdf"
-    with pytest.raises(FileNotFoundError, match=f".*: '{path}'$"):
+    path = str(tmp_path / "missing" / "test.asdf")
+    with pytest.raises(FileNotFoundError, match=f".*: '{re.escape(path)}'$"):
         generic_io.get_file(path, mode=mode)
 
 

--- a/asdf/tests/test_generic_io.py
+++ b/asdf/tests/test_generic_io.py
@@ -54,7 +54,8 @@ def test_mode_fail(tmp_path):
 @pytest.mark.parametrize("mode", ["r", "w", "rw"])
 def test_missing_directory(tmp_path, mode):
     path = str(tmp_path / "missing" / "test.asdf")
-    with pytest.raises(FileNotFoundError, match=f".*: '{re.escape(path)}'$"):
+    regex_path = re.escape(path.replace("\\", "\\\\"))
+    with pytest.raises(FileNotFoundError, match=f".*: '{regex_path}'$"):
         generic_io.get_file(path, mode=mode)
 
 


### PR DESCRIPTION
The use of atomic file produces filenames that can contain random characters. Fix the filename the error message prior to raising.

Without this PR
```python
import asdf
asdf.generic_io.get_file('missing/foo', 'w')
```
produces
```
FileNotFoundError: [Errno 2] No such file or directory: '/.../asdf/missing/.___atomic_writekdbtzq1a'
```

With this PR it produces
```
FileNotFoundError: [Errno 2] No such file or directory: 'missing/foo'
```