### PR TITLE
Forward port changelog changes for 2.14.4 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ------------------
 
 The ASDF Standard is at v1.6.0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Drop support for ASDF-in-FITS. [#1288]
 
@@ -43,6 +44,13 @@ The ASDF Standard is at v1.6.0
 - Deprecate asdf.tests.helpers [#1440]
 - respect umask when determining file permissions for written files [#1451]
 - rename master branch to main [#1479]
+
+2.14.4 (2022-03-17)
+-------------------
+
+The ASDF Standard is at v1.6.0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 - require jsonschema<4.18 [#1487]
 
 2.14.3 (2022-12-15)


### PR DESCRIPTION
Updates the main changelog to reflect the 2.14.4 release.