### PR TITLE
Add `zstd` as a built-in compression algorithm

### DIFF
--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -73,6 +73,6 @@ jobs:
           run: |
             python3 -m venv --system-site-packages tests
             source tests/bin/activate
-            pip3 install --upgrade pip setuptools gwcs pytest pytest-doctestplus pytest-remotedata
+            pip3 install --upgrade pip setuptools gwcs pytest pytest-doctestplus pytest-remotedata zstandard
             pip3 install -e .[all,tests]
             python3 -m pytest --remote-data

--- a/README.rst
+++ b/README.rst
@@ -162,9 +162,12 @@ It is possible to compress the array data when writing the file:
 
     af.write_to("compressed.asdf", all_array_compression="zlib")
 
-The built-in compression algorithms are ``'zlib'``, and ``'bzp2'``.  The
-``'lz4'`` algorithm becomes available when the `lz4 <https://python-lz4.readthedocs.io/>`__ package
-is installed.  Other compression algorithms may be available via extensions.
+The built-in compression algorithms are ``'zlib'``, and ``'bzp2'``.
+The ``'lz4'`` algorithm becomes available when the
+`lz4 <https://python-lz4.readthedocs.io/>`__ package is installed.
+The ``'zstd'`` algorithm becomes available when the
+`zstandard <https://python-zstandard.readthedocs.io//>`__ package is installed.
+Other compression algorithms may be available via extensions.
 
 .. _end-compress-file:
 

--- a/asdf/_tests/commands/tests/test_defragment.py
+++ b/asdf/_tests/commands/tests/test_defragment.py
@@ -52,3 +52,8 @@ def test_defragment_bzp2(tmpdir):
 def test_defragment_lz4(tmpdir):
     pytest.importorskip("lz4")
     _test_defragment(tmpdir, "lz4")
+
+
+def test_defragment_zstd(tmpdir):
+    pytest.importorskip("zstandard")
+    _test_defragment(tmpdir, "zstd")

--- a/asdf/_tests/test_array_blocks.py
+++ b/asdf/_tests/test_array_blocks.py
@@ -860,9 +860,11 @@ def test_block_allocation_on_validate():
 
 
 @pytest.mark.parametrize("all_array_storage", ["internal", "external", "inline"])
-@pytest.mark.parametrize("all_array_compression", [None, "", "zlib", "bzp2", "lz4", "input"])
+@pytest.mark.parametrize("all_array_compression",
+                         [None, "", "zlib", "bzp2", "lz4", "zstd", "input"])
 @pytest.mark.parametrize("compression_kwargs", [None, {}])
-def test_write_to_update_storage_options(tmp_path, all_array_storage, all_array_compression, compression_kwargs):
+def test_write_to_update_storage_options(tmp_path, all_array_storage,
+                                         all_array_compression, compression_kwargs):
     if all_array_compression == "bzp2" and compression_kwargs is not None:
         compression_kwargs = {"compresslevel": 1}
 

--- a/asdf/_tests/test_compression.py
+++ b/asdf/_tests/test_compression.py
@@ -113,6 +113,13 @@ def test_lz4(tmp_path):
     _roundtrip(tmp_path, tree, "lz4")
 
 
+def test_zstd(tmp_path):
+    pytest.importorskip("zstandard")
+    tree = _get_large_tree()
+
+    _roundtrip(tmp_path, tree, "zstd")
+
+
 def test_recompression(tmp_path):
     tree = _get_large_tree()
     tmpfile = os.path.join(str(tmp_path), "test1.asdf")

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -700,6 +700,8 @@ class AsdfFile:
 
             - ``lz4``: Use lz4 compression
 
+            - ``zstd``: Use zstd compression
+
             - ``input``: Use the same compression as in the file read.
               If there is no prior file, acts as None.
 
@@ -1084,6 +1086,8 @@ class AsdfFile:
 
             - ``lz4``: Use lz4 compression.
 
+            - ``zstd``: Use zstd compression.
+
             - ``input``: Use the same compression as in the file read.
               If there is no prior file, acts as None
 
@@ -1245,6 +1249,8 @@ class AsdfFile:
             - ``bzp2``: Use bzip2 compression.
 
             - ``lz4``: Use lz4 compression.
+
+            - ``zstd``: Use zstd compression.
 
             - ``input``: Use the same compression as in the file read.
               If there is no prior file, acts as None.

--- a/asdf/commands/defragment.py
+++ b/asdf/commands/defragment.py
@@ -33,8 +33,8 @@ class Defragment(Command):
             "-c",
             type=str,
             nargs="?",
-            choices=["zlib", "bzp2", "lz4"],
-            help="""Compress blocks using one of "zlib", "bzp2" or "lz4".""",
+            choices=["zlib", "bzp2", "lz4", "zstd"],
+            help="""Compress blocks using one of "zlib", "bzp2", "lz4" or "zstd".""",
         )
 
         parser.set_defaults(func=cls.run)

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -223,8 +223,9 @@ class ZlibCompressor:
         i = 0
         for block in blocks:
             decomp = decompressor.decompress(block)
-            out[i : i + len(decomp)] = decomp
-            i += len(decomp)
+            nbytes = len(decomp)
+            out[i : i + nbytes] = decomp
+            i += nbytes
         return i
 
 
@@ -239,8 +240,9 @@ class Bzp2Compressor:
         i = 0
         for block in blocks:
             decomp = decompressor.decompress(block)
-            out[i : i + len(decomp)] = decomp
-            i += len(decomp)
+            nbytes = len(decomp)
+            out[i : i + nbytes] = decomp
+            i += nbytes
         return i
 
 

--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -58,9 +58,8 @@ class Lz4Compressor:
             import lz4.block
         except ImportError as err:
             msg = (
-                "lz4 library in not installed in your Python environment, "
-                "therefore the compressed block in this ASDF file "
-                "can not be decompressed."
+                "The `lz4` library is not installed in your Python environment, "
+                "therefore the compressed block in this ASDF file cannot be decompressed."
             )
             raise ImportError(msg) from err
 
@@ -107,15 +106,15 @@ class Lz4Compressor:
                         blk = blk[4:]
 
                 if len(blk) < _size or _buffer is not None:
-                    # If we have a partial block, or we're already filling a buffer, use the buffer
+                    # If we have a partial block, or we're already filling a buffer,
+                    # use the buffer
                     if _buffer is None:
-                        _buffer = np.empty(
-                            _size,
-                            dtype=np.byte,
-                        )  # use numpy instead of bytearray so we can avoid zero initialization
+                        # use np.empty instead of bytearray so we can avoid zero fill:
+                        _buffer = np.empty(_size, dtype=np.byte)
                         _pos = 0
                     newbytes = min(_size - _pos, len(blk))  # don't fill past the buffer len!
-                    _buffer[_pos : _pos + newbytes] = np.frombuffer(blk[:newbytes], dtype=np.byte)
+                    _buffer[_pos : _pos + newbytes] = np.frombuffer(blk[:newbytes],
+                                                                    dtype=np.byte)
                     _pos += newbytes
                     blk = blk[newbytes:]
 
@@ -127,7 +126,8 @@ class Lz4Compressor:
                         _size = 0
                 else:
                     # We have at least one full block
-                    _out = self._api.decompress(memoryview(blk[:_size]), return_bytearray=True, **kwargs)
+                    _out = self._api.decompress(memoryview(blk[:_size]),
+                                                return_bytearray=True, **kwargs)
                     out[bytesout : bytesout + len(_out)] = _out
                     bytesout += len(_out)
                     blk = blk[_size:]

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -361,6 +361,8 @@ class AsdfConfig:
 
         - ``lz4``: Use lz4 compression.
 
+        - ``zstd``: Use zstd compression.
+
         - ``input``: Use the same compression as in the file read.
           If there is no prior file, acts as None
         """

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -243,6 +243,10 @@ The `lz4 <https://en.wikipedia.org/wiki/LZ_4>`__ compression algorithm is also
 supported, but requires the optional
 `lz4 <https://python-lz4.readthedocs.io/>`__ package in order to work.
 
+The `zstd <https://en.wikipedia.org/wiki/LZ_4>`__ compression algorithm is also
+supported, but requires the optional
+`zstandard <https://python-zstandard.readthedocs.io/>`__ package in order to work.
+
 When reading a file with compressed blocks, the blocks will be automatically
 decompressed when accessed. If a file with compressed blocks is read and then
 written out again, by default the new file will use the same compression as the

--- a/docs/asdf/install.rst
+++ b/docs/asdf/install.rst
@@ -20,6 +20,10 @@ types.  One recommended option is the `astropy <https://www.astropy.org/>`__ pac
 Optional support for `lz4 <https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)>`__
 compression is provided by the `lz4 <https://python-lz4.readthedocs.io/>`__ package.
 
+Optional support for `zstd <https://en.wikipedia.org/wiki/Zstd>`__
+compression is provided by the `zstandard <https://python-zstandard.readthedocs.io/>`__
+package.
+
 Installing with pip
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 all = [
   "lz4>=0.10",
+  "zstandard>=0.21.0",
 ]
 docs = [
   "sphinx-asdf>=0.1.4",
@@ -42,6 +43,7 @@ tests = [
   "fsspec[http]>=2022.8.2",
   "gwcs>=0.18.3",
   "lz4>=0.10",
+  "zstandard>=0.21.0",
   "psutil",
   "pytest>=6",
   "pytest-doctestplus",


### PR DESCRIPTION
Hello! I've been silently watching ASDF for a while now, in our search for a potential scientific data packaging format other than HDF5. I'm very impressed and convinced that ASDF is the one.

While looking into compression, I discovered `zstd`, and think it would be worthy to add zstd as a built-in compression algorithm, to complement `lz4`. `zstd` is the clear successor to `lz4`, written by the same author. The two are similar in their very high decompression speed, but zstd compresses faster at a given compression ratio, or compresses better at a given compression speed. Decompression speed is constant regardless of compression level.

In my own informal tests on a ~1GB 2D uint16 array, I find zstd at level 5 compresses in ~ 13 s and decompresses in ~ 3 s, with a compression ratio of 2.5. The closest I can get with lz4 is at "hi" compression level 9, which takes ~ 90 s to compress and ~ 2.5 s to decompress, with a compression ratio of 1.9. This is on a 7 year old i7-6600U laptop with 16 GB of RAM.

I know there have been a couple of mentions of zstd here in the issues/PRs, especially as a BOSC plugin. I tried setting it up as a plugin, but got stuck pretty quickly, and found it easier to simply add it as a built-in. The code is very analogous to the existing lz4, zlib and bz2 code. I also added a unit test, which seems to run successfully on my system (some other tests fail, esp YAML-related, but I think I may be missing some configuration settings or packages).

Please let me know how I can improve this. It would be great to see this state of the art compression algorithm built into ASDF!