### PR TITLE
drop depending on astropy.io.misc.asdf for test

### DIFF
--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -174,12 +174,18 @@ def test_array_inline_threshold_recursive(tmpdir):
     aff = models.AffineTransformation2D(matrix=[[1, 2], [3, 4]])
     tree = {"test": aff}
 
-    def check_asdf(asdf):
-        assert len(list(asdf._blocks.internal_blocks)) == 0
-
     with asdf.config_context() as config:
         config.array_inline_threshold = 100
-        helpers.assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf)
+        # we can no longer use _helpers.assert_roundtrip_tree here because
+        # the model no longer has a CustomType which results in equality testing
+        # using == which will fail
+        # this test appears to be designed to test the inline threshold so we can
+        # just look at the number of blocks
+        fn = str(tmpdir / "test.asdf")
+        af = asdf.AsdfFile(tree)
+        af.write_to(fn)
+        with asdf.open(fn) as af:
+            assert len(list(af._blocks.internal_blocks)) == 0
 
 
 def test_copy_inline():


### PR DESCRIPTION
Astropy removed astropy.io.misc.asdf in their development version.
https://github.com/astropy/astropy/pull/14668

ASDF has one test that silently depended on the astropy.io.misc.asdf submodule to provide an equality function for an AffineTransform.

The PR removing the public API for the legacy extension already deals with this issue but is unlikely to be quickly merged: https://github.com/asdf-format/asdf/pull/1464

This PR includes the updated test from #1464 to not depend on the types provided by the now non-existent astropy.io.misc.asdf which is causing devdeps jobs to fail (as seen in CI runs for this PR https://github.com/asdf-format/asdf/pull/1531).