### PR TITLE
update label_checker ci job for 2.15.1

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ contains(github.event.pull_request.labels.*.name, 'backport-2.15.x') }}
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          milestone: "2.15.0"
+          milestone: "2.15.1"
       - uses: andrefcdias/add-to-milestone@v1.3.0
         if: ${{ contains(github.event.pull_request.labels.*.name, 'development') && !contains(github.event.pull_request.labels.*.name, 'backport-2.15.x')}}
         with:


### PR DESCRIPTION
This PR updates the label checker ci job to use the new 2.15.1 milestone (instead of 2.15.0 which was closed following the 2.15.0 release).

The CI for this PR appears to run off the files in the target branch (main) and is failing to assign the updated 2.15.1 milestone.