### PR TITLE
test for valid fileno before creating RealFile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ The ASDF Standard is at v1.6.0
 - Remove deprecated legacy extension API [#1464]
 - Drop Python 3.8 support [#1556]
 - Drop NumPy 1.20, 1.21 support [#1568]
+- Fix issue opening files that don't support ``fileno`` [#1557]
 
 2.15.0 (2023-03-28)
 -------------------

--- a/asdf/_tests/test_generic_io.py
+++ b/asdf/_tests/test_generic_io.py
@@ -803,6 +803,11 @@ def test_fsspec(tmp_path):
         r = gf.read(len(ref))
         assert r == ref, (r, ref)
 
+        gf.seek(0)
+        arr = gf.read_into_array(len(ref))
+        for ai, i in zip(arr, ref):
+            assert ai == i
+
 
 @pytest.mark.remote_data()
 def test_fsspec_http(httpserver):
@@ -822,6 +827,11 @@ def test_fsspec_http(httpserver):
         gf = generic_io.get_file(f)
         r = gf.read(len(ref))
         assert r == ref, (r, ref)
+
+        gf.seek(0)
+        arr = gf.read_into_array(len(ref))
+        for ai, i in zip(arr, ref):
+            assert ai == i
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
fileno is needed for memory mapping and numpy.frombuffer. Test that fileno does not result in an ``io.UnsupportedOperation`` before creating a ``generic_io.RealFile`` and if the error occurs, create a ``generic_io.RandomAccessFile`` instead.

fixes issue #1552