### PR TITLE
Fix for missed warning supression

### DIFF
--- a/asdf/tests/test_file_format.py
+++ b/asdf/tests/test_file_format.py
@@ -150,6 +150,7 @@ def test_empty_file():
 
 
 @pytest.mark.filterwarnings("ignore::astropy.io.fits.verify.VerifyWarning")
+@pytest.mark.filterwarnings("ignore::asdf.exceptions.AsdfDeprecationWarning")
 def test_not_asdf_file():
     buff = io.BytesIO(b"SIMPLE")
     buff.seek(0)


### PR DESCRIPTION
While running individual tests, I found a test which raises a deprecation warning when run on its own. This in-itself is a bit disturbing as the warning does not appear when the entire test suite is run.

EDIT: Clarification, the failure that I am speaking of is when the `test_file_format.py` test suite is run by itself.