### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ The ASDF Standard is at v1.6.0
 - Remove deprecated legacy extension API [#1464]
 - Drop Python 3.8 support [#1556]
 - Drop NumPy 1.20, 1.21 support [#1568]
+- Drop asdf-unit-schemas dependency [#1576]
 
 2.15.0 (2023-03-28)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dynamic = [
 dependencies = [
   "asdf-standard>=1.0.1",
   "asdf-transform-schemas>=0.3",
-  "asdf-unit-schemas>=0.1",
   "importlib-metadata>=4.11.4",
   "jmespath>=0.6.2",
   "jsonschema<4.18,>=4.0.1", # jsonschema 4.18 contains incompatible changes: https://github.com/asdf-format/asdf/issues/1485


### PR DESCRIPTION
`asdf-unit-schemas` was never necessary for `asdf`, it only existed so that asdf-format/asdf-standard#342 could be merged without issue.

Since that entire line of support has been abandoned at this point, this dependency should be dropped.