### PR TITLE
update changelog for 2.15.0 release

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,8 @@
 version: 2
 
 build:
+  apt_packages:
+    - "graphviz"
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ The ASDF Standard is at v1.6.0
 - Add ``all_array_storage``, ``all_array_compression`` and
   ``all_array_compression_kwargs`` to ``asdf.config.AsdfConfig`` [#1468]
 
-2.15.0 (unreleased)
+2.15.0 (2023-03-28)
 -------------------
 
 The ASDF Standard is at v1.6.0


### PR DESCRIPTION
Add date to 2.15.0 changelog section to start the release process.

EDIT: this also includes a modification of the readthedocs configuration to allow the docs to build on rtd. They were failing with a missing `dot` command and the issue with this comment suggests that we were silently depending on this package which was previously installed in older rtd docker images: https://github.com/readthedocs/readthedocs.org/issues/8800#issuecomment-1007261093