### PR TITLE
Add a scheduled workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Monday at 6am UTC
-    - cron: '0 6 * * 1'
   push:
     branches:
       - master

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -2,9 +2,6 @@ name: Downstream
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Monday at 6am UTC
-    - cron: '0 6 * * 1'
   pull_request:
     # We also want this workflow triggered if the `Downstream CI` label is
     # added or present when PR is updated
@@ -12,8 +9,6 @@ on:
       - synchronize
       - labeled
   push:
-    branches:
-      - '*.*.x'
     tags:
       - '*'
 

--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -2,9 +2,6 @@ name: s390x
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Monday at 6am UTC
-    - cron: '0 6 * * 1'
   pull_request:
     # We also want this workflow triggered if the `s390x` label is
     # added or present when PR is updated
@@ -12,8 +9,6 @@ on:
       - synchronize
       - labeled
   push:
-    branches:
-      - '*.*.x'
     tags:
       - '*'
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,30 @@
+name: Scheduled Workflows
+
+on:
+  # Allow manual runs through the web UI
+  workflow_dispatch:
+  schedule:
+    #        ┌───────── minute (0 - 59)
+    #        │ ┌───────── hour (0 - 23)
+    #        │ │ ┌───────── day of the month (1 - 31)
+    #        │ │ │ ┌───────── month (1 - 12 or JAN-DEC)
+    #        │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
+    - cron: '0 6 * * 1'  # Every Monday at 6am UTC
+
+jobs:
+  dispatch_workflows:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        branch:
+          - master
+          - 2.15.x
+        workflow:
+          - ci.yml
+          - downstream.yml
+          - s390x.yml
+    steps:
+      - run: gh workflow run ${{ matrix.workflow }} --repo asdf-format/asdf --ref ${{ matrix.branch }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
I have noticed a few things have being occurring since we began splitting off the 2.15.x development for ASDF:
1. A lot of unnecessary workflow runs have taken place; namely, `downstream` and `s390x` workflows seem to be getting run on every push to the `master` and `2.15.x` branches. Essentially this results in a lot of duplicated CI runs. In turn we seem to be running out of runners for our actual PRs, so we end up waiting for CI to run. Since both `downstream` and `s390x` both take a long time to complete (for some of their jobs) and are intended as "smoke" testing, they do not need to be run on every merge to `master` or `2.15.x`. In reality, they only need to be run on a schedule, when called for by the appropriate label in on a PR, or when we push a tag for a release.
2. Our CI, cannot be automatically run on a schedule for the `2.15.x` branch. The way `cron` (scheduled) jobs work in GitHub actions is that they are only triggered on the default branch of the repo. Meaning our current `cron` jobs only run on `master` at the current time. This means `2.15.x` will only have tests run on it when changes are made to the branch, which will become an issue once the release is finalized.

This PR intends to fix both of these problems by introducing a `scheduled` workflow, which at heart is a workflow which triggers the: `ci`, `downstream`, and `s390x` workflows on both `master` and `2.15.x` branches(later release branches can be added). This means the `cron` only needs to be in the `scheduled` workflow and not in any of our other workflows. Also, since we can ensure the `downstream` and `s390x` workflows are properly triggered by `scheduled` workflow, we can reduce the running of `downstream` and `s390x` on all merges to the `master` and `2.15.x` branches, instead limiting them to the schedule, when called for within a PR, and on new tags.

Note that these changes were based on the discussion in OpenAstronomy/github-actions-workflows#108, with the `scheduled` workflow largely based on https://github.com/sunpy/sunpy/blob/main/.github/workflows/scheduled_builds.yml.

- [x] add the correct token to the ASDF secrets as `WORKFLOW_TOKEN` when this PR is merged.