### PR TITLE
Make the warning only issue on the very first subclass of `CustomType`

### DIFF
--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -12,7 +12,6 @@ from numpy.testing import assert_array_equal
 
 import asdf
 from asdf import util
-from asdf.exceptions import AsdfDeprecationWarning
 from asdf.tags.core import ndarray
 from asdf.tests import helpers
 from asdf.tests.objects import CustomTestType
@@ -25,22 +24,18 @@ TEST_DATA_PATH = helpers.get_test_data_path("", module=test_data)
 # These custom types and the custom extension are here purely for the purpose
 # of testing NDArray objects and making sure that they can be validated as part
 # of a nested hierarchy, and not just top-level objects.
-with pytest.warns(AsdfDeprecationWarning, match=".*subclasses the deprecated CustomType.*"):
-
-    class CustomNdim(CustomTestType):
-        name = "ndim"
-        organization = "nowhere.org"
-        standard = "custom"
-        version = "1.0.0"
+class CustomNdim(CustomTestType):
+    name = "ndim"
+    organization = "nowhere.org"
+    standard = "custom"
+    version = "1.0.0"
 
 
-with pytest.warns(AsdfDeprecationWarning, match=".*subclasses the deprecated CustomType.*"):
-
-    class CustomDatatype(CustomTestType):
-        name = "datatype"
-        organization = "nowhere.org"
-        standard = "custom"
-        version = "1.0.0"
+class CustomDatatype(CustomTestType):
+    name = "datatype"
+    organization = "nowhere.org"
+    standard = "custom"
+    version = "1.0.0"
 
 
 class CustomExtension:

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -228,15 +228,13 @@ def test_version_mismatch_with_supported_versions():
     class CustomFlow:
         pass
 
-    with pytest.warns(AsdfDeprecationWarning, match=".*subclasses the deprecated CustomType.*"):
-
-        class CustomFlowType(CustomTestType):
-            version = "1.1.0"
-            supported_versions = ["1.0.0", "1.1.0"]
-            name = "custom_flow"
-            organization = "nowhere.org"
-            standard = "custom"
-            types = [CustomFlow]
+    class CustomFlowType(CustomTestType):
+        version = "1.1.0"
+        supported_versions = ["1.0.0", "1.1.0"]
+        name = "custom_flow"
+        organization = "nowhere.org"
+        standard = "custom"
+        types = [CustomFlow]
 
     class CustomFlowExtension(CustomExtension):
         @property

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -44,21 +44,6 @@ def _from_tree_tagged_missing_requirements(cls, tree, ctx):
     raise TypeError(msg)
 
 
-def _find_first_child_class(sub_class, parent_class):
-    err = None
-    for b in sub_class.__bases__:
-        if b == parent_class:
-            return sub_class
-        try:
-            return _find_first_child_class(b, parent_class)
-        except ValueError as e:
-            err = e
-    if err:
-        raise err
-    msg = f"Failed to find {parent_class} in {sub_class}"
-    raise ValueError(msg)
-
-
 class ExtensionTypeMeta(type):
     """
     Custom class constructor for tag types.
@@ -501,11 +486,10 @@ class CustomType(ExtensionType, metaclass=ExtensionTypeMeta):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
-        # Create a warning for the first subclass of a CustomType class
-        scls = _find_first_child_class(cls, CustomType)
-        if scls.__name__ == cls.__name__:
+        # Create a warning for a direct child of a CustomType class (not in grandchild)
+        if CustomType in cls.__bases__:
             warnings.warn(
-                f"{scls.__name__} from {scls.__module__} subclasses the deprecated CustomType class. "
+                f"{cls.__name__} from {cls.__module__} subclasses the deprecated CustomType class. "
                 "Please see the new extension API "
                 "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
                 AsdfDeprecationWarning,

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -500,10 +500,13 @@ class CustomType(ExtensionType, metaclass=ExtensionTypeMeta):
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
+
+        # Create a warning for the first subclass of a CustomType class
         scls = _find_first_child_class(cls, CustomType)
-        warnings.warn(
-            f"{scls.__name__} from {scls.__module__} subclasses the deprecated CustomType class. "
-            "Please see the new extension API "
-            "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
-            AsdfDeprecationWarning,
-        )
+        if scls.__name__ == cls.__name__:
+            warnings.warn(
+                f"{scls.__name__} from {scls.__module__} subclasses the deprecated CustomType class. "
+                "Please see the new extension API "
+                "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+                AsdfDeprecationWarning,
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,7 @@ commands_pre=
     pip freeze
 commands=
     pytest astropy/astropy/io/misc/asdf --open-files --run-slow --remote-data \
-        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.types:504"
+        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.types"
 
 [testenv:asdf-astropy]
 changedir={envtmpdir}
@@ -165,7 +165,7 @@ commands_pre=
     pip freeze
 commands=
     pytest specutils \
-        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.types:504"
+        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.types"
 
 [testenv:gwcs]
 changedir={envtmpdir}


### PR DESCRIPTION
This makes the warning make sense, by only issuing it on immediate children of `CustomType`. It will make astropy/astropy#14395 much simpler.