### PR TITLE
add warning to asdftool extract and remove-hdu commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ The ASDF Standard is at v1.6.0
 - Add AsdfDeprecationWarning to asdf.resolver [#1362]
 - Add AsdfDeprecationWarning to asdf.tests.helpers.assert_extension_correctness [#1388]
 - Add AsdfDeprecationWarning to asdf.type_index [#1403]
+- Add warning to use of asdftool extract and remove-hdu about deprecation
+  and impending removal [#1411]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/commands/extract.py
+++ b/asdf/commands/extract.py
@@ -2,7 +2,10 @@
 Implementation of command for converting ASDF-in-FITS to standalone ASDF file.
 """
 
+import warnings
+
 import asdf
+from asdf.exceptions import AsdfWarning
 
 from .main import Command
 
@@ -44,6 +47,14 @@ class AsdfExtractor(Command):  # pragma: no cover
 
 def extract_file(input_file, output_file):
     """Function for performing extraction from ASDF-in-FITS to pure ASDF."""
+    # issue a non-deprecation warning here so that any usage of this command
+    # displays a warning
+    warnings.warn(
+        "extract is deprecated and will be removed in asdf-3.0. "
+        "Support for AsdfInFits files has been added to stdatamodels "
+        "https://github.com/spacetelescope/stdatamodels",
+        AsdfWarning,
+    )
     # local import to avoid issuing Deprecation warning on every use of asdftool
     from asdf.fits_embed import AsdfInFits
 

--- a/asdf/commands/remove_hdu.py
+++ b/asdf/commands/remove_hdu.py
@@ -2,7 +2,11 @@
 Implementation of command for removing ASDF HDU from ASDF-in-FITS file.
 """
 
+import warnings
+
 from astropy.io import fits
+
+from asdf.exceptions import AsdfWarning
 
 from .main import Command
 
@@ -39,6 +43,14 @@ class FitsExtractor(Command):  # pragma: no cover
 
 def remove_hdu(input_file, output_file):
     """Function for removing ASDF HDU from ASDF-in-FITS files"""
+    # issue a non-deprecation warning here so that any usage of this command
+    # displays a warning
+    warnings.warn(
+        "remove-hdu is deprecated and will be removed in asdf-3.0. "
+        "Support for AsdfInFits files has been added to stdatamodels "
+        "https://github.com/spacetelescope/stdatamodels",
+        AsdfWarning,
+    )
     # local import to trigger the deprecation warning since this command
     # relates to and mentions AsdfInFits
     from asdf.fits_embed import AsdfInFits  # noqa: F401

--- a/asdf/commands/tests/test_extract.py
+++ b/asdf/commands/tests/test_extract.py
@@ -7,7 +7,7 @@ from astropy.io.fits import HDUList, ImageHDU
 
 import asdf
 from asdf.commands import extract
-from asdf.exceptions import AsdfDeprecationWarning
+from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
 
 with pytest.warns(AsdfDeprecationWarning, match="AsdfInFits has been deprecated.*"):
     if "asdf.fits_embed" in sys.modules:
@@ -35,7 +35,8 @@ def test_extract(tmpdir):
         aif.write_to(asdf_in_fits)
 
     pure_asdf = str(tmpdir.join("extract.asdf"))
-    extract.extract_file(asdf_in_fits, pure_asdf)
+    with pytest.warns(AsdfWarning, match="extract is deprecated"):
+        extract.extract_file(asdf_in_fits, pure_asdf)
 
     assert os.path.exists(pure_asdf)
 

--- a/asdf/commands/tests/test_remove_hdu.py
+++ b/asdf/commands/tests/test_remove_hdu.py
@@ -6,7 +6,7 @@ import pytest
 from astropy.io import fits
 
 from asdf.commands import remove_hdu
-from asdf.exceptions import AsdfDeprecationWarning
+from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
 
 with pytest.warns(AsdfDeprecationWarning, match="AsdfInFits has been deprecated.*"):
     if "asdf.fits_embed" in sys.modules:
@@ -35,7 +35,8 @@ def test_remove_hdu(tmpdir):
         assert "ASDF" in hdul
 
     new_fits = str(tmpdir.join("remove.fits"))
-    remove_hdu(asdf_in_fits, new_fits)
+    with pytest.warns(AsdfWarning, match="remove-hdu is deprecated"):
+        remove_hdu(asdf_in_fits, new_fits)
 
     assert os.path.exists(new_fits)
 


### PR DESCRIPTION
these require AsdfInFits support and should have warnings that are not subclasses of DeprecationWarning so they are not ignored by default

fixes #1382