### PR TITLE
Allow converter deferral and move Reference to a converter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ The ASDF Standard is at v1.6.0
 - Drop Python 3.8 support [#1556]
 - Drop NumPy 1.20, 1.21 support [#1568]
 - Fix issue opening files that don't support ``fileno`` [#1557]
+- Allow Converters to defer conversion to other Converters
+  by returning ``None`` in ``Converter.select_tag`` [#1561]
 
 2.15.0 (2023-03-28)
 -------------------

--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -600,7 +600,10 @@ def test_converter_proxy():
 
     # Should fail because types must instances of type:
     with pytest.raises(TypeError, match=r"Converter property .* must contain str or type values"):
-        ConverterProxy(MinimumConverter(types=[object()]), extension)
+        # as the code will ignore types if no relevant tags are found
+        # include a tag from this extension to make sure the proxy considers
+        # the types
+        ConverterProxy(MinimumConverter(tags=[extension.tags[0].tag_uri], types=[object()]), extension)
 
 
 def test_get_cached_asdf_extension_list():

--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -18,6 +18,7 @@ from asdf.extension import (
     get_cached_extension_manager,
 )
 from asdf.extension._legacy import BuiltinExtension, _AsdfExtension, get_cached_asdf_extension_list
+from asdf.testing.helpers import roundtrip_object
 
 
 def test_builtin_extension():
@@ -763,3 +764,51 @@ def test_validator():
             af["foo"] = "bar"
             with pytest.raises(ValidationError, match=r"Node was doomed to fail"):
                 af.validate()
+
+
+def test_converter_deferral():
+    class Bar:
+        def __init__(self, value):
+            self.value = value
+
+    class Foo(Bar):
+        pass
+
+    class FooConverter:
+        tags = []
+        types = [Foo]
+
+        def select_tag(self, *args):
+            return None
+
+        def to_yaml_tree(self, obj, tag, ctx):
+            # convert Foo instance to Bar
+            return Bar(obj.value)
+
+        def from_yaml_tree(self, node, tag, ctx):
+            raise NotImplementedError()
+
+    class BarConverter:
+        tags = ["asdf://somewhere.org/tags/bar"]
+        types = [Bar]
+
+        def to_yaml_tree(self, obj, tag, ctx):
+            return {"value": obj.value}
+
+        def from_yaml_tree(self, node, tag, ctx):
+            return Bar(node["value"])
+
+    extension = FullExtension(converters=[FooConverter(), BarConverter()], tags=BarConverter.tags)
+    with config_context() as config:
+        config.add_extension(extension)
+
+        foo = Foo(26)
+        bar = Bar(42)
+
+        bar_rt = roundtrip_object(bar)
+        assert isinstance(bar_rt, Bar)
+        assert bar_rt.value == bar.value
+
+        foo_rt = roundtrip_object(foo)
+        assert isinstance(foo_rt, Bar)
+        assert foo_rt.value == foo.value

--- a/asdf/core/_converters/reference.py
+++ b/asdf/core/_converters/reference.py
@@ -1,0 +1,18 @@
+from asdf.extension import Converter
+
+
+class ReferenceConverter(Converter):
+    tags = []
+    types = ["asdf.reference.Reference"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        from asdf.generic_io import relative_uri
+
+        uri = relative_uri(ctx.url, obj._uri) if ctx.url is not None else obj._uri
+        return {"$ref": uri}
+
+    def from_yaml_tree(self, node, tag, ctx):
+        raise NotImplementedError()
+
+    def select_tag(self, obj, tags, ctx):
+        return None

--- a/asdf/core/_extensions.py
+++ b/asdf/core/_extensions.py
@@ -3,6 +3,7 @@ from asdf.extension import ManifestExtension
 from ._converters.complex import ComplexConverter
 from ._converters.constant import ConstantConverter
 from ._converters.external_reference import ExternalArrayReferenceConverter
+from ._converters.reference import ReferenceConverter
 from ._converters.tree import (
     AsdfObjectConverter,
     ExtensionMetadataConverter,
@@ -21,6 +22,7 @@ CONVERTERS = [
     HistoryEntryConverter(),
     SoftwareConverter(),
     SubclassMetadataConverter(),
+    ReferenceConverter(),
 ]
 
 

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -208,6 +208,11 @@ class ConverterProxy(Converter):
         self._tags = sorted(relevant_tags)
 
         self._types = []
+
+        if not len(self._tags) and not hasattr(delegate, "select_tag"):
+            # this converter supports no tags so don't inspect the types
+            return
+
         for typ in delegate.types:
             if isinstance(typ, (str, type)):
                 self._types.append(typ)

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -76,9 +76,11 @@ class Converter(abc.ABC):
 
         Returns
         -------
-        str
+        str or None
             The selected tag.  Should be one of the tags passed
-            to this method in the `tags` parameter.
+            to this method in the `tags` parameter.  If `None`
+            the result of ``to_yaml_tree`` will be used to look
+            up the next converter for this object.
         """
         return tags[0]
 
@@ -257,8 +259,8 @@ class ConverterProxy(Converter):
 
         Returns
         -------
-        str
-            Selected tag.
+        str or None
+            Selected tag or `None` to defer conversion.
         """
         method = getattr(self._delegate, "select_tag", None)
         if method is None:

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -33,22 +33,18 @@ class ExtensionManager:
                 if tag_def.tag_uri not in self._tag_defs_by_tag:
                     self._tag_defs_by_tag[tag_def.tag_uri] = tag_def
             for converter in extension.converters:
-                # If a converter's tags do not actually overlap with
-                # the extension tag list, then there's no reason to
-                # use it.
-                if len(converter.tags) > 0:
-                    for tag in converter.tags:
-                        if tag not in self._converters_by_tag:
-                            self._converters_by_tag[tag] = converter
-                    for typ in converter.types:
-                        if isinstance(typ, str):
-                            if typ not in self._converters_by_type:
-                                self._converters_by_type[typ] = converter
-                        else:
-                            type_class_name = get_class_name(typ, instance=False)
-                            if typ not in self._converters_by_type and type_class_name not in self._converters_by_type:
-                                self._converters_by_type[typ] = converter
-                                self._converters_by_type[type_class_name] = converter
+                for tag in converter.tags:
+                    if tag not in self._converters_by_tag:
+                        self._converters_by_tag[tag] = converter
+                for typ in converter.types:
+                    if isinstance(typ, str):
+                        if typ not in self._converters_by_type:
+                            self._converters_by_type[typ] = converter
+                    else:
+                        type_class_name = get_class_name(typ, instance=False)
+                        if typ not in self._converters_by_type and type_class_name not in self._converters_by_type:
+                            self._converters_by_type[typ] = converter
+                            self._converters_by_type[type_class_name] = converter
 
             validators.update(extension.validators)
 

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 
 import numpy as np
 
-from . import _types, generic_io, treeutil, util
+from . import generic_io, treeutil, util
 from .util import patched_urllib_parse
 
 __all__ = ["resolve_fragment", "Reference", "find_references", "resolve_references", "make_reference"]
@@ -42,9 +42,7 @@ def resolve_fragment(tree, pointer):
     return tree
 
 
-class Reference(_types._AsdfType):
-    yaml_tag = "tag:yaml.org,2002:map"
-
+class Reference:
     def __init__(self, uri, base_uri=None, asdffile=None, target=None):
         self._uri = uri
         if asdffile is not None:
@@ -104,15 +102,6 @@ class Reference(_types._AsdfType):
 
     def __contains__(self, item):
         return item in self._get_target()
-
-    @classmethod
-    def to_tree(cls, data, ctx):
-        uri = generic_io.relative_uri(ctx.uri, data._uri) if ctx.uri is not None else data._uri
-        return {"$ref": uri}
-
-    @classmethod
-    def validate(cls, data):
-        pass
 
 
 def find_references(tree, ctx):


### PR DESCRIPTION
Following the ASDF tag-up discussion here is another option for moving Reference to a converter based on the suggestions from @eslavich 

`asdf.reference.Reference` serializes to an untagged dictionary.
https://github.com/asdf-format/asdf/blob/b0c9a50e8d3add337e1271369a3bf834925176a4/asdf/reference.py#L45-L46
https://github.com/asdf-format/asdf/blob/b0c9a50e8d3add337e1271369a3bf834925176a4/asdf/reference.py#L108-L111

This type of conversion is unsupported in the new extension API (using Converters) in asdf main. To allow `Reference` to be moved to a `Converter` this PR introduces the ability to define converters that defer conversion to other converters (or in the case of `Reference` to un-tagged serialization to a yaml map).

This PR changes the public API of `Converter.select_tag` (in a backwards compatible way) allowing it to return `None` when asdf should convert the object being serialized with a different converter. When `select_tag` returns None, the deferring `Converter.to_yaml_tree` is called on the object being serialized to convert the object instance from one type (the one that triggered deferral) to another type (which can either then defer to another converter or return a valid tag and serialize the object).

In the case of `Reference` the new `ReferenceConverter.select_tag` returns None and `ReferenceConverter.to_yaml_tree` returns a 'vanilla' dictionary which will be converted to an untagged yaml map.

This converter deferral can be used to support subclasses that can be serialized as the superclass (which was done automatically with the old extension API) and docs were updated to describe options for how subclasses can be supported. The changes in this PR provide a migration path for user code that previously relied on ndarray subclass conversion as described in https://github.com/asdf-format/asdf/pull/1537