### PR TITLE
move SerializationContext to asdf.extension and add it to docs

### DIFF
--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -5,10 +5,10 @@ import pytest
 
 from asdf import config_context, get_config
 from asdf._tests._helpers import assert_no_warnings, assert_tree_match, yaml_to_asdf
-from asdf.asdf import AsdfFile, SerializationContext, open_asdf
+from asdf.asdf import AsdfFile, open_asdf
 from asdf.entry_points import get_extensions
 from asdf.exceptions import AsdfWarning
-from asdf.extension import ExtensionManager, ExtensionProxy
+from asdf.extension import ExtensionManager, ExtensionProxy, SerializationContext
 from asdf.extension._legacy import AsdfExtensionList
 from asdf.versioning import AsdfVersion
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -16,7 +16,7 @@ from . import block, constants, generic_io, reference, schema, treeutil, util, v
 from ._helpers import validate_version
 from .config import config_context, get_config
 from .exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning, DelimiterNotFoundError
-from .extension import Extension, ExtensionProxy, _legacy, get_cached_extension_manager
+from .extension import Extension, ExtensionProxy, SerializationContext, _legacy, get_cached_extension_manager
 from .search import AsdfSearchResult
 from .tags.core import AsdfObject, ExtensionMetadata, HistoryEntry, Software
 from .util import NotSet
@@ -389,7 +389,7 @@ class AsdfFile:
 
         Parameters
         ----------
-        serialization_context : asdf.asdf.SerializationContext
+        serialization_context : asdf.extension.SerializationContext
             The context that was used to serialize the tree.
         """
         if serialization_context.version < versioning.NEW_HISTORY_FORMAT_MIN_VERSION:
@@ -1825,162 +1825,3 @@ def open_asdf(
         ignore_missing_extensions=ignore_missing_extensions,
         **kwargs,
     )
-
-
-class SerializationContext:
-    """
-    Container for parameters of the current (de)serialization.
-
-    This class should not be instantiated directly and instead
-    will be created by the AsdfFile object and provided to extension
-    classes (like Converters) via method arguments.
-    """
-
-    def __init__(self, version, extension_manager, url, block_manager):
-        self._version = validate_version(version)
-        self._extension_manager = extension_manager
-        self._url = url
-        self._block_manager = block_manager
-
-        self.__extensions_used = set()
-
-    @property
-    def url(self):
-        """
-        The URL (if any) of the file being read or written.
-
-        Used to compute relative locations of external files referenced by this
-        ASDF file. The URL will not exist in some cases (e.g. when the file is
-        written to an `io.BytesIO`).
-
-        Returns
-        -------
-        str or None
-        """
-        return self._url
-
-    @property
-    def version(self):
-        """
-        Get the ASDF Standard version.
-
-        Returns
-        -------
-        str
-        """
-        return self._version
-
-    @property
-    def extension_manager(self):
-        """
-        Get the ExtensionManager for enabled extensions.
-
-        Returns
-        -------
-        asdf.extension.ExtensionManager
-        """
-        return self._extension_manager
-
-    def _mark_extension_used(self, extension):
-        """
-        Note that an extension was used when reading or writing the file.
-
-        Parameters
-        ----------
-        extension : asdf.extension.Extension
-        """
-        self.__extensions_used.add(ExtensionProxy.maybe_wrap(extension))
-
-    @property
-    def _extensions_used(self):
-        """
-        Get the set of extensions that were used when reading or writing the file.
-
-        Returns
-        -------
-        set of asdf.extension.Extension
-        """
-        return self.__extensions_used
-
-    def get_block_data_callback(self, index):
-        """
-        Generate a callable that when called will read data
-        from a block at the provided index
-
-        Parameters
-        ----------
-        index : int
-            Block index
-
-        Returns
-        -------
-        callback : callable
-            A callable that when called (with no arguments) returns
-            the block data as a one dimensional array of uint8
-        """
-        blk = self._block_manager.get_block(index)
-        return blk.generate_read_data_callback()
-
-    def assign_block_key(self, block_index, key):
-        """
-        Associate a unique hashable key with a block.
-
-        This is used during Converter.from_yaml_tree and allows
-        the AsdfFile to be aware of which blocks belong to the
-        object handled by the converter and allows load_block
-        to locate the block using the key instead of the index
-        (which might change if a file undergoes an AsdfFile.update).
-
-        If the block index is later needed (like during to_yaml_tree)
-        the key can be used with find_block_index to lookup the
-        block index.
-
-        Parameters
-        ----------
-
-        block_index : int
-            The index of the block to associate with the key
-
-        key : hashable
-            A unique hashable key to associate with a block
-        """
-        blk = self._block_manager.get_block(block_index)
-        if self._block_manager._key_to_block_mapping.get(key, blk) is not blk:
-            msg = f"key {key} is already assigned to a block"
-            raise ValueError(msg)
-        if blk in self._block_manager._key_to_block_mapping.values():
-            msg = f"block {block_index} is already assigned to a key"
-            raise ValueError(msg)
-        self._block_manager._key_to_block_mapping[key] = blk
-
-    def find_block_index(self, lookup_key, data_callback=None):
-        """
-        Find the index of a previously allocated or reserved block.
-
-        This is typically used inside asdf.extension.Converter.to_yaml_tree
-
-        Parameters
-        ----------
-        lookup_key : hashable
-            Unique key used to retrieve the index of a block that was
-            previously allocated or reserved. For ndarrays this is
-            typically the id of the base ndarray.
-
-        data_callback: callable, optional
-            Callable that when called will return data (ndarray) that will
-            be written to a block.
-            At the moment, this is only assigned if a new block
-            is created to avoid circular references during AsdfFile.update.
-
-        Returns
-        -------
-        block_index: int
-            Index of the block where data returned from data_callback
-            will be written.
-        """
-        new_block = lookup_key not in self._block_manager._key_to_block_mapping
-        blk = self._block_manager.find_or_create_block(lookup_key)
-        # if we're not creating a block, don't update the data callback
-        if data_callback is not None and (new_block or (blk._data_callback is None and blk._fd is None)):
-            blk._data_callback = data_callback
-        return self._block_manager.get_source(blk)

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1830,6 +1830,10 @@ def open_asdf(
 class SerializationContext:
     """
     Container for parameters of the current (de)serialization.
+
+    This class should not be instantiated directly and instead
+    will be created by the AsdfFile object and provided to extension
+    classes (like Converters) via method arguments.
     """
 
     def __init__(self, version, extension_manager, url, block_manager):
@@ -1850,7 +1854,7 @@ class SerializationContext:
         written to an `io.BytesIO`).
 
         Returns
-        --------
+        -------
         str or None
         """
         return self._url

--- a/asdf/extension/__init__.py
+++ b/asdf/extension/__init__.py
@@ -9,6 +9,7 @@ from ._converter import Converter, ConverterProxy
 from ._extension import Extension, ExtensionProxy
 from ._manager import ExtensionManager, get_cached_extension_manager
 from ._manifest import ManifestExtension
+from ._serialization_context import SerializationContext
 from ._tag import TagDefinition
 from ._validator import Validator
 
@@ -24,4 +25,5 @@ __all__ = [
     "ConverterProxy",
     "Compressor",
     "Validator",
+    "SerializationContext",
 ]

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -71,7 +71,7 @@ class Converter(abc.ABC):
         tags : list of str
             List of active tags to choose from.  Guaranteed to match
             one of the tag patterns listed in the 'tags' property.
-        ctx : asdf.asdf.SerializationContext
+        ctx : asdf.extension.SerializationContext
             Context of the current serialization request.
 
         Returns
@@ -111,7 +111,7 @@ class Converter(abc.ABC):
             The tag identifying the YAML type that ``obj`` should be
             converted into.  Selected by a call to this converter's
             select_tag method.
-        ctx : asdf.asdf.SerializationContext
+        ctx : asdf.extension.SerializationContext
             The context of the current serialization request.
 
         Returns
@@ -142,7 +142,7 @@ class Converter(abc.ABC):
             The YAML node to convert.
         tag : str
             The YAML tag of the object being converted.
-        ctx : asdf.asdf.SerializationContext
+        ctx : asdf.extension.SerializationContext
             The context of the current deserialization request.
 
         Returns
@@ -254,7 +254,7 @@ class ConverterProxy(Converter):
         ----------
         obj : object
             Instance of the custom type being converted.
-        ctx : asdf.asdf.SerializationContext
+        ctx : asdf.extension.SerializationContext
             Serialization parameters.
 
         Returns
@@ -279,7 +279,7 @@ class ConverterProxy(Converter):
         tag : str
             The tag identifying the YAML type that ``obj`` should be
             converted into.
-        ctx : asdf.asdf.SerializationContext
+        ctx : asdf.extension.SerializationContext
             Serialization parameters.
 
         Returns
@@ -299,7 +299,7 @@ class ConverterProxy(Converter):
             The YAML node to convert.
         tag : str
             The YAML tag of the object being converted.
-        ctx : asdf.asdf.SerializationContext
+        ctx : asdf.extension.SerializationContext
             Serialization parameters.
 
         Returns

--- a/asdf/extension/_serialization_context.py
+++ b/asdf/extension/_serialization_context.py
@@ -1,0 +1,161 @@
+from asdf._helpers import validate_version
+from asdf.extension import ExtensionProxy
+
+
+class SerializationContext:
+    """
+    Container for parameters of the current (de)serialization.
+
+    This class should not be instantiated directly and instead
+    will be created by the AsdfFile object and provided to extension
+    classes (like Converters) via method arguments.
+    """
+
+    def __init__(self, version, extension_manager, url, block_manager):
+        self._version = validate_version(version)
+        self._extension_manager = extension_manager
+        self._url = url
+        self._block_manager = block_manager
+
+        self.__extensions_used = set()
+
+    @property
+    def url(self):
+        """
+        The URL (if any) of the file being read or written.
+
+        Used to compute relative locations of external files referenced by this
+        ASDF file. The URL will not exist in some cases (e.g. when the file is
+        written to an `io.BytesIO`).
+
+        Returns
+        -------
+        str or None
+        """
+        return self._url
+
+    @property
+    def version(self):
+        """
+        Get the ASDF Standard version.
+
+        Returns
+        -------
+        str
+        """
+        return self._version
+
+    @property
+    def extension_manager(self):
+        """
+        Get the ExtensionManager for enabled extensions.
+
+        Returns
+        -------
+        asdf.extension.ExtensionManager
+        """
+        return self._extension_manager
+
+    def _mark_extension_used(self, extension):
+        """
+        Note that an extension was used when reading or writing the file.
+
+        Parameters
+        ----------
+        extension : asdf.extension.Extension
+        """
+        self.__extensions_used.add(ExtensionProxy.maybe_wrap(extension))
+
+    @property
+    def _extensions_used(self):
+        """
+        Get the set of extensions that were used when reading or writing the file.
+
+        Returns
+        -------
+        set of asdf.extension.Extension
+        """
+        return self.__extensions_used
+
+    def get_block_data_callback(self, index):
+        """
+        Generate a callable that when called will read data
+        from a block at the provided index
+
+        Parameters
+        ----------
+        index : int
+            Block index
+
+        Returns
+        -------
+        callback : callable
+            A callable that when called (with no arguments) returns
+            the block data as a one dimensional array of uint8
+        """
+        blk = self._block_manager.get_block(index)
+        return blk.generate_read_data_callback()
+
+    def assign_block_key(self, block_index, key):
+        """
+        Associate a unique hashable key with a block.
+
+        This is used during Converter.from_yaml_tree and allows
+        the AsdfFile to be aware of which blocks belong to the
+        object handled by the converter and allows load_block
+        to locate the block using the key instead of the index
+        (which might change if a file undergoes an AsdfFile.update).
+
+        If the block index is later needed (like during to_yaml_tree)
+        the key can be used with find_block_index to lookup the
+        block index.
+
+        Parameters
+        ----------
+
+        block_index : int
+            The index of the block to associate with the key
+
+        key : hashable
+            A unique hashable key to associate with a block
+        """
+        blk = self._block_manager.get_block(block_index)
+        if self._block_manager._key_to_block_mapping.get(key, blk) is not blk:
+            msg = f"key {key} is already assigned to a block"
+            raise ValueError(msg)
+        if blk in self._block_manager._key_to_block_mapping.values():
+            msg = f"block {block_index} is already assigned to a key"
+            raise ValueError(msg)
+        self._block_manager._key_to_block_mapping[key] = blk
+
+    def find_block_index(self, lookup_key, data_callback=None):
+        """
+        Find the index of a previously allocated or reserved block.
+
+        This is typically used inside asdf.extension.Converter.to_yaml_tree
+
+        Parameters
+        ----------
+        lookup_key : hashable
+            Unique key used to retrieve the index of a block that was
+            previously allocated or reserved. For ndarrays this is
+            typically the id of the base ndarray.
+
+        data_callback: callable, optional
+            Callable that when called will return data (ndarray) that will
+            be written to a block.
+            At the moment, this is only assigned if a new block
+            is created to avoid circular references during AsdfFile.update.
+
+        Returns
+        -------
+        block_index: int
+            Index of the block where data returned from data_callback
+            will be written.
+        """
+        new_block = lookup_key not in self._block_manager._key_to_block_mapping
+        blk = self._block_manager.find_or_create_block(lookup_key)
+        # if we're not creating a block, don't update the data callback
+        if data_callback is not None and (new_block or (blk._data_callback is None and blk._fd is None)):
+            blk._data_callback = data_callback
+        return self._block_manager.get_source(blk)

--- a/docs/asdf/developer_api.rst
+++ b/docs/asdf/developer_api.rst
@@ -7,6 +7,11 @@ Developer API
 The classes and functions documented here will be of use to developers who wish
 to create their own custom ASDF types and extensions.
 
+.. automodapi:: asdf.asdf
+    :no-inheritance-diagram:
+    :include: SerializationContext
+    :skip: AsdfConversionWarning, AsdfDeprecationWarning, AsdfObject, AsdfSearchResult, AsdfWarning, DelimiterNotFoundError, Extension, ExtensionMetadata, ExtensionProxy, HistoryEntry, Software, ValidationError, Version
+
 .. automodapi:: asdf.tagged
 
 .. automodapi:: asdf.exceptions

--- a/docs/asdf/developer_api.rst
+++ b/docs/asdf/developer_api.rst
@@ -7,11 +7,6 @@ Developer API
 The classes and functions documented here will be of use to developers who wish
 to create their own custom ASDF types and extensions.
 
-.. automodapi:: asdf.asdf
-    :no-inheritance-diagram:
-    :include: SerializationContext
-    :skip: AsdfConversionWarning, AsdfDeprecationWarning, AsdfObject, AsdfSearchResult, AsdfWarning, DelimiterNotFoundError, Extension, ExtensionMetadata, ExtensionProxy, HistoryEntry, Software, ValidationError, Version
-
 .. automodapi:: asdf.tagged
 
 .. automodapi:: asdf.exceptions

--- a/docs/asdf/developer_overview.rst
+++ b/docs/asdf/developer_overview.rst
@@ -711,9 +711,9 @@ the code (or users themselves) to create an empty dummy ``AsdfFile`` just
 to use the method.
 
 The new ``Converter`` interface also accepts a ``ctx`` variable, but
-instead of an ``AsdfFile`` it's an instance of `asdf.asdf.SerializationContext`.  This
+instead of an ``AsdfFile`` it's an instance of `asdf.extension.SerializationContext`.  This
 new object will serve the purpose of configuring serialization parameters
 and keeping necessary state, which means that the ``AsdfFile`` can go
-unmodified.  The `asdf.asdf.SerializationContext` will be relatively lightweight and
+unmodified.  The `asdf.extension.SerializationContext` will be relatively lightweight and
 creating it will not incur as much of a performance penalty as creating an
 ``AsdfFile``.

--- a/docs/asdf/developer_overview.rst
+++ b/docs/asdf/developer_overview.rst
@@ -711,9 +711,9 @@ the code (or users themselves) to create an empty dummy ``AsdfFile`` just
 to use the method.
 
 The new ``Converter`` interface also accepts a ``ctx`` variable, but
-instead of an ``AsdfFile`` it's an instance of ``SerializationContext``.  This
+instead of an ``AsdfFile`` it's an instance of `asdf.asdf.SerializationContext`.  This
 new object will serve the purpose of configuring serialization parameters
 and keeping necessary state, which means that the ``AsdfFile`` can go
-unmodified.  The ``SerializationContext`` will be relatively lightweight and
+unmodified.  The `asdf.asdf.SerializationContext` will be relatively lightweight and
 creating it will not incur as much of a performance penalty as creating an
 ``AsdfFile``.

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -356,7 +356,7 @@ array and store it in an ASDF block. This is the easiest and preferred means of
 storing data in ASDF blocks.
 
 For applications that require more flexibility,
-Converters can control block storage through use of the `asdf.asdf.SerializationContext`
+Converters can control block storage through use of the `asdf.extension.SerializationContext`
 provided as an argument to `Converter.to_yaml_tree` `Converter.from_yaml_tree` and `Converter.select_tag`.
 
 It is helpful to first review some details of how ASDF
@@ -423,17 +423,17 @@ A simple example of a Converter using block storage to store the ``payload`` for
 
 During read, ``Converter.from_yaml_tree`` will be called. Within this method
 the Converter should associate any used blocks with unique hashable keys by calling
-`asdf.asdf.SerializationContext.assign_block_key` and can generate (and use) a callable
-function that will return block data using `asdf.asdf.SerializationContext.get_block_data_callback`.
+`asdf.extension.SerializationContext.assign_block_key` and can generate (and use) a callable
+function that will return block data using `asdf.extension.SerializationContext.get_block_data_callback`.
 A callback for reading the data is provided to support lazy loading without
-keeping a reference to the `asdf.asdf.SerializationContext` (which is meant to be
+keeping a reference to the `asdf.extension.SerializationContext` (which is meant to be
 a short lived and lightweight object).
 
 During write, ``Converter.to_yaml_tree`` will be called. The Converter should
-use `asdf.asdf.SerializationContext.find_block_index` to find the location of an
+use `asdf.extension.SerializationContext.find_block_index` to find the location of an
 available block by providing a hashable key unique to this object (this should
 be the same key used during reading to allow ASDF to associate blocks and objects
-during in-place updates). The second argument to `asdf.asdf.SerializationContext.find_block_index`
+during in-place updates). The second argument to `asdf.extension.SerializationContext.find_block_index`
 must be a callable function (returning a ndarray) that ASDF will call when it
 is time to write data to the portion of the file corresponding to this block.
 Note that it's possible this callback will be called multiple times during a

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -356,7 +356,7 @@ array and store it in an ASDF block. This is the easiest and preferred means of
 storing data in ASDF blocks.
 
 For applications that require more flexibility,
-Converters can control block storage through use of the ``SerializationContext``
+Converters can control block storage through use of the `asdf.asdf.SerializationContext`
 provided as an argument to `Converter.to_yaml_tree` `Converter.from_yaml_tree` and `Converter.select_tag`.
 
 It is helpful to first review some details of how ASDF
@@ -423,17 +423,17 @@ A simple example of a Converter using block storage to store the ``payload`` for
 
 During read, ``Converter.from_yaml_tree`` will be called. Within this method
 the Converter should associate any used blocks with unique hashable keys by calling
-``SerializationContext.assign_block_key`` and can generate (and use) a callable
-function that will return block data using ``SerializationContext.get_block_data_callback``.
+`asdf.asdf.SerializationContext.assign_block_key` and can generate (and use) a callable
+function that will return block data using `asdf.asdf.SerializationContext.get_block_data_callback`.
 A callback for reading the data is provided to support lazy loading without
-keeping a reference to the ``SerializationContext`` (which is meant to be
+keeping a reference to the `asdf.asdf.SerializationContext` (which is meant to be
 a short lived and lightweight object).
 
 During write, ``Converter.to_yaml_tree`` will be called. The Converter should
-use ``SerializationContext.find_block_index`` to find the location of an
+use `asdf.asdf.SerializationContext.find_block_index` to find the location of an
 available block by providing a hashable key unique to this object (this should
 be the same key used during reading to allow ASDF to associate blocks and objects
-during in-place updates). The second argument to ``SerializationContext.find_block_index``
+during in-place updates). The second argument to `asdf.asdf.SerializationContext.find_block_index`
 must be a callable function (returning a ndarray) that ASDF will call when it
 is time to write data to the portion of the file corresponding to this block.
 Note that it's possible this callback will be called multiple times during a


### PR DESCRIPTION
As far as I can tell, the public usage of SerializationContext occurs exclusively through extensions.

Rather than document `asdf.asdf` (where `SerializationContext` was implemented prior to this PR) which was previously undocumented, this PR moves `SerializationContext` to `asdf.extension._serialization_context` and exposes it publicly at `asdf.extension.SerializationContext`.

Code that imports `SerializationContext` from `asdf.asdf` should continue to work (as `SerializationContext` is imported in `asdf.asdf`) but should be updated to import from the documented public location once this PR makes it into a release.

Link to relevant updated docs: https://asdf--1573.org.readthedocs.build/en/1573/api/asdf.extension.SerializationContext.html#asdf.extension.SerializationContext

Fixes https://github.com/asdf-format/asdf/issues/1565
Fixes https://github.com/asdf-format/asdf/issues/1549