### PR TITLE
allow Converter.select_tag to return special Reconvert

### DIFF
--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -600,7 +600,10 @@ def test_converter_proxy():
 
     # Should fail because types must instances of type:
     with pytest.raises(TypeError, match=r"Converter property .* must contain str or type values"):
-        ConverterProxy(MinimumConverter(types=[object()]), extension)
+        # as the code will ignore types if no relevant tags are found
+        # include a tag from this extension to make sure the proxy considers
+        # the types
+        ConverterProxy(MinimumConverter(tags=[extension.tags[0].tag_uri], types=[object()]), extension)
 
 
 def test_get_cached_asdf_extension_list():

--- a/asdf/core/_converters/reference.py
+++ b/asdf/core/_converters/reference.py
@@ -1,0 +1,18 @@
+from asdf.extension import Converter, Reconvert
+
+
+class ReferenceConverter(Converter):
+    tags = []
+    types = ["asdf.reference.Reference"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        raise NotImplementedError()
+
+    def from_yaml_tree(self, node, tag, ctx):
+        raise NotImplementedError()
+
+    def select_tag(self, obj, tag, ctx):
+        from asdf.generic_io import relative_uri
+
+        uri = relative_uri(ctx.url, obj._uri) if ctx.url is not None else obj._uri
+        return Reconvert({"$ref": uri})

--- a/asdf/core/_extensions.py
+++ b/asdf/core/_extensions.py
@@ -3,6 +3,7 @@ from asdf.extension import ManifestExtension
 from ._converters.complex import ComplexConverter
 from ._converters.constant import ConstantConverter
 from ._converters.external_reference import ExternalArrayReferenceConverter
+from ._converters.reference import ReferenceConverter
 from ._converters.tree import (
     AsdfObjectConverter,
     ExtensionMetadataConverter,
@@ -21,6 +22,7 @@ CONVERTERS = [
     HistoryEntryConverter(),
     SoftwareConverter(),
     SubclassMetadataConverter(),
+    ReferenceConverter(),
 ]
 
 

--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -5,7 +5,7 @@ additional custom types.
 
 
 from ._compressor import Compressor
-from ._converter import Converter, ConverterProxy
+from ._converter import Converter, ConverterProxy, Reconvert
 from ._extension import Extension, ExtensionProxy
 from ._manager import ExtensionManager, get_cached_extension_manager
 from ._manifest import ManifestExtension
@@ -24,4 +24,5 @@ __all__ = [
     "ConverterProxy",
     "Compressor",
     "Validator",
+    "Reconvert",
 ]

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -208,6 +208,11 @@ class ConverterProxy(Converter):
         self._tags = sorted(relevant_tags)
 
         self._types = []
+        if not len(self._tags) and not hasattr(delegate, "select_tag"):
+            # the wrapped Converter supports no tags relevant to this extension
+            # and doesn't implement select_tag (which might return a supported
+            # tag) so we don't need to process it's types
+            return
         for typ in delegate.types:
             if isinstance(typ, (str, type)):
                 self._types.append(typ)
@@ -400,3 +405,14 @@ class ConverterProxy(Converter):
         package_description = "(none)" if self.package_name is None else f"{self.package_name}=={self.package_version}"
 
         return f"<ConverterProxy class: {self.class_name} package: {package_description}>"
+
+
+class Reconvert:
+    """
+    A special return type for `select_tag` to tell asdf
+    that this object has been converted to a new type
+    and should be handled by a different converter
+    """
+
+    def __init__(self, obj):
+        self.obj = obj

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -33,22 +33,18 @@ class ExtensionManager:
                 if tag_def.tag_uri not in self._tag_defs_by_tag:
                     self._tag_defs_by_tag[tag_def.tag_uri] = tag_def
             for converter in extension.converters:
-                # If a converter's tags do not actually overlap with
-                # the extension tag list, then there's no reason to
-                # use it.
-                if len(converter.tags) > 0:
-                    for tag in converter.tags:
-                        if tag not in self._converters_by_tag:
-                            self._converters_by_tag[tag] = converter
-                    for typ in converter.types:
-                        if isinstance(typ, str):
-                            if typ not in self._converters_by_type:
-                                self._converters_by_type[typ] = converter
-                        else:
-                            type_class_name = get_class_name(typ, instance=False)
-                            if typ not in self._converters_by_type and type_class_name not in self._converters_by_type:
-                                self._converters_by_type[typ] = converter
-                                self._converters_by_type[type_class_name] = converter
+                for tag in converter.tags:
+                    if tag not in self._converters_by_tag:
+                        self._converters_by_tag[tag] = converter
+                for typ in converter.types:
+                    if isinstance(typ, str):
+                        if typ not in self._converters_by_type:
+                            self._converters_by_type[typ] = converter
+                    else:
+                        type_class_name = get_class_name(typ, instance=False)
+                        if typ not in self._converters_by_type and type_class_name not in self._converters_by_type:
+                            self._converters_by_type[typ] = converter
+                            self._converters_by_type[type_class_name] = converter
 
             validators.update(extension.validators)
 

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 
 import numpy as np
 
-from . import _types, generic_io, treeutil, util
+from . import generic_io, treeutil, util
 from .util import patched_urllib_parse
 
 __all__ = ["resolve_fragment", "Reference", "find_references", "resolve_references", "make_reference"]
@@ -42,9 +42,7 @@ def resolve_fragment(tree, pointer):
     return tree
 
 
-class Reference(_types._AsdfType):
-    yaml_tag = "tag:yaml.org,2002:map"
-
+class Reference:
     def __init__(self, uri, base_uri=None, asdffile=None, target=None):
         self._uri = uri
         if asdffile is not None:
@@ -104,15 +102,6 @@ class Reference(_types._AsdfType):
 
     def __contains__(self, item):
         return item in self._get_target()
-
-    @classmethod
-    def to_tree(cls, data, ctx):
-        uri = generic_io.relative_uri(ctx.uri, data._uri) if ctx.uri is not None else data._uri
-        return {"$ref": uri}
-
-    @classmethod
-    def validate(cls, data):
-        pass
 
 
 def find_references(tree, ctx):


### PR DESCRIPTION
This is **draft** PR and should not be merged.

It is missing tests and documentation for the API changes. It is intended to compare alternative approaches for updating the extension API to support `asdf.reference.Reference`.

This is an alternative set of changes (compared to #1559) to allow `asdf.reference.Reference` to be handled by a `Converter`.

This PR introduces a change to the extension API to allow `Converter.select_tag` to return a special `Reconvert` instance. This will inform asdf that the object that was to be handled by this converter has been transformed and should be handled by a different converter (or no other converter as is the case for `asdf.reference.Reference`).

This should also allow converters to delegate to other converters (to allow asdf-astropy to convert NdarrayMixin instances to ndarray and stdatamodels to convert FITS_rec to ndarray prior to serialization). The specific details for these converters need to be sorted once an approach for updating the extension API is generally agreed upon. To expand on the asdf-astropy/NdarrayMixin issue, the following `Converter` (with the changes in this PR) should fix the issue:
```python
class NdarrayMixinConverter(Converter):
    tags = []

    types = ["astropy.table.ndarray_mixin.NdarrayMixin"]

    def to_yaml_tree(self, obj, tag, ctx):
        raise NotImplementedError()

    def from_yaml_tree(self, node, tag, ctx):
        raise NotImplementedError()

    def select_tag(self, obj, tags, ctx):
        return Reconvert(np.ndarray(obj))
```

I think the user facing API is a bit more obvious compared to #1559. However, the introduction of a special return type does not appear to match the rest of the asdf API (I'm not sure there's another example where this technique is used). The usage of this return type in `select_tag` also feels a bit out-of-place as the object is converted to a new type in `select_tag` which then returns a non-tag object.

As can be seen in the above example (and with `ReferenceConverter`) slight changes were required to `ConverterProxy` and `Manager` to allows converters with no relevant tags to be included. This check for relevant tags was added to the proxy (which will skip proxying types for converters that have no relevant tags and don't implement select tag). However this broke one test which expected that a proxied converter without relevant tags would have it's types checked. The `test_converter_proxy` test was updated and a comment added to describe the change. 