### PR TITLE
Drop pytest-openfiles dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ The ASDF Standard is at v1.6.0
 - Add AsdfDeprecationWarning to asdf_extensions entry point [#1361]
 - Deprecate asdf.tests.helpers [#1440]
 - respect umask when determining file permissions for written files [#1451]
+- Remove the retired ``pytest-openfiles`` dependency and replace it with ``pytest>=7``
+  instead. [#1454]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/asdf/tests/test_fits_embed.py
+++ b/asdf/tests/test_fits_embed.py
@@ -380,7 +380,7 @@ def test_verify_with_astropy(tmp_path, dtype):
 def test_dangling_file_handle(tmp_path):
     """
     This tests the bug fix introduced in #533. Without the bug fix, this test
-    will fail when running the test suite with pytest-openfiles.
+    will fail with a ResourceWarning about unclosed file handles with pytest >= 7.
     """
     import gc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,8 @@ tests = [
   "gwcs>=0.18.3",
   "lz4>=0.10",
   "psutil",
-  "pytest>=6",
+  "pytest>=7",
   "pytest-doctestplus",
-  "pytest-openfiles",
   "pytest-remotedata",
 ]
 [project.urls]
@@ -109,7 +108,6 @@ minversion = 4.6
 norecursedirs = ['build', 'docs/_build', 'docs/sphinxext']
 doctest_plus = 'enabled'
 remote_data_strict = true
-open_files_ignore = ['test.fits', 'asdf.fits']
 # The asdf.asdftypes module emits a warning on import,
 # which pytest trips over during collection:
 filterwarnings = [

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
     pytest \
     compatibility: compatibility_tests/ \
     --remote-data \
-    coverage: --open-files \
+    coverage: \
     parallel: --numprocesses auto \
 # the OpenAstronomy workflow appends `--cov-report` in `{posargs}`, which `coverage` doesn't recognize
     !coverage: {posargs}
@@ -127,7 +127,7 @@ commands_pre =
     pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands=
-    pytest astropy/astropy/io/misc/asdf --open-files --run-slow --remote-data \
+    pytest astropy/astropy/io/misc/asdf --run-slow --remote-data \
         -W "ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.tests.helpers"
 
 [testenv:asdf-astropy]


### PR DESCRIPTION
astropy/pytest-openfiles#44 starts the retirement process of `pytest-openfiles`, which will complete in November 2023. `pytest-openfiles` can be entirely replaced by catching `ResourceWarnings` from emitted by `pytest >= 7`. Since ASDF turns all warnings into errors, if we require `pytest>=7` for testing, then we no-longer need `pytest-openfiles`.

This PR removes `pytest-openfiles` from our testing and pins `pytest` to above version 7.