### PR TITLE
Move label check to using `any_of` instead of `one_of`

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: backport-2.15.x,development
+          any_of: backport-2.15.x,development
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   set_milestone:
@@ -31,7 +31,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           milestone: "2.15"
       - uses: andrefcdias/add-to-milestone@v1.3.0
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'development') }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'development') && !contains(github.event.pull_request.labels.*.name, 'backport-2.15.x')}}
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           milestone: "3.0.0"


### PR DESCRIPTION
Looking at the documentation for the labeler action used, `any_of` is a better choice because It may become necessary to label with more than one backport label. This change supports that logic.