### PR TITLE
Add oldest dependencies testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,17 @@ jobs:
         - linux: py310-devdeps
         - linux: py311-devdeps
 
+  oldest:
+    needs: [core, asdf-schemas]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      submodules: false
+      # Any env name which does not start with `pyXY` will use this Python version.
+      default_python: '3.9'
+      envs: |
+        - linux: py38-oldestdeps
+        - linux: py39-oldestdeps
+
   compatibility:
     needs: [core, asdf-schemas]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
@@ -82,7 +93,7 @@ jobs:
         - linux: compatibility
 
   package:
-    needs: [test, dev, compatibility]
+    needs: [core, asdf-schemas]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
       upload_to_pypi: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ The ASDF Standard is at v1.6.0
 - Add AsdfDeprecationWarning to AsdfFile.blocks [#1336]
 - Document policy for ASDF release cycle including when support for ASDF versions
   end. Also document dependency support policy. [#1323]
+- Update lower pins on ``numpy`` (per release policy), ``packaging``, and ``pyyaml`` to
+  ones that we can successfully build and test against. [#1360]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ dependencies = [
   'importlib_resources>=3; python_version < "3.9"',
   "jmespath>=0.6.2",
   "jsonschema>=4.0.1",
-  "numpy>=1.18",
-  'numpy<1.25,>=1.18; python_version < "3.9"',
-  "packaging>=16",
-  "pyyaml>=3.10",
+  "numpy>=1.20",
+  'numpy<1.25,>=1.20; python_version < "3.9"',
+  "packaging>=19",
+  "pyyaml>=5.4.1",
   "semantic_version>=2.8",
 ]
 [project.optional-dependencies]
@@ -43,7 +43,7 @@ docs = [
 tests = [
   "astropy>=5.0.4",
   "fsspec[http]>=2022.8.2",
-  "gwcs",
+  "gwcs>=0.18.3",
   "lz4>=0.10",
   "psutil",
   "pytest>=6",

--- a/tox.ini
+++ b/tox.ini
@@ -7,25 +7,22 @@ setenv =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 deps=
     devdeps: -rrequirements-dev.txt
-    # Newer versions of gwcs require astropy 4.x, which
-    # isn't compatible with the older versions of numpy
-    # that we test with.
-    legacy: gwcs==0.9.1
-# NOTE: this dependency on `six` is only here because `gwcs <= 0.18.1` requires it
-    legacy: six~=1.4.0
-    legacy: semantic_version==2.8
-    legacy: pyyaml==3.13
-    legacy: jsonschema==4.0.1
-    legacy: numpy~=1.18
-    legacy: pytest~=6.0.0
-    legacy: astropy~=5.0.4
     numpydev: cython
+    oldestdeps: minimum_dependencies
 extras= all,tests
 # astropy will complain if the home directory is missing
 passenv= HOME
 usedevelop= true
-commands=
+commands_pre=
+    python -m pip install --upgrade pip
+
+    # Generate `requiremments-min.txt`
+    oldestdeps: minimum_dependencies asdf --filename {envtmpdir}/requirements-min.txt
+    # Force install everything from `requirements-min.txt`
+    oldestdeps: pip install -r {envtmpdir}/requirements-min.txt
+
     pip freeze
+commands=
     pytest --remote-data
 
 # coverage run must be used because the pytest-asdf plugin will interfere


### PR DESCRIPTION
Add testing against the oldest pinned versions of our dependencies.

Note that per https://github.com/asdf-format/asdf/pull/1331#discussion_r1096980876 I moved the script for generating the minimum dependencies out of ASDF and into its own package, see: https://github.com/WilliamJamieson/minimum_dependencies.

Closes #1331, as this supersedes it. 