### PR TITLE
deprecation asdf.extension legacy functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ The ASDF Standard is at v1.6.0
   and impending removal [#1411]
 - Deprecate AsdfFile attributes that use the legacy extension api [#1417]
 - Add AsdfDeprecationWarning to asdf.types [#1401]
+- deprecate default_extensions, get_default_resolver and
+  get_cached_asdf_extension_list in asdf.extension [#1409]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -16,14 +16,8 @@ from . import block, constants, generic_io, reference, schema, treeutil, util, v
 from ._helpers import validate_version
 from .config import config_context, get_config
 from .exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning
-from .extension import (
-    AsdfExtension,
-    AsdfExtensionList,
-    Extension,
-    ExtensionProxy,
-    get_cached_asdf_extension_list,
-    get_cached_extension_manager,
-)
+from .extension import AsdfExtension, AsdfExtensionList, Extension, ExtensionProxy, get_cached_extension_manager
+from .extension._legacy import _get_cached_asdf_extension_list as get_cached_asdf_extension_list
 from .search import AsdfSearchResult
 from .tags.core import AsdfObject, ExtensionMetadata, HistoryEntry, Software
 from .util import NotSet

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -17,7 +17,7 @@ from ._helpers import validate_version
 from .config import config_context, get_config
 from .exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning
 from .extension import AsdfExtension, AsdfExtensionList, Extension, ExtensionProxy, get_cached_extension_manager
-from .extension._legacy import _get_cached_asdf_extension_list as get_cached_asdf_extension_list
+from .extension._legacy import get_cached_asdf_extension_list
 from .search import AsdfSearchResult
 from .tags.core import AsdfObject, ExtensionMetadata, HistoryEntry, Software
 from .util import NotSet

--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -2,17 +2,15 @@
 Support for plugins that extend asdf to serialize
 additional custom types.
 """
+import warnings
+
+from asdf.exceptions import AsdfDeprecationWarning
+
 from . import _legacy
 from ._compressor import Compressor
 from ._converter import Converter, ConverterProxy
 from ._extension import Extension, ExtensionProxy
-from ._legacy import (
-    AsdfExtension,
-    AsdfExtensionList,
-    BuiltinExtension,
-    get_cached_asdf_extension_list,
-    get_default_resolver,
-)
+from ._legacy import AsdfExtension, AsdfExtensionList, BuiltinExtension
 from ._manager import ExtensionManager, get_cached_extension_manager
 from ._manifest import ManifestExtension
 from ._tag import TagDefinition
@@ -40,8 +38,53 @@ __all__ = [
 ]
 
 
+def get_cached_asdf_extension_list(extensions):
+    """
+    Get a previously created AsdfExtensionList for the specified
+    extensions, or create and cache one if necessary.  Building
+    the type index is expensive, so it helps performance to reuse
+    the index when possible.
+    Parameters
+    ----------
+    extensions : list of asdf.extension.AsdfExtension
+    Returns
+    -------
+    asdf.extension.AsdfExtensionList
+    """
+    from ._legacy import get_cached_asdf_extension_list
+
+    warnings.warn(
+        "get_cached_asdf_extension_list is deprecated. "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
+    return get_cached_asdf_extension_list(extensions)
+
+
+def get_default_resolver():
+    """
+    Get the resolver that includes mappings from all installed extensions.
+    """
+    from ._legacy import get_default_resolver
+
+    warnings.warn(
+        "get_default_resolver is deprecated. "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
+    return get_default_resolver()
+
+
 def __getattr__(name):
     if name == "default_extensions":
+        warnings.warn(
+            "default_extensions is deprecated. "
+            "Please see the new extension API "
+            "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+            AsdfDeprecationWarning,
+        )
         return _legacy.default_extensions
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)

--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -2,6 +2,7 @@
 Support for plugins that extend asdf to serialize
 additional custom types.
 """
+from . import _legacy
 from ._compressor import Compressor
 from ._converter import Converter, ConverterProxy
 from ._extension import Extension, ExtensionProxy
@@ -9,7 +10,6 @@ from ._legacy import (
     AsdfExtension,
     AsdfExtensionList,
     BuiltinExtension,
-    default_extensions,
     get_cached_asdf_extension_list,
     get_default_resolver,
 )
@@ -38,3 +38,10 @@ __all__ = [
     "get_default_resolver",
     "get_cached_asdf_extension_list",
 ]
+
+
+def __getattr__(name):
+    if name == "default_extensions":
+        return _legacy.default_extensions
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/asdf/extension/_legacy.py
+++ b/asdf/extension/_legacy.py
@@ -179,6 +179,16 @@ def get_cached_asdf_extension_list(extensions):
     -------
     asdf.extension.AsdfExtensionList
     """
+    warnings.warn(
+        "get_cached_asdf_extension_list is deprecated. "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
+    return _get_cached_asdf_extension_list(extensions)
+
+
+def _get_cached_asdf_extension_list(extensions):
     from ._extension import ExtensionProxy
 
     # The tuple makes the extensions hashable so that we
@@ -189,11 +199,11 @@ def get_cached_asdf_extension_list(extensions):
     # instances in identical order.
     extensions = tuple(ExtensionProxy.maybe_wrap(e) for e in extensions)
 
-    return _get_cached_asdf_extension_list(extensions)
+    return __get_cached_asdf_extension_list(extensions)
 
 
 @lru_cache
-def _get_cached_asdf_extension_list(extensions):
+def __get_cached_asdf_extension_list(extensions):
     return AsdfExtensionList(extensions)
 
 
@@ -229,7 +239,7 @@ class _DefaultExtensions:
 
     @property
     def extension_list(self):
-        return get_cached_asdf_extension_list(self.extensions)
+        return _get_cached_asdf_extension_list(self.extensions)
 
     @property
     def package_metadata(self):
@@ -248,11 +258,35 @@ class _DefaultExtensions:
         return self.extension_list.resolver
 
 
-default_extensions = _DefaultExtensions()
+_default_extensions = _DefaultExtensions()
+
+
+def __getattr__(name):
+    if name == "default_extensions":
+        warnings.warn(
+            "default_extensions is deprecated. "
+            "Please see the new extension API "
+            "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+            AsdfDeprecationWarning,
+        )
+        return _default_extensions
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
 
 
 def get_default_resolver():
     """
     Get the resolver that includes mappings from all installed extensions.
     """
-    return default_extensions.resolver
+    warnings.warn(
+        "get_default_resolver is deprecated. "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
+
+    return _get_default_resolver()
+
+
+def _get_default_resolver():
+    return _default_extensions.resolver

--- a/asdf/extension/_legacy.py
+++ b/asdf/extension/_legacy.py
@@ -179,16 +179,6 @@ def get_cached_asdf_extension_list(extensions):
     -------
     asdf.extension.AsdfExtensionList
     """
-    warnings.warn(
-        "get_cached_asdf_extension_list is deprecated. "
-        "Please see the new extension API "
-        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
-        AsdfDeprecationWarning,
-    )
-    return _get_cached_asdf_extension_list(extensions)
-
-
-def _get_cached_asdf_extension_list(extensions):
     from ._extension import ExtensionProxy
 
     # The tuple makes the extensions hashable so that we
@@ -199,11 +189,11 @@ def _get_cached_asdf_extension_list(extensions):
     # instances in identical order.
     extensions = tuple(ExtensionProxy.maybe_wrap(e) for e in extensions)
 
-    return __get_cached_asdf_extension_list(extensions)
+    return _get_cached_asdf_extension_list(extensions)
 
 
 @lru_cache
-def __get_cached_asdf_extension_list(extensions):
+def _get_cached_asdf_extension_list(extensions):
     return AsdfExtensionList(extensions)
 
 
@@ -239,7 +229,7 @@ class _DefaultExtensions:
 
     @property
     def extension_list(self):
-        return _get_cached_asdf_extension_list(self.extensions)
+        return get_cached_asdf_extension_list(self.extensions)
 
     @property
     def package_metadata(self):
@@ -258,35 +248,11 @@ class _DefaultExtensions:
         return self.extension_list.resolver
 
 
-_default_extensions = _DefaultExtensions()
-
-
-def __getattr__(name):
-    if name == "default_extensions":
-        warnings.warn(
-            "default_extensions is deprecated. "
-            "Please see the new extension API "
-            "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
-            AsdfDeprecationWarning,
-        )
-        return _default_extensions
-    msg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(msg)
+default_extensions = _DefaultExtensions()
 
 
 def get_default_resolver():
     """
     Get the resolver that includes mappings from all installed extensions.
     """
-    warnings.warn(
-        "get_default_resolver is deprecated. "
-        "Please see the new extension API "
-        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
-        AsdfDeprecationWarning,
-    )
-
-    return _get_default_resolver()
-
-
-def _get_default_resolver():
-    return _default_extensions.resolver
+    return default_extensions.resolver

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -16,7 +16,7 @@ from jsonschema.exceptions import RefResolutionError, ValidationError
 from . import constants, extension, generic_io, reference, tagged, treeutil, util, versioning, yamlutil
 from .config import get_config
 from .exceptions import AsdfDeprecationWarning, AsdfWarning
-from .extension._legacy import _get_default_resolver
+from .extension import _legacy
 from .util import patched_urllib_parse
 
 YAML_SCHEMA_METASCHEMA_ID = "http://stsci.edu/schemas/yaml-schema/draft-01"
@@ -243,7 +243,7 @@ class _ValidationContext:
 
 @lru_cache
 def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
-    meta_schema = _load_schema_cached(YAML_SCHEMA_METASCHEMA_ID, _get_default_resolver(), False, False)
+    meta_schema = _load_schema_cached(YAML_SCHEMA_METASCHEMA_ID, _legacy.get_default_resolver(), False, False)
 
     type_checker = mvalidators.Draft4Validator.TYPE_CHECKER.redefine_many(
         {
@@ -442,7 +442,7 @@ def load_schema(url, resolver=None, resolve_references=False, resolve_local_refs
     if resolver is None:
         # We can't just set this as the default in load_schema's definition
         # because invoking get_default_resolver at import time leads to a circular import.
-        resolver = _get_default_resolver()
+        resolver = _legacy.get_default_resolver()
 
     # We want to cache the work that went into constructing the schema, but returning
     # the same object is treacherous, because users who mutate the result will not
@@ -763,9 +763,9 @@ def check_schema(schema, validate_default=True):
         applicable_validators = methodcaller("items")
 
     meta_schema_id = schema.get("$schema", YAML_SCHEMA_METASCHEMA_ID)
-    meta_schema = _load_schema_cached(meta_schema_id, _get_default_resolver(), False, False)
+    meta_schema = _load_schema_cached(meta_schema_id, _legacy.get_default_resolver(), False, False)
 
-    resolver = _make_resolver(_get_default_resolver())
+    resolver = _make_resolver(_legacy.get_default_resolver())
 
     cls = mvalidators.create(
         meta_schema=meta_schema,

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -16,6 +16,7 @@ from jsonschema.exceptions import RefResolutionError, ValidationError
 from . import constants, extension, generic_io, reference, tagged, treeutil, util, versioning, yamlutil
 from .config import get_config
 from .exceptions import AsdfDeprecationWarning, AsdfWarning
+from .extension._legacy import _get_default_resolver
 from .util import patched_urllib_parse
 
 YAML_SCHEMA_METASCHEMA_ID = "http://stsci.edu/schemas/yaml-schema/draft-01"
@@ -242,7 +243,7 @@ class _ValidationContext:
 
 @lru_cache
 def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
-    meta_schema = _load_schema_cached(YAML_SCHEMA_METASCHEMA_ID, extension.get_default_resolver(), False, False)
+    meta_schema = _load_schema_cached(YAML_SCHEMA_METASCHEMA_ID, _get_default_resolver(), False, False)
 
     type_checker = mvalidators.Draft4Validator.TYPE_CHECKER.redefine_many(
         {
@@ -441,7 +442,7 @@ def load_schema(url, resolver=None, resolve_references=False, resolve_local_refs
     if resolver is None:
         # We can't just set this as the default in load_schema's definition
         # because invoking get_default_resolver at import time leads to a circular import.
-        resolver = extension.get_default_resolver()
+        resolver = _get_default_resolver()
 
     # We want to cache the work that went into constructing the schema, but returning
     # the same object is treacherous, because users who mutate the result will not
@@ -762,9 +763,9 @@ def check_schema(schema, validate_default=True):
         applicable_validators = methodcaller("items")
 
     meta_schema_id = schema.get("$schema", YAML_SCHEMA_METASCHEMA_ID)
-    meta_schema = _load_schema_cached(meta_schema_id, extension.get_default_resolver(), False, False)
+    meta_schema = _load_schema_cached(meta_schema_id, _get_default_resolver(), False, False)
 
-    resolver = _make_resolver(extension.get_default_resolver())
+    resolver = _make_resolver(_get_default_resolver())
 
     cls = mvalidators.create(
         meta_schema=meta_schema,

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -27,7 +27,7 @@ from asdf.asdf import AsdfFile, get_asdf_library_info
 from asdf.block import Block
 from asdf.constants import YAML_TAG_PREFIX
 from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning
-from asdf.extension._legacy import _default_extensions as default_extensions
+from asdf.extension import _legacy
 from asdf.tags.core import AsdfObject
 from asdf.versioning import (
     AsdfVersion,
@@ -98,7 +98,7 @@ def assert_tree_match(old_tree, new_tree, ctx=None, funcname="assert_equal", ign
 
     if ctx is None:
         version_string = str(versioning.default_version)
-        ctx = default_extensions.extension_list
+        ctx = _legacy.default_extensions.extension_list
     else:
         version_string = ctx.version_string
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -27,7 +27,7 @@ from asdf.asdf import AsdfFile, get_asdf_library_info
 from asdf.block import Block
 from asdf.constants import YAML_TAG_PREFIX
 from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning
-from asdf.extension import default_extensions
+from asdf.extension._legacy import _default_extensions as default_extensions
 from asdf.tags.core import AsdfObject
 from asdf.versioning import (
     AsdfVersion,

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -474,7 +474,8 @@ def test_resolver_deprecations():
 
 
 def test_get_default_resolver():
-    resolver = extension.get_default_resolver()
+    with pytest.warns(AsdfDeprecationWarning, match="get_default_resolver is deprecated"):
+        resolver = extension.get_default_resolver()
 
     result = resolver("tag:stsci.edu:asdf/core/ndarray-1.0.0")
 

--- a/asdf/tests/test_deprecated.py
+++ b/asdf/tests/test_deprecated.py
@@ -4,6 +4,7 @@ import pytest
 
 import asdf
 from asdf._types import CustomType
+import asdf.extension
 from asdf.exceptions import AsdfDeprecationWarning
 from asdf.tests.helpers import assert_extension_correctness
 from asdf.tests.objects import CustomExtension
@@ -68,3 +69,18 @@ def test_types_module_deprecation():
         if "asdf.types" in sys.modules:
             del sys.modules["asdf.types"]
         import asdf.types  # noqa: F401
+
+
+def test_default_extensions_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="default_extensions is deprecated"):
+        asdf.extension.default_extensions
+
+
+def test_default_resolver():
+    with pytest.warns(AsdfDeprecationWarning, match="get_default_resolver is deprecated"):
+        asdf.extension.get_default_resolver()
+
+
+def test_get_cached_asdf_extension_list_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="get_cached_asdf_extension_list is deprecated"):
+        asdf.extension.get_cached_asdf_extension_list([])

--- a/asdf/tests/test_deprecated.py
+++ b/asdf/tests/test_deprecated.py
@@ -3,8 +3,8 @@ import sys
 import pytest
 
 import asdf
-from asdf._types import CustomType
 import asdf.extension
+from asdf._types import CustomType
 from asdf.exceptions import AsdfDeprecationWarning
 from asdf.tests.helpers import assert_extension_correctness
 from asdf.tests.objects import CustomExtension

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -604,9 +604,12 @@ def test_converter_proxy():
 
 def test_get_cached_asdf_extension_list():
     extension = LegacyExtension()
-    extension_list = get_cached_asdf_extension_list([extension])
-    assert get_cached_asdf_extension_list([extension]) is extension_list
-    assert get_cached_asdf_extension_list([LegacyExtension()]) is not extension_list
+    with pytest.warns(AsdfDeprecationWarning, match="get_cached_asdf_extension_list is deprecated"):
+        extension_list = get_cached_asdf_extension_list([extension])
+    with pytest.warns(AsdfDeprecationWarning, match="get_cached_asdf_extension_list is deprecated"):
+        assert get_cached_asdf_extension_list([extension]) is extension_list
+    with pytest.warns(AsdfDeprecationWarning, match="get_cached_asdf_extension_list is deprecated"):
+        assert get_cached_asdf_extension_list([LegacyExtension()]) is not extension_list
 
 
 def test_manifest_extension():

--- a/asdf/tests/test_schema.py
+++ b/asdf/tests/test_schema.py
@@ -136,7 +136,8 @@ required: [foobar]
 
 
 def test_load_schema_with_file_url(tmp_path):
-    schema_def = """
+    with pytest.warns(AsdfDeprecationWarning, match="get_default_resolver is deprecated"):
+        schema_def = """
 %YAML 1.1
 %TAG !asdf! tag:stsci.edu:asdf/
 ---
@@ -151,9 +152,9 @@ properties:
 
 required: [foobar]
 ...
-    """.format(
-        extension.get_default_resolver()("tag:stsci.edu:asdf/core/ndarray-1.0.0"),
-    )
+        """.format(
+            extension.get_default_resolver()("tag:stsci.edu:asdf/core/ndarray-1.0.0"),
+        )
     schema_path = tmp_path / "nugatory.yaml"
     schema_path.write_bytes(schema_def.encode())
 
@@ -637,9 +638,11 @@ def test_self_reference_resolution():
 
 def test_schema_resolved_via_entry_points():
     """Test that entry points mappings to core schema works"""
-    r = extension.get_default_resolver()
+    with pytest.warns(AsdfDeprecationWarning, match="get_default_resolver is deprecated"):
+        r = extension.get_default_resolver()
     tag = types.format_tag("stsci.edu", "asdf", "1.0.0", "fits/fits")
-    url = extension.default_extensions.extension_list.tag_mapping(tag)
+    with pytest.warns(AsdfDeprecationWarning, match="default_extensions is deprecated"):
+        url = extension.default_extensions.extension_list.tag_mapping(tag)
 
     s = schema.load_schema(url, resolver=r, resolve_references=True)
     assert tag in repr(s)

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -2,7 +2,7 @@ from itertools import combinations
 
 import pytest
 
-from asdf.extension._legacy import _default_extensions as default_extensions
+from asdf.extension._legacy import default_extensions
 from asdf.schema import load_schema
 from asdf.versioning import (
     AsdfSpec,

--- a/asdf/tests/test_versioning.py
+++ b/asdf/tests/test_versioning.py
@@ -2,7 +2,7 @@ from itertools import combinations
 
 import pytest
 
-from asdf.extension import default_extensions
+from asdf.extension._legacy import _default_extensions as default_extensions
 from asdf.schema import load_schema
 from asdf.versioning import (
     AsdfSpec,

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -142,12 +142,10 @@ class AsdfSchemaItem(pytest.Item):
 
     def runtest(self):
         from asdf import schema
-        from asdf.extension import default_extensions
 
         # Make sure that each schema itself is valid.
         schema_tree = schema.load_schema(
             self.schema_path,
-            resolver=default_extensions.resolver,
             resolve_references=True,
         )
         schema.check_schema(schema_tree, validate_default=self.validate_default)

--- a/tox.ini
+++ b/tox.ini
@@ -128,7 +128,8 @@ commands_pre =
     pip freeze
 commands=
     pytest astropy/astropy/io/misc/asdf --open-files --run-slow --remote-data \
-        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.types"
+        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.types" \
+        -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.extension"
 
 [testenv:asdf-astropy]
 change_dir = {env_tmp_dir}


### PR DESCRIPTION
deprecates several helper functions/attributes exposed via `asdf.extensions` that are related to only the legacy extension api:
- default_extensions
- get_default_resolver
- get_cached_asdf_extension_list