### PR TITLE
free tree on AsdfFile.close

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ The ASDF Standard is at v1.6.0
 - Removed deprecated AsdfFile.open and deprecated asdf.open
   AsdfFile.write_to and AsdfFile.update kwargs [#1592]
 - Fix ``AsdfFile.info`` loading all array data [#1572]
+- Blank out AsdfFile.tree on close [#1575]
 
 2.15.1 (2023-08-07)
 -------------------

--- a/asdf/_tests/_issues/test_1558.py
+++ b/asdf/_tests/_issues/test_1558.py
@@ -1,0 +1,34 @@
+import weakref
+
+import numpy as np
+import pytest
+
+import asdf
+
+
+def test_1558(tmp_path):
+    """
+    closed AsdfFile instances hold private reference to tree
+
+    https://github.com/asdf-format/asdf/issues/1558
+    """
+
+    fn = tmp_path / "test.asdf"
+    asdf.AsdfFile({"a": np.arange(1000), "b": np.arange(42)}).write_to(fn)
+
+    with asdf.open(fn, copy_arrays=True, lazy_load=False) as af:
+        array_weakref = weakref.ref(af["a"])
+        array_ref = af["b"]
+
+    # we shouldn't be able to access the now closed file
+    with pytest.raises(OSError, match="Cannot access data"):
+        af["a"]
+    with pytest.raises(OSError, match="Cannot access data"):
+        af["b"]
+
+    # we also should not be able to resolve the weak reference
+    # meaning the tree should have been cleaned up
+    r = array_weakref()
+    assert r is None
+
+    assert array_ref is not None

--- a/asdf/_tests/_regtests/test_1558.py
+++ b/asdf/_tests/_regtests/test_1558.py
@@ -6,7 +6,7 @@ import pytest
 import asdf
 
 
-def test_1558(tmp_path):
+def test_asdffile_tree_cleared_on_close(tmp_path):
     """
     closed AsdfFile instances hold private reference to tree
 

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -454,6 +454,9 @@ class AsdfFile:
             self._fd.close()
             self._fd = None
             self._closed = True
+            # as we're closing the file, also empty out the
+            # tree so that references to array data can be released
+            self._tree = AsdfObject()
         for external in self._external_asdf_by_uri.values():
             external.close()
         self._external_asdf_by_uri.clear()


### PR DESCRIPTION
With these changes, when an AsdfFile object is closed the tree (which already could not be accessed because of the tree property gatekeeping) is set to a blank AsdfObject.

This allows the garbage collector to clean up objects referenced in the tree even though the AsdfFile object does not fall out of scope.

Fixes #1558