### PR TITLE
Automatically set automerge for meeseeksmachine

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -34,3 +34,16 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           milestone: "3.0.0"
+
+  enable_auto_merge:
+    name: Enable automerge
+    runs-on: ubuntu-latest
+    needs: [set_milestone]
+
+    # Specifically check that meeseeksmachine is opening the PR
+    if: github.event.pull_request.user.login == 'meeseeksmachine'
+    steps:
+    - uses: alexwilson/enable-github-automerge-action@main
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        merge-method: "REBASE"


### PR DESCRIPTION
Now that branch protection rules are in place for `2.15.x` and backport PRs have been reviewed. It makes sense for these PRs to automatically be "Rebased and Merged" to the `2.15.x` branch if the CI fully passes.

This PR adds CI to trigger adding the `meeseeksmachine` PRs to the automerge queue.