### PR TITLE
Add concurrency cancellations to workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
 
+# Only cancel in-progress jobs or runs for the current workflow
+#   This cancels the already triggered workflows for a specific PR without canceling
+#   other instances of this workflow (other PRs, scheduled triggers, etc) when something
+#   within that PR re-triggers this CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changelog:
     name: Confirm changelog entry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ on:
       - '*'
   pull_request:
 
+# Only cancel in-progress jobs or runs for the current workflow
+#   This cancels the already triggered workflows for a specific PR without canceling
+#   other instances of this workflow (other PRs, scheduled triggers, etc) when something
+#   within that PR re-triggers this CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   core:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -12,6 +12,14 @@ on:
     tags:
       - '*'
 
+# Only cancel in-progress jobs or runs for the current workflow
+#   This cancels the already triggered workflows for a specific PR without canceling
+#   other instances of this workflow (other PRs, scheduled triggers, etc) when something
+#   within that PR re-triggers this CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   asdf:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,8 +9,15 @@ on:
       - labeled
       - unlabeled
 
-jobs:
+# Only cancel in-progress jobs or runs for the current workflow
+#   This cancels the already triggered workflows for a specific PR without canceling
+#   other instances of this workflow (other PRs, scheduled triggers, etc) when something
+#   within that PR re-triggers this CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   check_labels:
     name: Check labels
     runs-on: ubuntu-latest

--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -12,6 +12,14 @@ on:
     tags:
       - '*'
 
+# Only cancel in-progress jobs or runs for the current workflow
+#   This cancels the already triggered workflows for a specific PR without canceling
+#   other instances of this workflow (other PRs, scheduled triggers, etc) when something
+#   within that PR re-triggers this CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   exotic_architechtures:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
To give us more available runners, jobs triggered by PRs should cancel previous jobs triggered by that PR (from the same workflow), so that only one instance of each job is running per PR. Currently, if a new commit is pushed to a PR, but the CI has not completed then that instance of the CI will continue to run in addition to the new set of CI which will be triggered by the new commit. This ends up causing us to continue to run no-longer-relevant CI jobs to completion, which uses up job runners.

This PR adds concurrency rules based on: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow to our PR related CI jobs. This should start freeing up runners for asdf.