### PR TITLE
drop python 3.8 support and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
         - linux: coverage
           name: Python 3.9 coverage
           python-version: 3.9
-        - linux: coverage
-          name: Python 3.8 coverage
-          python-version: 3.8
       coverage: codecov
 
   asdf-schemas:
@@ -71,7 +68,6 @@ jobs:
       # Any env name which does not start with `pyXY` will use this Python version.
       default_python: '3.9'
       envs: |
-        - linux: py38-devdeps-parallel
         - linux: py39-devdeps-parallel
         - linux: py310-devdeps-parallel
         - linux: py311-devdeps-parallel
@@ -84,7 +80,6 @@ jobs:
       # Any env name which does not start with `pyXY` will use this Python version.
       default_python: '3.9'
       envs: |
-        - linux: py38-oldestdeps-parallel
         - linux: py39-oldestdeps-parallel
 
   compatibility:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ The ASDF Standard is at v1.6.0
 - Move built-in tags to converters (except ndarray and integer). [#1474]
 - Add block storage support to Converter [#1508]
 - Remove deprecated legacy extension API [#1464]
+- Drop Python 3.8 support [#1556]
 
 2.15.0 (2023-03-28)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,12 @@ description = "Python implementation of the ASDF Standard"
 readme = 'README.rst'
 license = { file = 'LICENSE' }
 authors = [{ name = 'The ASDF Developers', email = 'help@stsci.edu' }]
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 classifiers = [
   'Development Status :: 5 - Production/Stable',
   "License :: OSI Approved :: BSD License",
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
-  'Programming Language :: Python :: 3.8',
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
@@ -23,11 +22,9 @@ dependencies = [
   "asdf-transform-schemas>=0.3",
   "asdf-unit-schemas>=0.1",
   "importlib-metadata>=4.11.4",
-  'importlib_resources>=3; python_version < "3.9"',
   "jmespath>=0.6.2",
   "jsonschema<4.18,>=4.0.1", # jsonschema 4.18 contains incompatible changes: https://github.com/asdf-format/asdf/issues/1485
   "numpy>=1.20",
-  'numpy<1.25,>=1.20; python_version < "3.9"',
   "packaging>=19",
   "pyyaml>=5.4.1",
   "semantic_version>=2.8",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,10 @@ git+https://github.com/asdf-format/asdf-standard
 git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-unit-schemas.git
 git+https://github.com/asdf-format/asdf-wcs-schemas
-git+https://github.com/astropy/astropy ; python_version > "3.8"
+git+https://github.com/astropy/astropy
 git+https://github.com/spacetelescope/gwcs
 git+https://github.com/yaml/pyyaml.git
 # jsonschema 4.18 contains incompatible changes: https://github.com/asdf-format/asdf/issues/1485
 #git+https://github.com/python-jsonschema/jsonschema
 
-scipy>=0.0.dev0
-numpy>=0.0.dev0 ; python_version > "3.8"
+numpy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-env_list = py{38,39,310}{,-compatibility,-coverage}{,-parallel}
+env_list = py{39,310}{,-compatibility,-coverage}{,-parallel}
 
 [testenv]
 set_env =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 deps =
     compatibility: virtualenv
     coverage: coverage


### PR DESCRIPTION
Use new nightly wheels repository: https://anaconda.org/scientific-python-nightly-wheels/repo

drop testing with development scipy (which is not a dependency)