### PR TITLE
Deprecate/assert extension correctness

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ The ASDF Standard is at v1.6.0
   writing ASDF in fits files is being moved to `stdatamodels
   <https://github.com/spacetelescope/stdatamodels>`_. [#1337]
 - Add AsdfDeprecationWarning to asdf.resolver [#1362]
+- Add AsdfDeprecationWarning to asdf.tests.helpers.assert_extension_correctness [#1388]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -26,7 +26,7 @@ from asdf import generic_io, versioning
 from asdf.asdf import AsdfFile, get_asdf_library_info
 from asdf.block import Block
 from asdf.constants import YAML_TAG_PREFIX
-from asdf.exceptions import AsdfConversionWarning
+from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning
 from asdf.extension import default_extensions
 from asdf.tags.core import AsdfObject
 from asdf.versioning import (
@@ -420,6 +420,14 @@ def assert_extension_correctness(extension):
     # locally import the deprecated Resolver and ResolverChain to avoid
     # exposing it as asdf.tests.helpers.Resolver/ResolverChain
     from asdf._resolver import Resolver, ResolverChain
+
+    warnings.warn(
+        "assert_extension_correctness is deprecated and depends "
+        "on the deprecated type system. Please use the new "
+        "extension API: "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
 
     resolver = ResolverChain(
         Resolver(extension.tag_mapping, "tag"),

--- a/asdf/tests/test_deprecated.py
+++ b/asdf/tests/test_deprecated.py
@@ -3,6 +3,8 @@ import sys
 import pytest
 
 from asdf.exceptions import AsdfDeprecationWarning
+from asdf.tests.helpers import assert_extension_correctness
+from asdf.tests.objects import CustomExtension
 from asdf.types import CustomType
 
 
@@ -27,3 +29,9 @@ def test_resolver_module_deprecation():
         if "asdf.resolver" in sys.modules:
             del sys.modules["asdf.resolver"]
         import asdf.resolver  # noqa: F401
+
+
+def test_assert_extension_correctness_deprecation():
+    extension = CustomExtension()
+    with pytest.warns(AsdfDeprecationWarning, match="assert_extension_correctness is deprecated.*"):
+        assert_extension_correctness(extension)

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -24,7 +24,8 @@ from asdf.types import CustomType
 
 def test_builtin_extension():
     extension = BuiltinExtension()
-    assert_extension_correctness(extension)
+    with pytest.warns(AsdfDeprecationWarning, match="assert_extension_correctness is deprecated.*"):
+        assert_extension_correctness(extension)
 
 
 with pytest.warns(AsdfDeprecationWarning, match=".*subclasses the deprecated CustomType.*"):


### PR DESCRIPTION
As pointed out in https://github.com/asdf-format/asdf/pull/1362#discussion_r1110267787
asdf.tests.helpers.assert_extension_correctness is only used for the legacy deprecated extension api and should be deprecated.