### PR TITLE
Module shadowing

### DIFF
--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -1,16 +1,27 @@
-import sys
 import warnings
 
 from . import _resolver
 from .exceptions import AsdfDeprecationWarning
 
-warnings.warn(
-    "asdf.resolver is deprecated "
-    "Please see Resources "
-    "https://asdf.readthedocs.io/en/stable/asdf/extending/resources.html",
-    AsdfDeprecationWarning,
-)
 
-# overwrite the hidden module __file__ so pytest doesn't throw an ImportPathMismatchError
-_resolver.__file__ = __file__
-sys.modules[__name__] = _resolver
+def _warn():
+    warnings.warn(
+        "asdf.resolver is deprecated "
+        "Please see Resources "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/resources.html",
+        AsdfDeprecationWarning,
+    )
+
+
+_warn()
+
+
+def __getattr__(name):
+    attr = getattr(_resolver, name)
+    _warn()
+    attr.__module__ = __name__
+    return attr
+
+
+def __dir__():
+    return dir(_resolver)

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -19,7 +19,8 @@ _warn()
 def __getattr__(name):
     attr = getattr(_resolver, name)
     _warn()
-    attr.__module__ = __name__
+    if hasattr(attr, "__module__"):
+        attr.__module__ = __name__
     return attr
 
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -7,20 +7,22 @@ from asdf.exceptions import AsdfDeprecationWarning
 
 from . import _helpers
 
-warnings.warn(
-    "asdf.tests.helpers is deprecated. Please see asdf.testing.helpers",
-    AsdfDeprecationWarning,
-)
 
+def _warn():
+    warnings.warn(
+        "asdf.tests.helpers is deprecated. Please see asdf.testing.helpers",
+        AsdfDeprecationWarning,
+    )
+
+
+_warn()
 
 __all__ = _helpers.__all__  # noqa: PLE0605
 
 
 def __getattr__(name):
-    warnings.warn(
-        "asdf.tests.helpers is deprecated. Please see asdf.testing.helpers",
-        AsdfDeprecationWarning,
-    )
+    _warn()
     attr = getattr(_helpers, name)
-    attr.__module__ = __name__  # make automodapi think this is local
+    if hasattr(attr, "__module__"):
+        attr.__module__ = __name__  # make automodapi think this is local
     return attr

--- a/asdf/tests/test_deprecated.py
+++ b/asdf/tests/test_deprecated.py
@@ -35,7 +35,12 @@ def test_resolver_module_deprecation():
         # sys.module and __file__ changes in asdf.resolver
         if "asdf.resolver" in sys.modules:
             del sys.modules["asdf.resolver"]
-        import asdf.resolver  # noqa: F401
+        import asdf.resolver
+    for attr in dir(asdf.resolver):
+        if attr in ("warnings", "AsdfDeprecationWarning") or attr[0] == "_":
+            continue
+        with pytest.warns(AsdfDeprecationWarning, match="^asdf.resolver is deprecated.*$"):
+            getattr(asdf.resolver, attr)
 
 
 def test_assert_extension_correctness_deprecation():
@@ -50,7 +55,10 @@ def test_type_index_module_deprecation():
         # sys.module and __file__ changes in asdf.type_index
         if "asdf.type_index" in sys.modules:
             del sys.modules["asdf.type_index"]
-        import asdf.type_index  # noqa: F401
+        import asdf.type_index
+    for attr in asdf.type_index.__all__:
+        with pytest.warns(AsdfDeprecationWarning, match="^asdf.type_index is deprecated.*$"):
+            getattr(asdf.type_index, attr)
 
 
 @pytest.mark.parametrize("attr", ["url_mapping", "tag_mapping", "resolver", "extension_list", "type_index"])
@@ -73,7 +81,10 @@ def test_types_module_deprecation():
     with pytest.warns(AsdfDeprecationWarning, match="^asdf.types is deprecated.*$"):
         if "asdf.types" in sys.modules:
             del sys.modules["asdf.types"]
-        import asdf.types  # noqa: F401
+        import asdf.types
+    for attr in asdf.types.__all__:
+        with pytest.warns(AsdfDeprecationWarning, match="^asdf.types is deprecated.*$"):
+            getattr(asdf.types, attr)
 
 
 def test_default_extensions_deprecation():

--- a/asdf/tests/test_deprecated.py
+++ b/asdf/tests/test_deprecated.py
@@ -36,8 +36,19 @@ def test_resolver_module_deprecation():
         if "asdf.resolver" in sys.modules:
             del sys.modules["asdf.resolver"]
         import asdf.resolver
+    # resolver does not define an __all__ so we will define one here
+    # for testing purposes
+    resolver_all = [
+        "Resolver",
+        "ResolverChain",
+        "DEFAULT_URL_MAPPING",
+        "DEFAULT_TAG_TO_URL_MAPPING",
+        "default_url_mapping",
+        "default_tag_to_url_mapping",
+        "default_resolver",
+    ]
     for attr in dir(asdf.resolver):
-        if attr in ("warnings", "AsdfDeprecationWarning") or attr[0] == "_":
+        if attr not in resolver_all:
             continue
         with pytest.warns(AsdfDeprecationWarning, match="^asdf.resolver is deprecated.*$"):
             getattr(asdf.resolver, attr)

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -20,5 +20,6 @@ __all__ = _type_index.__all__  # noqa: PLE0605
 def __getattr__(name):
     attr = getattr(_type_index, name)
     _warn()
-    attr.__module__ = __name__
+    if hasattr(attr, "__module__"):
+        attr.__module__ = __name__
     return attr

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -1,23 +1,24 @@
-import sys
 import warnings
 
 from . import _type_index
 from .exceptions import AsdfDeprecationWarning
 
-warnings.warn(
-    "asdf.type_index is deprecated "
-    "Please see the new extension API "
-    "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
-    AsdfDeprecationWarning,
-)
+
+def _warn():
+    warnings.warn(
+        "asdf.type_index is deprecated "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
 
 
-# overwrite the hidden module __file__ so pytest doesn't throw an ImportPathMismatchError
-_type_index.__file__ = __file__
-# overwrite the module name for each defined class to allow doc references to work
-for class_ in [
-    _type_index._AsdfWriteTypeIndex,
-    _type_index.AsdfTypeIndex,
-]:
-    class_.__module__ = __name__
-sys.modules[__name__] = _type_index
+_warn()
+__all__ = _type_index.__all__  # noqa: PLE0605
+
+
+def __getattr__(name):
+    attr = getattr(_type_index, name)
+    _warn()
+    attr.__module__ = __name__
+    return attr

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -20,5 +20,6 @@ __all__ = _types.__all__  # noqa: PLE0605
 def __getattr__(name):
     attr = getattr(_types, name)
     _warn()
-    attr.__module__ = __name__
+    if hasattr(attr, "__module__"):
+        attr.__module__ = __name__
     return attr

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -1,26 +1,24 @@
-import sys
 import warnings
 
 from . import _types
 from .exceptions import AsdfDeprecationWarning
 
-warnings.warn(
-    "asdf.types is deprecated "
-    "Please see the new extension API "
-    "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
-    AsdfDeprecationWarning,
-)
+
+def _warn():
+    warnings.warn(
+        "asdf.types is deprecated "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
 
 
-# overwrite the hidden module __file__ so pytest doesn't throw an ImportPathMismatchError
-_types.__file__ = __file__
-# overwrite the module name for each defined class to allow doc references to work
-for class_ in [
-    _types.ExtensionTypeMeta,
-    _types.AsdfTypeMeta,
-    _types.ExtensionType,
-    _types.AsdfType,
-    _types.CustomType,
-]:
-    class_.__module__ = __name__
-sys.modules[__name__] = _types
+_warn()
+__all__ = _types.__all__  # noqa: PLE0605
+
+
+def __getattr__(name):
+    attr = getattr(_types, name)
+    _warn()
+    attr.__module__ = __name__
+    return attr

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -20,6 +20,6 @@ __all__ = _types.__all__  # noqa: PLE0605
 def __getattr__(name):
     attr = getattr(_types, name)
     _warn()
-    if hasattr(attr, "__module__"):
+    if hasattr(attr, "__module__") and name != "format_tag":
         attr.__module__ = __name__
     return attr

--- a/docs/asdf/developer_api.rst
+++ b/docs/asdf/developer_api.rst
@@ -28,5 +28,6 @@ to create their own custom ASDF types and extensions.
     :skip: IntegerType
 
 .. automodapi:: asdf.testing.helpers
+    :include: format_tag
 
 .. automodapi:: asdf.tests.helpers

--- a/docs/asdf/developer_api.rst
+++ b/docs/asdf/developer_api.rst
@@ -28,6 +28,5 @@ to create their own custom ASDF types and extensions.
     :skip: IntegerType
 
 .. automodapi:: asdf.testing.helpers
-    :include: format_tag
 
 .. automodapi:: asdf.tests.helpers

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -219,6 +219,7 @@ class AsdfSchemaExampleItem(pytest.Item):
 
     def runtest(self):
         from asdf import AsdfFile, block, util
+        from asdf.exceptions import AsdfDeprecationWarning
         from asdf.tests import _helpers as helpers
 
         # Make sure that the examples in the schema files (and thus the
@@ -249,6 +250,7 @@ class AsdfSchemaExampleItem(pytest.Item):
             # Do not tolerate any warnings that occur during schema validation
             with warnings.catch_warnings():
                 warnings.simplefilter("error")
+                warnings.simplefilter("default", category=AsdfDeprecationWarning)
 
                 ff._open_impl(ff, buff, mode="rw")
         except Exception:


### PR DESCRIPTION
To add deprecation warnings, several public sub modules were 'shadowed' by moving them to a private file (prefixed with `_`) and adding a stub public module in their place that issued a deprecation warning then replaced itself with the private module. Here is one example:
https://github.com/asdf-format/asdf/blob/6b4701277bb25c1d4e8583b88bc2b125be9a36d6/asdf/types.py#L1-L26

This example illustrates one issue with this approach where certain objects needed special handling to allow doc references to work.

An alternative approach was used for `asdf.tests.helpers`.
https://github.com/asdf-format/asdf/blob/6b4701277bb25c1d4e8583b88bc2b125be9a36d6/asdf/tests/helpers.py#L1-L26

That has several benefits including:
- easier control over what attributes are exposed
- a hook to allow deprecation warnings to be issued for every attribute access and not just during module import (which can sometimes result in retrieval of a cached import and no deprecation warning).

This PR updates `asdf.types`, `asdf.type_index` and `asdf.resolver` module shadowing to align with the approach taken with `asdf.tests.helpers`.