### PR TITLE
Consolidate deprecations add deprecations page to docs

### DIFF
--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -429,9 +429,3 @@ def test_fsspec_http(httpserver):
     with fsspec.open(fn) as f:
         af = open_asdf(f)
         assert_tree_match(tree, af.tree)
-
-
-def test_blocks_deprecated():
-    af = AsdfFile()
-    with pytest.deprecated_call():
-        af.blocks

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -146,3 +146,9 @@ def test_asdf_tests_helpers_deprecation():
     for attr in _helpers.__all__:
         with pytest.warns(AsdfDeprecationWarning, match="asdf.tests.helpers is deprecated"):
             getattr(asdf.tests.helpers, attr)
+
+
+def test_blocks_deprecated():
+    af = asdf.AsdfFile()
+    with pytest.warns(AsdfDeprecationWarning, match="The property AsdfFile.blocks has been deprecated"):
+        af.blocks

--- a/asdf/fits_embed.py
+++ b/asdf/fits_embed.py
@@ -1,4 +1,6 @@
 """
+This module is deprecated. Please see :ref:`asdf-in-fits`
+
 Utilities for embedded ADSF files in FITS.
 """
 import io

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -1,3 +1,6 @@
+"""
+This module is deprecated. Please see :ref:`extending_resources`
+"""
 import warnings
 
 from . import _resolver

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -1,3 +1,6 @@
+"""
+This module is deprecated. Please see :ref:`extending_converters`
+"""
 import warnings
 
 from . import _type_index

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -1,3 +1,6 @@
+"""
+This module is deprecated. Please see :ref:`extending_converters`
+"""
 import warnings
 
 from . import _types

--- a/docs/asdf/asdf_tool.rst
+++ b/docs/asdf/asdf_tool.rst
@@ -1,4 +1,4 @@
-.. asdf_tool:
+.. _asdf_tool:
 
 Command line tool
 -----------------

--- a/docs/asdf/asdf_tool.rst
+++ b/docs/asdf/asdf_tool.rst
@@ -20,6 +20,8 @@ useful operations:
 
   - ``remove-hdu``: Remove ASDF extension from ASDF-in-FITS file (requires
     :ref:`astropy:getting-started`, see :ref:`asdf-in-fits`).
+    This command is deprecated as part of ASDF dropping support for
+    ASDF-in-FITS. See :ref:`asdf-in-fits` for migration information.
 
   - ``info``: Print a rendering of an ASDF tree.
 

--- a/docs/asdf/deprecations.rst
+++ b/docs/asdf/deprecations.rst
@@ -1,0 +1,85 @@
+.. currentmodule:: asdf
+
+.. _deprecations:
+
+************
+Deprecations
+************
+
+ASDF 2.15 introduced many new `asdf.exceptions.AsdfDeprecationWarning` messages. These
+warnings are subclasses of the built-in python `DeprecationWarning` and will by
+default be ignored except in `__main__` and with testing tools such as
+:ref:`pytest <pytest:deprecation-warnings>`.
+
+These are intended to highlight use of features that we will likely remove in the next
+major version of ASDF (see our :ref:`release_and_support` for more details about our
+versioning, compatibility and support policy).
+
+.. _legacy_extension_api_deprecation:
+
+Legacy Extension API Deprecation
+================================
+
+A large number of `asdf.exceptions.AsdfDeprecationWarning` messages appear related to
+use of the :ref:`legacy extension api <extending_legacy>`. Some examples include:
+
+* `asdf.types`
+* `asdf.types.CustomType`
+* ``asdf.type_index``
+* ``asdf.resolver``
+* the ``asdf_extensions`` entry point
+* portions of asdf.extension including:
+
+  * `asdf.extension.AsdfExtension`
+  * `asdf.extension.AsdfExtensionList`
+  * `asdf.extension.BuiltinExtension`
+  * ``asdf.extension.default_extensions``
+  * ``asdf.extension.get_cached_asdf_extensions``
+  * `asdf.extension.get_default_resolver`
+
+* attributes to asdf.AsdfFile including:
+
+  * `asdf.AsdfFile.run_hook`
+  * `asdf.AsdfFile.run_modifying_hook`
+  * `asdf.AsdfFile.url_mapping`
+  * `asdf.AsdfFile.tag_mapping`
+  * `asdf.AsdfFile.type_index`
+  * `asdf.AsdfFile.resolver`
+  * `asdf.AsdfFile.extension_list`
+
+This deprecated api is replaced by new-style :ref:`converters <extending_converters>`,
+:ref:`extensions <extending_extensions>` and :ref:`validators <extending_validators>`.
+`asdf-astropy <https://asdf-astropy.readthedocs.io/en/latest/>`_ is a useful example
+package that uses these new-style extension api.
+
+.. _asdf_in_fits_deprecation:
+
+ASDF-in-FITS Deprecation
+========================
+
+Support for `~asdf.fits_embed.AsdfInFits` (including the `~asdf.fits_embed` module) is
+deprecated. Code using this format can migrate to using `stdatamodels` which
+contains functions to read and write AsdfInFits files
+(see :external+stdatamodels:doc:`asdf_in_fits` for migration information).
+
+Without support for `~asdf.fits_embed.AsdfInFits` the ``extract`` and
+``remove_hdu`` commands for :ref:`asdftool <asdf_tool>` are no longer usable and are
+deprecated.
+
+.. _asdffile_blocks_deprecation:
+
+AsdfFile.blocks Deprecation
+===========================
+
+Direct usage of the ASDF block manager through `asdf.AsdfFile.blocks` is deprecated.
+The BlockManager api was not previously included in the documentation and
+was unused by the legacy and new style extensions. Planned features for ASDF 3.0
+include adding block storage support to :ref:`converters <extending_converters>`.
+
+.. _tests_helpers_deprecation:
+
+asdf.tests.helpers Deprecation
+==============================
+
+Use of `asdf.tests.helpers` is deprecated. Please see `asdf.testing.helpers`
+for alternative functions to aid in testing.

--- a/docs/asdf/deprecations.rst
+++ b/docs/asdf/deprecations.rst
@@ -63,7 +63,7 @@ contains functions to read and write AsdfInFits files
 (see :external+stdatamodels:doc:`asdf_in_fits` for migration information).
 
 Without support for `~asdf.fits_embed.AsdfInFits` the ``extract`` and
-``remove_hdu`` commands for :ref:`asdftool <asdf_tool>` are no longer usable and are
+``remove-hdu`` commands for :ref:`asdftool <asdf_tool>` are no longer usable and are
 deprecated.
 
 .. _asdffile_blocks_deprecation:

--- a/docs/asdf/developer_api.rst
+++ b/docs/asdf/developer_api.rst
@@ -9,6 +9,9 @@ to create their own custom ASDF types and extensions.
 
 .. automodapi:: asdf.tagged
 
+.. automodapi:: asdf.exceptions
+    :skip: ValidationError
+
 .. automodapi:: asdf.extension
 
 .. automodapi:: asdf.resource

--- a/docs/asdf/extending/legacy.rst
+++ b/docs/asdf/extending/legacy.rst
@@ -10,7 +10,8 @@ Deprecated extension API
     This page documents the original `asdf` extension API, which has been
     deprecated in favor of :ref:`extending_extensions`.  Since support
     for the deprecated API will be removed in `asdf` 3.0, we recommend that
-    all new extensions be implemented with the new API.
+    all new extensions be implemented with the new API. For more information
+    about this and other deprecations please see the :ref:`deprecations` page.
 
 Extensions provide a way for ASDF to represent complex types that are not
 defined by the ASDF standard. Examples of types that require custom extensions

--- a/docs/asdf/extending/legacy.rst
+++ b/docs/asdf/extending/legacy.rst
@@ -5,10 +5,12 @@
 Deprecated extension API
 ========================
 
-This page documents the original `asdf` extension API, which has been
-deprecated in favor of :ref:`extending_extensions`.  Since support
-for the deprecated API will be removed in `asdf` 3.0, we recommend that
-all new extensions be implemented with the new API.
+.. note::
+
+    This page documents the original `asdf` extension API, which has been
+    deprecated in favor of :ref:`extending_extensions`.  Since support
+    for the deprecated API will be removed in `asdf` 3.0, we recommend that
+    all new extensions be implemented with the new API.
 
 Extensions provide a way for ASDF to represent complex types that are not
 defined by the ASDF standard. Examples of types that require custom extensions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,3 +45,4 @@ nitpicky = True
 intersphinx_mapping["semantic_version"] = ("https://python-semanticversion.readthedocs.io/en/latest/", None)
 intersphinx_mapping["jsonschema"] = ("https://python-jsonschema.readthedocs.io/en/stable/", None)
 intersphinx_mapping["stdatamodels"] = ("https://stdatamodels.readthedocs.io/en/latest/", None)
+intersphinx_mapping["pytest"] = ("https://docs.pytest.org/en/latest/", None)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,6 +85,7 @@ Resources
   asdf/contributing
   asdf/CODE_OF_CONDUCT.md
   asdf/release_and_support
+  asdf/deprecations
   asdf/changes
   asdf/citation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,12 @@ Format (ASDF) files.
     **A**\ daptable **S**\ eismic **D**\ ata **F**\ ormat,
     go here: http://seismic-data.org/
 
+.. note::
+
+   ASDF 2.15 introduced a number of deprecation warnings in preparation
+   for changes planned for ASDF 3.0. Please see the :ref:`deprecations`
+   page for more information.
+
 Getting Started
 ===============
 


### PR DESCRIPTION
This aims to consolidate tests and documentation for the new deprecation warnings.

The testing missing from test_deprecations (those introduced in #1336) are moved to test_deprecations.

A `Deprecations` page is added to the docs describing the new deprecations and deprecation warnings with migration information. https://asdf--1459.org.readthedocs.build/en/1459/asdf/deprecations.html

Fixes #1346 