### PR TITLE
Fix bug with running tests in ASDF from path outside asdf

### DIFF
--- a/asdf/conftest.py
+++ b/asdf/conftest.py
@@ -7,6 +7,8 @@ import pytest
 
 from asdf.tests.httpserver import HTTPServer, RangeHTTPServer
 
+collect_ignore = ["asdftypes.py", "fits_embed.py", "resolver.py"]
+
 
 @pytest.fixture()
 def httpserver(request):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,13 +111,11 @@ open_files_ignore = ['test.fits', 'asdf.fits']
 # which pytest trips over during collection:
 filterwarnings = [
     'error',
-    'ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
-    'ignore:.*from astropy.io.misc.asdf.*subclasses the deprecated CustomType.*:asdf.exceptions.AsdfDeprecationWarning',
 ]
 # Configuration for pytest-doctestplus
 text_file_format = 'rst'
-addopts = '--color=yes --doctest-rst --ignore=asdf/fits_embed.py --ignore=asdf/resolver.py'
+addopts = '--color=yes --doctest-rst'
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
The use of relative paths for `--ignore` in the `addopts` configuration for `pytest` means that the tests will fail if pytest is triggered from a directory outside the `asdf` directory. This is because those paths are relative to where the `pytest` command is executed. This is causing the CI to fail in asdf-astropy: https://github.com/astropy/asdf-astropy/actions/runs/4220556775/jobs/7334281038 because warnings are being collected.

This PR fixes this by moving the `--ignore` command-line arguments to the `conftest.py`