### PR TITLE
Block data callback

### DIFF
--- a/asdf/_tests/test_array_blocks.py
+++ b/asdf/_tests/test_array_blocks.py
@@ -927,3 +927,47 @@ def test_block_key():
     bm.remove(blk)
     assert arr_blk in bm._internal_blocks
     assert blk not in bm._internal_blocks
+
+
+@pytest.mark.parametrize("memmap", [True, False])
+@pytest.mark.parametrize("lazy_load", [True, False])
+def test_data_callback(tmp_path, memmap, lazy_load):
+    class Callback:
+        def __init__(self, data):
+            self.n_calls = 0
+            self.data = data
+
+        def __call__(self):
+            self.n_calls += 1
+            return self.data
+
+    arr = np.array([1, 2, 3], dtype="uint8")
+    callback = Callback(arr)
+    b = block.Block(memmap=memmap, lazy_load=lazy_load, data_callback=callback)
+
+    assert callback.n_calls == 0
+    assert b.data is arr
+    assert callback.n_calls == 1
+    assert b._data is None
+    assert b.data is arr
+    assert callback.n_calls == 2
+
+    fn = tmp_path / "test.b"
+    with generic_io.get_file(fn, mode="w") as f:
+        b.write(f)
+    assert callback.n_calls == 3
+
+    with generic_io.get_file(fn, mode="r") as f:
+        rb = block.Block(memmap=memmap, lazy_load=lazy_load)
+        rb.read(f, past_magic=False)
+        assert_array_equal(rb.data, arr)
+
+    with pytest.raises(ValueError, match=r"Block.__init__ cannot contain non-None data and a non-None data_callback"):
+        b = block.Block(data=arr, memmap=memmap, lazy_load=lazy_load, data_callback=callback)
+
+    rb = block.Block(memmap=memmap, lazy_load=lazy_load, data_callback=callback)
+    with pytest.raises(RuntimeError, match=r"read called on a Block with a data_callback"), generic_io.get_file(
+        fn,
+        mode="r",
+    ) as f:
+        rb.read(f, past_magic=False)

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -839,7 +839,11 @@ class Block:
         ],
     )
 
-    def __init__(self, data=None, uri=None, array_storage="internal", memmap=True, lazy_load=True):
+    def __init__(self, data=None, uri=None, array_storage="internal", memmap=True, lazy_load=True, data_callback=None):
+        self._data_callback = data_callback
+        if self._data_callback is not None and data is not None:
+            msg = "Block.__init__ cannot contain non-None data and a non-None data_callback"
+            raise ValueError(msg)
         self._data = data
         self._uri = uri
         self._array_storage = array_storage
@@ -1032,6 +1036,9 @@ class Block:
             If `True`, validate the data against the checksum, and
             raise a `ValueError` if the data doesn't match.
         """
+        if self._data_callback is not None:
+            msg = "read called on a Block with a data_callback"
+            raise RuntimeError(msg)
         offset = None
         if fd.seekable():
             offset = fd.tell()
@@ -1174,7 +1181,14 @@ class Block:
         """
         self._header_size = self._header.size
 
-        data = self._flattened_data if self._data is not None else None
+        if self._data_callback is not None:
+            self._data = self._data_callback()
+            data = self._flattened_data
+            self.update_size()
+            self._data = None
+            self._allocated = self._size
+        else:
+            data = self._flattened_data if self._data is not None else None
 
         flags = 0
         data_size = used_size = allocated_size = 0
@@ -1237,21 +1251,23 @@ class Block:
         """
         Get the data for the block, as a numpy array.
         """
-        if self._data is None:
-            if self._fd.is_closed():
-                msg = "ASDF file has already been closed. Can not get the data."
-                raise OSError(msg)
+        if self._data is not None:
+            return self._data
+        if self._data_callback is not None:
+            return self._data_callback()
+        if self._fd.is_closed():
+            msg = "ASDF file has already been closed. Can not get the data."
+            raise OSError(msg)
 
-            # Be nice and reset the file position after we're done
-            curpos = self._fd.tell()
-            try:
-                self._memmap_data()
-                if not self._memmapped:
-                    self._fd.seek(self.data_offset)
-                    self._data = self._read_data(self._fd, self._size, self._data_size)
-            finally:
-                self._fd.seek(curpos)
-
+        # Be nice and reset the file position after we're done
+        curpos = self._fd.tell()
+        try:
+            self._memmap_data()
+            if not self._memmapped:
+                self._fd.seek(self.data_offset)
+                self._data = self._read_data(self._fd, self._size, self._data_size)
+        finally:
+            self._fd.seek(curpos)
         return self._data
 
     def close(self):
@@ -1279,6 +1295,7 @@ class UnloadedBlock:
         self._should_memmap = memmap
         self._memmapped = False
         self._lazy_load = lazy_load
+        self._data_callback = None
 
     def __len__(self):
         self.load()

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -1022,6 +1022,14 @@ class Block:
         requests it.  If the file is a stream or lazy_load is False,
         the data will be read into memory immediately.
 
+        As Block is used for reading, writing, configuring and
+        managing data there are circumstances where read should
+        not be used. For instance, if a data_callback is defined
+        a call to read would override the data corresponding to a
+        block and conflict with the use of the data_callback. To
+        signify this conflict, a RuntimeError is raised if read
+        is called on a block with a defined data_callback.
+
         Parameters
         ----------
         fd : GenericFile
@@ -1035,6 +1043,15 @@ class Block:
         validate_checksum : bool, optional
             If `True`, validate the data against the checksum, and
             raise a `ValueError` if the data doesn't match.
+
+        Raises
+        ------
+
+        RuntimeError
+            Read was called on a block with a defined data_callback.
+
+        ValueError
+            The read file contains invalid data.
         """
         if self._data_callback is not None:
             msg = "read called on a Block with a data_callback"


### PR DESCRIPTION
This adds a `data_callback` argument to `asdf.block.Block` that allow the block to dynamically load data during write. This is work towards a deferred block implementation where this callback will be used during the deferred write.