### PR TITLE
skip astropy dev testing for python 3.8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ git+https://github.com/asdf-format/asdf-standard
 git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-unit-schemas.git
 git+https://github.com/asdf-format/asdf-wcs-schemas
-git+https://github.com/astropy/astropy
+git+https://github.com/astropy/astropy ; python_version > "3.8"
 git+https://github.com/spacetelescope/gwcs
 git+https://github.com/yaml/pyyaml.git
 # jsonschema 4.18 contains incompatible changes: https://github.com/asdf-format/asdf/issues/1485


### PR DESCRIPTION
CI for a previous PR revealed that the python 3.8 devdeps job failed due to astropy dropping support for 3.8:
https://github.com/asdf-format/asdf/actions/runs/4789902511/jobs/8518523706

This PR removes astropy from python 3.8 devdeps testing (and continues to use the development version of astropy for python 3.9+).