### PR TITLE
Move array storage settings to config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ The ASDF Standard is at v1.6.0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Drop support for ASDF-in-FITS. [#1288]
+- Add ``all_array_storage``, ``all_array_compression`` and
+  ``all_array_compression_kwargs`` to ``asdf.config.AsdfConfig`` [#1468]
 
 2.15.0 (unreleased)
 -------------------

--- a/asdf/_tests/test_compression.py
+++ b/asdf/_tests/test_compression.py
@@ -225,8 +225,14 @@ class LzmaExtension(Extension):
 def test_compression_with_extension(tmp_path):
     tree = _get_large_tree()
 
+    with pytest.raises(ValueError, match="Supported compression types are"), config_context() as cfg:
+        cfg.all_array_compression = "lzma"
+
     with config_context() as config:
         config.add_extension(LzmaExtension())
+
+        with config_context() as cfg:
+            cfg.all_array_compression = "lzma"
 
         with pytest.raises(lzma.LZMAError, match=r"Invalid or unsupported options"):
             _roundtrip(tmp_path, tree, "lzma", write_options={"compression_kwargs": {"preset": 9000}})

--- a/asdf/_tests/test_config.py
+++ b/asdf/_tests/test_config.py
@@ -110,6 +110,39 @@ def test_array_inline_threshold():
         assert get_config().array_inline_threshold is None
 
 
+def test_all_array_storage():
+    with asdf.config_context() as config:
+        assert config.all_array_storage == asdf.config.DEFAULT_ALL_ARRAY_STORAGE
+        config.all_array_storage = "internal"
+        assert get_config().all_array_storage == "internal"
+        config.all_array_storage = None
+        assert get_config().all_array_storage is None
+        with pytest.raises(ValueError, match=r"Invalid value for all_array_storage"):
+            config.all_array_storage = "foo"
+
+
+def test_all_array_compression():
+    with asdf.config_context() as config:
+        assert config.all_array_compression == asdf.config.DEFAULT_ALL_ARRAY_COMPRESSION
+        config.all_array_compression = "zlib"
+        assert get_config().all_array_compression == "zlib"
+        config.all_array_compression = None
+        assert get_config().all_array_compression is None
+        with pytest.raises(ValueError, match=r"Supported compression types are"):
+            config.all_array_compression = "foo"
+
+
+def test_all_array_compression_kwargs():
+    with asdf.config_context() as config:
+        assert config.all_array_compression_kwargs == asdf.config.DEFAULT_ALL_ARRAY_COMPRESSION_KWARGS
+        config.all_array_compression_kwargs = {}
+        assert get_config().all_array_compression_kwargs == {}
+        config.all_array_compression_kwargs = None
+        assert get_config().all_array_compression_kwargs is None
+        with pytest.raises(ValueError, match=r"Invalid value for all_array_compression_kwargs"):
+            config.all_array_compression_kwargs = "foo"
+
+
 def test_resource_mappings():
     with asdf.config_context() as config:
         core_mappings = get_json_schema_resource_mappings() + asdf_standard.integration.get_resource_mappings()

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -422,7 +422,7 @@ class NDArrayType(_types.AsdfType):
         # Find all of the used data buffers so we can add or rearrange
         # them if necessary
         if isinstance(data, np.ndarray):
-            yield ctx._blocks.find_or_create_block_for_array(data, ctx)
+            yield ctx._blocks.find_or_create_block_for_array(data)
         elif isinstance(data, NDArrayType):
             yield data.block
 
@@ -444,7 +444,7 @@ class NDArrayType(_types.AsdfType):
 
         shape = data.shape
 
-        block = ctx._blocks.find_or_create_block_for_array(data, ctx)
+        block = ctx._blocks.find_or_create_block_for_array(data)
 
         # Compute the offset relative to the base array and not the
         # block data, in case the block is compressed.

--- a/docs/asdf/config.rst
+++ b/docs/asdf/config.rst
@@ -36,6 +36,9 @@ the currently active config:
     >>> asdf.get_config()
     <AsdfConfig
       array_inline_threshold: None
+      all_array_storage: None
+      all_array_compression: input
+      all_array_compression_kwargs: None
       default_version: 1.5.0
       io_block_size: -1
       legacy_fill_schema_defaults: True
@@ -56,6 +59,9 @@ This allows for short-lived configuration changes that do not impact other code:
     ...
     <AsdfConfig
       array_inline_threshold: None
+      all_array_storage: None
+      all_array_compression: input
+      all_array_compression_kwargs: None
       default_version: 1.5.0
       io_block_size: -1
       legacy_fill_schema_defaults: True
@@ -64,6 +70,9 @@ This allows for short-lived configuration changes that do not impact other code:
     >>> asdf.get_config()
     <AsdfConfig
       array_inline_threshold: None
+      all_array_storage: None
+      all_array_compression: input
+      all_array_compression_kwargs: None
       default_version: 1.5.0
       io_block_size: -1
       legacy_fill_schema_defaults: True


### PR DESCRIPTION
This PR moves:
- `all_array_storage`
- `all_array_compression`
- `all_array_compression_kwargs`

into `asdf.config.AsdfConfig`. These were previously passed around as arguments to several functions during `AsdfFile` writes. By moving them into the config the `AsdfFile` can continue to accept them as arguments to `AsdfFile.write_to` and `AsdfFile.update` (by using the arguments to set the values in the `AsdfConfig` context created within those functions) and now users can also adjust these settings in the config directly.

This helps to make these storage settings available to all functions called within the `AsdfConfig` contexts created during write without having to pass them around as arguments (this proved important for the upcoming deferred block and Converter block storage support).