### PR TITLE
add key support to block manager

### DIFF
--- a/asdf/_tests/test_array_blocks.py
+++ b/asdf/_tests/test_array_blocks.py
@@ -909,7 +909,7 @@ def test_block_key():
 
     # add a block for an array
     arr = np.array([1, 2, 3], dtype="uint8")
-    arr_blk = bm.find_or_create_block_for_array(arr, af)
+    arr_blk = bm.find_or_create_block_for_array(arr)
     assert arr_blk in bm._internal_blocks
 
     # now make a new block, add it using a key
@@ -918,6 +918,10 @@ def test_block_key():
     bm.add(blk, key)
     assert arr_blk in bm._internal_blocks
     assert blk in bm._internal_blocks
+
+    # make sure we can retrieve the block by the key
+    assert bm.find_or_create_block(key) is blk
+    assert isinstance(bm.find_or_create_block("bar"), block.Block)
 
     # now remove it, the original array block should remain
     bm.remove(blk)

--- a/asdf/_tests/test_array_blocks.py
+++ b/asdf/_tests/test_array_blocks.py
@@ -900,3 +900,26 @@ def test_write_to_update_storage_options(tmp_path, all_array_storage, all_array_
             compression_kwargs=compression_kwargs,
         )
         assert_result(ff2, arr2)
+
+
+def test_block_key():
+    # make an AsdfFile to get a BlockManager
+    af = asdf.AsdfFile()
+    bm = af._blocks
+
+    # add a block for an array
+    arr = np.array([1, 2, 3], dtype="uint8")
+    arr_blk = bm.find_or_create_block_for_array(arr, af)
+    assert arr_blk in bm._internal_blocks
+
+    # now make a new block, add it using a key
+    blk = block.Block(arr)
+    key = "foo"
+    bm.add(blk, key)
+    assert arr_blk in bm._internal_blocks
+    assert blk in bm._internal_blocks
+
+    # now remove it, the original array block should remain
+    bm.remove(blk)
+    assert arr_blk in bm._internal_blocks
+    assert blk not in bm._internal_blocks

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -91,9 +91,9 @@ class BlockManager:
         if block_set is not None:
             if block in block_set:
                 block_set.remove(block)
-                if block._data is not None and id(block._data) in self._data_to_block_mapping:
-                    del self._data_to_block_mapping[id(block._data)]
-
+                for key, blk in list(self._data_to_block_mapping.items()):
+                    if blk is block:
+                        del self._data_to_block_mapping[key]
         else:
             msg = f"Unknown array storage type {block.array_storage}"
             raise ValueError(msg)

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -53,7 +53,7 @@ class BlockManager:
         """
         return sum(len(x) for x in self._block_type_mapping.values())
 
-    def add(self, block):
+    def add(self, block, key=None):
         """
         Add an internal block to the manager.
         """
@@ -63,9 +63,9 @@ class BlockManager:
             # in the middle of the list.
             self.finish_reading_internal_blocks()
 
-        self._add(block)
+        self._add(block, key=key)
 
-    def _add(self, block):
+    def _add(self, block, key=None):
         block_set = self._block_type_mapping.get(block.array_storage, None)
         if block_set is not None:
             if block not in block_set:
@@ -78,8 +78,10 @@ class BlockManager:
             msg = "Can not add second streaming block"
             raise ValueError(msg)
 
-        if block._data is not None:
-            self._data_to_block_mapping[id(block._data)] = block
+        if block._data is not None or key is not None:
+            if key is None:
+                key = id(block._data)
+            self._data_to_block_mapping[key] = block
 
     def remove(self, block):
         """

--- a/asdf/block.py
+++ b/asdf/block.py
@@ -750,6 +750,30 @@ class BlockManager:
 
         return block
 
+    def find_or_create_block(self, key):
+        """
+        For a given hashable key, looks for an existing block. If not
+        found, adds a new block to the block list. Returns the index
+        in the block list to the array.
+
+        Parameters
+        ----------
+        key : hashable
+
+        Returns
+        -------
+        block : Block
+        """
+        block = self._data_to_block_mapping.get(key)
+        if block is not None:
+            return block
+
+        block = Block()
+        self.add(block, key=key)
+        self._handle_global_block_settings(block)
+
+        return block
+
     def get_streamed_block(self):
         """
         Get the streamed block, which is always the last one.  A


### PR DESCRIPTION
This PR adds an optional `key` argument to `BlockManager.add` and adds `BlockManger.find_or_create_block` to support providing a hashable  `key` when adding a block (different from the default `id(block._data)` used when a key is not provided. This is useful when `id(block._data)` is inconsistent, unavailable, expensive or otherwise inconvenient to use. This is work towards a deferred block system that will add block storage support to the converter.

Note that `BlockManager.__getitem__` was specifically not updated as it would require another local import and provides no additional functionality over the more explicit `find_or_create_block.