### PR TITLE
Resolve `PT011` error code

### DIFF
--- a/asdf/commands/tests/test_diff.py
+++ b/asdf/commands/tests/test_diff.py
@@ -64,7 +64,10 @@ def test_diff_simple_inline_array():
 def test_file_not_found():
     # Try to open files that exist but are not valid asdf
     filenames = ["frames.diff", "blocks.diff"]
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        RuntimeError,
+        match=r"Input object does not appear to be an ASDF file or a FITS with ASDF extension",
+    ):
         diff([get_test_data_path(name) for name in filenames], False)
 
 

--- a/asdf/tags/core/tests/test_complex.py
+++ b/asdf/tags/core/tests/test_complex.py
@@ -34,7 +34,7 @@ a: !core/complex-1.0.0
     ],
 )
 def test_invalid_complex(invalid):
-    with pytest.raises(asdf.ValidationError), asdf.open(make_complex_asdf(invalid)):
+    with pytest.raises(asdf.ValidationError, match=r".* does not match.*"), asdf.open(make_complex_asdf(invalid)):
         pass
 
 

--- a/asdf/tags/core/tests/test_history.py
+++ b/asdf/tags/core/tests/test_history.py
@@ -44,7 +44,7 @@ def test_history():
     )
     assert len(ff.tree["history"]["entries"]) == 1
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r".* is not valid under any of the given schemas"):
         ff.add_history_entry("That happened", {"author": "John Doe", "version": "2.0"})
     assert len(ff.tree["history"]["entries"]) == 1
 
@@ -192,12 +192,18 @@ history:
     """
 
     buff = yaml_to_asdf(yaml)
-    with pytest.raises(RuntimeError), asdf.open(buff, strict_extension_check=True):
+    with pytest.raises(
+        RuntimeError,
+        match=r"File was created with extension class .*, which is not currently installed",
+    ), asdf.open(buff, strict_extension_check=True):
         pass
 
     # Make sure to test for incompatibility with ignore_missing_extensions
     buff.seek(0)
-    with pytest.raises(ValueError), asdf.open(buff, strict_extension_check=True, ignore_missing_extensions=True):
+    with pytest.raises(
+        ValueError,
+        match=r"'strict_extension_check' and 'ignore_missing_extensions' are incompatible options",
+    ), asdf.open(buff, strict_extension_check=True, ignore_missing_extensions=True):
         pass
 
 

--- a/asdf/tags/core/tests/test_ndarray.py
+++ b/asdf/tags/core/tests/test_ndarray.py
@@ -532,7 +532,9 @@ def test_invalid_mask_datatype(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff):
+    with pytest.raises(jsonschema.ValidationError, match=r".* is not valid under any of the given schemas"), asdf.open(
+        buff,
+    ):
         pass
 
 
@@ -544,7 +546,10 @@ def test_ndim_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff, extensions=CustomExtension()):
+    with pytest.raises(jsonschema.ValidationError, match=r"Wrong number of dimensions:.*"), asdf.open(
+        buff,
+        extensions=CustomExtension(),
+    ):
         pass
 
     content = """
@@ -595,7 +600,10 @@ def test_ndim_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff, extensions=CustomExtension()):
+    with pytest.raises(jsonschema.ValidationError, match=r"Wrong number of dimensions:.*"), asdf.open(
+        buff,
+        extensions=CustomExtension(),
+    ):
         pass
 
 
@@ -619,7 +627,10 @@ def test_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff, extensions=CustomExtension()):
+    with pytest.raises(jsonschema.ValidationError, match=r"Can not safely cast from .* to .*"), asdf.open(
+        buff,
+        extensions=CustomExtension(),
+    ):
         pass
 
     content = """
@@ -641,7 +652,10 @@ def test_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff, extensions=CustomExtension()):
+    with pytest.raises(jsonschema.ValidationError, match=r"Expected datatype .*, got .*"), asdf.open(
+        buff,
+        extensions=CustomExtension(),
+    ):
         pass
 
     content = """
@@ -656,7 +670,10 @@ def test_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff, extensions=CustomExtension()):
+    with pytest.raises(jsonschema.ValidationError, match=r"Expected scalar datatype .*, got .*"), asdf.open(
+        buff,
+        extensions=CustomExtension(),
+    ):
         pass
 
 
@@ -688,7 +705,10 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff, extensions=CustomExtension()):
+    with pytest.raises(jsonschema.ValidationError, match=r"Can not safely cast to expected datatype.*"), asdf.open(
+        buff,
+        extensions=CustomExtension(),
+    ):
         pass
 
     content = """
@@ -705,7 +725,10 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff, extensions=CustomExtension()):
+    with pytest.raises(jsonschema.ValidationError, match=r"Mismatch in number of columns:.*"), asdf.open(
+        buff,
+        extensions=CustomExtension(),
+    ):
         pass
 
     content = """
@@ -715,7 +738,10 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff, extensions=CustomExtension()):
+    with pytest.raises(jsonschema.ValidationError, match=r"Expected structured datatype.*"), asdf.open(
+        buff,
+        extensions=CustomExtension(),
+    ):
         pass
 
     content = """
@@ -730,7 +756,10 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError), asdf.open(buff, extensions=CustomExtension()):
+    with pytest.raises(jsonschema.ValidationError, match=r"Expected datatype .*, got .*"), asdf.open(
+        buff,
+        extensions=CustomExtension(),
+    ):
         pass
 
     content = """
@@ -765,7 +794,7 @@ def test_inline_shape_mismatch():
     """
 
     buff = helpers.yaml_to_asdf(content)
-    with pytest.raises(ValueError), asdf.open(buff):
+    with pytest.raises(ValueError, match=r"inline data doesn't match the given shape"), asdf.open(buff):
         pass
 
 
@@ -930,8 +959,8 @@ def test_problematic_class_attributes(tmp_path):
     with asdf.open(file_path) as af:
         assert isinstance(af["arr"], ndarray.NDArrayType)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match=r".* object has no attribute 'name'"):
             af["arr"].name
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match=r".* object has no attribute 'version'"):
             af["arr"].version

--- a/asdf/tests/test_array_blocks.py
+++ b/asdf/tests/test_array_blocks.py
@@ -34,7 +34,7 @@ def test_external_block_non_url():
     assert ff.get_array_storage(my_array) == "external"
 
     buff = io.BytesIO()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Can't write external blocks, since URI of main file is unknown."):
         ff.write_to(buff)
 
 
@@ -42,16 +42,16 @@ def test_invalid_array_storage():
     my_array = RNG.normal(size=(8, 8))
     tree = {"my_array": my_array}
     ff = asdf.AsdfFile(tree)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"array_storage must be one of.*"):
         ff.set_array_storage(my_array, "foo")
 
     b = block.Block()
     b._array_storage = "foo"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Unknown array storage type foo"):
         ff._blocks.add(b)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Unknown array storage type foo"):
         ff._blocks.remove(b)
 
 
@@ -485,7 +485,7 @@ def test_deferred_block_loading(small_tree):
         ff2.tree["not_shared"] * 2
         assert len([x for x in ff2._blocks.blocks if isinstance(x, block.Block)]) == 2
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Block .* not found."):
             ff2._blocks.get_block(2)
 
 
@@ -708,7 +708,7 @@ def test_invalid_block_index_first_block_value():
 
 def test_invalid_block_id():
     ff = asdf.AsdfFile()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Invalid source id .*"):
         ff._blocks.get_block(-2)
 
 

--- a/asdf/tests/test_asdf.py
+++ b/asdf/tests/test_asdf.py
@@ -85,10 +85,10 @@ def test_asdf_file_version():
         assert af.version == AsdfVersion("1.3.0")
         assert af.version_string == "1.3.0"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"ASDF Standard version .* is not supported by asdf==.*"):
             AsdfFile(version="0.5.4")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"ASDF Standard version .* is not supported by asdf==.*"):
             AsdfFile(version=AsdfVersion("0.5.4"))
 
         af = AsdfFile()
@@ -101,10 +101,10 @@ def test_asdf_file_version():
         assert af.version == AsdfVersion("1.4.0")
         assert af.version_string == "1.4.0"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"ASDF Standard version .* is not supported by asdf==.*"):
             af.version = "0.5.4"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"ASDF Standard version .* is not supported by asdf==.*"):
             af.version = AsdfVersion("2.5.4")
 
         af.version = "1.0.0"
@@ -128,8 +128,12 @@ def test_asdf_file_extensions():
         af.extensions = arg
         assert af.extensions == [ExtensionProxy(extension)]
 
+    msg = (
+        r"[The extensions parameter must be an extension.*, "
+        r"Extension must implement the Extension or AsdfExtension interface]"
+    )
     for arg in (object(), [object()]):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=msg):
             AsdfFile(extensions=arg)
 
 
@@ -184,8 +188,12 @@ def test_open_asdf_extensions(tmp_path):
         with open_asdf(path, extensions=arg) as af:
             assert af.extensions == [ExtensionProxy(extension)]
 
+    msg = (
+        r"[The extensions parameter must be an extension.*, "
+        r"Extension must implement the Extension or AsdfExtension interface]"
+    )
     for arg in (object(), [object()]):
-        with pytest.raises(TypeError), open_asdf(path, extensions=arg) as af:
+        with pytest.raises(TypeError, match=msg), open_asdf(path, extensions=arg) as af:
             pass
 
 
@@ -206,10 +214,10 @@ def test_serialization_context():
 
     assert context.url == context._url == "file://test.asdf"
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Extension must implement the Extension or AsdfExtension interface"):
         context._mark_extension_used(object())
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"ASDF Standard version .* is not supported by asdf==.*"):
         SerializationContext("0.5.4", extension_manager, None)
 
 
@@ -371,7 +379,10 @@ def test_bad_input(tmp_path):
     with open(text_file, "w") as fh:
         fh.write("I <3 ASDF!!!!!")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"Input object does not appear to be an ASDF file or a FITS with ASDF extension",
+    ):
         open_asdf(text_file)
 
 
@@ -383,7 +394,10 @@ def test_unclosed_file(tmp_path):
     path = tmp_path / "empty.asdf"
     path.touch()
 
-    with pytest.raises(ValueError), open_asdf(path):
+    with pytest.raises(
+        ValueError,
+        match=r"Input object does not appear to be an ASDF file or a FITS with ASDF extension",
+    ), open_asdf(path):
         pass
 
 

--- a/asdf/tests/test_compression.py
+++ b/asdf/tests/test_compression.py
@@ -68,9 +68,9 @@ def _roundtrip(tmp_path, tree, compression=None, write_options=None, read_option
 def test_invalid_compression():
     tree = _get_large_tree()
     ff = asdf.AsdfFile(tree)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Supported compression types are: .*, not 'foo'"):
         ff.set_array_compression(tree["science_data"], "foo")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Unknown compression type: .*"):
         compression._get_compressor("foo")
 
 
@@ -87,10 +87,10 @@ def test_decompress_too_long_short():
     fio.read_blocks = blocks
     compression.decompress(fio, size, 1024, "zlib")
     fio.seek(0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Decompressed data wrong size"):
         compression.decompress(fio, size, 1025, "zlib")
     fio.seek(0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"memoryview assignment: lvalue and rvalue have different structures"):
         compression.decompress(fio, size, 1023, "zlib")
 
 
@@ -175,7 +175,7 @@ def test_set_array_compression(tmp_path):
     with asdf.AsdfFile(tree) as af_out:
         af_out.set_array_compression(zlib_data, "zlib", level=1)
         af_out.set_array_compression(bzp2_data, "bzp2", compresslevel=9000)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"compresslevel must be between 1 and 9"):
             af_out.write_to(tmpfile)
         af_out.set_array_compression(bzp2_data, "bzp2", compresslevel=9)
         af_out.write_to(tmpfile)
@@ -228,7 +228,7 @@ def test_compression_with_extension(tmp_path):
     with config_context() as config:
         config.add_extension(LzmaExtension())
 
-        with pytest.raises(lzma.LZMAError):
+        with pytest.raises(lzma.LZMAError, match=r"Invalid or unsupported options"):
             _roundtrip(tmp_path, tree, "lzma", write_options={"compression_kwargs": {"preset": 9000}})
         fn = _roundtrip(tmp_path, tree, "lzma", write_options={"compression_kwargs": {"preset": 6}})
 

--- a/asdf/tests/test_config.py
+++ b/asdf/tests/test_config.py
@@ -88,7 +88,7 @@ def test_default_version():
         assert asdf.config.DEFAULT_DEFAULT_VERSION != "1.2.0"
         config.default_version = "1.2.0"
         assert config.default_version == "1.2.0"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"ASDF Standard version .* is not supported by asdf==.*"):
             config.default_version = "0.1.5"
 
 
@@ -168,7 +168,7 @@ def test_resource_mappings():
         assert len(config.resource_mappings) == len(default_mappings)
 
         # But not omit both:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Must specify at least one of mapping or package"):
             config.remove_resource_mapping()
 
         # Removing a mapping should be idempotent:
@@ -284,7 +284,7 @@ def test_extensions():
         assert len(config.extensions) == len(original_extensions) + 1
 
         # ... but not omit both:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Must specify at least one of extension or package"):
             config.remove_extension()
 
         # Removing an extension should be idempotent:

--- a/asdf/tests/test_extension.py
+++ b/asdf/tests/test_extension.py
@@ -163,7 +163,7 @@ def test_extension_proxy_maybe_wrap():
     assert proxy.delegate is extension
     assert ExtensionProxy.maybe_wrap(proxy) is proxy
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Extension must implement the Extension or AsdfExtension interface"):
         ExtensionProxy.maybe_wrap(object())
 
 
@@ -242,35 +242,35 @@ def test_extension_proxy():
     assert proxy.class_name == "asdf.tests.test_extension.FullExtension"
 
     # Should fail when the input is not one of the two extension interfaces:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Extension must implement the Extension or AsdfExtension interface"):
         ExtensionProxy(object)
 
     # Should fail with a bad converter:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Converter must implement the .* interface"):
         ExtensionProxy(FullExtension(converters=[object()]))
 
     # Should fail with a bad compressor:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Extension property 'compressors' must contain instances of .*"):
         ExtensionProxy(FullExtension(compressors=[object()]))
 
     # Should fail with a bad validator
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Extension property 'validators' must contain instances of .*"):
         ExtensionProxy(FullExtension(validators=[object()]))
 
     # Unparsable ASDF Standard requirement:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Invalid specifier:.*"):
         ExtensionProxy(FullExtension(asdf_standard_requirement="asdf-standard >= 1.4.0"))
 
     # Unrecognized ASDF Standard requirement type:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Extension property 'asdf_standard_requirement' must be str or None"):
         ExtensionProxy(FullExtension(asdf_standard_requirement=object()))
 
     # Bad tag:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Extension property 'tags' must contain str or .* values"):
         ExtensionProxy(FullExtension(tags=[object()]))
 
     # Bad legacy class names:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Extension property 'legacy_class_names' must contain str values"):
         ExtensionProxy(FullExtension(legacy_class_names=[object]))
 
 
@@ -425,18 +425,18 @@ def test_extension_manager():
         manager.get_tag_definition("asdf://somewhere.org/extensions/full/tags/baz-1.0").tag_uri
         == "asdf://somewhere.org/extensions/full/tags/baz-1.0"
     )
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match=r"No support available for YAML tag.*"):
         manager.get_tag_definition("asdf://somewhere.org/extensions/full/tags/bar-1.0")
 
     assert manager.get_converter_for_tag("asdf://somewhere.org/extensions/full/tags/foo-1.0").delegate is converter1
     assert manager.get_converter_for_tag("asdf://somewhere.org/extensions/full/tags/baz-1.0").delegate is converter2
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match=r"No support available for YAML tag.*"):
         manager.get_converter_for_tag("asdf://somewhere.org/extensions/full/tags/bar-1.0")
 
     assert manager.get_converter_for_type(FooType).delegate is converter1
     assert manager.get_converter_for_type(BarType).delegate is converter1
     assert manager.get_converter_for_type(BazType).delegate is converter2
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match=r"\"No support available for Python type .*\""):
         manager.get_converter_for_type(object)
 
 
@@ -462,7 +462,7 @@ def test_tag_definition():
 
     assert "URI: asdf://somewhere.org/extensions/foo/tags/foo-1.0" in repr(tag_def)
 
-    with pytest.warns(AsdfDeprecationWarning):
+    with pytest.warns(AsdfDeprecationWarning, match=r"The .* property is deprecated.*"):
         assert tag_def.schema_uri == "asdf://somewhere.org/extensions/foo/schemas/foo-1.0"
 
     tag_def = TagDefinition(
@@ -479,10 +479,13 @@ def test_tag_definition():
         "asdf://somewhere.org/extensions/foo/schemas/foo-1.0",
         "asdf://somewhere.org/extensions/foo/schemas/base-1.0",
     ]
-    with pytest.warns(AsdfDeprecationWarning), pytest.raises(RuntimeError):
+    with pytest.warns(AsdfDeprecationWarning, match=r"The .* property is deprecated.*"), pytest.raises(
+        RuntimeError,
+        match=r"Cannot use .* when multiple schema URIs are present",
+    ):
         tag_def.schema_uri
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"URI patterns are not permitted in TagDefinition"):
         TagDefinition("asdf://somewhere.org/extensions/foo/tags/foo-*")
 
 
@@ -589,15 +592,15 @@ def test_converter_proxy():
     assert "package: foo==1.2.3" in repr(proxy)
 
     # Should error because object() does fulfill the Converter interface:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Converter must implement the .*"):
         ConverterProxy(object(), extension)
 
     # Should fail because tags must be str:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Converter property .* must contain str values"):
         ConverterProxy(MinimumConverter(tags=[object()]), extension)
 
     # Should fail because types must instances of type:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Converter property .* must contain str or type values"):
         ConverterProxy(MinimumConverter(types=[object()]), extension)
 
 
@@ -759,5 +762,5 @@ def test_validator():
             af.validate()
 
             af["foo"] = "bar"
-            with pytest.raises(ValidationError):
+            with pytest.raises(ValidationError, match=r"Node was doomed to fail"):
                 af.validate()

--- a/asdf/tests/test_file_format.py
+++ b/asdf/tests/test_file_format.py
@@ -18,18 +18,18 @@ baz: 42
     path = os.path.join(str(tmp_path), "test.asdf")
 
     buff = io.BytesIO(content)
-    with pytest.raises(ValueError), asdf.open(buff):
+    with pytest.raises(ValueError, match=r"End of YAML marker not found"), asdf.open(buff):
         pass
 
     buff.seek(0)
     fd = generic_io.InputStream(buff, "r")
-    with pytest.raises(ValueError), asdf.open(fd):
+    with pytest.raises(ValueError, match=r"End of YAML marker not found"), asdf.open(buff):
         pass
 
     with open(path, "wb") as fd:
         fd.write(content)
 
-    with open(path, "rb") as fd, pytest.raises(ValueError), asdf.open(fd):
+    with open(path, "rb") as fd, pytest.raises(ValueError, match=r"End of YAML marker not found"), asdf.open(fd):
         pass
 
 
@@ -66,13 +66,19 @@ def test_no_asdf_header(tmp_path):
     path = os.path.join(str(tmp_path), "test.asdf")
 
     buff = io.BytesIO(content)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"Input object does not appear to be an ASDF file or a FITS with ASDF extension",
+    ):
         asdf.open(buff)
 
     with open(path, "wb") as fd:
         fd.write(content)
 
-    with open(path, "rb") as fd, pytest.raises(ValueError):
+    with open(path, "rb") as fd, pytest.raises(
+        ValueError,
+        match=r"Input object does not appear to be an ASDF file or a FITS with ASDF extension",
+    ):
         asdf.open(fd)
 
 
@@ -117,16 +123,16 @@ def test_invalid_source(small_tree):
     with asdf.open(buff) as ff2:
         ff2._blocks.get_block(0)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Block .* not found."):
             ff2._blocks.get_block(2)
 
-        with pytest.raises(IOError):
+        with pytest.raises(IOError, match=r"<.* nodename nor servname provided, or not known>"):
             ff2._blocks.get_block("http://ABadUrl.verybad/test.asdf")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=r"Unknown source .*"):
             ff2._blocks.get_block(42.0)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"block not found."):
             ff2._blocks.get_source(42.0)
 
         block = ff2._blocks.get_block(0)
@@ -155,13 +161,19 @@ def test_not_asdf_file():
     buff = io.BytesIO(b"SIMPLE")
     buff.seek(0)
 
-    with pytest.raises(ValueError), asdf.open(buff):
+    with pytest.raises(
+        ValueError,
+        match=r"Input object does not appear to be an ASDF file or a FITS with ASDF extension",
+    ), asdf.open(buff):
         pass
 
     buff = io.BytesIO(b"SIMPLE\n")
     buff.seek(0)
 
-    with pytest.raises(ValueError), asdf.open(buff):
+    with pytest.raises(
+        ValueError,
+        match=r"Input object does not appear to be an ASDF file or a FITS with ASDF extension",
+    ), asdf.open(buff):
         pass
 
 
@@ -169,7 +181,7 @@ def test_junk_file():
     buff = io.BytesIO(b"#ASDF 1.0.0\nFOO")
     buff.seek(0)
 
-    with pytest.raises(ValueError), asdf.open(buff):
+    with pytest.raises(ValueError, match=r"Invalid content between header and tree"), asdf.open(buff):
         pass
 
 
@@ -183,7 +195,7 @@ def test_block_mismatch():
     )
 
     buff.seek(0)
-    with pytest.raises(ValueError), asdf.open(buff):
+    with pytest.raises(ValueError, match=r"Header size must be >= 48"), asdf.open(buff):
         pass
 
 
@@ -193,7 +205,7 @@ def test_block_header_too_small():
     buff = io.BytesIO(b"#ASDF 1.0.0\n\xd3BLK\0\0")
 
     buff.seek(0)
-    with pytest.raises(ValueError), asdf.open(buff):
+    with pytest.raises(ValueError, match=r"Header size must be >= 48"), asdf.open(buff):
         pass
 
 
@@ -205,7 +217,7 @@ def test_invalid_version(tmp_path):
 foo : bar
 ..."""
     buff = io.BytesIO(content)
-    with pytest.raises(ValueError), asdf.open(buff):
+    with pytest.raises(ValueError, match=r"ASDF Standard version .* is not supported by asdf==.*"), asdf.open(buff):
         pass
 
 

--- a/asdf/tests/test_file_format.py
+++ b/asdf/tests/test_file_format.py
@@ -126,7 +126,9 @@ def test_invalid_source(small_tree):
         with pytest.raises(ValueError, match=r"Block .* not found."):
             ff2._blocks.get_block(2)
 
-        with pytest.raises(IOError, match=r"<.* nodename nor servname provided, or not known>"):
+        # This error message changes depending on how remote-data is configured
+        # for the CI run.
+        with pytest.raises(IOError):  # noqa: PT011
             ff2._blocks.get_block("http://ABadUrl.verybad/test.asdf")
 
         with pytest.raises(TypeError, match=r"Unknown source .*"):

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -277,7 +277,7 @@ invalid_software: !core/software-1.0.0
 
     for open_method in [asdf.open, asdf.fits_embed.AsdfInFits.open]:
         get_config().validate_on_read = True
-        with pytest.raises(ValidationError), open_method(tmpfile):
+        with pytest.raises(ValidationError, match=r".* is not of type .*"), open_method(tmpfile):
             pass
 
         get_config().validate_on_read = False
@@ -292,7 +292,10 @@ def test_bad_fits_input(tmp_path):
     with open(path, "wb") as f:
         f.write(asdf.constants.FITS_MAGIC)
 
-    with pytest.raises(ValueError), asdf_open(path):
+    with pytest.raises(
+        ValueError,
+        match=r"Input object does not appear to be an ASDF file or a FITS with ASDF extension",
+    ), asdf_open(path):
         pass
 
 
@@ -356,7 +359,10 @@ def test_extension_check():
     with assert_no_warnings(), asdf.open(testfile, ignore_missing_extensions=True):
         pass
 
-    with pytest.raises(RuntimeError), asdf.open(testfile, strict_extension_check=True):
+    with pytest.raises(
+        RuntimeError,
+        match=r"File.* was created with extension class .*, which is not currently installed",
+    ), asdf.open(testfile, strict_extension_check=True):
         pass
 
 

--- a/asdf/tests/test_helpers.py
+++ b/asdf/tests/test_helpers.py
@@ -43,5 +43,8 @@ def test_conversion_error(tmp_path):
     foo = FooType(10, "hello")
     tree = {"foo": foo}
 
-    with pytest.raises(AsdfConversionWarning), pytest.warns(AsdfWarning, match=r"Unable to locate schema file"):
+    with pytest.raises(
+        AsdfConversionWarning,
+        match=r"Failed to convert .* to custom type .* Using raw Python data structure instead",
+    ), pytest.warns(AsdfWarning, match=r"Unable to locate schema file"):
         assert_roundtrip_tree(tree, tmp_path, extensions=FooExtension())

--- a/asdf/tests/test_integration.py
+++ b/asdf/tests/test_integration.py
@@ -63,7 +63,7 @@ def test_serialize_custom_type(tmp_path):
             assert af2["foo"].value == "bar"
 
         af["foo"] = Foo(12)
-        with pytest.raises(asdf.ValidationError):
+        with pytest.raises(asdf.ValidationError, match=r".* is not of type .*"):
             af.write_to(path)
 
 
@@ -127,11 +127,11 @@ def test_serialize_with_multiple_schemas(tmp_path):
             assert af2["foo_foo"].value_value == "bar_bar"
 
         af["foo_foo"] = FooFoo(12, "bar_bar")
-        with pytest.raises(asdf.ValidationError):
+        with pytest.raises(asdf.ValidationError, match=r".* is not of type .*"):
             af.write_to(path)
 
         af["foo_foo"] = FooFoo("bar", 34)
-        with pytest.raises(asdf.ValidationError):
+        with pytest.raises(asdf.ValidationError, match=r".* is not of type .*"):
             af.write_to(path)
 
 

--- a/asdf/tests/test_reference.py
+++ b/asdf/tests/test_reference.py
@@ -56,7 +56,7 @@ def test_external_reference(tmp_path):
 
         assert_array_equal(ff.tree["science_data"], exttree["cool_stuff"]["a"])
         assert len(ff._external_asdf_by_uri) == 1
-        with pytest.raises((ValueError, RuntimeError)):
+        with pytest.raises((ValueError, RuntimeError), match=r"assignment destination is read-only"):
             # Assignment destination is readonly
             ff.tree["science_data"][0] = 42
 
@@ -116,15 +116,15 @@ def test_external_reference_invalid(tmp_path):
     tree = {"foo": {"$ref": "fail.asdf"}}
 
     ff = asdf.AsdfFile(tree)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Resolved to relative URL"):
         ff.resolve_references()
 
     ff = asdf.AsdfFile(tree, uri="http://httpstat.us/404")
-    with pytest.raises(IOError):
+    with pytest.raises(IOError, match=r"HTTP Error 404: Not Found"):
         ff.resolve_references()
 
     ff = asdf.AsdfFile(tree, uri=util.filepath_to_url(os.path.join(str(tmp_path), "main.asdf")))
-    with pytest.raises(IOError):
+    with pytest.raises(IOError, match=r"No such file or directory: .*"):
         ff.resolve_references()
 
 
@@ -138,6 +138,7 @@ def test_external_reference_invalid_fragment(tmp_path):
 
     with asdf.AsdfFile(tree, uri=util.filepath_to_url(os.path.join(str(tmp_path), "main.asdf"))) as ff, pytest.raises(
         ValueError,
+        match=r"Unresolvable reference: .*",
     ):
         ff.resolve_references()
 
@@ -145,6 +146,7 @@ def test_external_reference_invalid_fragment(tmp_path):
 
     with asdf.AsdfFile(tree, uri=util.filepath_to_url(os.path.join(str(tmp_path), "main.asdf"))) as ff, pytest.raises(
         ValueError,
+        match=r"Unresolvable reference: .*",
     ):
         ff.resolve_references()
 

--- a/asdf/tests/test_resolver.py
+++ b/asdf/tests/test_resolver.py
@@ -66,10 +66,10 @@ def test_resolver_non_prefix():
 
 
 def test_resolver_invalid_mapping():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Invalid mapping .*"):
         Resolver([("foo",)], "test")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Invalid mapping .*"):
         Resolver([12], "test")
 
 

--- a/asdf/tests/test_resource.py
+++ b/asdf/tests/test_resource.py
@@ -68,7 +68,7 @@ def test_proxy_maybe_wrap():
     assert proxy.delegate is mapping
     assert ResourceMappingProxy.maybe_wrap(proxy) is proxy
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Resource mapping must implement the Mapping interface"):
         ResourceMappingProxy.maybe_wrap([])
 
 

--- a/asdf/tests/test_search.py
+++ b/asdf/tests/test_search.py
@@ -50,10 +50,10 @@ def test_multiple_results(asdf_file):
     assert "root['foo']" in result.paths
     assert "root['nested']['foo']" in result.paths
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match=r"More than one result"):
         result.path
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match=r"More than one result"):
         result.node
 
     result.replace(54)
@@ -88,7 +88,7 @@ def test_by_type(asdf_file):
     result = asdf_file.search(type_=re.compile("^i.t$"))
     assert result.nodes == [42, 24, 24, 0, 1, 2]
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"type must be .*"):
         asdf_file.search(type_=4)
 
 
@@ -110,7 +110,7 @@ def test_by_value_with_ndarray():
 
 
 def test_by_filter(asdf_file):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"filter must accept 1 or 2 arguments"):
         asdf_file.search(filter_=lambda: True)
 
     result = asdf_file.search(filter_=lambda n: isinstance(n, int) and n % 2 == 0)
@@ -145,7 +145,7 @@ def test_index_operator(asdf_file):
     assert len(result.nodes) == 1
     assert result.node == 24
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"This node cannot be indexed"):
         asdf_file.search()["foo"][0]
 
 

--- a/asdf/tests/test_stream.py
+++ b/asdf/tests/test_stream.py
@@ -175,7 +175,7 @@ def test_too_many_streams():
 
     ff = asdf.AsdfFile(tree)
     ff.set_array_storage(tree["stream1"], "streamed")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Can not add second streaming block"):
         ff.set_array_storage(tree["stream2"], "streamed")
 
 

--- a/asdf/tests/test_types.py
+++ b/asdf/tests/test_types.py
@@ -537,17 +537,17 @@ def test_incompatible_version_check():
     assert TestType5.incompatible_version("1.0.0") is True
     assert TestType5.incompatible_version("1.1.0") is True
 
-    with pytest.raises(ValueError), pytest.warns(
+    with pytest.raises(ValueError, match=r"Invalid version string: .*"), pytest.warns(
         AsdfDeprecationWarning,
-        match=".*subclasses the deprecated CustomType.*",
+        match=r".*subclasses the deprecated CustomType.*",
     ):
 
         class TestType6(types.CustomType):
             supported_versions = "blue"
 
-    with pytest.raises(ValueError), pytest.warns(
+    with pytest.raises(ValueError, match=r"Invalid version string: .*"), pytest.warns(
         AsdfDeprecationWarning,
-        match=".*subclasses the deprecated CustomType.*",
+        match=r".*subclasses the deprecated CustomType.*",
     ):
 
         class TestType7(types.CustomType):

--- a/asdf/tests/test_yaml.py
+++ b/asdf/tests/test_yaml.py
@@ -73,7 +73,7 @@ def test_arbitrary_python_object():
 
     buff = io.BytesIO()
     ff = asdf.AsdfFile(tree)
-    with pytest.raises(yaml.YAMLError):
+    with pytest.raises(yaml.YAMLError, match=r"\('cannot represent an object', .*\)"):
         ff.write_to(buff)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,6 @@ extend-ignore = [
     "PLR0913", # Too many arguments to function call
     "PLR0915", # Too many statements
     "PLR2004", # Magic value used in comparison
-    "PT011", # `pytest.raises(...)` is too broad, set the `match` parameter or use a more specific exception
     "SLF001", # Private member accessed
     "TRY002", # Create your own exception
     "TRY301", # Abstract raise to an inner function


### PR DESCRIPTION
Fixes #1342

Adds`match` checks to all the `pytest.raises` checks, so that error messages are checked.