### PR TITLE
Try using uses instead of a PAT

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,6 +11,9 @@ on:
     #        │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
     - cron: '0 6 * * 1'  # Every Monday at 6am UTC
 
+  #TMP
+  pull_request:
+
 jobs:
   dispatch_workflows:
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -24,7 +24,5 @@ jobs:
           - ci.yml
           - downstream.yml
           - s390x.yml
-    steps:
-      - run: gh workflow run ${{ matrix.workflow }} --repo asdf-format/asdf --ref ${{ matrix.branch }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+
+    uses: asdf-format/asdf/.github/workflows/${{ matrix.workflows }}@${{ matrix.branch }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -15,17 +15,29 @@ on:
   pull_request:
 
 jobs:
-  dispatch_workflows:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        branch:
-          - master
-          - 2.15.x
-        workflow:
-          - ci.yml
-          - downstream.yml
-          - s390x.yml
+  # dispatch_workflows:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       branch:
+  #         - master
+  #         - 2.15.x
+  #       workflow:
+  #         - ci.yml
+  #         - downstream.yml
+  #         - s390x.yml
 
-    uses: asdf-format/asdf/.github/workflows/${{ matrix.workflows }}@${{ matrix.branch }}
+  #   uses: asdf-format/asdf/.github/workflows/${{ matrix.workflows }}@${{ matrix.branch }}
+  ci_master:
+    uses: asdf-format/asdf/.github/workflows/ci.yml@master
+  downstream_master:
+    uses: asdf-format/asdf/.github/workflows/downstream.yml@master
+  s390x_master:
+    uses: asdf-format/asdf/.github/workflows/s390x.yml@master
+  ci_2_15_x:
+    uses: asdf-format/asdf/.github/workflows/ci.yml@2.15.x
+  downstream_2_15_x:
+    uses: asdf-format/asdf/.github/workflows/downstream.yml@2.15.x
+  s390x_2_15_x:
+    uses: asdf-format/asdf/.github/workflows/s390x.yml@2.15.x


### PR DESCRIPTION
See if we can run `scheduled` without a PAT.

Suggested by @zanecodes