### PR TITLE
Replace LZ4 block compressor with frame compressor

### DIFF
--- a/asdf/compression.py
+++ b/asdf/compression.py
@@ -169,12 +169,13 @@ class Lz4Compressor:
             A block of compressed data
         """
         if "mode" in kwargs:
-            raise ValueError("Deprecated compression kwarg `mode`, use integer "
-                             "`compression_level` instead (fast: 0--2, high: 3--16, "
-                             "default: 0")
+            raise ValueError(
+                "Deprecated compression kwarg `mode`, use integer "
+                "`compression_level` instead (fast: 0--2, high: 3--16, "
+                "default: 0"
+            )
         if "compression_block_size" in kwargs:
-            raise ValueError("Deprecated compression kwarg `compression_block_size`, "
-                             "`block_size` instead")
+            raise ValueError("Deprecated compression kwarg `compression_block_size`, " "`block_size` instead")
 
         # override default 64 KiB block size:
         block_size = kwargs.pop("block_size", self._api.BLOCKSIZE_MAX4MB)


### PR DESCRIPTION
The lz4 frame format is now preferred over the bare block format (implemented in ASDF in 2017):

https://python-lz4.readthedocs.io/en/stable/lz4.frame.html

https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md

Justification:

* More portable across implementations (more metadata)
* Has a stream API that is directly analogous to Python's zlib and bz2 -> greatly simplifies decompression code in ASDF
* Seems to decompress streamed data faster than the existing custom ASDF streaming implementation: 2 s vs 3 s for ~ 1 GB of array data, and ~ 30 MB less memory. Compression speeds and ratios seem to be unchanged.

Unfortunately, the two formats are incompatible, so decompression of the block format in existing .asdf files would need to remain for backward compatibility.

Perhaps this can be implemented as an extension instead, and the existing lz4 block format left unchanged?