### PR TITLE
limit ruff rules

### DIFF
--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -25,7 +25,7 @@ from ._convenience import info
 from ._types import CustomType
 from ._version import version as __version__
 from .asdf import AsdfFile
-from .asdf import open_asdf as open  # noqa: A001
+from .asdf import open_asdf as open
 from .config import config_context, get_config
 from .stream import Stream
 from .tags.core import IntegerType

--- a/asdf/_convenience.py
+++ b/asdf/_convenience.py
@@ -41,7 +41,7 @@ def info(node_or_path, max_rows=DEFAULT_MAX_ROWS, max_cols=DEFAULT_MAX_COLS, sho
     """
     with _manage_node(node_or_path) as node:
         lines = render_tree(node, max_rows=max_rows, max_cols=max_cols, show_values=show_values, identifier="root")
-        print("\n".join(lines))  # noqa: T201
+        print("\n".join(lines))
 
 
 @contextmanager

--- a/asdf/_tests/_helpers.py
+++ b/asdf/_tests/_helpers.py
@@ -490,7 +490,7 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
             try:
                 with generic_io.get_file(schema_location) as f:
                     yaml.safe_load(f.read())
-            except Exception as err:  # noqa: BLE001
+            except Exception as err:
                 msg = (
                     f"{extension_type.__name__} supports tag, {check_type.yaml_tag}, "
                     f"which resolves to schema at {schema_location}, but "

--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -960,7 +960,7 @@ def test_problematic_class_attributes(tmp_path):
         assert isinstance(af["arr"], ndarray.NDArrayType)
 
         with pytest.raises(AttributeError, match=r".* object has no attribute 'name'"):
-            af["arr"].name  # noqa: B018
+            af["arr"].name
 
         with pytest.raises(AttributeError, match=r".* object has no attribute 'version'"):
-            af["arr"].version  # noqa: B018
+            af["arr"].version

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -93,7 +93,7 @@ def test_types_module_deprecation():
 
 def test_default_extensions_deprecation():
     with pytest.warns(AsdfDeprecationWarning, match="default_extensions is deprecated"):
-        asdf.extension.default_extensions  # noqa: B018
+        asdf.extension.default_extensions
 
 
 def test_default_resolver():
@@ -108,8 +108,8 @@ def test_get_cached_asdf_extension_list_deprecation():
 
 def test_asdf_type_format_tag():
     with pytest.warns(AsdfDeprecationWarning, match="asdf.types.format_tag is deprecated"):
-        asdf._types.format_tag  # noqa: B018
-    asdf.testing.helpers.format_tag  # noqa: B018
+        asdf._types.format_tag
+    asdf.testing.helpers.format_tag
 
 
 @pytest.mark.parametrize("name", ["AsdfExtension", "AsdfExtensionList", "BuiltinExtension"])
@@ -120,7 +120,7 @@ def test_extension_class_deprecation(name):
 
 def test_top_level_asdf_extension_deprecation():
     with pytest.warns(AsdfDeprecationWarning, match="AsdfExtension is deprecated"):
-        asdf.AsdfExtension  # noqa: B018
+        asdf.AsdfExtension
 
 
 def test_deprecated_entry_point(mock_entry_points):  # noqa: F811
@@ -144,4 +144,4 @@ def test_asdf_tests_helpers_deprecation():
 def test_blocks_deprecated():
     af = asdf.AsdfFile()
     with pytest.warns(AsdfDeprecationWarning, match="The property AsdfFile.blocks has been deprecated"):
-        af.blocks  # noqa: B018
+        af.blocks

--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -483,7 +483,7 @@ def test_tag_definition():
         RuntimeError,
         match=r"Cannot use .* when multiple schema URIs are present",
     ):
-        tag_def.schema_uri  # noqa: B018
+        tag_def.schema_uri
 
     with pytest.raises(ValueError, match=r"URI patterns are not permitted in TagDefinition"):
         TagDefinition("asdf://somewhere.org/extensions/foo/tags/foo-*")

--- a/asdf/_tests/test_file_format.py
+++ b/asdf/_tests/test_file_format.py
@@ -128,7 +128,7 @@ def test_invalid_source(small_tree):
 
         # This error message changes depending on how remote-data is configured
         # for the CI run.
-        with pytest.raises(IOError):  # noqa: PT011
+        with pytest.raises(IOError):
             ff2._blocks.get_block("http://ABadUrl.verybad/test.asdf")
 
         with pytest.raises(TypeError, match=r"Unknown source .*"):

--- a/asdf/_tests/test_generic_io.py
+++ b/asdf/_tests/test_generic_io.py
@@ -113,7 +113,7 @@ def test_path(tree, tmp_path):
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(list(ff._blocks.internal_blocks)) == 2
-        next(ff._blocks.internal_blocks).data  # noqa: B018
+        next(ff._blocks.internal_blocks).data
         assert isinstance(next(ff._blocks.internal_blocks)._data, np.core.memmap)
 
 
@@ -122,7 +122,7 @@ def test_open2(tree, tmp_path):
 
     def get_write_fd():
         # cannot use context manager here because it closes the file
-        f = generic_io.get_file(open(path, "wb"), mode="w", close=True)  # noqa: SIM115
+        f = generic_io.get_file(open(path, "wb"), mode="w", close=True)
         assert isinstance(f, generic_io.RealFile)
         assert f._uri == util.filepath_to_url(path)
         return f
@@ -130,7 +130,7 @@ def test_open2(tree, tmp_path):
     def get_read_fd():
         # Must open with mode=rw in order to get memmapped data
         # cannot use context manager here because it closes the file
-        f = generic_io.get_file(open(path, "r+b"), mode="rw", close=True)  # noqa: SIM115
+        f = generic_io.get_file(open(path, "r+b"), mode="rw", close=True)
         assert isinstance(f, generic_io.RealFile)
         assert f._uri == util.filepath_to_url(path)
         return f
@@ -160,14 +160,14 @@ def test_io_open(tree, tmp_path):
 
     def get_write_fd():
         # cannot use context manager here because it closes the file
-        f = generic_io.get_file(open(path, "wb"), mode="w", close=True)  # noqa: SIM115
+        f = generic_io.get_file(open(path, "wb"), mode="w", close=True)
         assert isinstance(f, generic_io.RealFile)
         assert f._uri == util.filepath_to_url(path)
         return f
 
     def get_read_fd():
         # cannot use context manager here because it closes the file
-        f = generic_io.get_file(open(path, "r+b"), mode="rw", close=True)  # noqa: SIM115
+        f = generic_io.get_file(open(path, "r+b"), mode="rw", close=True)
         assert isinstance(f, generic_io.RealFile)
         assert f._uri == util.filepath_to_url(path)
         return f
@@ -249,7 +249,7 @@ def test_urlopen(tree, httpserver):
 
     def get_write_fd():
         # cannot use context manager here because it closes the file
-        return generic_io.get_file(open(path, "wb"), mode="w")  # noqa: SIM115
+        return generic_io.get_file(open(path, "wb"), mode="w")
 
     def get_read_fd():
         return generic_io.get_file(urllib_request.urlopen(httpserver.url + "test.asdf"))
@@ -266,7 +266,7 @@ def test_http_connection(tree, httpserver):
 
     def get_write_fd():
         # cannot use context manager here because it closes the file
-        return generic_io.get_file(open(path, "wb"), mode="w")  # noqa: SIM115
+        return generic_io.get_file(open(path, "wb"), mode="w")
 
     def get_read_fd():
         fd = generic_io.get_file(httpserver.url + "test.asdf")
@@ -739,12 +739,12 @@ def test_blocksize(tree, tmp_path):
 
     def get_write_fd():
         # cannot use context manager here because it closes the file
-        return generic_io.get_file(open(path, "wb"), mode="w", close=True)  # noqa: SIM115
+        return generic_io.get_file(open(path, "wb"), mode="w", close=True)
 
     def get_read_fd():
         # Must open with mode=rw in order to get memmapped data
         # cannot use context manager here because it closes the file
-        return generic_io.get_file(open(path, "r+b"), mode="rw", close=True)  # noqa: SIM115
+        return generic_io.get_file(open(path, "r+b"), mode="rw", close=True)
 
     with config_context() as config:
         config.io_block_size = 1233  # make sure everything works with a strange blocksize

--- a/asdf/_tests/test_reference_files.py
+++ b/asdf/_tests/test_reference_files.py
@@ -65,7 +65,7 @@ def test_reference_file(reference_file):
 
     try:
         _compare_trees(name_without_ext, expect_warnings=expect_warnings)
-    except Exception:  # noqa: BLE001
+    except Exception:
         if known_fail:
             pytest.xfail()
         else:

--- a/asdf/_tests/test_search.py
+++ b/asdf/_tests/test_search.py
@@ -51,10 +51,10 @@ def test_multiple_results(asdf_file):
     assert "root['nested']['foo']" in result.paths
 
     with pytest.raises(RuntimeError, match=r"More than one result"):
-        result.path  # noqa: B018
+        result.path
 
     with pytest.raises(RuntimeError, match=r"More than one result"):
-        result.node  # noqa: B018
+        result.node
 
     result.replace(54)
     assert asdf_file["foo"] == 54

--- a/asdf/_tests/test_tagged.py
+++ b/asdf/_tests/test_tagged.py
@@ -38,7 +38,7 @@ def test_tagged_list_isinstance():
 def test_tagged_list_base():
     value = TaggedList([0, 1, 2, ["foo"]], "tag:nowhere.org:custom/foo-1.0.0")
 
-    assert not (value == value.base)  # base is not a tagged list  # noqa: SIM201
+    assert not (value == value.base)  # base is not a tagged list
     assert value.data == value.base  # but the data is
 
     assert isinstance(value.base, list)
@@ -78,7 +78,7 @@ def test_tagged_dict_isinstance():
 def test_tagged_dict_base():
     value = TaggedDict({"a": 0, "b": 1, "c": 2, "nested": {"d": 3}}, "tag:nowhere.org:custom/foo-1.0.0")
 
-    assert not (value == value.base)  # base is not a tagged  dict  # noqa: SIM201
+    assert not (value == value.base)  # base is not a tagged  dict
     assert value.data == value.base  # but the data is
 
     assert isinstance(value.base, dict)
@@ -111,7 +111,7 @@ def test_tagged_string_base():
     value = TaggedString("You're it!")
     value._tag = "tag:nowhere.org:custom/foo-1.0.0"
 
-    assert not (value == value.base)  # base is not a tagged  dict  # noqa: SIM201
+    assert not (value == value.base)  # base is not a tagged  dict
     assert value.data == value.base  # but the data is
 
     assert isinstance(value.base, str)

--- a/asdf/_tests/test_types.py
+++ b/asdf/_tests/test_types.py
@@ -91,7 +91,7 @@ def fractiontype_factory():
 
 
 def fractional2dcoordtype_factory():
-    FractionType = fractiontype_factory()  # noqa: N806
+    FractionType = fractiontype_factory()
 
     with pytest.warns(AsdfDeprecationWarning, match=".*subclasses the deprecated CustomType.*"):
 
@@ -119,7 +119,7 @@ def fractional2dcoordtype_factory():
 
 
 def test_custom_tag():
-    FractionType = fractiontype_factory()  # noqa: N806
+    FractionType = fractiontype_factory()
 
     class FractionExtension(CustomExtension):
         @property

--- a/asdf/_tests/test_versioning.py
+++ b/asdf/_tests/test_versioning.py
@@ -40,8 +40,8 @@ def test_version_and_version_equality():
     assert ver0 is not ver1
     assert ver0 == ver1
     assert ver1 == ver0
-    assert not (ver0 != ver1)  # noqa: SIM202
-    assert not (ver1 != ver0)  # noqa: SIM202
+    assert not (ver0 != ver1)
+    assert not (ver1 != ver0)
 
 
 def test_version_and_string_equality():
@@ -50,8 +50,8 @@ def test_version_and_string_equality():
 
     assert version == string_ver
     assert string_ver == version
-    assert not (version != string_ver)  # noqa: SIM202
-    assert not (string_ver != version)  # noqa: SIM202
+    assert not (version != string_ver)
+    assert not (string_ver != version)
 
 
 def test_version_and_tuple_equality():
@@ -60,8 +60,8 @@ def test_version_and_tuple_equality():
 
     assert version == tuple_ver
     assert tuple_ver == version
-    assert not (version != tuple_ver)  # noqa: SIM202
-    assert not (tuple_ver != version)  # noqa: SIM202
+    assert not (version != tuple_ver)
+    assert not (tuple_ver != version)
 
 
 def test_version_and_version_inequality():
@@ -76,7 +76,7 @@ def test_version_and_version_inequality():
 
     versions = [ver0, ver1, ver2, ver3, ver4, ver5, ver6, ver7]
     for x, y in combinations(versions, 2):
-        assert not (x == y)  # noqa: SIM201
+        assert not (x == y)
         assert x != y
 
     assert ver0 < ver1 < ver2 < ver3 < ver4 < ver5 < ver6 < ver7
@@ -111,25 +111,25 @@ def test_version_and_string_inequality():
     assert version <= "2.1.0"
     assert version <= "2.1.1"
 
-    assert "1.0.0" < version  # noqa: SIM300
-    assert "1.0.1" < version  # noqa: SIM300
-    assert "1.1.0" < version  # noqa: SIM300
-    assert "1.1.1" < version  # noqa: SIM300
-    assert ("2.0.0" < version) is False  # noqa: SIM300
-    assert ("2.0.0" > version) is False  # noqa: SIM300
-    assert "2.0.1" > version  # noqa: SIM300
-    assert "2.1.0" > version  # noqa: SIM300
-    assert "2.1.1" > version  # noqa: SIM300
+    assert "1.0.0" < version
+    assert "1.0.1" < version
+    assert "1.1.0" < version
+    assert "1.1.1" < version
+    assert ("2.0.0" < version) is False
+    assert ("2.0.0" > version) is False
+    assert "2.0.1" > version
+    assert "2.1.0" > version
+    assert "2.1.1" > version
 
-    assert "1.0.0" <= version  # noqa: SIM300
-    assert "1.0.1" <= version  # noqa: SIM300
-    assert "1.1.0" <= version  # noqa: SIM300
-    assert "1.1.1" <= version  # noqa: SIM300
-    assert "2.0.0" <= version  # noqa: SIM300
-    assert "2.0.0" >= version  # noqa: SIM300
-    assert "2.0.1" >= version  # noqa: SIM300
-    assert "2.1.0" >= version  # noqa: SIM300
-    assert "2.1.1" >= version  # noqa: SIM300
+    assert "1.0.0" <= version
+    assert "1.0.1" <= version
+    assert "1.1.0" <= version
+    assert "1.1.1" <= version
+    assert "2.0.0" <= version
+    assert "2.0.0" >= version
+    assert "2.0.1" >= version
+    assert "2.1.0" >= version
+    assert "2.1.1" >= version
 
 
 def test_version_and_tuple_inequality():
@@ -155,25 +155,25 @@ def test_version_and_tuple_inequality():
     assert version <= (2, 1, 0)
     assert version <= (2, 1, 1)
 
-    assert (1, 0, 0) < version  # noqa: SIM300
-    assert (1, 0, 1) < version  # noqa: SIM300
-    assert (1, 1, 0) < version  # noqa: SIM300
-    assert (1, 1, 1) < version  # noqa: SIM300
-    assert ((2, 0, 0) < version) is False  # noqa: SIM300
-    assert ((2, 0, 0) > version) is False  # noqa: SIM300
-    assert (2, 0, 1) > version  # noqa: SIM300
-    assert (2, 1, 0) > version  # noqa: SIM300
-    assert (2, 1, 1) > version  # noqa: SIM300
+    assert (1, 0, 0) < version
+    assert (1, 0, 1) < version
+    assert (1, 1, 0) < version
+    assert (1, 1, 1) < version
+    assert ((2, 0, 0) < version) is False
+    assert ((2, 0, 0) > version) is False
+    assert (2, 0, 1) > version
+    assert (2, 1, 0) > version
+    assert (2, 1, 1) > version
 
-    assert (1, 0, 0) <= version  # noqa: SIM300
-    assert (1, 0, 1) <= version  # noqa: SIM300
-    assert (1, 1, 0) <= version  # noqa: SIM300
-    assert (1, 1, 1) <= version  # noqa: SIM300
-    assert (2, 0, 0) <= version  # noqa: SIM300
-    assert (2, 0, 0) >= version  # noqa: SIM300
-    assert (2, 0, 1) >= version  # noqa: SIM300
-    assert (2, 1, 0) >= version  # noqa: SIM300
-    assert (2, 1, 1) >= version  # noqa: SIM300
+    assert (1, 0, 0) <= version
+    assert (1, 0, 1) <= version
+    assert (1, 1, 0) <= version
+    assert (1, 1, 1) <= version
+    assert (2, 0, 0) <= version
+    assert (2, 0, 0) >= version
+    assert (2, 0, 1) >= version
+    assert (2, 1, 0) >= version
+    assert (2, 1, 1) >= version
 
 
 def test_spec_version_match():
@@ -266,14 +266,14 @@ def test_spec_equal():
     assert version1 == spec
 
     assert spec != "1.1.0"
-    assert "1.1.0" != spec  # noqa: SIM300
+    assert "1.1.0" != spec
     assert spec == "1.3.0"
-    assert "1.3.0" == spec  # noqa: SIM300
+    assert "1.3.0" == spec
 
     assert spec != (1, 1, 0)
-    assert (1, 1, 0) != spec  # noqa: SIM300
+    assert (1, 1, 0) != spec
     assert spec == (1, 3, 0)
-    assert (1, 3, 0) == spec  # noqa: SIM300
+    assert (1, 3, 0) == spec
 
 
 def _standard_versioned_tags():
@@ -358,7 +358,7 @@ def test_version_map_support(version, schema_type, tag):
 
     try:
         load_schema(tag)
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         msg = (
             f"ASDF Standard version {version} requires support for "
             f"{tag}, but the corresponding schema cannot be loaded."

--- a/asdf/_type_index.py
+++ b/asdf/_type_index.py
@@ -301,7 +301,7 @@ class AsdfTypeIndex:
             _serialization_context._mark_extension_used(self._extension_by_type[asdftype])
         return asdftype
 
-    @lru_cache(5)  # noqa: B019
+    @lru_cache(5)
     def has_hook(self, hook_name):
         """
         Returns `True` if the given hook name exists on any of the managed

--- a/asdf/_types.py
+++ b/asdf/_types.py
@@ -69,7 +69,7 @@ class ExtensionTypeMeta(type):
             finally:
                 cls._import_cache[modname] = has_module
                 if not has_module:
-                    return False  # noqa: B012
+                    return False
 
         return True
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -996,7 +996,7 @@ class AsdfFile:
             raise
 
     @classmethod
-    def open(  # noqa: A003
+    def open(
         cls,
         fd,
         uri=None,

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1657,7 +1657,7 @@ class AsdfFile:
             identifier="root",
             refresh_extension_manager=refresh_extension_manager,
         )
-        print("\n".join(lines))  # noqa: T201
+        print("\n".join(lines))
 
     def search(self, key=NotSet, type_=NotSet, value=NotSet, filter_=None):
         """

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -223,7 +223,7 @@ def edit(path):
             try:
                 new_asdf_version = parse_asdf_version(new_content)
                 new_yaml_version = parse_yaml_version(new_content)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 print(f"Error: failed to parse ASDF header: {str(e)}")
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
@@ -264,7 +264,7 @@ def edit(path):
                 if choice == "c":
                     continue
 
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 print("Error: failed to read updated file as ASDF:")
                 print_exception(e)
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -191,7 +191,7 @@ def edit(path):
     # Extract the YAML portion of the original file:
     with generic_io.get_file(path, mode="r") as fd:
         if fd.peek(len(constants.ASDF_MAGIC)) != constants.ASDF_MAGIC:
-            print(f"Error: '{path}' is not an ASDF file.")  # noqa: T201
+            print(f"Error: '{path}' is not an ASDF file.")
             return 1
 
         original_content, available_bytes, contains_blocks = read_yaml(fd)
@@ -217,14 +217,14 @@ def edit(path):
                 new_content = f.read()
 
             if new_content == original_content:
-                print("No changes made to file")  # noqa: T201
+                print("No changes made to file")
                 return 0
 
             try:
                 new_asdf_version = parse_asdf_version(new_content)
                 new_yaml_version = parse_yaml_version(new_content)
             except Exception as e:  # noqa: BLE001
-                print(f"Error: failed to parse ASDF header: {str(e)}")  # noqa: T201
+                print(f"Error: failed to parse ASDF header: {str(e)}")
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
                     return 1
@@ -232,7 +232,7 @@ def edit(path):
                 continue
 
             if new_asdf_version != original_asdf_version or new_yaml_version != original_yaml_version:
-                print("Error: cannot modify ASDF Standard or YAML version using this tool.")  # noqa: T201
+                print("Error: cannot modify ASDF Standard or YAML version using this tool.")
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
                     return 1
@@ -246,7 +246,7 @@ def edit(path):
                 with open_asdf(io.BytesIO(new_content), _force_raw_types=True):
                     pass
             except yaml.YAMLError as e:
-                print("Error: failed to parse updated YAML:")  # noqa: T201
+                print("Error: failed to parse updated YAML:")
                 print_exception(e)
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
@@ -255,7 +255,7 @@ def edit(path):
                 continue
 
             except schema.ValidationError as e:
-                print("Warning: updated ASDF tree failed validation:")  # noqa: T201
+                print("Warning: updated ASDF tree failed validation:")
                 print_exception(e)
                 choice = request_input("(c)ontinue editing, (f)orce update, or (a)bort? ", ["c", "f", "a"])
                 if choice == "a":
@@ -265,7 +265,7 @@ def edit(path):
                     continue
 
             except Exception as e:  # noqa: BLE001
-                print("Error: failed to read updated file as ASDF:")  # noqa: T201
+                print("Error: failed to read updated file as ASDF:")
                 print_exception(e)
                 choice = request_input("(c)ontinue editing or (a)bort? ", ["c", "a"])
                 if choice == "a":
@@ -291,7 +291,7 @@ def edit(path):
     else:
         # File does not have sufficient space, and binary blocks
         # are present.
-        print("Warning: updated YAML larger than allocated space.  File must be rewritten.")  # noqa: T201
+        print("Warning: updated YAML larger than allocated space.  File must be rewritten.")
         choice = request_input("(c)ontinue or (a)bort? ", ["c", "a"])
         if choice == "a":
             return 1
@@ -346,7 +346,7 @@ def print_exception(e):
     if len(lines) > 20:
         lines = lines[0:20] + ["..."]
     for line in lines:
-        print(f"    {line}")  # noqa: T201
+        print(f"    {line}")
 
 
 def request_input(message, choices):
@@ -366,7 +366,7 @@ def request_input(message, choices):
         if choice in choices:
             return choice
 
-        print(f"Invalid choice: {choice}")  # noqa: T201
+        print(f"Invalid choice: {choice}")
 
     return None
 

--- a/asdf/commands/extension.py
+++ b/asdf/commands/extension.py
@@ -64,9 +64,9 @@ def _print_extension_details(ext, tags_only):
             tag_uris.append(typ.make_yaml_tag(typ.name))
 
     if len(tag_uris) > 0:
-        print("tags:")  # noqa: T201
+        print("tags:")
         for tag_uri in sorted(tag_uris):
-            print(f"  - {tag_uri}")  # noqa: T201
+            print(f"  - {tag_uri}")
 
     if not tags_only:
         types = []
@@ -77,14 +77,14 @@ def _print_extension_details(ext, tags_only):
             types.extend(typ.types)
 
         if len(types) > 0:
-            print("types:")  # noqa: T201
+            print("types:")
             for typ in sorted(types, key=_format_type_name):
-                print(f"  - {_format_type_name(typ)}")  # noqa: T201
+                print(f"  - {_format_type_name(typ)}")
 
 
 def find_extensions(summary, tags_only):
     for ext in get_extensions():
-        print(_format_extension(ext))  # noqa: T201
+        print(_format_extension(ext))
         if not summary:
             _print_extension_details(ext, tags_only)
-            print()  # noqa: T201
+            print()

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -46,7 +46,7 @@ def _list_entry_points(group, proxy_class):
 
         def _handle_error(e):
             warnings.warn(
-                f"{group} plugin from package {package_name}=={package_version} failed to load:\n\n"  # noqa: B023
+                f"{group} plugin from package {package_name}=={package_version} failed to load:\n\n"
                 f"{e.__class__.__name__}: {e}",
                 AsdfWarning,
             )
@@ -94,7 +94,7 @@ def _list_entry_points(group, proxy_class):
                         )
                 elements = entry_point.load()()
 
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             _handle_error(e)
             continue
 
@@ -106,7 +106,7 @@ def _list_entry_points(group, proxy_class):
             # Catch errors instantiating the proxy class and warn instead of raising
             try:
                 results.append(proxy_class(element, package_name=package_name, package_version=package_version))
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 _handle_error(e)
 
     return results

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -256,7 +256,7 @@ class GenericFile(metaclass=util.InheritDocstrings):
         if block_size == -1:
             try:
                 block_size = os.fstat(self._fd.fileno()).st_blksize
-            except Exception:  # noqa: BLE001
+            except Exception:
                 block_size = io.DEFAULT_BUFFER_SIZE
 
         if block_size <= 0:
@@ -1013,7 +1013,7 @@ def _http_to_temp(init, mode, uri=None):
     if block_size == -1:
         try:
             block_size = os.fstat(fd.fileno()).st_blksize
-        except Exception:  # noqa: BLE001
+        except Exception:
             block_size = io.DEFAULT_BUFFER_SIZE
 
     try:
@@ -1147,18 +1147,14 @@ def get_file(init, mode="r", uri=None, close=False):
                 else url2pathname(parsed.path)
             )
             try:
-                fd = (
-                    atomicfile.atomic_open(realpath, realmode)
-                    if mode == "w"
-                    else open(realpath, realmode)  # noqa: SIM115
-                )
+                fd = atomicfile.atomic_open(realpath, realmode) if mode == "w" else open(realpath, realmode)
 
                 fd = fd.__enter__()
             except FileNotFoundError as e:
                 # atomic_open will create an Exception with an odd looking path
                 # overwrite the error message to make it more informative
                 e.filename = realpath
-                raise e  # noqa: TRY201
+                raise e
 
             return RealFile(fd, mode, close=True, uri=uri)
 

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -86,7 +86,7 @@ class Reference(_types.AsdfType):
             return None
         try:
             return getattr(self._get_target(), attr)
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             msg = f"No attribute '{attr}'"
             raise AttributeError(msg) from err
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -82,7 +82,7 @@ def validate_tag(validator, tag_pattern, instance, schema):
         yield ValidationError(f"mismatched tags, wanted '{tag_pattern}', got '{instance_tag}'")
 
 
-def validate_propertyOrder(validator, order, instance, schema):  # noqa: N802
+def validate_propertyOrder(validator, order, instance, schema):
     """
     Stores a value on the `tagged.TaggedDict` instance so that
     properties can be written out in the preferred order.  In that
@@ -100,7 +100,7 @@ def validate_propertyOrder(validator, order, instance, schema):  # noqa: N802
     instance.property_order = order
 
 
-def validate_flowStyle(validator, flow_style, instance, schema):  # noqa: N802
+def validate_flowStyle(validator, flow_style, instance, schema):
     """
     Sets a flag on the `tagged.TaggedList` or `tagged.TaggedDict`
     object so that the YAML generator knows which style to use to
@@ -253,7 +253,7 @@ def _create_validator(validators=YAML_VALIDATORS, visit_repeat_nodes=False):
         },
     )
     id_of = mvalidators.Draft4Validator.ID_OF
-    ASDFvalidator = mvalidators.create(  # noqa: N806
+    ASDFvalidator = mvalidators.create(
         meta_schema=meta_schema,
         validators=validators,
         type_checker=type_checker,
@@ -518,7 +518,7 @@ def _load_schema_cached(url, resolver, resolve_references, resolve_local_refs):
 
         schema = treeutil.walk_and_modify(schema, resolve_refs)
 
-    return schema  # noqa: RET504
+    return schema
 
 
 def get_validator(

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -37,7 +37,7 @@ class AsdfSearchResult:
         self._max_cols = max_cols
         self._show_values = show_values
 
-    def format(self, max_rows=NotSet, max_cols=NotSet, show_values=NotSet):  # noqa: A003
+    def format(self, max_rows=NotSet, max_cols=NotSet, show_values=NotSet):
         """
         Change formatting parameters of the rendered tree.
 
@@ -98,7 +98,7 @@ class AsdfSearchResult:
         try:
             result = a == b
 
-        except Exception:  # noqa: BLE001
+        except Exception:
             return False
 
         if isinstance(result, bool):

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -87,7 +87,7 @@ def asdf_datatype_to_numpy_dtype(datatype, byteorder=None):
 
             else:
                 msg = "Error parsing asdf datatype"
-                raise RuntimeError(msg)  # noqa: TRY004
+                raise RuntimeError(msg)
 
         return np.dtype(datatype_list)
 

--- a/asdf/tests/helpers.py
+++ b/asdf/tests/helpers.py
@@ -16,7 +16,7 @@ def _warn():
 
 _warn()
 
-__all__ = _helpers.__all__  # noqa: PLE0605
+__all__ = _helpers.__all__
 
 
 def __getattr__(name):

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -17,7 +17,7 @@ def _warn():
 
 
 _warn()
-__all__ = _type_index.__all__  # noqa: PLE0605
+__all__ = _type_index.__all__
 
 
 def __getattr__(name):

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -17,7 +17,7 @@ def _warn():
 
 
 _warn()
-__all__ = _types.__all__  # noqa: PLE0605
+__all__ = _types.__all__
 
 
 def __getattr__(name):

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -372,7 +372,7 @@ def minversion(module, version, inclusive=True):
             return False
     else:
         msg = f"module argument must be an actual imported module, or the import name of the module; got {repr(module)}"
-        raise ValueError(msg)  # noqa: TRY004
+        raise ValueError(msg)
 
     if module_version is None:
         try:

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -127,7 +127,7 @@ class AsdfSpec(SimpleSpec):
     def select(self, versions):
         return super().select(self.__iterate_versions(versions))
 
-    def filter(self, versions):  # noqa: A003
+    def filter(self, versions):
         return super().filter(self.__iterate_versions(versions))
 
     def __eq__(self, other):

--- a/compatibility_tests/assert_file_correct.py
+++ b/compatibility_tests/assert_file_correct.py
@@ -1,5 +1,3 @@
-# noqa: INP001
-
 import argparse
 from pathlib import Path
 

--- a/compatibility_tests/common.py
+++ b/compatibility_tests/common.py
@@ -1,5 +1,3 @@
-# noqa: INP001
-
 import numpy as np
 
 import asdf

--- a/compatibility_tests/generate_file.py
+++ b/compatibility_tests/generate_file.py
@@ -1,5 +1,3 @@
-# noqa: INP001
-
 import argparse
 from pathlib import Path
 

--- a/compatibility_tests/test_file_compatibility.py
+++ b/compatibility_tests/test_file_compatibility.py
@@ -1,5 +1,3 @@
-# noqa: INP001
-
 import json
 import os
 import subprocess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,29 +162,16 @@ exclude_lines = [
 [tool.ruff]
 target-version = "py38"
 line-length = 120
-select = ["ALL"]
+select = [
+    # minimal set to match pre-ruff behavior
+    "E", # pycodestyle
+    "F", # pyflakes, autoflake
+    "I", # isort
+    "S", # bandit
+    "UP", # pyupgrade
+    "RUF",  # ruff specific, includes yesqa
+]
 extend-ignore = [
-    # Ignored check groups
-    "C90", # mccabe complexity
-    "D", # pydocstyle
-    "ANN", # flake8-annotations
-    "FBT", # flake8-boolean-trap
-    "ARG", # flake8-unused-arguments
-    "DTZ", # flake8-datetimez
-    "PTH", # flake8-use-pathlib
-    # Individually ignored checks
-    "B028",  # No explicit stacklevel argument
-    "PIE810", # Call `startswith` once with a `tuple`
-    "PLC1901", # compare-to-empty-string
-    "PLR0911", # Too many return statements
-    "PLR0912", # Too many branches
-    "PLR0913", # Too many arguments to function call
-    "PLR0915", # Too many statements
-    "PLR2004", # Magic value used in comparison
-    "SLF001", # Private member accessed
-    "TRY002", # Create your own exception
-    "TRY301", # Abstract raise to an inner function
-    "TRY400", # Use logging.exception instead of logging.error
     "S310", # URL open for permitted schemes
 ]
 extend-exclude = ["asdf/extern/*", "docs/*"]

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -254,7 +254,7 @@ class AsdfSchemaExampleItem(pytest.Item):
 
                 ff._open_impl(ff, buff, mode="rw")
         except Exception:
-            print(f"Example: {self.example.description}\n From file: {self.filename}")  # noqa: T201
+            print(f"Example: {self.example.description}\n From file: {self.filename}")
             raise
 
         # Just test we can write it out.  A roundtrip test


### PR DESCRIPTION
Prior to this PR ASDF included all new ruff rules. The ruff version in kept up-to-date with weekly pre-commit automatic updates. These updates often include new rules that were automatically enabled because of the 'all' rule selection setting. These frequent style updates will cause the code in the main branch to quickly diverge from the older (2.15) branch. The pace of ruff development currently outpaces ASDF and ASDF PRs often fall stale due to style issues after a few weeks.

This PR drops the 'all' rule selection setting and replaces it with a set of rules that matches ASDF prior to the use of ruff.
Using this commit as a reference:
https://github.com/asdf-format/asdf/commit/40131769b51b145dd25e79ab4a2d8ede10604036
ASDF has dropped the following tools, replacing them with ruff:
- yesqa: replaced with "RUF" rules
- pyupgrade: replaced with "UP" rules
- autoflake8 and pyflakes: replaced with "F" rules
- isort: replaced with "I" rules
- bandit: replaced with "S" rules
- pycodestyle: was not previously used, but the "E" rules are default enabled for ruff so I'm including them here with the expectation that they will be stable and require infrequent changes