### PR TITLE
Remove concurrency cancel for `Label Checker` job

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,14 +9,6 @@ on:
       - labeled
       - unlabeled
 
-# Only cancel in-progress jobs or runs for the current workflow
-#   This cancels the already triggered workflows for a specific PR without canceling
-#   other instances of this workflow (other PRs, scheduled triggers, etc) when something
-#   within that PR re-triggers this CI
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   check_labels:
     name: Check labels


### PR DESCRIPTION
Concurrency groups act funny on `pull_request_target` triggered workflows (`github.ref` becomes the branch being merged into not a reference to the PR branch). Label Checker is a very small and fast workflow, so we don't need concurrency cancelations with it