### PR TITLE
Use reusable changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,11 +17,8 @@ jobs:
     name: Confirm changelog entry
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: true
-      - name: Grep for PR number in CHANGES.rst
-        run: grep -P '\[[^\]]*#${{github.event.number}}[,\]]' CHANGES.rst
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-entry-needed') }}
+    - name: Check change log entry
+      uses: pllim/action-check_astropy_changelog@main
+      env:
+        CHANGELOG_FILENAME: CHANGES.rst
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ contains(github.event.pull_request.labels.*.name, 'backport-2.15.x') }}
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          milestone: "2.15"
+          milestone: "2.15.0"
       - uses: andrefcdias/add-to-milestone@v1.3.0
         if: ${{ contains(github.event.pull_request.labels.*.name, 'development') && !contains(github.event.pull_request.labels.*.name, 'backport-2.15.x')}}
         with:


### PR DESCRIPTION
The meeseeks backports shouldn't have to have a `no-changelog-entry-needed` label for their CI. This PR solves this by moving to the old workflow that was used by astropy for its changelog and is still used by jdaviz. This workflow happens to include skips for meeseeks.

Note the original ASDF workflow was a copy of the astropy one from before it was refactored into the reusable workflow, being used here. So they should operate exactly the same, except for the additional meeseeks logic.