### PR TITLE
convert Reference to Converter

### DIFF
--- a/asdf/core/_converters/reference.py
+++ b/asdf/core/_converters/reference.py
@@ -1,0 +1,18 @@
+from asdf.extension import Converter
+
+
+class ReferenceConverter(Converter):
+    tags = ["*"]
+    types = ["asdf.reference.Reference"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        from asdf.generic_io import relative_uri
+
+        uri = relative_uri(ctx.url, obj._uri) if ctx.url is not None else obj._uri
+        return {"$ref": uri}
+
+    def from_yaml_tree(self, node, tag, ctx):
+        pass
+
+    def select_tag(self, obj, tag, ctx):
+        return "tag:yaml.org,2002:map"

--- a/asdf/core/_extensions.py
+++ b/asdf/core/_extensions.py
@@ -3,6 +3,7 @@ from asdf.extension import ManifestExtension
 from ._converters.complex import ComplexConverter
 from ._converters.constant import ConstantConverter
 from ._converters.external_reference import ExternalArrayReferenceConverter
+from ._converters.reference import ReferenceConverter
 from ._converters.tree import (
     AsdfObjectConverter,
     ExtensionMetadataConverter,
@@ -21,6 +22,7 @@ CONVERTERS = [
     HistoryEntryConverter(),
     SoftwareConverter(),
     SubclassMetadataConverter(),
+    ReferenceConverter(),
 ]
 
 

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -195,6 +195,9 @@ class ConverterProxy(Converter):
 
         relevant_tags = set()
         for tag in delegate.tags:
+            if tag == "*":
+                relevant_tags.add(tag)
+                break
             if isinstance(tag, str):
                 relevant_tags.update(t.tag_uri for t in extension.tags if uri_match(tag, t.tag_uri))
             else:

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -38,6 +38,8 @@ class ExtensionManager:
                 # use it.
                 if len(converter.tags) > 0:
                     for tag in converter.tags:
+                        if tag == "*":
+                            continue
                         if tag not in self._converters_by_tag:
                             self._converters_by_tag[tag] = converter
                     for typ in converter.types:

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 
 import numpy as np
 
-from . import _types, generic_io, treeutil, util
+from . import generic_io, treeutil, util
 from .util import patched_urllib_parse
 
 __all__ = ["resolve_fragment", "Reference", "find_references", "resolve_references", "make_reference"]
@@ -42,9 +42,7 @@ def resolve_fragment(tree, pointer):
     return tree
 
 
-class Reference(_types._AsdfType):
-    yaml_tag = "tag:yaml.org,2002:map"
-
+class Reference:
     def __init__(self, uri, base_uri=None, asdffile=None, target=None):
         self._uri = uri
         if asdffile is not None:
@@ -104,15 +102,6 @@ class Reference(_types._AsdfType):
 
     def __contains__(self, item):
         return item in self._get_target()
-
-    @classmethod
-    def to_tree(cls, data, ctx):
-        uri = generic_io.relative_uri(ctx.uri, data._uri) if ctx.uri is not None else data._uri
-        return {"$ref": uri}
-
-    @classmethod
-    def validate(cls, data):
-        pass
 
 
 def find_references(tree, ctx):


### PR DESCRIPTION
This is draft PR and should not be merged.

I'm not at the moment seeing a way to move `asdf.reference.Reference` to a `Converter` without changes to the the extension API.

The core issue is that `Reference` does not have a tag and instead uses the yaml map tag: "tag:yaml.org,2002:map" (which does not appear in the manifest for the asdf core extension). This causes the converter to be ignored in the extension because of the code in the `ConverterProxy` filters out any tag definitions that aren't in the extension:
https://github.com/asdf-format/asdf/blob/b0c9a50e8d3add337e1271369a3bf834925176a4/asdf/extension/_converter.py#L196-L202
and the manager doesn't include converters with no tags:
https://github.com/asdf-format/asdf/blob/b0c9a50e8d3add337e1271369a3bf834925176a4/asdf/extension/_manager.py#L39

To work around this issue, this PR introduces a special tag `"*"` to be used for converters that should always be included in the extension. The `ReferenceConverter` then exploits `select_tag` to return the standard yaml map tag.