### PR TITLE
np.product is deprecated in numpy 1.25

### DIFF
--- a/asdf/block.py
+++ b/asdf/block.py
@@ -583,7 +583,7 @@ class BlockManager:
         if all_array_storage is None:
             threshold = get_config().array_inline_threshold
             if threshold is not None and block.array_storage in ["internal", "inline"]:
-                if np.product(block.data.shape) < threshold:
+                if np.prod(block.data.shape) < threshold:
                     self.set_array_storage(block, "inline")
                 else:
                     self.set_array_storage(block, "internal")

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -329,7 +329,7 @@ class NDArrayType(_types.AsdfType):
                 msg = "'*' may only be in first entry of shape"
                 raise ValueError(msg)
 
-            stride = strides[0] if strides is not None else np.product(shape[1:]) * dtype.itemsize
+            stride = strides[0] if strides is not None else np.prod(shape[1:]) * dtype.itemsize
 
             missing = int(block_size / stride)
             return [missing] + shape[1:]


### PR DESCRIPTION
This is from https://github.com/astropy/astropy/actions/runs/4376653449/jobs/7659080296 for https://github.com/astropy/astropy/pull/14510