### PR TITLE
Revert "Remove legacy extension api"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,6 @@ The ASDF Standard is at v1.6.0
   ``all_array_compression_kwargs`` to ``asdf.config.AsdfConfig`` [#1468]
 - Move built-in tags to converters (except ndarray and integer). [#1474]
 - Add block storage support to Converter [#1508]
-- Remove deprecated legacy extension API [#1464]
 
 2.15.0 (2023-03-28)
 -------------------
@@ -28,7 +27,7 @@ The ASDF Standard is at v1.6.0
   ones that we can successfully build and test against. [#1360]
 - Provide more informative filename when failing to open a file [#1357]
 - Add new plugin type for custom schema validators. [#1328]
-- Add AsdfDeprecationWarning to ``asdf.types.CustomType`` [#1359]
+- Add AsdfDeprecationWarning to `~asdf.types.CustomType` [#1359]
 - Throw more useful error when provided with a path containing an
   extra leading slash [#1356]
 - Add AsdfDeprecationWarning to AsdfInFits. Support for reading and

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -5,6 +5,8 @@ Data Format (ASDF) files
 
 __all__ = [
     "AsdfFile",
+    "CustomType",
+    "AsdfExtension",
     "Stream",
     "open",
     "IntegerType",
@@ -20,6 +22,7 @@ __all__ = [
 from jsonschema import ValidationError
 
 from ._convenience import info
+from ._types import CustomType
 from ._version import version as __version__
 from .asdf import AsdfFile
 from .asdf import open_asdf as open
@@ -27,3 +30,14 @@ from .config import config_context, get_config
 from .stream import Stream
 from .tags.core import IntegerType
 from .tags.core.external_reference import ExternalArrayReference
+
+
+def __getattr__(name):
+    if name == "AsdfExtension":
+        # defer import to only issue deprecation warning when
+        # asdf.AsdfExtension is used
+        from asdf import extension
+
+        return extension.AsdfExtension
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/asdf/_tests/_helpers.py
+++ b/asdf/_tests/_helpers.py
@@ -412,7 +412,7 @@ def assert_extension_correctness(extension):
 
     Parameters
     ----------
-    extension : asdf._AsdfExtension
+    extension : asdf.AsdfExtension
         The extension to validate
     """
     __tracebackhide__ = True

--- a/asdf/_tests/commands/tests/test_tags.py
+++ b/asdf/_tests/commands/tests/test_tags.py
@@ -4,6 +4,7 @@ import pytest
 
 from asdf import AsdfFile
 from asdf.commands import list_tags
+from asdf.exceptions import AsdfDeprecationWarning
 
 
 @pytest.mark.parametrize("display_classes", [True, False])
@@ -19,7 +20,8 @@ def test_all_tags_present():
     tags = {line.strip() for line in iostream.readlines()}
 
     af = AsdfFile()
-    for tag in af._type_index._type_by_tag:
-        assert tag in tags
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfFile.type_index is deprecated"):
+        for tag in af.type_index._type_by_tag:
+            assert tag in tags
     for tag in af.extension_manager._converters_by_tag:
         assert tag in tags

--- a/asdf/_tests/objects.py
+++ b/asdf/_tests/objects.py
@@ -1,7 +1,6 @@
 import pytest
 
-from asdf import util
-from asdf._types import CustomType
+from asdf import CustomType, util
 from asdf.exceptions import AsdfDeprecationWarning
 
 from ._helpers import get_test_data_path

--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -14,6 +14,7 @@ import asdf
 from asdf import util
 from asdf._tests import _helpers as helpers
 from asdf._tests.objects import CustomTestType
+from asdf.exceptions import AsdfDeprecationWarning
 from asdf.tags.core import ndarray
 
 from . import data as test_data
@@ -130,7 +131,8 @@ def test_dont_load_data():
 
     buff.seek(0)
     with asdf.open(buff) as ff:
-        ff._run_hook("reserve_blocks")
+        with pytest.warns(AsdfDeprecationWarning, match="AsdfFile.run_hook is deprecated"):
+            ff.run_hook("reserve_blocks")
 
         # repr and str shouldn't load data
         str(ff.tree["science_data"])

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -12,9 +12,8 @@ from jsonschema.exceptions import ValidationError
 from numpy.testing import assert_array_equal
 
 import asdf
-import asdf.extension._legacy as _legacy_extension
 from asdf import _resolver as resolver
-from asdf import config_context, get_config, treeutil, versioning
+from asdf import config_context, extension, get_config, schema, treeutil, versioning
 from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
 from asdf.extension import ExtensionProxy
 
@@ -257,6 +256,16 @@ def test_copy(tmp_path):
     assert_array_equal(ff2.tree["my_array"], ff2.tree["my_array"])
 
 
+def test_tag_to_schema_resolver_deprecation():
+    ff = asdf.AsdfFile()
+    with pytest.warns(AsdfDeprecationWarning):
+        ff.tag_to_schema_resolver("foo")
+
+    with pytest.warns(AsdfDeprecationWarning):
+        extension_list = extension.default_extensions.extension_list
+        extension_list.tag_to_schema_resolver("foo")
+
+
 def test_access_tree_outside_handler(tmp_path):
     tempname = str(tmp_path / "test.asdf")
 
@@ -463,13 +472,15 @@ def test_resolver_deprecations():
         resolver.default_resolver,
         resolver.default_tag_to_url_mapping,
         resolver.default_url_mapping,
+        schema.default_ext_resolver,
     ]:
         with pytest.warns(AsdfDeprecationWarning):
             resolver_method("foo")
 
 
 def test_get_default_resolver():
-    resolver = _legacy_extension.get_default_resolver()
+    with pytest.warns(AsdfDeprecationWarning, match="get_default_resolver is deprecated"):
+        resolver = extension.get_default_resolver()
 
     result = resolver("tag:stsci.edu:asdf/core/ndarray-1.0.0")
 

--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -125,7 +125,10 @@ def test_asdf_file_extensions():
         af.extensions = arg
         assert af.extensions == [ExtensionProxy(extension)]
 
-    msg = r"[The extensions parameter must be an extension.*, Extension must implement the Extension interface]"
+    msg = (
+        r"[The extensions parameter must be an extension.*, "
+        r"Extension must implement the Extension or AsdfExtension interface]"
+    )
     for arg in (object(), [object()]):
         with pytest.raises(TypeError, match=msg):
             AsdfFile(extensions=arg)
@@ -182,7 +185,10 @@ def test_open_asdf_extensions(tmp_path):
         with open_asdf(path, extensions=arg) as af:
             assert af.extensions == [ExtensionProxy(extension)]
 
-    msg = r"[The extensions parameter must be an extension.*, Extension must implement the Extension interface]"
+    msg = (
+        r"[The extensions parameter must be an extension.*, "
+        r"Extension must implement the Extension or AsdfExtension interface]"
+    )
     for arg in (object(), [object()]):
         with pytest.raises(TypeError, match=msg), open_asdf(path, extensions=arg) as af:
             pass
@@ -205,7 +211,7 @@ def test_serialization_context():
 
     assert context.url == context._url == "file://test.asdf"
 
-    with pytest.raises(TypeError, match=r"Extension must implement the Extension interface"):
+    with pytest.raises(TypeError, match=r"Extension must implement the Extension or AsdfExtension interface"):
         context._mark_extension_used(object())
 
     with pytest.raises(ValueError, match=r"ASDF Standard version .* is not supported by asdf==.*"):

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -6,6 +6,7 @@ import asdf
 import asdf._types
 import asdf.extension
 import asdf.testing.helpers
+from asdf import entry_points
 from asdf._tests._helpers import assert_extension_correctness
 from asdf._tests.objects import CustomExtension
 from asdf._types import CustomType
@@ -21,16 +22,111 @@ def test_custom_type_warning():
             pass
 
 
+def test_resolver_module_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="^asdf.resolver is deprecated.*$"):
+        # importlib.reload doesn't appear to work here likely because of the
+        # sys.module and __file__ changes in asdf.resolver
+        if "asdf.resolver" in sys.modules:
+            del sys.modules["asdf.resolver"]
+        import asdf.resolver
+    # resolver does not define an __all__ so we will define one here
+    # for testing purposes
+    resolver_all = [
+        "Resolver",
+        "ResolverChain",
+        "DEFAULT_URL_MAPPING",
+        "DEFAULT_TAG_TO_URL_MAPPING",
+        "default_url_mapping",
+        "default_tag_to_url_mapping",
+        "default_resolver",
+    ]
+    for attr in dir(asdf.resolver):
+        if attr not in resolver_all:
+            continue
+        with pytest.warns(AsdfDeprecationWarning, match="^asdf.resolver is deprecated.*$"):
+            getattr(asdf.resolver, attr)
+
+
 def test_assert_extension_correctness_deprecation():
     extension = CustomExtension()
     with pytest.warns(AsdfDeprecationWarning, match="assert_extension_correctness is deprecated.*"):
         assert_extension_correctness(extension)
 
 
+def test_type_index_module_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="^asdf.type_index is deprecated.*$"):
+        # importlib.reload doesn't appear to work here likely because of the
+        # sys.module and __file__ changes in asdf.type_index
+        if "asdf.type_index" in sys.modules:
+            del sys.modules["asdf.type_index"]
+        import asdf.type_index
+    for attr in asdf.type_index.__all__:
+        with pytest.warns(AsdfDeprecationWarning, match="^asdf.type_index is deprecated.*$"):
+            getattr(asdf.type_index, attr)
+
+
+@pytest.mark.parametrize("attr", ["url_mapping", "tag_mapping", "resolver", "extension_list", "type_index"])
+def test_asdffile_legacy_extension_api_attr_deprecations(attr):
+    with asdf.AsdfFile() as af, pytest.warns(AsdfDeprecationWarning, match=f"AsdfFile.{attr} is deprecated"):
+        getattr(af, attr)
+
+
+def test_asdfile_run_hook_deprecation():
+    with asdf.AsdfFile() as af, pytest.warns(AsdfDeprecationWarning, match="AsdfFile.run_hook is deprecated"):
+        af.run_hook("foo")
+
+
+def test_asdfile_run_modifying_hook_deprecation():
+    with asdf.AsdfFile() as af, pytest.warns(AsdfDeprecationWarning, match="AsdfFile.run_modifying_hook is deprecated"):
+        af.run_modifying_hook("foo")
+
+
+def test_types_module_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="^asdf.types is deprecated.*$"):
+        if "asdf.types" in sys.modules:
+            del sys.modules["asdf.types"]
+        import asdf.types
+    for attr in asdf.types.__all__:
+        with pytest.warns(AsdfDeprecationWarning, match="^asdf.types is deprecated.*$"):
+            getattr(asdf.types, attr)
+
+
+def test_default_extensions_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="default_extensions is deprecated"):
+        asdf.extension.default_extensions
+
+
+def test_default_resolver():
+    with pytest.warns(AsdfDeprecationWarning, match="get_default_resolver is deprecated"):
+        asdf.extension.get_default_resolver()
+
+
+def test_get_cached_asdf_extension_list_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="get_cached_asdf_extension_list is deprecated"):
+        asdf.extension.get_cached_asdf_extension_list([])
+
+
 def test_asdf_type_format_tag():
     with pytest.warns(AsdfDeprecationWarning, match="asdf.types.format_tag is deprecated"):
         asdf._types.format_tag
     asdf.testing.helpers.format_tag
+
+
+@pytest.mark.parametrize("name", ["AsdfExtension", "AsdfExtensionList", "BuiltinExtension"])
+def test_extension_class_deprecation(name):
+    with pytest.warns(AsdfDeprecationWarning, match=f"{name} is deprecated"):
+        getattr(asdf.extension, name)
+
+
+def test_top_level_asdf_extension_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfExtension is deprecated"):
+        asdf.AsdfExtension
+
+
+def test_deprecated_entry_point(mock_entry_points):  # noqa: F811
+    mock_entry_points.append(("asdf_extensions", "legacy", "asdf.tests.test_entry_points:LegacyExtension"))
+    with pytest.warns(AsdfDeprecationWarning, match=".* uses the deprecated entry point asdf_extensions"):
+        entry_points.get_extensions()
 
 
 def test_asdf_tests_helpers_deprecation():

--- a/asdf/_tests/test_entry_points.py
+++ b/asdf/_tests/test_entry_points.py
@@ -8,7 +8,7 @@ import pytest
 
 from asdf import entry_points
 from asdf._version import version as asdf_package_version
-from asdf.exceptions import AsdfWarning
+from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
 from asdf.extension import ExtensionProxy
 from asdf.resource import ResourceMappingProxy
 
@@ -151,18 +151,24 @@ def test_get_extensions(mock_entry_points):
     )
     with pytest.warns(
         AsdfWarning,
-        match=r"TypeError: Extension must implement the Extension interface",
+        match=r"TypeError: Extension must implement the Extension or AsdfExtension interface",
     ):
         extensions = entry_points.get_extensions()
     assert len(extensions) == 2
 
     mock_entry_points.clear()
     mock_entry_points.append(("asdf_extensions", "legacy", "asdf._tests.test_entry_points:LegacyExtension"))
-    extensions = entry_points.get_extensions()
-    assert len(extensions) == 0  # asdf_extensions is no longer supported
+    with pytest.warns(AsdfDeprecationWarning, match=".* uses the deprecated entry point asdf_extensions"):
+        extensions = entry_points.get_extensions()
+    assert len(extensions) == 1
+    for e in extensions:
+        assert isinstance(e, ExtensionProxy)
+        assert e.package_name == "asdf"
+        assert e.package_version == asdf_package_version
+        assert e.legacy is True
 
     mock_entry_points.clear()
-    mock_entry_points.append(("asdf.extensions", "failing", "asdf._tests.test_entry_points:FauxLegacyExtension"))
+    mock_entry_points.append(("asdf_extensions", "failing", "asdf._tests.test_entry_points:FauxLegacyExtension"))
     with pytest.warns(AsdfWarning, match=r"TypeError"):
         extensions = entry_points.get_extensions()
     assert len(extensions) == 0

--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -15,9 +15,10 @@ from asdf.extension import (
     ManifestExtension,
     TagDefinition,
     Validator,
+    get_cached_asdf_extension_list,
     get_cached_extension_manager,
 )
-from asdf.extension._legacy import BuiltinExtension, _AsdfExtension, get_cached_asdf_extension_list
+from asdf.extension._legacy import AsdfExtension, BuiltinExtension
 
 
 def test_builtin_extension():
@@ -162,7 +163,7 @@ def test_extension_proxy_maybe_wrap():
     assert proxy.delegate is extension
     assert ExtensionProxy.maybe_wrap(proxy) is proxy
 
-    with pytest.raises(TypeError, match=r"Extension must implement the Extension interface"):
+    with pytest.raises(TypeError, match=r"Extension must implement the Extension or AsdfExtension interface"):
         ExtensionProxy.maybe_wrap(object())
 
 
@@ -172,7 +173,7 @@ def test_extension_proxy():
     proxy = ExtensionProxy(extension)
 
     assert isinstance(proxy, Extension)
-    assert isinstance(proxy, _AsdfExtension)
+    assert isinstance(proxy, AsdfExtension)
 
     assert proxy.extension_uri == "asdf://somewhere.org/extensions/minimum-1.0"
     assert proxy.legacy_class_names == set()
@@ -241,7 +242,7 @@ def test_extension_proxy():
     assert proxy.class_name == "asdf._tests.test_extension.FullExtension"
 
     # Should fail when the input is not one of the two extension interfaces:
-    with pytest.raises(TypeError, match=r"Extension must implement the Extension interface"):
+    with pytest.raises(TypeError, match=r"Extension must implement the Extension or AsdfExtension interface"):
         ExtensionProxy(object)
 
     # Should fail with a bad converter:
@@ -605,9 +606,12 @@ def test_converter_proxy():
 
 def test_get_cached_asdf_extension_list():
     extension = LegacyExtension()
-    extension_list = get_cached_asdf_extension_list([extension])
-    assert get_cached_asdf_extension_list([extension]) is extension_list
-    assert get_cached_asdf_extension_list([LegacyExtension()]) is not extension_list
+    with pytest.warns(AsdfDeprecationWarning, match="get_cached_asdf_extension_list is deprecated"):
+        extension_list = get_cached_asdf_extension_list([extension])
+    with pytest.warns(AsdfDeprecationWarning, match="get_cached_asdf_extension_list is deprecated"):
+        assert get_cached_asdf_extension_list([extension]) is extension_list
+    with pytest.warns(AsdfDeprecationWarning, match="get_cached_asdf_extension_list is deprecated"):
+        assert get_cached_asdf_extension_list([LegacyExtension()]) is not extension_list
 
 
 def test_manifest_extension():

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -10,11 +10,10 @@ import asdf
 import asdf.testing.helpers
 from asdf import _resolver as resolver
 from asdf import _types as types
-from asdf import config_context, constants, get_config, schema, tagged, util, yamlutil
+from asdf import config_context, constants, extension, get_config, schema, tagged, util, yamlutil
 from asdf._tests import _helpers as helpers
 from asdf._tests.objects import CustomExtension
 from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning
-from asdf.extension import _legacy as _legacy_extension
 
 with pytest.warns(AsdfDeprecationWarning, match=".*subclasses the deprecated CustomType.*"):
 
@@ -138,7 +137,8 @@ required: [foobar]
 
 
 def test_load_schema_with_file_url(tmp_path):
-    schema_def = """
+    with pytest.warns(AsdfDeprecationWarning, match="get_default_resolver is deprecated"):
+        schema_def = """
 %YAML 1.1
 %TAG !asdf! tag:stsci.edu:asdf/
 ---
@@ -153,9 +153,9 @@ properties:
 
 required: [foobar]
 ...
-    """.format(
-        _legacy_extension.get_default_resolver()("tag:stsci.edu:asdf/core/ndarray-1.0.0"),
-    )
+        """.format(
+            extension.get_default_resolver()("tag:stsci.edu:asdf/core/ndarray-1.0.0"),
+        )
     schema_path = tmp_path / "nugatory.yaml"
     schema_path.write_bytes(schema_def.encode())
 
@@ -264,8 +264,9 @@ def test_asdf_file_resolver_hashing():
     a1 = asdf.AsdfFile()
     a2 = asdf.AsdfFile()
 
-    assert hash(a1._resolver) == hash(a2._resolver)
-    assert a1._resolver == a2._resolver
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfFile.resolver is deprecated"):
+        assert hash(a1.resolver) == hash(a2.resolver)
+        assert a1.resolver == a2.resolver
 
 
 def test_load_schema_from_resource_mapping():
@@ -644,9 +645,11 @@ def test_self_reference_resolution():
 
 def test_schema_resolved_via_entry_points():
     """Test that entry points mappings to core schema works"""
-    r = _legacy_extension.get_default_resolver()
+    with pytest.warns(AsdfDeprecationWarning, match="get_default_resolver is deprecated"):
+        r = extension.get_default_resolver()
     tag = asdf.testing.helpers.format_tag("stsci.edu", "asdf", "1.0.0", "fits/fits")
-    url = _legacy_extension.default_extensions.extension_list.tag_mapping(tag)
+    with pytest.warns(AsdfDeprecationWarning, match="default_extensions is deprecated"):
+        url = extension.default_extensions.extension_list.tag_mapping(tag)
 
     s = schema.load_schema(url, resolver=r, resolve_references=True)
     assert tag in repr(s)

--- a/asdf/_tests/test_types.py
+++ b/asdf/_tests/test_types.py
@@ -36,7 +36,7 @@ class FractionWithInverse(Fraction):
 
 with pytest.warns(AsdfDeprecationWarning, match=".*subclasses the deprecated CustomType.*"):
 
-    class FractionWithInverseType(types.CustomType):
+    class FractionWithInverseType(asdf.CustomType):
         name = "fraction_with_inverse"
         organization = "nowhere.org"
         version = (1, 0, 0)
@@ -604,7 +604,7 @@ def test_super_use_in_versioned_subclass():
         match=".*subclasses the deprecated CustomType.*",
     ):
 
-        class FooType(types.CustomType):
+        class FooType(asdf.CustomType):
             name = "foo"
             version = (1, 0, 0)
             supported_versions = [(1, 1, 0), (1, 2, 0)]

--- a/asdf/_types.py
+++ b/asdf/_types.py
@@ -9,7 +9,7 @@ from . import tagged, util
 from .exceptions import AsdfDeprecationWarning
 from .versioning import AsdfSpec, AsdfVersion
 
-__all__ = ["format_tag", "CustomType", "ExtensionType"]  # noqa: F822
+__all__ = ["format_tag", "CustomType", "AsdfType", "ExtensionType"]  # noqa: F822
 
 
 # regex used to parse module name from optional version string
@@ -161,7 +161,7 @@ class AsdfTypeMeta(ExtensionTypeMeta):
         new_cls = super().__new__(cls, name, bases, attrs)
         # Classes using this metaclass get added to the list of built-in
         # extensions
-        if name != "_AsdfType":
+        if name != "AsdfType":
             _all_asdftypes.add(new_cls)
 
         return new_cls
@@ -388,7 +388,7 @@ class ExtensionType:
         return False
 
 
-class _AsdfType(ExtensionType, metaclass=AsdfTypeMeta):
+class AsdfType(ExtensionType, metaclass=AsdfTypeMeta):
     """
     Base class for all built-in ASDF types. Types that inherit this class will
     be automatically added to the list of built-ins. This should *not* be used

--- a/asdf/asdftypes.py
+++ b/asdf/asdftypes.py
@@ -1,0 +1,14 @@
+import warnings
+
+from ._types import AsdfType, CustomType, ExtensionTypeMeta, format_tag
+from .exceptions import AsdfDeprecationWarning
+
+# This is not exhaustive, but represents the public API
+from .versioning import join_tag_version, split_tag_version
+
+__all__ = ["join_tag_version", "split_tag_version", "AsdfType", "CustomType", "format_tag", "ExtensionTypeMeta"]
+
+warnings.warn(
+    "The module asdf.asdftypes has been deprecated and will be removed in 3.0. Use asdf.types instead.",
+    AsdfDeprecationWarning,
+)

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -163,7 +163,7 @@ class AsdfConfig:
 
         Parameters
         ----------
-        extension : asdf.extension.Extension
+        extension : asdf.extension.AsdfExtension or asdf.extension.Extension
         """
         with self._lock:
             extension = ExtensionProxy.maybe_wrap(extension)
@@ -175,7 +175,7 @@ class AsdfConfig:
 
         Parameters
         ----------
-        extension : asdf.extension.Extension or str, optional
+        extension : asdf.extension.AsdfExtension or asdf.extension.Extension or str, optional
             An extension instance or URI pattern to remove.
         package : str, optional
             Remove only extensions provided by this package.  If the ``extension``

--- a/asdf/entry_points.py
+++ b/asdf/entry_points.py
@@ -7,7 +7,7 @@ import warnings
 # see issue https://github.com/asdf-format/asdf/issues/1254
 from importlib_metadata import entry_points
 
-from .exceptions import AsdfWarning
+from .exceptions import AsdfDeprecationWarning, AsdfWarning
 from .extension import ExtensionProxy
 from .resource import ResourceMappingProxy
 
@@ -54,10 +54,44 @@ def _list_entry_points(group, proxy_class):
         # Catch errors loading entry points and warn instead of raising
         try:
             with warnings.catch_warnings():
-                if entry_point.group == LEGACY_EXTENSIONS_GROUP and entry_point.name != "builtin":
-                    # for now, the builtin extension is still registered via asdf_extensions
-                    # so we only load this legacy extension and ignore all non-builtin extensions
-                    continue
+                if entry_point.group == LEGACY_EXTENSIONS_GROUP:
+                    if entry_point.name in ("astropy", "astropy-asdf"):
+                        # Filter out the legacy `CustomType` deprecation warnings from the
+                        # deprecated astropy.io.misc.asdf
+                        # Testing will turn these into errors
+                        # Most of the astropy.io.misc.asdf deprecation warnings fall under this category
+                        warnings.filterwarnings(
+                            "ignore",
+                            category=AsdfDeprecationWarning,
+                            message=r".*from astropy.io.misc.asdf.* subclasses the deprecated CustomType .*",
+                        )
+                        warnings.filterwarnings(
+                            "ignore",
+                            category=AsdfDeprecationWarning,
+                            message="asdf.types is deprecated",
+                        )
+                        warnings.filterwarnings(
+                            "ignore",
+                            category=AsdfDeprecationWarning,
+                            message="AsdfExtension is deprecated",
+                        )
+                        warnings.filterwarnings(
+                            "ignore",
+                            category=AsdfDeprecationWarning,
+                            message="BuiltinExtension is deprecated",
+                        )
+                        warnings.filterwarnings(
+                            "ignore",
+                            category=AsdfDeprecationWarning,
+                            message="asdf.tests.helpers is deprecated",
+                        )
+                    elif entry_point.name != "builtin":
+                        warnings.warn(
+                            f"{package_name} uses the deprecated entry point {LEGACY_EXTENSIONS_GROUP}. "
+                            f"Please use the new extension api and entry point {EXTENSIONS_GROUP}: "
+                            "https://asdf.readthedocs.io/en/stable/asdf/extending/extensions.html",
+                            AsdfDeprecationWarning,
+                        )
                 elements = entry_point.load()()
 
         except Exception as e:

--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -2,8 +2,11 @@
 Support for plugins that extend asdf to serialize
 additional custom types.
 """
+import warnings
 
+from asdf.exceptions import AsdfDeprecationWarning
 
+from . import _legacy
 from ._compressor import Compressor
 from ._converter import Converter, ConverterProxy
 from ._extension import Extension, ExtensionProxy
@@ -24,4 +27,71 @@ __all__ = [
     "ConverterProxy",
     "Compressor",
     "Validator",
+    # Legacy API
+    "AsdfExtension",
+    "AsdfExtensionList",
+    "BuiltinExtension",
+    "default_extensions",
+    "get_default_resolver",
+    "get_cached_asdf_extension_list",
 ]
+
+
+def get_cached_asdf_extension_list(extensions):
+    """
+    Get a previously created AsdfExtensionList for the specified
+    extensions, or create and cache one if necessary.  Building
+    the type index is expensive, so it helps performance to reuse
+    the index when possible.
+    Parameters
+    ----------
+    extensions : list of asdf.extension.AsdfExtension
+    Returns
+    -------
+    asdf.extension.AsdfExtensionList
+    """
+    from ._legacy import get_cached_asdf_extension_list
+
+    warnings.warn(
+        "get_cached_asdf_extension_list is deprecated. "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
+    return get_cached_asdf_extension_list(extensions)
+
+
+def get_default_resolver():
+    """
+    Get the resolver that includes mappings from all installed extensions.
+    """
+    from ._legacy import get_default_resolver
+
+    warnings.warn(
+        "get_default_resolver is deprecated. "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
+    return get_default_resolver()
+
+
+_deprecated_legacy = {
+    "default_extensions",
+    "AsdfExtension",
+    "AsdfExtensionList",
+    "BuiltinExtension",
+}
+
+
+def __getattr__(name):
+    if name in _deprecated_legacy:
+        warnings.warn(
+            f"{name} is deprecated. "
+            "Please see the new extension API "
+            "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+            AsdfDeprecationWarning,
+        )
+        return getattr(_legacy, name)
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/asdf/extension/_extension.py
+++ b/asdf/extension/_extension.py
@@ -6,7 +6,7 @@ from asdf.util import get_class_name
 
 from ._compressor import Compressor
 from ._converter import ConverterProxy
-from ._legacy import _AsdfExtension
+from ._legacy import AsdfExtension
 from ._tag import TagDefinition
 from ._validator import Validator
 
@@ -131,7 +131,7 @@ class Extension(abc.ABC):
         return []
 
 
-class ExtensionProxy(Extension, _AsdfExtension):
+class ExtensionProxy(Extension, AsdfExtension):
     """
     Proxy that wraps an extension, provides default implementations
     of optional methods, and carries additional information on the
@@ -146,8 +146,8 @@ class ExtensionProxy(Extension, _AsdfExtension):
         return ExtensionProxy(delegate)
 
     def __init__(self, delegate, package_name=None, package_version=None):
-        if not isinstance(delegate, (Extension, _AsdfExtension)):
-            msg = "Extension must implement the Extension interface"
+        if not isinstance(delegate, (Extension, AsdfExtension)):
+            msg = "Extension must implement the Extension or AsdfExtension interface"
             raise TypeError(msg)
 
         self._delegate = delegate
@@ -156,7 +156,7 @@ class ExtensionProxy(Extension, _AsdfExtension):
 
         self._class_name = get_class_name(delegate)
 
-        self._legacy = isinstance(delegate, _AsdfExtension)
+        self._legacy = isinstance(delegate, AsdfExtension)
 
         # Sort these out up-front so that errors are raised when the extension is loaded
         # and not in the middle of the user's session.  The extension will fail to load
@@ -325,7 +325,7 @@ class ExtensionProxy(Extension, _AsdfExtension):
 
         Returns
         -------
-        asdf.extension.Extension
+        asdf.extension.Extension or asdf.extension.AsdfExtension
         """
         return self._delegate
 
@@ -367,7 +367,7 @@ class ExtensionProxy(Extension, _AsdfExtension):
     @property
     def legacy(self):
         """
-        Get the extension's legacy flag.  Subclasses of ``asdf.extension._AsdfExtension``
+        Get the extension's legacy flag.  Subclasses of `asdf.extension.AsdfExtension`
         are marked `True`.
 
         Returns

--- a/asdf/extension/_legacy.py
+++ b/asdf/extension/_legacy.py
@@ -7,10 +7,10 @@ from asdf import _types as types
 from asdf._type_index import AsdfTypeIndex
 from asdf.exceptions import AsdfDeprecationWarning
 
-__all__ = ["_AsdfExtension"]
+__all__ = ["AsdfExtension"]
 
 
-class _AsdfExtension(metaclass=abc.ABCMeta):
+class AsdfExtension(metaclass=abc.ABCMeta):
     """
     Abstract base class defining a (legacy) extension to ASDF.
     New code should use `asdf.extension.Extension` instead.
@@ -18,7 +18,7 @@ class _AsdfExtension(metaclass=abc.ABCMeta):
 
     @classmethod
     def __subclasshook__(cls, class_):
-        if cls is _AsdfExtension:
+        if cls is AsdfExtension:
             return hasattr(class_, "types") and hasattr(class_, "tag_mapping")
         return NotImplemented
 
@@ -173,7 +173,7 @@ def get_cached_asdf_extension_list(extensions):
 
     Parameters
     ----------
-    extensions : list of asdf.extension._AsdfExtension
+    extensions : list of asdf.extension.AsdfExtension
 
     Returns
     -------

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -203,7 +203,7 @@ def get_cached_extension_manager(extensions):
 
     Parameters
     ----------
-    extensions : list of asdf.extension.Extension
+    extensions : list of asdf.extension.AsdfExtension or asdf.extension.Extension
 
     Returns
     -------

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -42,7 +42,7 @@ def resolve_fragment(tree, pointer):
     return tree
 
 
-class Reference(_types._AsdfType):
+class Reference(_types.AsdfType):
     yaml_tag = "tag:yaml.org,2002:map"
 
     def __init__(self, uri, base_uri=None, asdffile=None, target=None):

--- a/asdf/resolver.py
+++ b/asdf/resolver.py
@@ -1,0 +1,31 @@
+"""
+This module is deprecated. Please see :ref:`extending_resources`
+"""
+import warnings
+
+from . import _resolver
+from .exceptions import AsdfDeprecationWarning
+
+
+def _warn():
+    warnings.warn(
+        "asdf.resolver is deprecated "
+        "Please see Resources "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/resources.html",
+        AsdfDeprecationWarning,
+    )
+
+
+_warn()
+
+
+def __getattr__(name):
+    attr = getattr(_resolver, name)
+    _warn()
+    if hasattr(attr, "__module__"):
+        attr.__module__ = __name__
+    return attr
+
+
+def __dir__():
+    return dir(_resolver)

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -13,7 +13,7 @@ import yaml
 from jsonschema import validators as mvalidators
 from jsonschema.exceptions import RefResolutionError, ValidationError
 
-from . import constants, generic_io, reference, tagged, treeutil, util, versioning, yamlutil
+from . import constants, extension, generic_io, reference, tagged, treeutil, util, versioning, yamlutil
 from .config import get_config
 from .exceptions import AsdfDeprecationWarning, AsdfWarning
 from .extension import _legacy
@@ -21,7 +21,23 @@ from .util import patched_urllib_parse
 
 YAML_SCHEMA_METASCHEMA_ID = "http://stsci.edu/schemas/yaml-schema/draft-01"
 
+
 __all__ = ["validate", "fill_defaults", "remove_defaults", "check_schema"]
+
+
+def default_ext_resolver(uri):
+    """
+    Resolver that uses tag/url mappings from all installed extensions
+    """
+    # Deprecating this because it doesn't play nicely with the caching on
+    # load_schema(...).
+    warnings.warn(
+        "The 'default_ext_resolver(...)' function is deprecated. Use "
+        "'asdf.extension.get_default_resolver()(...)' instead.",
+        AsdfDeprecationWarning,
+    )
+    return extension.get_default_resolver()(uri)
+
 
 PYTHON_TYPE_TO_YAML_TAG = {
     None: "null",
@@ -534,9 +550,8 @@ def get_validator(
         A dictionary mapping properties to validators to use (instead
         of the built-in ones and ones provided by extension types).
 
-    url_mapping : callable, optional
-        A callable that takes one string argument and returns a string
-        to convert remote URLs into local ones.
+    url_mapping : resolver.Resolver, optional
+        A resolver to convert remote URLs into local ones.
 
     _visit_repeat_nodes : bool, optional
         Force the validator to visit nodes that it has already

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -5,7 +5,7 @@ import numpy as np
 from asdf import _types
 
 
-class IntegerType(_types._AsdfType):
+class IntegerType(_types.AsdfType):
     """
     Enables the storage of arbitrarily large integer values
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -226,7 +226,7 @@ def numpy_array_to_list(array):
     return ascii_to_unicode(tolist(array))
 
 
-class NDArrayType(_types._AsdfType):
+class NDArrayType(_types.AsdfType):
     name = "core/ndarray"
     version = "1.0.0"
     supported_versions = {"1.0.0", "1.1.0"}
@@ -390,7 +390,7 @@ class NDArrayType(_types._AsdfType):
             msg = f"'{self.__class__.name}' object has no attribute '{name}'"
             raise AttributeError(msg)
 
-        return _types._AsdfType.__getattribute__(self, name)
+        return _types.AsdfType.__getattribute__(self, name)
 
     @classmethod
     def from_tree(cls, node, ctx):

--- a/asdf/type_index.py
+++ b/asdf/type_index.py
@@ -1,0 +1,28 @@
+"""
+This module is deprecated. Please see :ref:`extending_converters`
+"""
+import warnings
+
+from . import _type_index
+from .exceptions import AsdfDeprecationWarning
+
+
+def _warn():
+    warnings.warn(
+        "asdf.type_index is deprecated "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
+
+
+_warn()
+__all__ = _type_index.__all__
+
+
+def __getattr__(name):
+    attr = getattr(_type_index, name)
+    _warn()
+    if hasattr(attr, "__module__"):
+        attr.__module__ = __name__
+    return attr

--- a/asdf/types.py
+++ b/asdf/types.py
@@ -1,0 +1,28 @@
+"""
+This module is deprecated. Please see :ref:`extending_converters`
+"""
+import warnings
+
+from . import _types
+from .exceptions import AsdfDeprecationWarning
+
+
+def _warn():
+    warnings.warn(
+        "asdf.types is deprecated "
+        "Please see the new extension API "
+        "https://asdf.readthedocs.io/en/stable/asdf/extending/converters.html",
+        AsdfDeprecationWarning,
+    )
+
+
+_warn()
+__all__ = _types.__all__
+
+
+def __getattr__(name):
+    attr = getattr(_types, name)
+    _warn()
+    if hasattr(attr, "__module__") and name != "format_tag":
+        attr.__module__ = __name__
+    return attr

--- a/docs/asdf/deprecations.rst
+++ b/docs/asdf/deprecations.rst
@@ -21,31 +21,31 @@ Legacy Extension API Deprecation
 ================================
 
 A large number of `asdf.exceptions.AsdfDeprecationWarning` messages appear related to
-use of the ``legacy extension api``. Some examples include:
+use of the :ref:`legacy extension api <extending_legacy>`. Some examples include:
 
-* ``asdf.types``
-* ``asdf.types.CustomType``
+* `asdf.types`
+* `asdf.types.CustomType`
 * ``asdf.type_index``
 * ``asdf.resolver``
 * the ``asdf_extensions`` entry point
 * portions of asdf.extension including:
 
-  * ``asdf.extension.AsdfExtension``
-  * ``asdf.extension.AsdfExtensionList``
-  * ``asdf.extension.BuiltinExtension``
+  * `asdf.extension.AsdfExtension`
+  * `asdf.extension.AsdfExtensionList`
+  * `asdf.extension.BuiltinExtension`
   * ``asdf.extension.default_extensions``
   * ``asdf.extension.get_cached_asdf_extensions``
-  * ``asdf.extension.get_default_resolver``
+  * `asdf.extension.get_default_resolver`
 
 * attributes to asdf.AsdfFile including:
 
-  * ``asdf.AsdfFile.run_hook``
-  * ``asdf.AsdfFile.run_modifying_hook``
-  * ``asdf.AsdfFile.url_mapping``
-  * ``asdf.AsdfFile.tag_mapping``
-  * ``asdf.AsdfFile.type_index``
-  * ``asdf.AsdfFile.resolver``
-  * ``asdf.AsdfFile.extension_list``
+  * `asdf.AsdfFile.run_hook`
+  * `asdf.AsdfFile.run_modifying_hook`
+  * `asdf.AsdfFile.url_mapping`
+  * `asdf.AsdfFile.tag_mapping`
+  * `asdf.AsdfFile.type_index`
+  * `asdf.AsdfFile.resolver`
+  * `asdf.AsdfFile.extension_list`
 
 This deprecated api is replaced by new-style :ref:`converters <extending_converters>`,
 :ref:`extensions <extending_extensions>` and :ref:`validators <extending_validators>`.

--- a/docs/asdf/developer_api.rst
+++ b/docs/asdf/developer_api.rst
@@ -7,6 +7,8 @@ Developer API
 The classes and functions documented here will be of use to developers who wish
 to create their own custom ASDF types and extensions.
 
+.. automodapi:: asdf.types
+
 .. automodapi:: asdf.tagged
 
 .. automodapi:: asdf.exceptions
@@ -29,7 +31,6 @@ to create their own custom ASDF types and extensions.
 .. automodapi:: asdf.tags.core
     :skip: ExternalArrayReference
     :skip: IntegerType
-    :no-inheritance-diagram:
 
 .. automodapi:: asdf.testing.helpers
 

--- a/docs/asdf/developer_versioning.rst
+++ b/docs/asdf/developer_versioning.rst
@@ -14,35 +14,6 @@ The ASDF Standard document provides a helpful :ref:`overview <asdf-standard:vers
 of the various ASDF versioning conventions.  We will be concerned with the *standard version*
 and individual *tag versions*.
 
-Authors of new tags and schemas should strive to use the conventions described
-by `semantic versioning <https://semver.org/>`_. Tags and schemas for types
-that have not been serialized before should begin at ``1.0.0``. Versions for a
-particular tag type need not move in lock-step with other tag types in the same
-extension.
-
-The patch version should be bumped for bug fixes and other minor,
-backwards-compatible changes. New features can be indicated with increments to
-the minor version, as long as they remain backwards compatible with older
-versions of the schema. Any changes that break backwards compatibility must be
-indicated by a major version update.
-
-Since ASDF is intended to be an archival file format, authors of tags and
-schemas should work to ensure that ASDF files created with older extensions can
-continue to be processed. This means that every time a schema version is bumped
-(with the possible exception of patch updates), a **new** schema file should be
-created.
-
-For example, if we currently have a schema for ``xyz-1.0.0``, and we wish to
-make changes and bump the version to ``xyz-1.1.0``, we should leave the
-original schema intact. A **new** schema file should be created for
-``xyz-1.1.0``, which can exist in parallel with the old file. The version of
-the corresponding tag type should be bumped to ``1.1.0``.
-
-For more details on the behavior of schema and tag versioning from a user
-perspective, see :ref:`version_and_compat`, and also
-:ref:`custom_type_versions`.
-
-
 Overview
 --------
 

--- a/docs/asdf/extending/legacy.rst
+++ b/docs/asdf/extending/legacy.rst
@@ -1,0 +1,926 @@
+.. currentmodule:: asdf.extensions
+
+.. _extending_legacy:
+
+Deprecated extension API
+========================
+
+.. note::
+
+    This page documents the original `asdf` extension API, which has been
+    deprecated in favor of :ref:`extending_extensions`.  Since support
+    for the deprecated API will be removed in `asdf` 3.0, we recommend that
+    all new extensions be implemented with the new API. For more information
+    about this and other deprecations please see the :ref:`deprecations` page.
+
+Extensions provide a way for ASDF to represent complex types that are not
+defined by the ASDF standard. Examples of types that require custom extensions
+include types from third-party libraries, user-defined types, and complex types
+that are part of the Python standard library but are not handled in the ASDF
+standard. From ASDF's perspective, these are all considered 'custom' types.
+
+Supporting new types in ASDF is easy. Three components are required:
+
+1. A YAML Schema file for each new type.
+
+2. A tag class (inheriting from `asdf.CustomType`) corresponding to each new
+   custom type. The class must override `~asdf.CustomType.to_tree` and
+   `~asdf.CustomType.from_tree` from `asdf.CustomType` in order to define how
+   ASDF serializes and deserializes the custom type.
+
+3. A Python class to define an "extension" to ASDF, which is a set of related
+   types. This class must implement the `asdf.extension.AsdfExtension` abstract base
+   class. In general, a third-party library that defines multiple custom types
+   can group them all in the same extension.
+
+.. note::
+
+    The mechanisms of tag classes and extension classes are specific to this
+    particular implementation of ASDF. As of this writing, this is the only
+    complete implementation of the ASDF Standard. However, other language
+    implementations may use other mechanisms for processing custom types.
+
+    All implementations of ASDF, regardless of language, will make use of the
+    same schemas for abstract data type definitions. This allows all ASDF files
+    to be language-agnostic, and also enables interoperability.
+
+An Example
+----------
+
+As an example, we will write an extension for ASDF that allows us to represent
+Python's standard `fractions.Fraction` class for representing rational numbers.
+We will call our new ASDF type ``fraction``.
+
+First, the YAML Schema, defining the type as a pair of integers:
+
+.. code-block:: yaml
+
+    %YAML 1.1
+    ---
+    $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+    id: "http://nowhere.org/schemas/custom/fraction-1.0.0"
+    title: An example custom type for handling fractions
+
+    tag: "tag:nowhere.org:custom/fraction-1.0.0"
+    type: array
+    items:
+      type: integer
+    minItems: 2
+    maxItems: 2
+    ...
+
+Then, the Python implementation of the tag class and extension class. See the
+`asdf.CustomType` and `asdf.extension.AsdfExtension` documentation for more information:
+
+.. runcode:: hidden
+
+    import os
+    import asdf
+    # This is a hack in order to get the example below to work properly
+    __file__ = os.path.join(asdf.__path__[0], 'tests', 'data', 'fraction-1.0.0.yaml')
+
+.. runcode::
+
+    import os
+
+    import asdf
+    from asdf import util
+
+    import fractions
+
+    class FractionType(asdf.CustomType):
+        name = 'fraction'
+        organization = 'nowhere.org'
+        version = (1, 0, 0)
+        standard = 'custom'
+        types = [fractions.Fraction]
+
+        @classmethod
+        def to_tree(cls, node, ctx):
+            return [node.numerator, node.denominator]
+
+        @classmethod
+        def from_tree(cls, tree, ctx):
+            return fractions.Fraction(tree[0], tree[1])
+
+    class FractionExtension(asdf.AsdfExtension):
+        @property
+        def types(self):
+            return [FractionType]
+
+        @property
+        def tag_mapping(self):
+            return [('tag:nowhere.org:custom',
+                     'http://nowhere.org/schemas/custom{tag_suffix}')]
+
+        @property
+        def url_mapping(self):
+            return [('http://nowhere.org/schemas/custom/',
+                     util.filepath_to_url(os.path.dirname(__file__))
+                     + '/{url_suffix}.yaml')]
+
+Note that the method `~asdf.CustomType.to_tree` of the tag class
+``FractionType`` defines how the library converts `fractions.Fraction` into a
+tree that can be stored by ASDF. Conversely, the method
+`~asdf.CustomType.from_tree` defines how the library reads a serialized
+representation of the object and converts it back into an instance of
+`fractions.Fraction`.
+
+Note that the values of the `~asdf.CustomType.name`,
+`~asdf.CustomType.organization`, `~asdf.CustomType.standard`, and
+`~asdf.CustomType.version` fields are all reflected in the ``id`` and ``tag``
+definitions in the schema.
+
+Note also that the base of the ``tag`` value (up to the ``name`` and ``version``
+components) is reflected in `~asdf.extension.AsdfExtension.tag_mapping` property of the
+``FractionExtension`` type, which is used to map tags to URLs. The
+`~asdf.extension.AsdfExtension.url_mapping` is used to map URLs (of the same form as the
+``id`` field in the schema) to the actual location of a schema file.
+
+Once these classes and the schema have been defined, we can save an ASDF file
+using them:
+
+.. runcode::
+
+    tree = {'fraction': fractions.Fraction(10, 3)}
+
+    with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
+        ff.write_to("test.asdf")
+
+.. asdf:: test.asdf ignore_unrecognized_tag
+
+Defining custom types
+---------------------
+
+In the example above, we showed how to create an extension that is capable of
+serializing `fractions.Fraction`. The custom tag type that we created was
+defined as a subclass of `asdf.CustomType`.
+
+Custom type attributes
+**********************
+
+We overrode the following attributes of `~asdf.CustomType` in order to define
+``FractionType`` (each bullet is also a link to the API documentation):
+
+* `~asdf.CustomType.name`
+* `~asdf.CustomType.organization`
+* `~asdf.CustomType.version`
+* `~asdf.CustomType.standard`
+* `~asdf.CustomType.types`
+
+Each of these attributes is important, and each is described in more detail in
+the linked API documentation.
+
+The choice of `~asdf.CustomType.name` should be descriptive of the custom type
+that is being serialized. The choice of `~asdf.CustomType.organization`, and
+`~asdf.CustomType.standard` is fairly arbitrary, but also important. Custom
+types that are provided by the same package should be grouped into the same
+`~asdf.CustomType.standard` and `~asdf.CustomType.organization`.
+
+These three values, along with the `~asdf.CustomType.version`, are used to
+define the YAML tag that will mark the serialized type in ASDF files. In our
+example, the tag becomes ``tag:nowhere.org:custom/fraction-1.0.0``. The tag
+is important when defining the `asdf.extension.AsdfExtension` subclass.
+
+Critically, these values must all be reflected in the associated schema.
+
+Custom type methods
+*******************
+
+In addition to the attributes mentioned above, we also overrode the following
+methods of `~asdf.CustomType` (each bullet is also a link to the API
+documentation):
+
+* `~asdf.CustomType.to_tree`
+* `~asdf.CustomType.from_tree`
+
+The `~asdf.CustomType.to_tree` method defines how an instance of a custom data
+type is converted into data structures that represent a YAML tree that can be
+serialized to a file.
+
+The `~asdf.CustomType.from_tree` method defines how a YAML tree can be
+converted back into an instance of the original custom data type.
+
+In the example above, we used a `list` to contain the important attributes of
+`fractions.Fraction`. However, this choice is fairly arbitrary, as long as it
+is consistent between the way that `~asdf.CustomType.to_tree` and
+`~asdf.CustomType.from_tree` are defined. For example, we could have also
+chosen to use a `dict`:
+
+.. runcode::
+
+    import asdf
+    import fractions
+
+    class FractionType(asdf.CustomType):
+        name = 'fraction'
+        organization = 'nowhere.org'
+        version = (1, 0, 0)
+        standard = 'custom'
+        types = [fractions.Fraction]
+
+        @classmethod
+        def to_tree(cls, node, ctx):
+            return dict(numerator=node.numerator,
+                        denominator=node.denominator)
+
+        @classmethod
+        def from_tree(cls, tree, ctx):
+            return fractions.Fraction(tree['numerator'],
+                                      tree['denominator'])
+
+.. runcode:: hidden
+
+    # Redefine the fraction extension for the sake of the example
+    FractionExtension.types = [FractionType]
+
+    tree = {'fraction': fractions.Fraction(10, 3)}
+
+    with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
+        ff.write_to("test.asdf")
+
+In this case, the associated schema would look like the following::
+
+    %YAML 1.1
+    ---
+    $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+    id: "http://nowhere.org/schemas/custom/fraction-1.0.0"
+    title: An example custom type for handling fractions
+
+    tag: "tag:nowhere.org:custom/fraction-1.0.0"
+    type: object
+    properties:
+      numerator:
+        type: integer
+      denominator:
+        type: integer
+    ...
+
+We can compare the output using this representation to the example above:
+
+.. asdf:: test.asdf ignore_unrecognized_tag
+
+
+Serializing more complex types
+******************************
+
+Sometimes the custom types that we wish to represent in ASDF themselves have
+attributes which are also custom types. As a somewhat contrived example,
+consider a 2D cartesian coordinate that uses ``fraction.Fraction`` to represent
+each of the components. We will call this type ``Fractional2DCoordinate``.
+
+First we need to define a schema to represent this new type::
+
+    %YAML 1.1
+    ---
+    $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+    id: "http://nowhere.org/schemas/custom/fractional_2d_coord-1.0.0"
+    title: An example custom type for handling components
+
+    tag: "tag:nowhere.org:custom/fractional_2d_coord-1.0.0"
+    type: object
+    properties:
+      x:
+        $ref: fraction-1.0.0
+      y:
+        $ref: fraction-1.0.0
+    ...
+
+Note that in the schema, the ``x`` and ``y`` attributes are expressed as
+references to our ``fraction-1.0.0`` schema. Since both of these schemas are
+defined under the same standard and organization, we can simply use the name
+and version of the ``fraction-1.0.0`` schema to refer to it. However, if the
+reference type was defined in a different organization and standard, it would
+be necessary to use the entire YAML tag in the reference (e.g.
+``tag:nowhere.org:custom/fraction-1.0.0``). Relative tag references are also
+allowed where appropriate.
+
+.. runcode:: hidden
+
+    class Fractional2DCoordinate:
+        x = None
+        y = None
+
+We also need to define the custom tag type that corresponds to our new type:
+
+.. runcode::
+
+    import asdf
+
+    class Fractional2DCoordinateType(asdf.CustomType):
+        name = 'fractional_2d_coord'
+        organization = 'nowhere.org'
+        version = (1, 0, 0)
+        standard = 'custom'
+        types = [Fractional2DCoordinate]
+
+        @classmethod
+        def to_tree(cls, node, ctx):
+            tree = dict()
+            tree['x'] = node.x
+            tree['y'] = node.y
+            return tree
+
+        @classmethod
+        def from_tree(cls, tree, ctx):
+            coord = Fractional2DCoordinate()
+            coord.x = tree['x']
+            coord.y = tree['y']
+            return coord
+
+In previous versions of this library, it was necessary for our
+``Fractional2DCoordinateType`` class to call `~asdf.yamlutil` functions
+explicitly to convert the ``x`` and ``y`` components to and from
+their tree representations.  Now, the library will automatically
+convert nested custom types before calling `~asdf.CustomType.from_tree`,
+and after receiving the result from `~asdf.CustomType.to_tree`.
+
+Since ``Fractional2DCoordinateType`` shares the same
+`~asdf.CustomType.organization` and `~asdf.CustomType.standard` as
+``FractionType``, it can be added to the same extension class:
+
+.. runcode::
+
+    class FractionExtension(asdf.AsdfExtension):
+        @property
+        def types(self):
+            return [FractionType, Fractional2DCoordinateType]
+
+        @property
+        def tag_mapping(self):
+            return [('tag:nowhere.org:custom',
+                     'http://nowhere.org/schemas/custom{tag_suffix}')]
+
+        @property
+        def url_mapping(self):
+            return [('http://nowhere.org/schemas/custom/',
+                     util.filepath_to_url(os.path.dirname(__file__))
+                     + '/{url_suffix}.yaml')]
+
+Now we can use this extension to create an ASDF file:
+
+.. runcode::
+
+    coord = Fractional2DCoordinate()
+    coord.x = fractions.Fraction(22, 7)
+    coord.y = fractions.Fraction(355, 113)
+
+    tree = {'coordinate': coord}
+
+    with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
+        ff.write_to("coord.asdf")
+
+.. asdf:: coord.asdf ignore_unrecognized_tag
+
+Note that in the resulting ASDF file, the ``x`` and ``y`` components of
+our new ``fraction_2d_coord`` type are tagged as ``fraction-1.0.0``.
+
+Serializing reference cycles
+****************************
+
+Special considerations must be made when deserializing a custom type that
+contains a reference to itself among its descendants.  Consider a
+`fractions.Fraction` subclass that maintains a reference to its multiplicative
+inverse:
+
+.. runcode::
+
+    class FractionWithInverse(fractions.Fraction):
+        def __init__(self, *args, **kwargs):
+            self._inverse = None
+
+        @property
+        def inverse(self):
+            return self._inverse
+
+        @inverse.setter
+        def inverse(self, value):
+            self._inverse = value
+
+The inverse of the inverse of a fraction is the fraction itself,
+so you might wish to construct your objects in the following way:
+
+.. runcode::
+
+    f1 = FractionWithInverse(3, 5)
+    f2 = FractionWithInverse(5, 3)
+    f1.inverse = f2
+    f2.inverse = f1
+
+Which creates an "infinite loop" between the two fractions.  An ordinary
+`~asdf.CustomType` wouldn't be able to deserialize this, since each object
+requires that the other be deserialized first!  Let's see what happens
+when we define our `~asdf.CustomType.from_tree` method in a naive way:
+
+.. runcode::
+
+    class FractionWithInverseType(asdf.CustomType):
+        name = 'fraction_with_inverse'
+        organization = 'nowhere.org'
+        version = (1, 0, 0)
+        standard = 'custom'
+        types = [FractionWithInverse]
+
+        @classmethod
+        def to_tree(cls, node, ctx):
+            return {
+                "numerator": node.numerator,
+                "denominator": node.denominator,
+                "inverse": node.inverse
+            }
+
+        @classmethod
+        def from_tree(cls, tree, ctx):
+            result = FractionWithInverse(
+                tree["numerator"],
+                tree["denominator"]
+            )
+            result.inverse = tree["inverse"]
+            return result
+
+After adding our type to the extension class, the tree will serialize correctly:
+
+.. runcode:: hidden
+
+    FractionExtension.types = [FractionType, Fractional2DCoordinateType, FractionWithInverseType]
+
+.. runcode::
+
+    tree = {'fraction': f1}
+
+    with asdf.AsdfFile(tree, extensions=FractionExtension()) as ff:
+        ff.write_to("with_inverse.asdf")
+
+But upon deserialization, we notice a problem:
+
+.. runcode::
+
+    with asdf.open("with_inverse.asdf", extensions=FractionExtension()) as ff:
+        reconstituted_f1 = ff["fraction"]
+
+    assert reconstituted_f1.inverse.inverse is asdf.treeutil.PendingValue
+
+The presence of `~asdf.treeutil._PendingValue` is `asdf`'s way of telling you
+that the value corresponding to the key ``inverse`` was not fully deserialized
+at the time that you retrieved it.  We can handle this situation by making our
+`~asdf.CustomType.from_tree` a generator function:
+
+.. runcode::
+
+    class FractionWithInverseType(asdf.CustomType):
+        name = 'fraction_with_inverse'
+        organization = 'nowhere.org'
+        version = (1, 0, 0)
+        standard = 'custom'
+        types = [FractionWithInverse]
+
+        @classmethod
+        def to_tree(cls, node, ctx):
+            return {
+                "numerator": node.numerator,
+                "denominator": node.denominator,
+                "inverse": node.inverse
+            }
+
+        @classmethod
+        def from_tree(cls, tree, ctx):
+            result = FractionWithInverse(
+                tree["numerator"],
+                tree["denominator"]
+            )
+            yield result
+            result.inverse = tree["inverse"]
+
+The generator version of `~asdf.CustomType.from_tree` yields the partially constructed
+``FractionWithInverse`` object before setting its inverse property.  This allows
+asdf to proceed to constructing the inverse ``FractionWithInverse`` object,
+and resume the original `~asdf.CustomType.from_tree` execution only when the inverse
+is actually available.
+
+With this new version of `~asdf.CustomType.from_tree`, we can successfully deserialize
+our ASDF file:
+
+.. runcode:: hidden
+
+    FractionExtension.types = [FractionType, Fractional2DCoordinateType, FractionWithInverseType]
+
+.. runcode::
+
+    with asdf.open("with_inverse.asdf", extensions=FractionExtension()) as ff:
+            reconstituted_f1 = ff["fraction"]
+
+    assert reconstituted_f1.inverse.inverse is reconstituted_f1
+
+
+Assigning schema and tag versions
+*********************************
+
+Authors of new tags and schemas should strive to use the conventions described
+by `semantic versioning <https://semver.org/>`_. Tags and schemas for types
+that have not been serialized before should begin at ``1.0.0``. Versions for a
+particular tag type need not move in lock-step with other tag types in the same
+extension.
+
+The patch version should be bumped for bug fixes and other minor,
+backwards-compatible changes. New features can be indicated with increments to
+the minor version, as long as they remain backwards compatible with older
+versions of the schema. Any changes that break backwards compatibility must be
+indicated by a major version update.
+
+Since ASDF is intended to be an archival file format, authors of tags and
+schemas should work to ensure that ASDF files created with older extensions can
+continue to be processed. This means that every time a schema version is bumped
+(with the possible exception of patch updates), a **new** schema file should be
+created.
+
+For example, if we currently have a schema for ``xyz-1.0.0``, and we wish to
+make changes and bump the version to ``xyz-1.1.0``, we should leave the
+original schema intact. A **new** schema file should be created for
+``xyz-1.1.0``, which can exist in parallel with the old file. The version of
+the corresponding tag type should be bumped to ``1.1.0``.
+
+For more details on the behavior of schema and tag versioning from a user
+perspective, see :ref:`version_and_compat`, and also
+:ref:`custom_type_versions`.
+
+Explicit version support
+************************
+
+To some extent schemas and tag classes will be closely tied to the custom data
+types that they represent. This means that in some cases API changes or other
+changes to the representation of the underlying types will force us to modify
+our schemas and tag classes. ASDF's schema versioning allows us to handle
+changes in schemas over time.
+
+Let's consider an imaginary custom type called ``Person`` that we want to
+serialize in ASDF. The first version of ``Person`` was constructed using a
+first and last name:
+
+.. code-block:: python
+
+    person = Person("James", "Webb")
+    print(person.first, person.last)
+
+Our version 1.0.0 YAML schema for ``Person`` might look like the following:
+
+.. code-block:: yaml
+
+   %YAML 1.1
+   ---
+   $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+   id: "http://nowhere.org/schemas/custom/person-1.0.0"
+   title: An example custom type for representing a Person
+
+   tag: "tag:nowhere.org:custom/person-1.0.0"
+   type: array
+   items:
+     type: string
+   minItems: 2
+   maxItems: 2
+   ...
+
+And our tag implementation would look something like this:
+
+.. code-block:: python
+
+    import asdf
+    from people import Person
+
+
+    class PersonType(asdf.CustomType):
+        name = "person"
+        organization = "nowhere.org"
+        version = (1, 0, 0)
+        standard = "custom"
+        types = [Person]
+
+        @classmethod
+        def to_tree(cls, node, ctx):
+            return [node.first, node.last]
+
+        @classmethod
+        def from_tree(cls, tree, ctx):
+            return Person(tree[0], tree[1])
+
+However, a newer version of ``Person`` now requires a middle name in the
+constructor as well:
+
+.. code-block:: python
+
+    person = Person("James", "Edwin", "Webb")
+    print(person.first, person.middle, person.last)
+
+So we update our YAML schema to version 1.1.0 in order to support newer
+versions of Person:
+
+.. code-block:: yaml
+
+   %YAML 1.1
+   ---
+   $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+   id: "http://nowhere.org/schemas/custom/person-1.1.0"
+   title: An example custom type for representing a Person
+
+   tag: "tag:nowhere.org:custom/person-1.1.0"
+   type: array
+   items:
+     type: string
+   minItems: 3
+   maxItems: 3
+   ...
+
+We need to update our tag class implementation as well. However, we need to be
+careful. We still want to be able to read version 1.0.0 of our schema and be
+able to convert it to the newer version of ``Person`` objects. To accomplish
+this, we will make use of the `~asdf.CustomType.supported_versions` attribute
+for our tag class. This will allow us to declare explicit support for the
+schema versions our tag class implements.
+
+Under the hood, `asdf` creates multiple copies of our ``PersonType`` tag class,
+each with a different `~asdf.CustomType.version` attribute corresponding to one
+of the supported versions. This means that in our new tag class implementation,
+we can condition our `~asdf.CustomType.from_tree` implementation on the value
+of ``version`` to determine which schema version should be used when reading:
+
+.. code-block:: python
+
+    import asdf
+    from people import Person
+
+
+    class PersonType(asdf.CustomType):
+        name = "person"
+        organization = "nowhere.org"
+        version = (1, 1, 0)
+        supported_versions = [(1, 0, 0), (1, 1, 0)]
+        standard = "custom"
+        types = [Person]
+
+        @classmethod
+        def to_tree(cls, node, ctx):
+            return [node.first, node.middle, node.last]
+
+        @classmethod
+        def from_tree(cls, tree, ctx):
+            # Handle the older version of the person schema
+            if cls.version == (1, 0, 0):
+                # Construct a Person object with an empty middle name field
+                return Person(tree[0], "", tree[1])
+            else:
+                # The newer version of the schema stores the middle name too
+                return person(tree[0], tree[1], tree[2])
+
+Note that the implementation of ``to_tree`` is not conditioned on
+``cls.version`` since we do not need to convert new ``Person`` objects back to
+the older version of the schema.
+
+Handling subclasses
+*******************
+
+By default, if a custom type is serialized by an `asdf` tag class, then all
+subclasses of that type can also be serialized. However, no attributes that are
+specific to the subclass will be stored in the file. When reading the file, an
+instance of the base custom type will be returned instead of the subclass that
+was written.
+
+To properly handle subclasses of custom types already recognized by `asdf`, it is
+necessary to implement a separate tag class that is specific to the subclass to
+be serialized.
+
+Previous versions of this library implemented an experimental feature that
+allowed ADSF to serialize subclass attributes using the same tag class, but
+this feature was dropped as it produced files that were not portable.
+
+Creating custom schemas
+-----------------------
+
+All custom types to be serialized by `asdf` require custom schemas. The best
+resource for creating ASDF schemas can be found in the :ref:`ASDF Standard
+<asdf-standard:asdf-schemas>` documentation.
+
+In most cases, ASDF schemas will be included as part of a packaged software
+distribution. In these cases, it is important for the
+`~asdf.extension.AsdfExtension.url_mapping` of the corresponding `~asdf.extension.AsdfExtension`
+extension class to map the schema URL to an actual location on disk. However,
+it is possible for schemas to be hosted online as well, in which case the URL
+mapping can map (perhaps trivially) to an actual network location. See
+:ref:`defining_extensions` for more information.
+
+It is also important for packages that provide custom schemas to test them,
+both to make sure that they are valid, and to ensure that any examples they
+provide are also valid. See :ref:`testing_custom_schemas` for more information.
+
+Adding custom validators
+------------------------
+
+A new type may also add new validation keywords to the schema
+language. This can be used to impose type-specific restrictions on the
+values in an ASDF file.  This feature is used internally so a schema
+can specify the required datatype of an array.
+
+To support custom validation keywords, set the `~asdf.CustomType.validators`
+member of a `~asdf.CustomType` subclass to a dictionary where the keys are the
+validation keyword name and the values are validation functions.  The
+validation functions are of the same form as the validation functions in the
+underlying `jsonschema` library, and are passed the following arguments:
+
+  - ``validator``: A `jsonschema.Validator` instance.
+
+  - ``value``: The value of the schema keyword.
+
+  - ``instance``: The instance to validate.  This will be made up of
+    basic datatypes as represented in the YAML file (list, dict,
+    number, strings), and not include any object types.
+
+  - ``schema``: The entire schema that applies to instance.  Useful to
+    get other related schema keywords.
+
+The validation function should either return ``None`` if the instance
+is valid or ``yield`` one or more `jsonschema.ValidationError` objects if
+the instance is invalid.
+
+To continue the example from above, for the ``FractionType`` say we
+want to add a validation keyword "``simplified``" that, when ``true``,
+asserts that the corresponding fraction is in simplified form:
+
+.. code-block:: python
+
+    from asdf import ValidationError
+
+
+    def validate_simplified(validator, simplified, instance, schema):
+        if simplified:
+            reduced = fraction.Fraction(instance[0], instance[1])
+            if reduced.numerator != instance[0] or reduced.denominator != instance[1]:
+                yield ValidationError("Fraction is not in simplified form.")
+
+
+    FractionType.validators = {"simplified": validate_simplified}
+
+.. _defining_extensions:
+
+Defining custom extension classes
+---------------------------------
+
+Extension classes are the mechanism that `asdf` uses to register custom tag types
+so that they can be used when processing ASDF files. Packages that define their
+own custom tag types must also define extensions in order for those types to be
+used.
+
+All extension classes must implement the `asdf.extension.AsdfExtension` abstract base
+class. A custom extension will override each of the following properties of
+`asdf.extension.AsdfExtension` (the text in each bullet is also a link to the corresponding
+documentation):
+
+* `~asdf.extension.AsdfExtension.types`
+* `~asdf.extension.AsdfExtension.tag_mapping`
+* `~asdf.extension.AsdfExtension.url_mapping`
+
+.. _packaging_extensions:
+
+Overriding built-in extensions
+******************************
+
+It is possible for externally defined extensions to override tag types that are
+provided by `asdf`'s built-in extension. For example, maybe an external package
+wants to provide a different implementation of `~asdf.tags.core.NDArrayType`.
+In this case, the external package does not need to provide custom schemas
+since the schema for the type to be overridden is already provided as part of
+the ASDF standard.
+
+Instead, the extension class may inherit from `asdf`'s
+`asdf.extension.BuiltinExtension` and simply override the
+`~asdf.extension.AsdfExtension.types` property to indicate the type that is being
+overridden.  Doing this preserves the `~asdf.extension.AsdfExtension.tag_mapping` and
+`~asdf.extension.AsdfExtension.url_mapping` that is used by the ``BuiltinExtension``, which
+allows the schemas that are packaged by `asdf` to be located.
+
+`asdf` will give precedence to the type that is provided by the external
+extension, effectively overriding the corresponding type in the built-in
+extension. Note that it is currently undefined if multiple external extensions
+are provided that override the same built-in type.
+
+Packaging custom extensions
+---------------------------
+
+Packaging schemas
+*****************
+
+If a package provides custom schemas, the schema files must be installed as
+part of that package distribution. In general, schema files must be installed
+into a subdirectory of the package distribution. The `asdf` extension class must
+supply a `~asdf.extension.AsdfExtension.url_mapping` that maps to the installed location
+of the schemas. See :ref:`defining_extensions` for more details.
+
+Registering entry points
+************************
+
+Packages that provide their own ASDF extensions can (and should!) install them
+so that they are automatically detectable by the `asdf` Python package. This is
+accomplished using Python's `setuptools <https://setuptools.pypa.io/en/latest/index.html>`_
+entry points. Entry points are registered in a package's ``setup.py`` file.
+
+Consider a package that provides an extension class ``MyPackageExtension`` in the
+submodule ``mypackage.asdf.extensions``. We need to register this class as an
+extension entry point that `asdf` will recognize. First, we create a dictionary:
+
+.. code:: python
+
+    entry_points = {}
+    entry_points["asdf_extensions"] = [
+        "mypackage = mypackage.asdf.extensions:MyPackageExtension"
+    ]
+
+The key used in the ``entry_points`` dictionary must be ``'asdf_extensions'``.
+The value must be an array of one or more strings, each with the following
+format:
+
+    ``extension_name = fully.specified.submodule:ExtensionClass``
+
+The extension name can be any arbitrary string, but it should be descriptive of
+the package and the extension. In most cases the package itself name will
+suffice.
+
+Note that depending on individual package requirements, there may be other
+entries in the ``entry_points`` dictionary.
+
+The entry points must be passed to the call to ``setuptools.setup``:
+
+.. code:: python
+
+    from setuptools import setup
+
+    entry_points = {}
+    entry_points["asdf_extensions"] = [
+        "mypackage = mypackage.asdf.extensions:MyPackageExtension"
+    ]
+
+    setup(
+        # We omit other package-specific arguments that are not
+        # relevant to this example
+        entry_points=entry_points,
+    )
+
+When running ``python setup.py install`` or ``python setup.py develop`` on this
+package, the entry points will be registered automatically. This allows the
+`asdf` package to recognize the extensions without any user intervention. Users
+of your package that wish to read ASDF files using types that you have
+registered will not need to use any extension explicitly. Instead, `asdf` will
+automatically recognize the types you have registered and will process them
+appropriately. See :ref:`other_packages` for more information on using
+extensions.
+
+.. _testing_custom_schemas:
+
+Testing custom schemas
+----------------------
+
+Packages that provide their own schemas can test them using `asdf`'s
+:ref:`pytest <pytest:toc>` plugin for schema testing.
+Schemas are tested for overall validity, and any examples given within the
+schemas are also tested.
+
+The schema tester plugin is automatically registered when the `asdf` package is
+installed. In order to enable testing, it is necessary to add the directory
+containing your schema files to the pytest section of your project's build configuration
+(``pyproject.toml`` or ``setup.cfg``). If you do not already have such a file, creating
+one with the following should be sufficient:
+
+.. tab:: pyproject.toml
+
+    .. code-block:: toml
+
+        [tool.pytest.ini_options]
+        asdf_schema_root = 'path/to/schemas another/path/to/schemas'
+
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [tool:pytest]
+        asdf_schema_root = path/to/schemas another/path/to/schemas
+
+The schema directory paths should be paths that are relative to the top of the
+package directory **when it is installed**. If this is different from the path
+in the source directory, then both paths can be used to facilitate in-place
+testing (see `asdf`'s own ``pyproject.toml`` for an example of this).
+
+.. note::
+
+   Older versions of `asdf` (prior to 2.4.0) required the plugin to be registered
+   in your project's ``conftest.py`` file. As of 2.4.0, the plugin is now
+   registered automatically and so this line should be removed from your
+   ``conftest.py`` file, unless you need to retain compatibility with older
+   versions of `asdf`.
+
+The ``asdf_schema_skip_names`` configuration variable can be used to skip
+schema files that live within one of the ``asdf_schema_root`` directories but
+should not be tested. The names should be given as simple base file names
+(without directory paths or extensions). Again, see `asdf`'s own ``pyproject.toml`` file
+for an example.
+
+The schema tests do **not** run by default. In order to enable the tests by
+default for your package, add ``asdf_schema_tests_enabled = 'true'`` to the
+``[tool.pytest.ini_options]`` section of your ``pyproject.toml`` file (or ``[tool:pytest]`` in ``setup.cfg``).
+If you do not wish to enable the schema tests by default, you can add the ``--asdf-tests`` option to
+the ``pytest`` command line to enable tests on a per-run basis.

--- a/docs/asdf/extending/schemas.rst
+++ b/docs/asdf/extending/schemas.rst
@@ -241,61 +241,6 @@ function will validate a Python object against a schema:
 The validate function will return successfully if the object is valid, or raise
 an error if not.
 
-.. _testing_custom_schemas:
-
-Testing custom schemas
-----------------------
-
-Packages that provide their own schemas can test them using `asdf`'s
-:ref:`pytest <pytest:toc>` plugin for schema testing.
-Schemas are tested for overall validity, and any examples given within the
-schemas are also tested.
-
-The schema tester plugin is automatically registered when the `asdf` package is
-installed. In order to enable testing, it is necessary to add the directory
-containing your schema files to the pytest section of your project's build configuration
-(``pyproject.toml`` or ``setup.cfg``). If you do not already have such a file, creating
-one with the following should be sufficient:
-
-.. tab:: pyproject.toml
-
-    .. code-block:: toml
-
-        [tool.pytest.ini_options]
-        asdf_schema_root = 'path/to/schemas another/path/to/schemas'
-
-.. tab:: setup.cfg
-
-    .. code-block:: ini
-
-        [tool:pytest]
-        asdf_schema_root = path/to/schemas another/path/to/schemas
-
-The schema directory paths should be paths that are relative to the top of the
-package directory **when it is installed**. If this is different from the path
-in the source directory, then both paths can be used to facilitate in-place
-testing (see `asdf`'s own ``pyproject.toml`` for an example of this).
-
-.. note::
-
-   Older versions of `asdf` (prior to 2.4.0) required the plugin to be registered
-   in your project's ``conftest.py`` file. As of 2.4.0, the plugin is now
-   registered automatically and so this line should be removed from your
-   ``conftest.py`` file, unless you need to retain compatibility with older
-   versions of `asdf`.
-
-The ``asdf_schema_skip_names`` configuration variable can be used to skip
-schema files that live within one of the ``asdf_schema_root`` directories but
-should not be tested. The names should be given as simple base file names
-(without directory paths or extensions). Again, see `asdf`'s own ``pyproject.toml`` file
-for an example.
-
-The schema tests do **not** run by default. In order to enable the tests by
-default for your package, add ``asdf_schema_tests_enabled = 'true'`` to the
-``[tool.pytest.ini_options]`` section of your ``pyproject.toml`` file (or ``[tool:pytest]`` in ``setup.cfg``).
-If you do not wish to enable the schema tests by default, you can add the ``--asdf-tests`` option to
-the ``pytest`` command line to enable tests on a per-run basis.
-
 See also:
 =========
 

--- a/docs/asdf/user_api.rst
+++ b/docs/asdf/user_api.rst
@@ -7,8 +7,8 @@ User API
 .. automodapi:: asdf
     :include-all-objects:
     :inherited-members:
-    :no-inheritance-diagram:
     :skip: ValidationError
+    :skip: AsdfExtension
 
 .. automodapi:: asdf.search
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,7 @@ Extending ASDF
   asdf/extending/manifests
   asdf/extending/compressors
   asdf/extending/validators
+  asdf/extending/legacy
 
 API Documentation
 =================


### PR DESCRIPTION
Reverts asdf-format/asdf#1464

Astropy is testing against our 3.0 development version. A few tests in their v5.0, v5.2 and v5.3 branches have not been updated.
https://github.com/astropy/astropy/issues/14795

Until those are fixed it's likely easiest to revert the changes here to avoid having them pin ASDF
https://github.com/astropy/astropy/pull/14796