### PR TITLE
rename master branch to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,17 @@
 version: 2
 updates:
 
-  # Maintain dependencies for GitHub Actions (master)
+  # Maintain dependencies for GitHub Actions (main)
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "weekly"
 
-  # Maintain dependencies for pip (master)
+  # Maintain dependencies for pip (main)
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "weekly"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
       - stable
       - '*.x'
     tags:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         branch:
-          - master
+          - main
           - 2.15.x
         workflow:
           - ci.yml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,7 @@ The ASDF Standard is at v1.6.0
 - Add AsdfDeprecationWarning to asdf_extensions entry point [#1361]
 - Deprecate asdf.tests.helpers [#1440]
 - respect umask when determining file permissions for written files [#1451]
+- rename master branch to main [#1479]
 
 2.14.3 (2022-12-15)
 -------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,9 +25,9 @@ Contributing Code and Bug Fixes
 
 To contribute code to ASDF please fork ASDF first and then open a pull request
 from your fork to ASDF. Typically, the main development work is done on the
-"master" branch.  The rest of the branches are for release maintenance and should
+"main" branch.  The rest of the branches are for release maintenance and should
 not be used normally. Unless otherwise told by a maintainer, pull request should
-be made and submitted to the "master" branch.
+be made and submitted to the "main" branch.
 
 .. note::
     The "stable" branch is protected and used for official releases.

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ ASDF - Advanced Scientific Data Format
 .. image:: https://readthedocs.org/projects/asdf/badge/?version=latest
     :target: https://asdf.readthedocs.io/en/latest/
 
-.. image:: https://codecov.io/gh/asdf-format/asdf/branch/master/graphs/badge.svg
+.. image:: https://codecov.io/gh/asdf-format/asdf/branch/main/graphs/badge.svg
     :target: https://codecov.io/gh/asdf-format/asdf
 
 .. _begin-zenodo:
@@ -288,7 +288,7 @@ can be installed using ``pip``:
 
 .. _begin-source-install-text:
 
-The latest development version of ASDF is available from the ``master`` branch
+The latest development version of ASDF is available from the ``main`` branch
 `on github <https://github.com/asdf-format/asdf>`__. To clone the project:
 
 ::

--- a/docs/asdf/developer_versioning.rst
+++ b/docs/asdf/developer_versioning.rst
@@ -169,14 +169,14 @@ Update the asdf-standard submodule commit pointer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The asdf-standard repository is integrated into the asdf repository
-as a submodule.  To pull in new commits from the remote master (
+as a submodule.  To pull in new commits from the remote main (
 assumed to be named ``origin``:
 
 .. code-block:: console
 
     $ cd asdf-standard
     $ git fetch origin
-    $ git checkout origin/master
+    $ git checkout origin/main
 
 Support the new standard version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
After this PR is merged the `master` branch can be renamed to `main`.

We should probably merge https://github.com/asdf-format/asdf-standard/pull/370 first as `asdf-standard` has a hard coded reference to `master`. It's possible github will redirect these (based on https://github.com/github/renaming, but i'm not sure if the ci jobs are considered "web requests").