### PR TITLE
drop isort as ruff sorts imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,11 +47,6 @@ repos:
     - id: ruff
       args: ["--fix"]
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.12.0
-  hooks:
-    - id: isort
-
 - repo: https://github.com/psf/black
   rev: 23.1.0
   hooks:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,7 +38,7 @@ If you have difficulties with tests failing or writing new tests please reach ou
 to the maintainers, who are glad to assist you.
 
 .. note::
-    ASDF uses both ``black`` and ``isort`` to format your code, so we ask that
+    ASDF uses both ``black`` and ``ruff`` to format your code, so we ask that
     you run these tools regularly on your code to ensure that it is formatted
     correctly.
 

--- a/README.rst
+++ b/README.rst
@@ -38,9 +38,6 @@ ASDF - Advanced Scientific Data Format
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
 
-.. image:: https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336
-    :target: https://pycqa.github.io/isort/
-
 .. _end-badges:
 
 .. _begin-summary-text:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,12 +97,6 @@ force-exclude = '''
 )
 '''
 
-[tool.isort]
-profile = "black"
-filter_files = true
-line_length = 120
-extend_skip_glob = ["asdf/extern/*", ".eggs/*", ".tox/*"]
-
 [tool.pytest.ini_options]
 testpaths = ['asdf', 'docs']
 minversion = 4.6


### PR DESCRIPTION
ruff sorts imports:
https://beta.ruff.rs/docs/rules/#isort-i

and currently does so in way that can be inconsistent with isort. Ruff will fix to:
```python
from . import _fizz, bam
from . import _foo as foo

_fizz()
foo()
bam()
```
whereas isort will fix to:
```python
from . import _fizz
from . import _foo as foo
from . import bam

_fizz()
foo()
bam()
```

This PR drops the use of isort.
