### PR TITLE
Bugfix for docs on python 3.11

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,12 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
-  apt_packages:
-    - graphviz
+  os: "ubuntu-20.04"
   tools:
-    python: "3.9"
+    python: "mambaforge-4.10"
+
+conda:
+  environment: docs/rtd_environment.yaml
 
 sphinx:
   builder: html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,10 @@
+import sys
 from pathlib import Path
 
-import tomli
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
 
 # The standard library importlib.metadata returns duplicate entrypoints
 # for all python versions up to and including 3.11
@@ -12,7 +16,8 @@ from sphinx_asdf.conf import *  # noqa: F403
 
 # Get configuration information from `pyproject.toml`
 with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as configuration_file:
-    conf = tomli.load(configuration_file)
+    conf = tomllib.load(configuration_file)
+
 configuration = conf["project"]
 
 # -- Project information ------------------------------------------------------

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,0 +1,8 @@
+name: rtd311
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.11
+  - pip
+  - graphviz


### PR DESCRIPTION
`tomli` usage combine with `tomli` pin is incorrect for `python 3.11`. Also, switch to using conda and `python 3.11` for RTD build.