### PR TITLE
raise AttributeError for __asdf_traverse__ on NDArrayType

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ The ASDF Standard is at v1.6.0
 - Remove deprecated TagDefinition.schema_uri [#1595]
 - Removed deprecated AsdfFile.open and deprecated asdf.open
   AsdfFile.write_to and AsdfFile.update kwargs [#1592]
+- Fix ``AsdfFile.info`` loading all array data [#1572]
 
 2.15.1 (2023-08-07)
 -------------------

--- a/asdf/_tests/_issues/test_1553.py
+++ b/asdf/_tests/_issues/test_1553.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+import asdf
+
+
+def test_1553(tmp_path):
+    """
+    AsdfFile.info loads array data
+
+    https://github.com/asdf-format/asdf/issues/1553
+    """
+    fn = tmp_path / "test.asdf"
+    tree = dict([(k, np.arange(ord(k))) for k in "abc"])
+    asdf.AsdfFile(tree).write_to(fn)
+
+    with asdf.open(fn) as af:
+        assert "unloaded" in str(af["b"])
+        af.info()
+        assert "unloaded" in str(af["b"])

--- a/asdf/_tests/_regtests/test_1553.py
+++ b/asdf/_tests/_regtests/test_1553.py
@@ -3,9 +3,9 @@ import numpy as np
 import asdf
 
 
-def test_1553(tmp_path):
+def test_asdf_info_should_not_load_arrays(tmp_path):
     """
-    AsdfFile.info loads array data
+    AsdfFile.info should not load array data
 
     https://github.com/asdf-format/asdf/issues/1553
     """

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -368,6 +368,13 @@ class NDArrayType(_types._AsdfType):
         # number of array creations in the general case.
         if attr == "__array_struct__":
             raise AttributeError
+        # AsdfFile.info will call hasattr(obj, "__asdf_traverse__") which
+        # will trigger this method, making the array, and loading the array
+        # data. Intercept this and raise AttributeError as this class does
+        # not support that method
+        # see: https://github.com/asdf-format/asdf/issues/1553
+        if attr == "__asdf_traverse__":
+            raise AttributeError
         return getattr(self._make_array(), attr)
 
     def __setitem__(self, *args):


### PR DESCRIPTION
NDArrayType does not implement this method and if not intercepted (and an AttributeError raised) than AsdfFile.info will load all array data

Fixes: https://github.com/asdf-format/asdf/issues/1553

This PR adds a regression test for this bug.