### PR TITLE
Remove warning ignores from CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -133,8 +133,7 @@ commands_pre=
     pip install -r {envtmpdir}/requirements.txt
     pip freeze
 commands=
-    pytest astropy/astropy/io/misc/asdf --open-files --run-slow --remote-data \
-        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.types"
+    pytest astropy/astropy/io/misc/asdf --open-files --run-slow --remote-data
 
 [testenv:asdf-astropy]
 changedir={envtmpdir}
@@ -164,8 +163,7 @@ commands_pre=
     pip install -r {envtmpdir}/requirements.txt
     pip freeze
 commands=
-    pytest specutils \
-        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.types"
+    pytest specutils
 
 [testenv:gwcs]
 changedir={envtmpdir}


### PR DESCRIPTION
- `astropy` resolved the `CustomType` warnings in astropy/astropy#14395.
- `specutils` resolved the `CustomType` warnings in astropy/specutils#1012