### PR TITLE
Vendorize jsonschema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,16 @@ jobs:
           python-version: 3.9
       coverage: codecov
 
+  jsonschema:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    if: (github.repository == 'asdf-format/asdf' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'jsonschema')))
+    with:
+      submodules: false
+      # Any env name which does not start with `pyXY` will use this Python version.
+      default_python: '3.10'
+      envs: |
+        - linux: jsonschema
+
   asdf-schemas:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,6 @@ build
 eggs
 .eggs
 parts
-bin
-!asdf/json/bin
 var
 sdist
 develop-eggs

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ eggs
 .eggs
 parts
 bin
+!asdf/json/bin
 var
 sdist
 develop-eggs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: "asdf/(extern||_jsonschema)/.*"
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -39,7 +40,7 @@ repos:
   rev: '1.0.0'
   hooks:
     - id: flynt
-      exclude: "asdf/extern/.*"
+      exclude: "asdf/(extern||_jsonschema)/.*"
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: 'v0.0.280'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ The ASDF Standard is at v1.6.0
   by returning ``None`` in ``Converter.select_tag`` [#1561]
 - Convert numpy scalars to python types during yaml encoding
   to handle NEP51 changes for numpy 2.0 [#1605]
+- Vendorize jsonschema 4.17.3 [#1591]
 
 2.15.0 (2023-03-28)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -371,6 +371,13 @@ There are two mailing lists for ASDF:
     **F**\ ormat, information can be found
     `here <https://seismic-data.org/>`__.
 
+License
+-------
+
+ASDF is licensed under a BSD 3-clause style license. See `LICENSE.rst <LICENSE.rst>`_
+for the `licenses folder <https://github.com/asdf-format/asdf/tree/main/licenses>`_ for
+licenses for any included software.
+
 Contributing
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -375,7 +375,7 @@ License
 -------
 
 ASDF is licensed under a BSD 3-clause style license. See `LICENSE.rst <LICENSE.rst>`_
-for the `licenses folder <https://github.com/asdf-format/asdf/tree/main/licenses>`_ for
+for the `licenses folder <licenses>`_ for
 licenses for any included software.
 
 Contributing

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -17,13 +17,12 @@ __all__ = [
 ]
 
 
-from jsonschema import ValidationError
-
 from ._convenience import info
 from ._version import version as __version__
 from .asdf import AsdfFile
 from .asdf import open_asdf as open
 from .config import config_context, get_config
+from .exceptions import ValidationError
 from .stream import Stream
 from .tags.core import IntegerType
 from .tags.core.external_reference import ExternalArrayReference

--- a/asdf/_jsonschema/COPYING
+++ b/asdf/_jsonschema/COPYING
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Julian Berman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/asdf/_jsonschema/README.md
+++ b/asdf/_jsonschema/README.md
@@ -1,0 +1,7 @@
+The files in this directory were originally cloned from
+
+jsonschema 4.17.3
+
+https://github.com/python-jsonschema/jsonschema/releases/tag/v4.17.3
+
+See COPYING for use restrictions

--- a/asdf/_jsonschema/__init__.py
+++ b/asdf/_jsonschema/__init__.py
@@ -1,0 +1,55 @@
+"""
+An implementation of JSON Schema for Python
+
+The main functionality is provided by the validator classes for each of the
+supported JSON Schema versions.
+
+Most commonly, `asdf._jsonschema.validators.validate` is the quickest way to simply
+validate a given instance under a schema, and will create a validator
+for you.
+"""
+import warnings
+
+from asdf._jsonschema._format import FormatChecker
+from asdf._jsonschema._types import TypeChecker
+from asdf._jsonschema.exceptions import (
+    ErrorTree,
+    FormatError,
+    RefResolutionError,
+    SchemaError,
+    ValidationError,
+)
+from asdf._jsonschema.protocols import Validator
+from asdf._jsonschema.validators import (
+    Draft3Validator,
+    Draft4Validator,
+    Draft6Validator,
+    Draft7Validator,
+    Draft201909Validator,
+    Draft202012Validator,
+    RefResolver,
+    validate,
+)
+
+
+def __getattr__(name):
+    format_checkers = {
+        "draft3_format_checker": Draft3Validator,
+        "draft4_format_checker": Draft4Validator,
+        "draft6_format_checker": Draft6Validator,
+        "draft7_format_checker": Draft7Validator,
+        "draft201909_format_checker": Draft201909Validator,
+        "draft202012_format_checker": Draft202012Validator,
+    }
+    ValidatorForFormat = format_checkers.get(name)
+    if ValidatorForFormat is not None:
+        warnings.warn(
+            f"Accessing asdf._jsonschema.{name} is deprecated and will be "
+            "removed in a future release. Instead, use the FORMAT_CHECKER "
+            "attribute on the corresponding Validator.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ValidatorForFormat.FORMAT_CHECKER
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/asdf/_jsonschema/_format.py
+++ b/asdf/_jsonschema/_format.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from uuid import UUID
+import datetime
+import ipaddress
+import re
+import typing
+import warnings
+
+from asdf._jsonschema.exceptions import FormatError
+
+_FormatCheckCallable = typing.Callable[[object], bool]
+_F = typing.TypeVar("_F", bound=_FormatCheckCallable)
+_RaisesType = typing.Union[
+    typing.Type[Exception], typing.Tuple[typing.Type[Exception], ...],
+]
+
+
+class FormatChecker:
+    """
+    A ``format`` property checker.
+
+    JSON Schema does not mandate that the ``format`` property actually do any
+    validation. If validation is desired however, instances of this class can
+    be hooked into validators to enable format validation.
+
+    `FormatChecker` objects always return ``True`` when asked about
+    formats that they do not know how to validate.
+
+    To add a check for a custom format use the `FormatChecker.checks`
+    decorator.
+
+    Arguments:
+
+        formats:
+
+            The known formats to validate. This argument can be used to
+            limit which formats will be used during validation.
+    """
+
+    checkers: dict[
+        str,
+        tuple[_FormatCheckCallable, _RaisesType],
+    ] = {}
+
+    def __init__(self, formats: typing.Iterable[str] | None = None):
+        if formats is None:
+            formats = self.checkers.keys()
+        self.checkers = {k: self.checkers[k] for k in formats}
+
+    def __repr__(self):
+        return "<FormatChecker checkers={}>".format(sorted(self.checkers))
+
+    def checks(
+        self, format: str, raises: _RaisesType = (),
+    ) -> typing.Callable[[_F], _F]:
+        """
+        Register a decorated function as validating a new format.
+
+        Arguments:
+
+            format:
+
+                The format that the decorated function will check.
+
+            raises:
+
+                The exception(s) raised by the decorated function when an
+                invalid instance is found.
+
+                The exception object will be accessible as the
+                `asdf._jsonschema.exceptions.ValidationError.cause` attribute of the
+                resulting validation error.
+        """
+
+        def _checks(func: _F) -> _F:
+            self.checkers[format] = (func, raises)
+            return func
+
+        return _checks
+
+    @classmethod
+    def cls_checks(
+        cls, format: str, raises: _RaisesType = (),
+    ) -> typing.Callable[[_F], _F]:
+        warnings.warn(
+            (
+                "FormatChecker.cls_checks is deprecated. Call "
+                "FormatChecker.checks on a specific FormatChecker instance "
+                "instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls._cls_checks(format=format, raises=raises)
+
+    @classmethod
+    def _cls_checks(
+        cls, format: str, raises: _RaisesType = (),
+    ) -> typing.Callable[[_F], _F]:
+        def _checks(func: _F) -> _F:
+            cls.checkers[format] = (func, raises)
+            return func
+
+        return _checks
+
+    def check(self, instance: object, format: str) -> None:
+        """
+        Check whether the instance conforms to the given format.
+
+        Arguments:
+
+            instance (*any primitive type*, i.e. str, number, bool):
+
+                The instance to check
+
+            format:
+
+                The format that instance should conform to
+
+        Raises:
+
+            FormatError:
+
+                if the instance does not conform to ``format``
+        """
+
+        if format not in self.checkers:
+            return
+
+        func, raises = self.checkers[format]
+        result, cause = None, None
+        try:
+            result = func(instance)
+        except raises as e:
+            cause = e
+        if not result:
+            raise FormatError(f"{instance!r} is not a {format!r}", cause=cause)
+
+    def conforms(self, instance: object, format: str) -> bool:
+        """
+        Check whether the instance conforms to the given format.
+
+        Arguments:
+
+            instance (*any primitive type*, i.e. str, number, bool):
+
+                The instance to check
+
+            format:
+
+                The format that instance should conform to
+
+        Returns:
+
+            bool: whether it conformed
+        """
+
+        try:
+            self.check(instance, format)
+        except FormatError:
+            return False
+        else:
+            return True
+
+
+draft3_format_checker = FormatChecker()
+draft4_format_checker = FormatChecker()
+draft6_format_checker = FormatChecker()
+draft7_format_checker = FormatChecker()
+draft201909_format_checker = FormatChecker()
+draft202012_format_checker = FormatChecker()
+
+_draft_checkers: dict[str, FormatChecker] = dict(
+    draft3=draft3_format_checker,
+    draft4=draft4_format_checker,
+    draft6=draft6_format_checker,
+    draft7=draft7_format_checker,
+    draft201909=draft201909_format_checker,
+    draft202012=draft202012_format_checker,
+)
+
+
+def _checks_drafts(
+    name=None,
+    draft3=None,
+    draft4=None,
+    draft6=None,
+    draft7=None,
+    draft201909=None,
+    draft202012=None,
+    raises=(),
+) -> typing.Callable[[_F], _F]:
+    draft3 = draft3 or name
+    draft4 = draft4 or name
+    draft6 = draft6 or name
+    draft7 = draft7 or name
+    draft201909 = draft201909 or name
+    draft202012 = draft202012 or name
+
+    def wrap(func: _F) -> _F:
+        if draft3:
+            func = _draft_checkers["draft3"].checks(draft3, raises)(func)
+        if draft4:
+            func = _draft_checkers["draft4"].checks(draft4, raises)(func)
+        if draft6:
+            func = _draft_checkers["draft6"].checks(draft6, raises)(func)
+        if draft7:
+            func = _draft_checkers["draft7"].checks(draft7, raises)(func)
+        if draft201909:
+            func = _draft_checkers["draft201909"].checks(draft201909, raises)(
+                func,
+            )
+        if draft202012:
+            func = _draft_checkers["draft202012"].checks(draft202012, raises)(
+                func,
+            )
+
+        # Oy. This is bad global state, but relied upon for now, until
+        # deprecation. See #519 and test_format_checkers_come_with_defaults
+        FormatChecker._cls_checks(
+            draft202012 or draft201909 or draft7 or draft6 or draft4 or draft3,
+            raises,
+        )(func)
+        return func
+
+    return wrap
+
+
+@_checks_drafts(name="idn-email")
+@_checks_drafts(name="email")
+def is_email(instance: object) -> bool:
+    if not isinstance(instance, str):
+        return True
+    return "@" in instance
+
+
+@_checks_drafts(
+    draft3="ip-address",
+    draft4="ipv4",
+    draft6="ipv4",
+    draft7="ipv4",
+    draft201909="ipv4",
+    draft202012="ipv4",
+    raises=ipaddress.AddressValueError,
+)
+def is_ipv4(instance: object) -> bool:
+    if not isinstance(instance, str):
+        return True
+    return bool(ipaddress.IPv4Address(instance))
+
+
+@_checks_drafts(name="ipv6", raises=ipaddress.AddressValueError)
+def is_ipv6(instance: object) -> bool:
+    if not isinstance(instance, str):
+        return True
+    address = ipaddress.IPv6Address(instance)
+    return not getattr(address, "scope_id", "")
+
+
+with suppress(ImportError):
+    from fqdn import FQDN
+
+    @_checks_drafts(
+        draft3="host-name",
+        draft4="hostname",
+        draft6="hostname",
+        draft7="hostname",
+        draft201909="hostname",
+        draft202012="hostname",
+    )
+    def is_host_name(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        return FQDN(instance).is_valid
+
+
+with suppress(ImportError):
+    # The built-in `idna` codec only implements RFC 3890, so we go elsewhere.
+    import idna
+
+    @_checks_drafts(
+        draft7="idn-hostname",
+        draft201909="idn-hostname",
+        draft202012="idn-hostname",
+        raises=(idna.IDNAError, UnicodeError),
+    )
+    def is_idn_host_name(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        idna.encode(instance)
+        return True
+
+
+try:
+    import rfc3987
+except ImportError:
+    with suppress(ImportError):
+        from rfc3986_validator import validate_rfc3986
+
+        @_checks_drafts(name="uri")
+        def is_uri(instance: object) -> bool:
+            if not isinstance(instance, str):
+                return True
+            return validate_rfc3986(instance, rule="URI")
+
+        @_checks_drafts(
+            draft6="uri-reference",
+            draft7="uri-reference",
+            draft201909="uri-reference",
+            draft202012="uri-reference",
+            raises=ValueError,
+        )
+        def is_uri_reference(instance: object) -> bool:
+            if not isinstance(instance, str):
+                return True
+            return validate_rfc3986(instance, rule="URI_reference")
+
+else:
+
+    @_checks_drafts(
+        draft7="iri",
+        draft201909="iri",
+        draft202012="iri",
+        raises=ValueError,
+    )
+    def is_iri(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        return rfc3987.parse(instance, rule="IRI")
+
+    @_checks_drafts(
+        draft7="iri-reference",
+        draft201909="iri-reference",
+        draft202012="iri-reference",
+        raises=ValueError,
+    )
+    def is_iri_reference(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        return rfc3987.parse(instance, rule="IRI_reference")
+
+    @_checks_drafts(name="uri", raises=ValueError)
+    def is_uri(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        return rfc3987.parse(instance, rule="URI")
+
+    @_checks_drafts(
+        draft6="uri-reference",
+        draft7="uri-reference",
+        draft201909="uri-reference",
+        draft202012="uri-reference",
+        raises=ValueError,
+    )
+    def is_uri_reference(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        return rfc3987.parse(instance, rule="URI_reference")
+
+
+with suppress(ImportError):
+    from rfc3339_validator import validate_rfc3339
+
+    @_checks_drafts(name="date-time")
+    def is_datetime(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        return validate_rfc3339(instance.upper())
+
+    @_checks_drafts(
+        draft7="time",
+        draft201909="time",
+        draft202012="time",
+    )
+    def is_time(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        return is_datetime("1970-01-01T" + instance)
+
+
+@_checks_drafts(name="regex", raises=re.error)
+def is_regex(instance: object) -> bool:
+    if not isinstance(instance, str):
+        return True
+    return bool(re.compile(instance))
+
+
+@_checks_drafts(
+    draft3="date",
+    draft7="date",
+    draft201909="date",
+    draft202012="date",
+    raises=ValueError,
+)
+def is_date(instance: object) -> bool:
+    if not isinstance(instance, str):
+        return True
+    return bool(instance.isascii() and datetime.date.fromisoformat(instance))
+
+
+@_checks_drafts(draft3="time", raises=ValueError)
+def is_draft3_time(instance: object) -> bool:
+    if not isinstance(instance, str):
+        return True
+    return bool(datetime.datetime.strptime(instance, "%H:%M:%S"))
+
+
+with suppress(ImportError):
+    from webcolors import CSS21_NAMES_TO_HEX
+    import webcolors
+
+    def is_css_color_code(instance: object) -> bool:
+        return webcolors.normalize_hex(instance)
+
+    @_checks_drafts(draft3="color", raises=(ValueError, TypeError))
+    def is_css21_color(instance: object) -> bool:
+        if (
+            not isinstance(instance, str)
+            or instance.lower() in CSS21_NAMES_TO_HEX
+        ):
+            return True
+        return is_css_color_code(instance)
+
+
+with suppress(ImportError):
+    import jsonpointer
+
+    @_checks_drafts(
+        draft6="json-pointer",
+        draft7="json-pointer",
+        draft201909="json-pointer",
+        draft202012="json-pointer",
+        raises=jsonpointer.JsonPointerException,
+    )
+    def is_json_pointer(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        return bool(jsonpointer.JsonPointer(instance))
+
+    # TODO: I don't want to maintain this, so it
+    #       needs to go either into jsonpointer (pending
+    #       https://github.com/stefankoegl/python-json-pointer/issues/34) or
+    #       into a new external library.
+    @_checks_drafts(
+        draft7="relative-json-pointer",
+        draft201909="relative-json-pointer",
+        draft202012="relative-json-pointer",
+        raises=jsonpointer.JsonPointerException,
+    )
+    def is_relative_json_pointer(instance: object) -> bool:
+        # Definition taken from:
+        # https://tools.ietf.org/html/draft-handrews-relative-json-pointer-01#section-3
+        if not isinstance(instance, str):
+            return True
+        if not instance:
+            return False
+
+        non_negative_integer, rest = [], ""
+        for i, character in enumerate(instance):
+            if character.isdigit():
+                # digits with a leading "0" are not allowed
+                if i > 0 and int(instance[i - 1]) == 0:
+                    return False
+
+                non_negative_integer.append(character)
+                continue
+
+            if not non_negative_integer:
+                return False
+
+            rest = instance[i:]
+            break
+        return (rest == "#") or bool(jsonpointer.JsonPointer(rest))
+
+
+with suppress(ImportError):
+    import uri_template
+
+    @_checks_drafts(
+        draft6="uri-template",
+        draft7="uri-template",
+        draft201909="uri-template",
+        draft202012="uri-template",
+    )
+    def is_uri_template(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        return uri_template.validate(instance)
+
+
+with suppress(ImportError):
+    import isoduration
+
+    @_checks_drafts(
+        draft201909="duration",
+        draft202012="duration",
+        raises=isoduration.DurationParsingException,
+    )
+    def is_duration(instance: object) -> bool:
+        if not isinstance(instance, str):
+            return True
+        isoduration.parse_duration(instance)
+        # FIXME: See bolsote/isoduration#25 and bolsote/isoduration#21
+        return instance.endswith(tuple("DMYWHMS"))
+
+
+@_checks_drafts(
+    draft201909="uuid",
+    draft202012="uuid",
+    raises=ValueError,
+)
+def is_uuid(instance: object) -> bool:
+    if not isinstance(instance, str):
+        return True
+    UUID(instance)
+    return all(instance[position] == "-" for position in (8, 13, 18, 23))

--- a/asdf/_jsonschema/_legacy_validators.py
+++ b/asdf/_jsonschema/_legacy_validators.py
@@ -1,0 +1,319 @@
+from asdf._jsonschema import _utils
+from asdf._jsonschema.exceptions import ValidationError
+
+
+def id_of_ignore_ref(property="$id"):
+    def id_of(schema):
+        """
+        Ignore an ``$id`` sibling of ``$ref`` if it is present.
+
+        Otherwise, return the ID of the given schema.
+        """
+        if schema is True or schema is False or "$ref" in schema:
+            return ""
+        return schema.get(property, "")
+    return id_of
+
+
+def ignore_ref_siblings(schema):
+    """
+    Ignore siblings of ``$ref`` if it is present.
+
+    Otherwise, return all keywords.
+
+    Suitable for use with `create`'s ``applicable_validators`` argument.
+    """
+    ref = schema.get("$ref")
+    if ref is not None:
+        return [("$ref", ref)]
+    else:
+        return schema.items()
+
+
+def dependencies_draft3(validator, dependencies, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
+    for property, dependency in dependencies.items():
+        if property not in instance:
+            continue
+
+        if validator.is_type(dependency, "object"):
+            yield from validator.descend(
+                instance, dependency, schema_path=property,
+            )
+        elif validator.is_type(dependency, "string"):
+            if dependency not in instance:
+                message = f"{dependency!r} is a dependency of {property!r}"
+                yield ValidationError(message)
+        else:
+            for each in dependency:
+                if each not in instance:
+                    message = f"{each!r} is a dependency of {property!r}"
+                    yield ValidationError(message)
+
+
+def dependencies_draft4_draft6_draft7(
+    validator,
+    dependencies,
+    instance,
+    schema,
+):
+    """
+    Support for the ``dependencies`` keyword from pre-draft 2019-09.
+
+    In later drafts, the keyword was split into separate
+    ``dependentRequired`` and ``dependentSchemas`` validators.
+    """
+    if not validator.is_type(instance, "object"):
+        return
+
+    for property, dependency in dependencies.items():
+        if property not in instance:
+            continue
+
+        if validator.is_type(dependency, "array"):
+            for each in dependency:
+                if each not in instance:
+                    message = f"{each!r} is a dependency of {property!r}"
+                    yield ValidationError(message)
+        else:
+            yield from validator.descend(
+                instance, dependency, schema_path=property,
+            )
+
+
+def disallow_draft3(validator, disallow, instance, schema):
+    for disallowed in _utils.ensure_list(disallow):
+        if validator.evolve(schema={"type": [disallowed]}).is_valid(instance):
+            message = f"{disallowed!r} is disallowed for {instance!r}"
+            yield ValidationError(message)
+
+
+def extends_draft3(validator, extends, instance, schema):
+    if validator.is_type(extends, "object"):
+        yield from validator.descend(instance, extends)
+        return
+    for index, subschema in enumerate(extends):
+        yield from validator.descend(instance, subschema, schema_path=index)
+
+
+def items_draft3_draft4(validator, items, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
+
+    if validator.is_type(items, "object"):
+        for index, item in enumerate(instance):
+            yield from validator.descend(item, items, path=index)
+    else:
+        for (index, item), subschema in zip(enumerate(instance), items):
+            yield from validator.descend(
+                item, subschema, path=index, schema_path=index,
+            )
+
+
+def items_draft6_draft7_draft201909(validator, items, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
+
+    if validator.is_type(items, "array"):
+        for (index, item), subschema in zip(enumerate(instance), items):
+            yield from validator.descend(
+                item, subschema, path=index, schema_path=index,
+            )
+    else:
+        for index, item in enumerate(instance):
+            yield from validator.descend(item, items, path=index)
+
+
+def minimum_draft3_draft4(validator, minimum, instance, schema):
+    if not validator.is_type(instance, "number"):
+        return
+
+    if schema.get("exclusiveMinimum", False):
+        failed = instance <= minimum
+        cmp = "less than or equal to"
+    else:
+        failed = instance < minimum
+        cmp = "less than"
+
+    if failed:
+        message = f"{instance!r} is {cmp} the minimum of {minimum!r}"
+        yield ValidationError(message)
+
+
+def maximum_draft3_draft4(validator, maximum, instance, schema):
+    if not validator.is_type(instance, "number"):
+        return
+
+    if schema.get("exclusiveMaximum", False):
+        failed = instance >= maximum
+        cmp = "greater than or equal to"
+    else:
+        failed = instance > maximum
+        cmp = "greater than"
+
+    if failed:
+        message = f"{instance!r} is {cmp} the maximum of {maximum!r}"
+        yield ValidationError(message)
+
+
+def properties_draft3(validator, properties, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
+    for property, subschema in properties.items():
+        if property in instance:
+            yield from validator.descend(
+                instance[property],
+                subschema,
+                path=property,
+                schema_path=property,
+            )
+        elif subschema.get("required", False):
+            error = ValidationError(f"{property!r} is a required property")
+            error._set(
+                validator="required",
+                validator_value=subschema["required"],
+                instance=instance,
+                schema=schema,
+            )
+            error.path.appendleft(property)
+            error.schema_path.extend([property, "required"])
+            yield error
+
+
+def type_draft3(validator, types, instance, schema):
+    types = _utils.ensure_list(types)
+
+    all_errors = []
+    for index, type in enumerate(types):
+        if validator.is_type(type, "object"):
+            errors = list(validator.descend(instance, type, schema_path=index))
+            if not errors:
+                return
+            all_errors.extend(errors)
+        else:
+            if validator.is_type(instance, type):
+                return
+    else:
+        reprs = []
+        for type in types:
+            try:
+                reprs.append(repr(type["name"]))
+            except Exception:
+                reprs.append(repr(type))
+        yield ValidationError(
+            f"{instance!r} is not of type {', '.join(reprs)}",
+            context=all_errors,
+        )
+
+
+def contains_draft6_draft7(validator, contains, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
+
+    if not any(
+        validator.evolve(schema=contains).is_valid(element)
+        for element in instance
+    ):
+        yield ValidationError(
+            f"None of {instance!r} are valid under the given schema",
+        )
+
+
+def recursiveRef(validator, recursiveRef, instance, schema):
+    lookup_url, target = validator.resolver.resolution_scope, validator.schema
+
+    for each in reversed(validator.resolver._scopes_stack[1:]):
+        lookup_url, next_target = validator.resolver.resolve(each)
+        if next_target.get("$recursiveAnchor"):
+            target = next_target
+        else:
+            break
+
+    fragment = recursiveRef.lstrip("#")
+    subschema = validator.resolver.resolve_fragment(target, fragment)
+    # FIXME: This is gutted (and not calling .descend) because it can trigger
+    #        recursion errors, so there's a bug here. Re-enable the tests to
+    #        see it.
+    subschema
+    return []
+
+
+def find_evaluated_item_indexes_by_schema(validator, instance, schema):
+    """
+    Get all indexes of items that get evaluated under the current schema
+
+    Covers all keywords related to unevaluatedItems: items, prefixItems, if,
+    then, else, contains, unevaluatedItems, allOf, oneOf, anyOf
+    """
+    if validator.is_type(schema, "boolean"):
+        return []
+    evaluated_indexes = []
+
+    if "additionalItems" in schema:
+        return list(range(0, len(instance)))
+
+    if "$ref" in schema:
+        scope, resolved = validator.resolver.resolve(schema["$ref"])
+        validator.resolver.push_scope(scope)
+
+        try:
+            evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                validator, instance, resolved,
+            )
+        finally:
+            validator.resolver.pop_scope()
+
+    if "items" in schema:
+        if validator.is_type(schema["items"], "object"):
+            return list(range(0, len(instance)))
+        evaluated_indexes += list(range(0, len(schema["items"])))
+
+    if "if" in schema:
+        if validator.evolve(schema=schema["if"]).is_valid(instance):
+            evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                validator, instance, schema["if"],
+            )
+            if "then" in schema:
+                evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                    validator, instance, schema["then"],
+                )
+        else:
+            if "else" in schema:
+                evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                    validator, instance, schema["else"],
+                )
+
+    for keyword in ["contains", "unevaluatedItems"]:
+        if keyword in schema:
+            for k, v in enumerate(instance):
+                if validator.evolve(schema=schema[keyword]).is_valid(v):
+                    evaluated_indexes.append(k)
+
+    for keyword in ["allOf", "oneOf", "anyOf"]:
+        if keyword in schema:
+            for subschema in schema[keyword]:
+                errs = list(validator.descend(instance, subschema))
+                if not errs:
+                    evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                        validator, instance, subschema,
+                    )
+
+    return evaluated_indexes
+
+
+def unevaluatedItems_draft2019(validator, unevaluatedItems, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
+    evaluated_item_indexes = find_evaluated_item_indexes_by_schema(
+        validator, instance, schema,
+    )
+    unevaluated_items = [
+        item for index, item in enumerate(instance)
+        if index not in evaluated_item_indexes
+    ]
+    if unevaluated_items:
+        error = "Unevaluated items are not allowed (%s %s unexpected)"
+        yield ValidationError(error % _utils.extras_msg(unevaluated_items))

--- a/asdf/_jsonschema/_types.py
+++ b/asdf/_jsonschema/_types.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import numbers
+import typing
+
+from pyrsistent import pmap
+from pyrsistent.typing import PMap
+import attr
+
+from asdf._jsonschema.exceptions import UndefinedTypeCheck
+
+
+# unfortunately, the type of pmap is generic, and if used as the attr.ib
+# converter, the generic type is presented to mypy, which then fails to match
+# the concrete type of a type checker mapping
+# this "do nothing" wrapper presents the correct information to mypy
+def _typed_pmap_converter(
+    init_val: typing.Mapping[
+        str,
+        typing.Callable[["TypeChecker", typing.Any], bool],
+    ],
+) -> PMap[str, typing.Callable[["TypeChecker", typing.Any], bool]]:
+    return pmap(init_val)
+
+
+def is_array(checker, instance):
+    return isinstance(instance, list)
+
+
+def is_bool(checker, instance):
+    return isinstance(instance, bool)
+
+
+def is_integer(checker, instance):
+    # bool inherits from int, so ensure bools aren't reported as ints
+    if isinstance(instance, bool):
+        return False
+    return isinstance(instance, int)
+
+
+def is_null(checker, instance):
+    return instance is None
+
+
+def is_number(checker, instance):
+    # bool inherits from int, so ensure bools aren't reported as ints
+    if isinstance(instance, bool):
+        return False
+    return isinstance(instance, numbers.Number)
+
+
+def is_object(checker, instance):
+    return isinstance(instance, dict)
+
+
+def is_string(checker, instance):
+    return isinstance(instance, str)
+
+
+def is_any(checker, instance):
+    return True
+
+
+@attr.s(frozen=True, repr=False)
+class TypeChecker:
+    """
+    A :kw:`type` property checker.
+
+    A `TypeChecker` performs type checking for a `Validator`, converting
+    between the defined JSON Schema types and some associated Python types or
+    objects.
+
+    Modifying the behavior just mentioned by redefining which Python objects
+    are considered to be of which JSON Schema types can be done using
+    `TypeChecker.redefine` or `TypeChecker.redefine_many`, and types can be
+    removed via `TypeChecker.remove`. Each of these return a new `TypeChecker`.
+
+    Arguments:
+
+        type_checkers:
+
+            The initial mapping of types to their checking functions.
+    """
+
+    _type_checkers: PMap[
+        str, typing.Callable[["TypeChecker", typing.Any], bool],
+    ] = attr.ib(
+        default=pmap(),
+        converter=_typed_pmap_converter,
+    )
+
+    def __repr__(self):
+        types = ", ".join(repr(k) for k in sorted(self._type_checkers))
+        return f"<{self.__class__.__name__} types={{{types}}}>"
+
+    def is_type(self, instance, type: str) -> bool:
+        """
+        Check if the instance is of the appropriate type.
+
+        Arguments:
+
+            instance:
+
+                The instance to check
+
+            type:
+
+                The name of the type that is expected.
+
+        Raises:
+
+            `asdf._jsonschema.exceptions.UndefinedTypeCheck`:
+
+                if ``type`` is unknown to this object.
+        """
+        try:
+            fn = self._type_checkers[type]
+        except KeyError:
+            raise UndefinedTypeCheck(type) from None
+
+        return fn(self, instance)
+
+    def redefine(self, type: str, fn) -> "TypeChecker":
+        """
+        Produce a new checker with the given type redefined.
+
+        Arguments:
+
+            type:
+
+                The name of the type to check.
+
+            fn (collections.abc.Callable):
+
+                A callable taking exactly two parameters - the type
+                checker calling the function and the instance to check.
+                The function should return true if instance is of this
+                type and false otherwise.
+        """
+        return self.redefine_many({type: fn})
+
+    def redefine_many(self, definitions=()) -> "TypeChecker":
+        """
+        Produce a new checker with the given types redefined.
+
+        Arguments:
+
+            definitions (dict):
+
+                A dictionary mapping types to their checking functions.
+        """
+        type_checkers = self._type_checkers.update(definitions)
+        return attr.evolve(self, type_checkers=type_checkers)
+
+    def remove(self, *types) -> "TypeChecker":
+        """
+        Produce a new checker with the given types forgotten.
+
+        Arguments:
+
+            types:
+
+                the names of the types to remove.
+
+        Raises:
+
+            `asdf._jsonschema.exceptions.UndefinedTypeCheck`:
+
+                if any given type is unknown to this object
+        """
+
+        type_checkers = self._type_checkers
+        for each in types:
+            try:
+                type_checkers = type_checkers.remove(each)
+            except KeyError:
+                raise UndefinedTypeCheck(each)
+        return attr.evolve(self, type_checkers=type_checkers)
+
+
+draft3_type_checker = TypeChecker(
+    {
+        "any": is_any,
+        "array": is_array,
+        "boolean": is_bool,
+        "integer": is_integer,
+        "object": is_object,
+        "null": is_null,
+        "number": is_number,
+        "string": is_string,
+    },
+)
+draft4_type_checker = draft3_type_checker.remove("any")
+draft6_type_checker = draft4_type_checker.redefine(
+    "integer",
+    lambda checker, instance: (
+        is_integer(checker, instance)
+        or isinstance(instance, float) and instance.is_integer()
+    ),
+)
+draft7_type_checker = draft6_type_checker
+draft201909_type_checker = draft7_type_checker
+draft202012_type_checker = draft201909_type_checker

--- a/asdf/_jsonschema/_types.py
+++ b/asdf/_jsonschema/_types.py
@@ -3,24 +3,14 @@ from __future__ import annotations
 import numbers
 import typing
 
-from pyrsistent import pmap
-from pyrsistent.typing import PMap
 import attr
 
 from asdf._jsonschema.exceptions import UndefinedTypeCheck
 
 
-# unfortunately, the type of pmap is generic, and if used as the attr.ib
-# converter, the generic type is presented to mypy, which then fails to match
-# the concrete type of a type checker mapping
-# this "do nothing" wrapper presents the correct information to mypy
-def _typed_pmap_converter(
-    init_val: typing.Mapping[
-        str,
-        typing.Callable[["TypeChecker", typing.Any], bool],
-    ],
-) -> PMap[str, typing.Callable[["TypeChecker", typing.Any], bool]]:
-    return pmap(init_val)
+def _as_dict(init):
+    init = init or {}
+    return dict(init)
 
 
 def is_array(checker, instance):
@@ -82,12 +72,7 @@ class TypeChecker:
             The initial mapping of types to their checking functions.
     """
 
-    _type_checkers: PMap[
-        str, typing.Callable[["TypeChecker", typing.Any], bool],
-    ] = attr.ib(
-        default=pmap(),
-        converter=_typed_pmap_converter,
-    )
+    _type_checkers = attr.ib(default={}, converter=_as_dict)
 
     def __repr__(self):
         types = ", ".join(repr(k) for k in sorted(self._type_checkers))
@@ -149,7 +134,8 @@ class TypeChecker:
 
                 A dictionary mapping types to their checking functions.
         """
-        type_checkers = self._type_checkers.update(definitions)
+        type_checkers = self._type_checkers.copy()
+        type_checkers.update(definitions)
         return attr.evolve(self, type_checkers=type_checkers)
 
     def remove(self, *types) -> "TypeChecker":
@@ -169,10 +155,10 @@ class TypeChecker:
                 if any given type is unknown to this object
         """
 
-        type_checkers = self._type_checkers
+        type_checkers = self._type_checkers.copy()
         for each in types:
             try:
-                type_checkers = type_checkers.remove(each)
+                del type_checkers[each]
             except KeyError:
                 raise UndefinedTypeCheck(each)
         return attr.evolve(self, type_checkers=type_checkers)

--- a/asdf/_jsonschema/_utils.py
+++ b/asdf/_jsonschema/_utils.py
@@ -1,0 +1,349 @@
+from collections.abc import Mapping, MutableMapping, Sequence
+from urllib.parse import urlsplit
+import itertools
+import json
+import re
+import sys
+
+# The files() API was added in Python 3.9.
+if sys.version_info >= (3, 9):  # pragma: no cover
+    from importlib import resources
+else:  # pragma: no cover
+    import importlib_resources as resources  # type: ignore
+
+
+class URIDict(MutableMapping):
+    """
+    Dictionary which uses normalized URIs as keys.
+    """
+
+    def normalize(self, uri):
+        return urlsplit(uri).geturl()
+
+    def __init__(self, *args, **kwargs):
+        self.store = dict()
+        self.store.update(*args, **kwargs)
+
+    def __getitem__(self, uri):
+        return self.store[self.normalize(uri)]
+
+    def __setitem__(self, uri, value):
+        self.store[self.normalize(uri)] = value
+
+    def __delitem__(self, uri):
+        del self.store[self.normalize(uri)]
+
+    def __iter__(self):
+        return iter(self.store)
+
+    def __len__(self):
+        return len(self.store)
+
+    def __repr__(self):
+        return repr(self.store)
+
+
+class Unset:
+    """
+    An as-of-yet unset attribute or unprovided default parameter.
+    """
+
+    def __repr__(self):
+        return "<unset>"
+
+
+def load_schema(name):
+    """
+    Load a schema from ./schemas/``name``.json and return it.
+    """
+
+    path = resources.files(__package__).joinpath(f"schemas/{name}.json")
+    data = path.read_text(encoding="utf-8")
+    return json.loads(data)
+
+
+def format_as_index(container, indices):
+    """
+    Construct a single string containing indexing operations for the indices.
+
+    For example for a container ``bar``, [1, 2, "foo"] -> bar[1][2]["foo"]
+
+    Arguments:
+
+        container (str):
+
+            A word to use for the thing being indexed
+
+        indices (sequence):
+
+            The indices to format.
+    """
+
+    if not indices:
+        return container
+    return f"{container}[{']['.join(repr(index) for index in indices)}]"
+
+
+def find_additional_properties(instance, schema):
+    """
+    Return the set of additional properties for the given ``instance``.
+
+    Weeds out properties that should have been validated by ``properties`` and
+    / or ``patternProperties``.
+
+    Assumes ``instance`` is dict-like already.
+    """
+
+    properties = schema.get("properties", {})
+    patterns = "|".join(schema.get("patternProperties", {}))
+    for property in instance:
+        if property not in properties:
+            if patterns and re.search(patterns, property):
+                continue
+            yield property
+
+
+def extras_msg(extras):
+    """
+    Create an error message for extra items or properties.
+    """
+
+    if len(extras) == 1:
+        verb = "was"
+    else:
+        verb = "were"
+    return ", ".join(repr(extra) for extra in sorted(extras)), verb
+
+
+def ensure_list(thing):
+    """
+    Wrap ``thing`` in a list if it's a single str.
+
+    Otherwise, return it unchanged.
+    """
+
+    if isinstance(thing, str):
+        return [thing]
+    return thing
+
+
+def _mapping_equal(one, two):
+    """
+    Check if two mappings are equal using the semantics of `equal`.
+    """
+    if len(one) != len(two):
+        return False
+    return all(
+        key in two and equal(value, two[key])
+        for key, value in one.items()
+    )
+
+
+def _sequence_equal(one, two):
+    """
+    Check if two sequences are equal using the semantics of `equal`.
+    """
+    if len(one) != len(two):
+        return False
+    return all(equal(i, j) for i, j in zip(one, two))
+
+
+def equal(one, two):
+    """
+    Check if two things are equal evading some Python type hierarchy semantics.
+
+    Specifically in JSON Schema, evade `bool` inheriting from `int`,
+    recursing into sequences to do the same.
+    """
+    if isinstance(one, str) or isinstance(two, str):
+        return one == two
+    if isinstance(one, Sequence) and isinstance(two, Sequence):
+        return _sequence_equal(one, two)
+    if isinstance(one, Mapping) and isinstance(two, Mapping):
+        return _mapping_equal(one, two)
+    return unbool(one) == unbool(two)
+
+
+def unbool(element, true=object(), false=object()):
+    """
+    A hack to make True and 1 and False and 0 unique for ``uniq``.
+    """
+
+    if element is True:
+        return true
+    elif element is False:
+        return false
+    return element
+
+
+def uniq(container):
+    """
+    Check if all of a container's elements are unique.
+
+    Tries to rely on the container being recursively sortable, or otherwise
+    falls back on (slow) brute force.
+    """
+    try:
+        sort = sorted(unbool(i) for i in container)
+        sliced = itertools.islice(sort, 1, None)
+
+        for i, j in zip(sort, sliced):
+            if equal(i, j):
+                return False
+
+    except (NotImplementedError, TypeError):
+        seen = []
+        for e in container:
+            e = unbool(e)
+
+            for i in seen:
+                if equal(i, e):
+                    return False
+
+            seen.append(e)
+    return True
+
+
+def find_evaluated_item_indexes_by_schema(validator, instance, schema):
+    """
+    Get all indexes of items that get evaluated under the current schema
+
+    Covers all keywords related to unevaluatedItems: items, prefixItems, if,
+    then, else, contains, unevaluatedItems, allOf, oneOf, anyOf
+    """
+    if validator.is_type(schema, "boolean"):
+        return []
+    evaluated_indexes = []
+
+    if "items" in schema:
+        return list(range(0, len(instance)))
+
+    if "$ref" in schema:
+        scope, resolved = validator.resolver.resolve(schema["$ref"])
+        validator.resolver.push_scope(scope)
+
+        try:
+            evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                validator, instance, resolved,
+            )
+        finally:
+            validator.resolver.pop_scope()
+
+    if "prefixItems" in schema:
+        evaluated_indexes += list(range(0, len(schema["prefixItems"])))
+
+    if "if" in schema:
+        if validator.evolve(schema=schema["if"]).is_valid(instance):
+            evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                validator, instance, schema["if"],
+            )
+            if "then" in schema:
+                evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                    validator, instance, schema["then"],
+                )
+        else:
+            if "else" in schema:
+                evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                    validator, instance, schema["else"],
+                )
+
+    for keyword in ["contains", "unevaluatedItems"]:
+        if keyword in schema:
+            for k, v in enumerate(instance):
+                if validator.evolve(schema=schema[keyword]).is_valid(v):
+                    evaluated_indexes.append(k)
+
+    for keyword in ["allOf", "oneOf", "anyOf"]:
+        if keyword in schema:
+            for subschema in schema[keyword]:
+                errs = list(validator.descend(instance, subschema))
+                if not errs:
+                    evaluated_indexes += find_evaluated_item_indexes_by_schema(
+                        validator, instance, subschema,
+                    )
+
+    return evaluated_indexes
+
+
+def find_evaluated_property_keys_by_schema(validator, instance, schema):
+    """
+    Get all keys of items that get evaluated under the current schema
+
+    Covers all keywords related to unevaluatedProperties: properties,
+    additionalProperties, unevaluatedProperties, patternProperties,
+    dependentSchemas, allOf, oneOf, anyOf, if, then, else
+    """
+    if validator.is_type(schema, "boolean"):
+        return []
+    evaluated_keys = []
+
+    if "$ref" in schema:
+        scope, resolved = validator.resolver.resolve(schema["$ref"])
+        validator.resolver.push_scope(scope)
+
+        try:
+            evaluated_keys += find_evaluated_property_keys_by_schema(
+                validator, instance, resolved,
+            )
+        finally:
+            validator.resolver.pop_scope()
+
+    for keyword in [
+        "properties", "additionalProperties", "unevaluatedProperties",
+    ]:
+        if keyword in schema:
+            if validator.is_type(schema[keyword], "boolean"):
+                for property, value in instance.items():
+                    if validator.evolve(schema=schema[keyword]).is_valid(
+                        {property: value},
+                    ):
+                        evaluated_keys.append(property)
+
+            if validator.is_type(schema[keyword], "object"):
+                for property, subschema in schema[keyword].items():
+                    if property in instance and validator.evolve(
+                        schema=subschema,
+                    ).is_valid(instance[property]):
+                        evaluated_keys.append(property)
+
+    if "patternProperties" in schema:
+        for property, value in instance.items():
+            for pattern, _ in schema["patternProperties"].items():
+                if re.search(pattern, property) and validator.evolve(
+                    schema=schema["patternProperties"],
+                ).is_valid({property: value}):
+                    evaluated_keys.append(property)
+
+    if "dependentSchemas" in schema:
+        for property, subschema in schema["dependentSchemas"].items():
+            if property not in instance:
+                continue
+            evaluated_keys += find_evaluated_property_keys_by_schema(
+                validator, instance, subschema,
+            )
+
+    for keyword in ["allOf", "oneOf", "anyOf"]:
+        if keyword in schema:
+            for subschema in schema[keyword]:
+                errs = list(validator.descend(instance, subschema))
+                if not errs:
+                    evaluated_keys += find_evaluated_property_keys_by_schema(
+                        validator, instance, subschema,
+                    )
+
+    if "if" in schema:
+        if validator.evolve(schema=schema["if"]).is_valid(instance):
+            evaluated_keys += find_evaluated_property_keys_by_schema(
+                validator, instance, schema["if"],
+            )
+            if "then" in schema:
+                evaluated_keys += find_evaluated_property_keys_by_schema(
+                    validator, instance, schema["then"],
+                )
+        else:
+            if "else" in schema:
+                evaluated_keys += find_evaluated_property_keys_by_schema(
+                    validator, instance, schema["else"],
+                )
+
+    return evaluated_keys

--- a/asdf/_jsonschema/_validators.py
+++ b/asdf/_jsonschema/_validators.py
@@ -1,0 +1,476 @@
+from fractions import Fraction
+from urllib.parse import urldefrag, urljoin
+import re
+
+from asdf._jsonschema._utils import (
+    ensure_list,
+    equal,
+    extras_msg,
+    find_additional_properties,
+    find_evaluated_item_indexes_by_schema,
+    find_evaluated_property_keys_by_schema,
+    unbool,
+    uniq,
+)
+from asdf._jsonschema.exceptions import FormatError, ValidationError
+
+
+def patternProperties(validator, patternProperties, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
+    for pattern, subschema in patternProperties.items():
+        for k, v in instance.items():
+            if re.search(pattern, k):
+                yield from validator.descend(
+                    v, subschema, path=k, schema_path=pattern,
+                )
+
+
+def propertyNames(validator, propertyNames, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
+    for property in instance:
+        yield from validator.descend(instance=property, schema=propertyNames)
+
+
+def additionalProperties(validator, aP, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
+    extras = set(find_additional_properties(instance, schema))
+
+    if validator.is_type(aP, "object"):
+        for extra in extras:
+            yield from validator.descend(instance[extra], aP, path=extra)
+    elif not aP and extras:
+        if "patternProperties" in schema:
+            if len(extras) == 1:
+                verb = "does"
+            else:
+                verb = "do"
+
+            joined = ", ".join(repr(each) for each in sorted(extras))
+            patterns = ", ".join(
+                repr(each) for each in sorted(schema["patternProperties"])
+            )
+            error = f"{joined} {verb} not match any of the regexes: {patterns}"
+            yield ValidationError(error)
+        else:
+            error = "Additional properties are not allowed (%s %s unexpected)"
+            yield ValidationError(error % extras_msg(extras))
+
+
+def items(validator, items, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
+
+    prefix = len(schema.get("prefixItems", []))
+    total = len(instance)
+    if items is False and total > prefix:
+        message = f"Expected at most {prefix} items, but found {total}"
+        yield ValidationError(message)
+    else:
+        for index in range(prefix, total):
+            yield from validator.descend(
+                instance=instance[index],
+                schema=items,
+                path=index,
+            )
+
+
+def additionalItems(validator, aI, instance, schema):
+    if (
+        not validator.is_type(instance, "array")
+        or validator.is_type(schema.get("items", {}), "object")
+    ):
+        return
+
+    len_items = len(schema.get("items", []))
+    if validator.is_type(aI, "object"):
+        for index, item in enumerate(instance[len_items:], start=len_items):
+            yield from validator.descend(item, aI, path=index)
+    elif not aI and len(instance) > len(schema.get("items", [])):
+        error = "Additional items are not allowed (%s %s unexpected)"
+        yield ValidationError(
+            error % extras_msg(instance[len(schema.get("items", [])):]),
+        )
+
+
+def const(validator, const, instance, schema):
+    if not equal(instance, const):
+        yield ValidationError(f"{const!r} was expected")
+
+
+def contains(validator, contains, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
+
+    matches = 0
+    min_contains = schema.get("minContains", 1)
+    max_contains = schema.get("maxContains", len(instance))
+
+    for each in instance:
+        if validator.evolve(schema=contains).is_valid(each):
+            matches += 1
+            if matches > max_contains:
+                yield ValidationError(
+                    "Too many items match the given schema "
+                    f"(expected at most {max_contains})",
+                    validator="maxContains",
+                    validator_value=max_contains,
+                )
+                return
+
+    if matches < min_contains:
+        if not matches:
+            yield ValidationError(
+                f"{instance!r} does not contain items "
+                "matching the given schema",
+            )
+        else:
+            yield ValidationError(
+                "Too few items match the given schema (expected at least "
+                f"{min_contains} but only {matches} matched)",
+                validator="minContains",
+                validator_value=min_contains,
+            )
+
+
+def exclusiveMinimum(validator, minimum, instance, schema):
+    if not validator.is_type(instance, "number"):
+        return
+
+    if instance <= minimum:
+        yield ValidationError(
+            f"{instance!r} is less than or equal to "
+            f"the minimum of {minimum!r}",
+        )
+
+
+def exclusiveMaximum(validator, maximum, instance, schema):
+    if not validator.is_type(instance, "number"):
+        return
+
+    if instance >= maximum:
+        yield ValidationError(
+            f"{instance!r} is greater than or equal "
+            f"to the maximum of {maximum!r}",
+        )
+
+
+def minimum(validator, minimum, instance, schema):
+    if not validator.is_type(instance, "number"):
+        return
+
+    if instance < minimum:
+        message = f"{instance!r} is less than the minimum of {minimum!r}"
+        yield ValidationError(message)
+
+
+def maximum(validator, maximum, instance, schema):
+    if not validator.is_type(instance, "number"):
+        return
+
+    if instance > maximum:
+        message = f"{instance!r} is greater than the maximum of {maximum!r}"
+        yield ValidationError(message)
+
+
+def multipleOf(validator, dB, instance, schema):
+    if not validator.is_type(instance, "number"):
+        return
+
+    if isinstance(dB, float):
+        quotient = instance / dB
+        try:
+            failed = int(quotient) != quotient
+        except OverflowError:
+            # When `instance` is large and `dB` is less than one,
+            # quotient can overflow to infinity; and then casting to int
+            # raises an error.
+            #
+            # In this case we fall back to Fraction logic, which is
+            # exact and cannot overflow.  The performance is also
+            # acceptable: we try the fast all-float option first, and
+            # we know that fraction(dB) can have at most a few hundred
+            # digits in each part.  The worst-case slowdown is therefore
+            # for already-slow enormous integers or Decimals.
+            failed = (Fraction(instance) / Fraction(dB)).denominator != 1
+    else:
+        failed = instance % dB
+
+    if failed:
+        yield ValidationError(f"{instance!r} is not a multiple of {dB}")
+
+
+def minItems(validator, mI, instance, schema):
+    if validator.is_type(instance, "array") and len(instance) < mI:
+        yield ValidationError(f"{instance!r} is too short")
+
+
+def maxItems(validator, mI, instance, schema):
+    if validator.is_type(instance, "array") and len(instance) > mI:
+        yield ValidationError(f"{instance!r} is too long")
+
+
+def uniqueItems(validator, uI, instance, schema):
+    if (
+        uI
+        and validator.is_type(instance, "array")
+        and not uniq(instance)
+    ):
+        yield ValidationError(f"{instance!r} has non-unique elements")
+
+
+def pattern(validator, patrn, instance, schema):
+    if (
+        validator.is_type(instance, "string")
+        and not re.search(patrn, instance)
+    ):
+        yield ValidationError(f"{instance!r} does not match {patrn!r}")
+
+
+def format(validator, format, instance, schema):
+    if validator.format_checker is not None:
+        try:
+            validator.format_checker.check(instance, format)
+        except FormatError as error:
+            yield ValidationError(error.message, cause=error.cause)
+
+
+def minLength(validator, mL, instance, schema):
+    if validator.is_type(instance, "string") and len(instance) < mL:
+        yield ValidationError(f"{instance!r} is too short")
+
+
+def maxLength(validator, mL, instance, schema):
+    if validator.is_type(instance, "string") and len(instance) > mL:
+        yield ValidationError(f"{instance!r} is too long")
+
+
+def dependentRequired(validator, dependentRequired, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
+    for property, dependency in dependentRequired.items():
+        if property not in instance:
+            continue
+
+        for each in dependency:
+            if each not in instance:
+                message = f"{each!r} is a dependency of {property!r}"
+                yield ValidationError(message)
+
+
+def dependentSchemas(validator, dependentSchemas, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
+    for property, dependency in dependentSchemas.items():
+        if property not in instance:
+            continue
+        yield from validator.descend(
+            instance, dependency, schema_path=property,
+        )
+
+
+def enum(validator, enums, instance, schema):
+    if instance == 0 or instance == 1:
+        unbooled = unbool(instance)
+        if all(unbooled != unbool(each) for each in enums):
+            yield ValidationError(f"{instance!r} is not one of {enums!r}")
+    elif instance not in enums:
+        yield ValidationError(f"{instance!r} is not one of {enums!r}")
+
+
+def ref(validator, ref, instance, schema):
+    resolve = getattr(validator.resolver, "resolve", None)
+    if resolve is None:
+        with validator.resolver.resolving(ref) as resolved:
+            yield from validator.descend(instance, resolved)
+    else:
+        scope, resolved = validator.resolver.resolve(ref)
+        validator.resolver.push_scope(scope)
+
+        try:
+            yield from validator.descend(instance, resolved)
+        finally:
+            validator.resolver.pop_scope()
+
+
+def dynamicRef(validator, dynamicRef, instance, schema):
+    _, fragment = urldefrag(dynamicRef)
+
+    for url in validator.resolver._scopes_stack:
+        lookup_url = urljoin(url, dynamicRef)
+        with validator.resolver.resolving(lookup_url) as subschema:
+            if ("$dynamicAnchor" in subschema
+                    and fragment == subschema["$dynamicAnchor"]):
+                yield from validator.descend(instance, subschema)
+                break
+    else:
+        with validator.resolver.resolving(dynamicRef) as subschema:
+            yield from validator.descend(instance, subschema)
+
+
+def type(validator, types, instance, schema):
+    types = ensure_list(types)
+
+    if not any(validator.is_type(instance, type) for type in types):
+        reprs = ", ".join(repr(type) for type in types)
+        yield ValidationError(f"{instance!r} is not of type {reprs}")
+
+
+def properties(validator, properties, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
+    for property, subschema in properties.items():
+        if property in instance:
+            yield from validator.descend(
+                instance[property],
+                subschema,
+                path=property,
+                schema_path=property,
+            )
+
+
+def required(validator, required, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+    for property in required:
+        if property not in instance:
+            yield ValidationError(f"{property!r} is a required property")
+
+
+def minProperties(validator, mP, instance, schema):
+    if validator.is_type(instance, "object") and len(instance) < mP:
+        yield ValidationError(f"{instance!r} does not have enough properties")
+
+
+def maxProperties(validator, mP, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+    if validator.is_type(instance, "object") and len(instance) > mP:
+        yield ValidationError(f"{instance!r} has too many properties")
+
+
+def allOf(validator, allOf, instance, schema):
+    for index, subschema in enumerate(allOf):
+        yield from validator.descend(instance, subschema, schema_path=index)
+
+
+def anyOf(validator, anyOf, instance, schema):
+    all_errors = []
+    for index, subschema in enumerate(anyOf):
+        errs = list(validator.descend(instance, subschema, schema_path=index))
+        if not errs:
+            break
+        all_errors.extend(errs)
+    else:
+        yield ValidationError(
+            f"{instance!r} is not valid under any of the given schemas",
+            context=all_errors,
+        )
+
+
+def oneOf(validator, oneOf, instance, schema):
+    subschemas = enumerate(oneOf)
+    all_errors = []
+    for index, subschema in subschemas:
+        errs = list(validator.descend(instance, subschema, schema_path=index))
+        if not errs:
+            first_valid = subschema
+            break
+        all_errors.extend(errs)
+    else:
+        yield ValidationError(
+            f"{instance!r} is not valid under any of the given schemas",
+            context=all_errors,
+        )
+
+    more_valid = [
+        each for _, each in subschemas
+        if validator.evolve(schema=each).is_valid(instance)
+    ]
+    if more_valid:
+        more_valid.append(first_valid)
+        reprs = ", ".join(repr(schema) for schema in more_valid)
+        yield ValidationError(f"{instance!r} is valid under each of {reprs}")
+
+
+def not_(validator, not_schema, instance, schema):
+    if validator.evolve(schema=not_schema).is_valid(instance):
+        message = f"{instance!r} should not be valid under {not_schema!r}"
+        yield ValidationError(message)
+
+
+def if_(validator, if_schema, instance, schema):
+    if validator.evolve(schema=if_schema).is_valid(instance):
+        if "then" in schema:
+            then = schema["then"]
+            yield from validator.descend(instance, then, schema_path="then")
+    elif "else" in schema:
+        else_ = schema["else"]
+        yield from validator.descend(instance, else_, schema_path="else")
+
+
+def unevaluatedItems(validator, unevaluatedItems, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
+    evaluated_item_indexes = find_evaluated_item_indexes_by_schema(
+        validator, instance, schema,
+    )
+    unevaluated_items = [
+        item for index, item in enumerate(instance)
+        if index not in evaluated_item_indexes
+    ]
+    if unevaluated_items:
+        error = "Unevaluated items are not allowed (%s %s unexpected)"
+        yield ValidationError(error % extras_msg(unevaluated_items))
+
+
+def unevaluatedProperties(validator, unevaluatedProperties, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+    evaluated_keys = find_evaluated_property_keys_by_schema(
+        validator, instance, schema,
+    )
+    unevaluated_keys = []
+    for property in instance:
+        if property not in evaluated_keys:
+            for _ in validator.descend(
+                instance[property],
+                unevaluatedProperties,
+                path=property,
+                schema_path=property,
+            ):
+                # FIXME: Include context for each unevaluated property
+                #        indicating why it's invalid under the subschema.
+                unevaluated_keys.append(property)
+
+    if unevaluated_keys:
+        if unevaluatedProperties is False:
+            error = "Unevaluated properties are not allowed (%s %s unexpected)"
+            yield ValidationError(error % extras_msg(unevaluated_keys))
+        else:
+            error = (
+                "Unevaluated properties are not valid under "
+                "the given schema (%s %s unevaluated and invalid)"
+            )
+            yield ValidationError(error % extras_msg(unevaluated_keys))
+
+
+def prefixItems(validator, prefixItems, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
+
+    for (index, item), subschema in zip(enumerate(instance), prefixItems):
+        yield from validator.descend(
+            instance=item,
+            schema=subschema,
+            schema_path=index,
+            path=index,
+        )

--- a/asdf/_jsonschema/conftest.py
+++ b/asdf/_jsonschema/conftest.py
@@ -1,0 +1,10 @@
+
+import pytest
+
+
+collect_ignore_glob = []
+
+
+def pytest_configure(config):
+    if not config.option.jsonschema:
+        collect_ignore_glob.append("*")

--- a/asdf/_jsonschema/exceptions.py
+++ b/asdf/_jsonschema/exceptions.py
@@ -1,0 +1,408 @@
+"""
+Validation errors, and some surrounding helpers.
+"""
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from pprint import pformat
+from textwrap import dedent, indent
+import heapq
+import itertools
+import warnings
+
+import attr
+
+from asdf._jsonschema import _utils
+
+WEAK_MATCHES: frozenset[str] = frozenset(["anyOf", "oneOf"])
+STRONG_MATCHES: frozenset[str] = frozenset()
+
+try:
+    from jsonschema.exceptions import _unset
+except ImportError:
+    _unset = _utils.Unset()
+
+
+class _Error(Exception):
+    def __init__(
+        self,
+        message,
+        validator=_unset,
+        path=(),
+        cause=None,
+        context=(),
+        validator_value=_unset,
+        instance=_unset,
+        schema=_unset,
+        schema_path=(),
+        parent=None,
+        type_checker=_unset,
+    ):
+        super(_Error, self).__init__(
+            message,
+            validator,
+            path,
+            cause,
+            context,
+            validator_value,
+            instance,
+            schema,
+            schema_path,
+            parent,
+        )
+        self.message = message
+        self.path = self.relative_path = deque(path)
+        self.schema_path = self.relative_schema_path = deque(schema_path)
+        self.context = list(context)
+        self.cause = self.__cause__ = cause
+        self.validator = validator
+        self.validator_value = validator_value
+        self.instance = instance
+        self.schema = schema
+        self.parent = parent
+        self._type_checker = type_checker
+
+        for error in context:
+            error.parent = self
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}: {self.message!r}>"
+
+    def __str__(self):
+        essential_for_verbose = (
+            self.validator, self.validator_value, self.instance, self.schema,
+        )
+        if any(m is _unset for m in essential_for_verbose):
+            return self.message
+
+        schema_path = _utils.format_as_index(
+            container=self._word_for_schema_in_error_message,
+            indices=list(self.relative_schema_path)[:-1],
+        )
+        instance_path = _utils.format_as_index(
+            container=self._word_for_instance_in_error_message,
+            indices=self.relative_path,
+        )
+        prefix = 16 * " "
+
+        return dedent(
+            f"""\
+            {self.message}
+
+            Failed validating {self.validator!r} in {schema_path}:
+                {indent(pformat(self.schema, width=72), prefix).lstrip()}
+
+            On {instance_path}:
+                {indent(pformat(self.instance, width=72), prefix).lstrip()}
+            """.rstrip(),
+        )
+
+    @classmethod
+    def create_from(cls, other):
+        return cls(**other._contents())
+
+    @property
+    def absolute_path(self):
+        parent = self.parent
+        if parent is None:
+            return self.relative_path
+
+        path = deque(self.relative_path)
+        path.extendleft(reversed(parent.absolute_path))
+        return path
+
+    @property
+    def absolute_schema_path(self):
+        parent = self.parent
+        if parent is None:
+            return self.relative_schema_path
+
+        path = deque(self.relative_schema_path)
+        path.extendleft(reversed(parent.absolute_schema_path))
+        return path
+
+    @property
+    def json_path(self):
+        path = "$"
+        for elem in self.absolute_path:
+            if isinstance(elem, int):
+                path += "[" + str(elem) + "]"
+            else:
+                path += "." + elem
+        return path
+
+    def _set(self, type_checker=None, **kwargs):
+        if type_checker is not None and self._type_checker is _unset:
+            self._type_checker = type_checker
+
+        for k, v in kwargs.items():
+            if getattr(self, k) is _unset:
+                setattr(self, k, v)
+
+    def _contents(self):
+        attrs = (
+            "message", "cause", "context", "validator", "validator_value",
+            "path", "schema_path", "instance", "schema", "parent",
+        )
+        return dict((attr, getattr(self, attr)) for attr in attrs)
+
+    def _matches_type(self):
+        try:
+            expected = self.schema["type"]
+        except (KeyError, TypeError):
+            return False
+
+        if isinstance(expected, str):
+            return self._type_checker.is_type(self.instance, expected)
+
+        return any(
+            self._type_checker.is_type(self.instance, expected_type)
+            for expected_type in expected
+        )
+
+
+try:
+    from jsonschema import ValidationError
+except ImportError:
+    class ValidationError(_Error):
+        """
+        An instance was invalid under a provided schema.
+        """
+
+        _word_for_schema_in_error_message = "schema"
+        _word_for_instance_in_error_message = "instance"
+
+
+class SchemaError(_Error):
+    """
+    A schema was invalid under its corresponding metaschema.
+    """
+
+    _word_for_schema_in_error_message = "metaschema"
+    _word_for_instance_in_error_message = "schema"
+
+
+try:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from jsonschema import RefResolutionError
+except ImportError:
+    @attr.s(hash=True)
+    class RefResolutionError(Exception):
+        """
+        A ref could not be resolved.
+        """
+
+        _cause = attr.ib()
+
+        def __str__(self):
+            return str(self._cause)
+
+
+class UndefinedTypeCheck(Exception):
+    """
+    A type checker was asked to check a type it did not have registered.
+    """
+
+    def __init__(self, type):
+        self.type = type
+
+    def __str__(self):
+        return f"Type {self.type!r} is unknown to this type checker"
+
+
+class UnknownType(Exception):
+    """
+    A validator was asked to validate an instance against an unknown type.
+    """
+
+    def __init__(self, type, instance, schema):
+        self.type = type
+        self.instance = instance
+        self.schema = schema
+
+    def __str__(self):
+        prefix = 16 * " "
+
+        return dedent(
+            f"""\
+            Unknown type {self.type!r} for validator with schema:
+                {indent(pformat(self.schema, width=72), prefix).lstrip()}
+
+            While checking instance:
+                {indent(pformat(self.instance, width=72), prefix).lstrip()}
+            """.rstrip(),
+        )
+
+
+class FormatError(Exception):
+    """
+    Validating a format failed.
+    """
+
+    def __init__(self, message, cause=None):
+        super(FormatError, self).__init__(message, cause)
+        self.message = message
+        self.cause = self.__cause__ = cause
+
+    def __str__(self):
+        return self.message
+
+
+class ErrorTree:
+    """
+    ErrorTrees make it easier to check which validations failed.
+    """
+
+    _instance = _unset
+
+    def __init__(self, errors=()):
+        self.errors = {}
+        self._contents = defaultdict(self.__class__)
+
+        for error in errors:
+            container = self
+            for element in error.path:
+                container = container[element]
+            container.errors[error.validator] = error
+
+            container._instance = error.instance
+
+    def __contains__(self, index):
+        """
+        Check whether ``instance[index]`` has any errors.
+        """
+
+        return index in self._contents
+
+    def __getitem__(self, index):
+        """
+        Retrieve the child tree one level down at the given ``index``.
+
+        If the index is not in the instance that this tree corresponds
+        to and is not known by this tree, whatever error would be raised
+        by ``instance.__getitem__`` will be propagated (usually this is
+        some subclass of `LookupError`.
+        """
+
+        if self._instance is not _unset and index not in self:
+            self._instance[index]
+        return self._contents[index]
+
+    def __setitem__(self, index, value):
+        """
+        Add an error to the tree at the given ``index``.
+        """
+        self._contents[index] = value
+
+    def __iter__(self):
+        """
+        Iterate (non-recursively) over the indices in the instance with errors.
+        """
+
+        return iter(self._contents)
+
+    def __len__(self):
+        """
+        Return the `total_errors`.
+        """
+        return self.total_errors
+
+    def __repr__(self):
+        total = len(self)
+        errors = "error" if total == 1 else "errors"
+        return f"<{self.__class__.__name__} ({total} total {errors})>"
+
+    @property
+    def total_errors(self):
+        """
+        The total number of errors in the entire tree, including children.
+        """
+
+        child_errors = sum(len(tree) for _, tree in self._contents.items())
+        return len(self.errors) + child_errors
+
+
+def by_relevance(weak=WEAK_MATCHES, strong=STRONG_MATCHES):
+    """
+    Create a key function that can be used to sort errors by relevance.
+
+    Arguments:
+        weak (set):
+            a collection of validation keywords to consider to be
+            "weak".  If there are two errors at the same level of the
+            instance and one is in the set of weak validation keywords,
+            the other error will take priority. By default, :kw:`anyOf`
+            and :kw:`oneOf` are considered weak keywords and will be
+            superseded by other same-level validation errors.
+
+        strong (set):
+            a collection of validation keywords to consider to be
+            "strong"
+    """
+    def relevance(error):
+        validator = error.validator
+        return (
+            -len(error.path),
+            validator not in weak,
+            validator in strong,
+            not error._matches_type(),
+        )
+    return relevance
+
+
+relevance = by_relevance()
+
+
+def best_match(errors, key=relevance):
+    """
+    Try to find an error that appears to be the best match among given errors.
+
+    In general, errors that are higher up in the instance (i.e. for which
+    `ValidationError.path` is shorter) are considered better matches,
+    since they indicate "more" is wrong with the instance.
+
+    If the resulting match is either :kw:`oneOf` or :kw:`anyOf`, the
+    *opposite* assumption is made -- i.e. the deepest error is picked,
+    since these keywords only need to match once, and any other errors
+    may not be relevant.
+
+    Arguments:
+        errors (collections.abc.Iterable):
+
+            the errors to select from. Do not provide a mixture of
+            errors from different validation attempts (i.e. from
+            different instances or schemas), since it won't produce
+            sensical output.
+
+        key (collections.abc.Callable):
+
+            the key to use when sorting errors. See `relevance` and
+            transitively `by_relevance` for more details (the default is
+            to sort with the defaults of that function). Changing the
+            default is only useful if you want to change the function
+            that rates errors but still want the error context descent
+            done by this function.
+
+    Returns:
+        the best matching error, or ``None`` if the iterable was empty
+
+    .. note::
+
+        This function is a heuristic. Its return value may change for a given
+        set of inputs from version to version if better heuristics are added.
+    """
+    errors = iter(errors)
+    best = next(errors, None)
+    if best is None:
+        return
+    best = max(itertools.chain([best], errors), key=key)
+
+    while best.context:
+        # Calculate the minimum via nsmallest, because we don't recurse if
+        # all nested errors have the same relevance (i.e. if min == max == all)
+        smallest = heapq.nsmallest(2, best.context, key=key)
+        if len(smallest) == 2 and key(smallest[0]) == key(smallest[1]):
+            return best
+        best = smallest[0]
+    return best

--- a/asdf/_jsonschema/json/.gitignore
+++ b/asdf/_jsonschema/json/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/asdf/_jsonschema/json/CONTRIBUTING.md
+++ b/asdf/_jsonschema/json/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to the Suite
+
+All contributors to the test suite should familiarize themselves with this document.
+
+Both pull requests *and* reviews are welcome from any and all, regardless of their "formal" relationship (or lack thereof) with the JSON Schema organization.
+
+## Commit Access
+
+Any existing members with commit access to the repository may nominate new members to get access, or a contributor may request access for themselves.
+Access generally should be granted liberally to anyone who has shown positive contributions to the repository or organization.
+All who are active in other parts of the JSON Schema organization should get access to this repository as well.
+Access for a former contributor may be removed after long periods of inactivity.
+
+## Reviewing a Pull Request
+
+Pull requests may (and often should) be reviewed for approval by a single reviewer whose job it is to confirm the change is specified, correct, minimal and follows general style in the repository.
+A reviewer who does not feel comfortable signing off on the correctness of a change is free to comment without explicit approval.
+Other contributors are also encouraged to comment on pull requests whenever they have feedback, even if another contributor has submitted review comments.
+A submitter may also choose to request additional feedback if they feel the change is particularly technical or complex, or requires expertise in a particular area of the specification.
+If additional reviewers have participated in a pull request, the submitter should not rely on a single reviewer's approval without some form of confirmation that all participating reviewers are satisfied.
+On the other hand, whenever possible, reviewers who have minor comments should explicitly mention that they are OK with the PR being merged after or potentially *without* addressing them.
+
+When submitting a change, explicitly soliciting a specific reviewer explicitly is currently not needed, as the entire review team is generally pinged for pull requests.
+Nevertheless, submitters may choose to do so if they want specific review from an individual, or if a pull request is sitting without review for a period of time.
+For the latter scenario, leaving a comment on the pull request or in Slack is also reasonable.
+
+Confirming that a pull request runs successfully on an implementation is *not* generally sufficient to merge, though it is helpful evidence, and highly encouraged.
+Proposed changes should be confirmed by reading the specification and ensuring the behavior is specified and correct.
+Submitters are encouraged to link to the specification whenever doing so will be helpful to a reviewer.
+
+A reviewer may indicate that the proposed changes are too large for them to review.
+In such cases the submitter may wait for another reviewer who is comfortable reviewing the changes, but is generally strongly encouraged to split up the changes into multiple smaller ones.
+
+Reviewing pull requests is an extremely valuable contribution!
+New reviewers are highly encouraged to attempt to review pull requests even if they do not have experience doing so, and to themselves expect feedback from the submitter or from other reviewers on improving the quality of their reviews.
+In such cases the submitter should use their judgement to decide whether the new contributor's review is sufficient for merging, or whether they should wait for further feedback.
+
+## Merging Changes
+
+Approval of a change may be given using the GitHub UI or via a comment reply.
+Once it has been given, the pull request may be merged at any point.
+
+To merge a pull request, *either* the submitter or reviewer must have commit access to the repo (though this is also partially simply because that party's access is needed to merge).
+
+*Either* the submitter or reviewer may be the one to do the actual merge (whether via hitting the merge button or externally to the GitHub UI).
+If the submitter wishes to make final changes after a review they should attempt to say so (and thereby take responsibility for merging themselves).
+Contributors *should not* leave pull requests stagnant whenever possible, and particularly after they have been reviewed and approved.
+
+Changes should not be merged while continuous integration is failing.
+Failures typically are not spurious and indicate issues with the changes.
+In the event the change is indeed correct and CI is flaky or itself incorrect, effort should be made by the submitter, reviewer, or a solicited other contributor to fix the CI before the change is made.
+Improvements to CI itself are very valuable as well, and reviewers who find repeated issues with proposed changes are highly encouraged to improve CI for any changes which may be automatically detected.
+
+Changes should be merged *as-is* and not squashed into single commits.
+Submitters are free to structure their commits as they wish throughout the review process, or in some cases to restructure the commits after a review is finished and they are merging the branch, but are not required to do so, and reviewers should not do so on behalf of the submitter without being requested to do so.
+
+Contributors with commit access may choose to merge pull requests (or commit directly) to the repository for trivial changes.
+The definition of "trivial" is intentionally slightly ambiguous, and intended to be followed by good-faith contributors.
+An example of a trivial change is fixing a typo in the README, or bumping a version of a dependency used by the continuous integration suite.
+If another contributor takes issue with a change merged in this fashion, simply commenting politely that they have concerns about the change (either in an issue or directly) is the right remedy.
+
+## Writing Good Tests
+
+Be familiar with the test structure and assumptions documented in the [README](README.md).
+
+Test cases should include both valid and invalid instances which exercise the test case schema whenever possible.
+Exceptions include schemas where only one result is ever possible (such as the `false` schema, or ones using keywords which only produce annotations).
+
+Schemas should be *minimal*, by which we mean that they should contain only those keywords which are being tested by the specific test case, and should not contain complex values when simpler ones would do.
+The same applies to instances -- prefer simpler instances to more complex ones, and when testing string instances, consider using ones which are self-descriptive whenever it aids readability.
+
+Comments can and should be used to explain tests which are unclear or complex.
+The `comment` field is present both for test cases and individual tests for this purpose.
+Links to the relevant specification sections are also encouraged, though they can be tedious to maintain from one version to the next.
+
+When adding test cases, they should be added to all past (and future) versions of the specification which they apply to, potentially with minor modifications (e.g. changing `$id` to `id` or accounting for `$ref` not allowing siblings on older drafts).
+
+Changing the schema used in a particular test case should be done with extra caution, though it is not formally discouraged if the change simplifies the schema.
+Contributors should not generally append *additional* behavior to existing test case schemas, unless doing so has specific justification.
+Instead, new cases should be added, as it can often be subtle to predict which precise parts of a test case are unique.
+Adding additional *tests* however (instances) is of course safe and encouraged if gaps are found.
+
+Tests which are *incorrect* (against the specification) should be prioritized for fixing or removal whenever possible, as their continued presence in the suite can create confusion for downstream users of the suite.
+
+## Proposing Changes to the Policy
+
+This policy itself is of course changeable, and changes to it may be proposed in a discussion.

--- a/asdf/_jsonschema/json/LICENSE
+++ b/asdf/_jsonschema/json/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012 Julian Berman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/asdf/_jsonschema/json/README.md
+++ b/asdf/_jsonschema/json/README.md
@@ -1,0 +1,344 @@
+# JSON Schema Test Suite
+
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/json-schema-org/.github/blob/main/CODE_OF_CONDUCT.md)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Financial Contributors on Open Collective](https://opencollective.com/json-schema/all/badge.svg?label=financial+contributors)](https://opencollective.com/json-schema)
+
+[![DOI](https://zenodo.org/badge/5952934.svg)](https://zenodo.org/badge/latestdoi/5952934)
+[![Build Status](https://github.com/json-schema-org/JSON-Schema-Test-Suite/workflows/Test%20Suite%20Sanity%20Checking/badge.svg)](https://github.com/json-schema-org/JSON-Schema-Test-Suite/actions?query=workflow%3A%22Test+Suite+Sanity+Checking%22)
+
+This repository contains a set of JSON objects that implementers of JSON Schema validation libraries can use to test their validators.
+
+It is meant to be language agnostic and should require only a JSON parser.
+The conversion of the JSON objects into tests within a specific language and test framework of choice is left to be done by the validator implementer.
+
+## Coverage
+
+All JSON Schema specification releases should be well covered by this suite, including drafts 2020-12, 2019-09, 07, 06, 04 and 03.
+Drafts 04 and 03 are considered "frozen" in that less effort is put in to backport new tests to these versions.
+
+Additional coverage is always welcome, particularly for bugs encountered in real-world implementations.
+If you see anything missing or incorrect, please feel free to [file an issue](https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues) or [submit a PR](https://github.com/json-schema-org/JSON-Schema-Test-Suite).
+
+## Introduction to the Test Suite Structure
+
+The tests in this suite are contained in the `tests` directory at the root of this repository.
+Inside that directory is a subdirectory for each released version of the specification.
+
+The structure and contents of each file in these directories is described below.
+
+In addition to the version-specific subdirectories, two additional directories are present:
+
+1. `draft-next/`: containing tests for the next version of the specification whilst it is in development
+2. `latest/`: a symbolic link which points to the directory which is the most recent release (which may be useful for implementations providing specific entry points for validating against the latest version of the specification)
+
+Inside each version directory there are a number of `.json` files each containing a collection of related tests.
+Often the grouping is by property under test, but not always.
+In addition to the `.json` files, each version directory contains one or more special subdirectories whose purpose is [described below](#subdirectories-within-each-draft), and which contain additional `.json` files.
+
+Each `.json` file consists of a single JSON array of test cases.
+
+### Terminology
+
+For clarity, we first define this document's usage of some testing terminology:
+
+| term            | definition                                                                                                                                                        |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **test suite**  | the entirety of the contents of this repository, containing tests for multiple different releases of the JSON Schema specification                                |
+| **test case**   | a single schema, along with a description and an array of *test*s                                                                                                 |
+| **test**        | within a *test case*, a single test example, containing a description, instance and a boolean indicating whether the instance is valid under the test case schema |
+| **test runner** | a program, external to this repository and authored by a user of this suite, which is executing each of the tests in the suite                                    |
+
+An example illustrating this structure is immediately below, and a JSON Schema containing a formal definition of the contents of test cases can be found [alongside this README](./test-schema.json).
+
+### Sample Test Case
+
+Here is a single *test case*, containing one or more tests:
+
+```json
+{
+    "description": "The test case description",
+    "schema": { "type": "string" },
+    "tests": [
+        {
+            "description": "a test with a valid instance",
+            "data": "a string",
+            "valid": true
+        },
+        {
+            "description": "a test with an invalid instance",
+            "data": 15,
+            "valid": false
+        }
+    ]
+}
+```
+
+### Subdirectories Within Each Draft
+
+There is currently only one additional subdirectory that may exist within each draft test directory.
+
+This is:
+
+1. `optional/`: Contains tests that are considered optional.
+
+Note, the `optional/` subdirectory today conflates many reasons why a test may be optional -- it may be because tests within a particular file are indeed not required by the specification but still potentially useful to an implementer, or it may be because tests within it only apply to programming languages with particular functionality (in
+which case they are not truly optional in such a language).
+In the future this directory structure will be made richer to reflect these differences more clearly.
+
+## Using the Suite to Test a Validator Implementation
+
+The test suite structure was described [above](#introduction-to-the-test-suite-structure).
+
+If you are authoring a new validator implementation, or adding support for an additional version of the specification, this section describes:
+
+1. How to implement a test runner which passes tests to your validator
+2. Assumptions the suite makes about how the test runner will configure your validator
+3. Invariants the test suite claims to hold for its tests
+
+### How to Implement a Test Runner
+
+Presented here is a possible implementation of a test runner.
+The precise steps described do not need to be followed exactly, but the results of your own procedure should produce the same effects.
+
+To test a specific version:
+
+* For 2019-09 and later published drafts, implementations that are able to detect the draft of each schema via `$schema` SHOULD be configured to do so
+* For draft-07 and earlier, draft-next, and implementations unable to detect via `$schema`, implementations MUST be configured to expect the draft matching the test directory name
+* Load any remote references [described below](additional-assumptions) and configure your implementation to retrieve them via their URIs
+* Walk the filesystem tree for that version's subdirectory and for each `.json` file found:
+
+    * if the file is located in the root of the version directory:
+
+        * for each test case present in the file:
+
+            * load the schema from the `"schema"` property
+            * load (or log) the test case description from the `"description"` property for debugging or outputting
+            * for each test in the `"tests"` property:
+
+                * load the instance to be tested from the `"data"` property
+                * load (or log) the individual test description from the `"description"` property for debugging or outputting
+
+                * use the schema loaded above to validate whether the instance is considered valid under your implementation
+
+                * if the result from your implementation matches the value found in the `"valid"` property, your implementation correctly implements the specific example
+                * if the result does not match, or your implementation errors or crashes, your implementation does not correctly implement the specific example
+
+    * otherwise it is located in a special subdirectory as described above.
+      Follow the additional assumptions and restrictions for the containing subdirectory, then run the test case as above.
+
+If your implementation supports multiple versions, run the above procedure for each version supported, configuring your implementation as appropriate to call each version individually.
+
+### Additional Assumptions
+
+1. The suite, notably in its `refRemote.json` file in each draft, expects a number of remote references to be configured.
+   These are JSON documents, identified by URI, which are used by the suite to test the behavior of the `$ref` keyword (and related keywords).
+   Depending on your implementation, you may configure how to "register" these *either*:
+
+    * by directly retrieving them off the filesystem from the `remotes/` directory, in which case you should load each schema with a retrieval URI of `http://localhost:1234` followed by the relative path from the remotes directory -- e.g. a `$ref` to `http://localhost:1234/foo/bar/baz.json` is expected to resolve to the contents of the file at `remotes/foo/bar/baz.json`
+
+    * or alternatively, by executing `bin/jsonschema_suite remotes` using the executable in the `bin/` directory, which will output a JSON object containing all of the remotes combined, e.g.:
+
+    ```
+
+    $  bin/jsonschema_suite remotes
+    ```
+    ```json
+    {
+        "http://localhost:1234/baseUriChange/folderInteger.json": {
+            "type": "integer"
+        },
+        "http://localhost:1234/baseUriChangeFolder/folderInteger.json": {
+            "type": "integer"
+        }
+    }
+    ```
+
+2. Test cases found within [special subdirectories](#subdirectories-within-each-draft) may require additional configuration to run.
+   In particular, tests within the `optional/format` subdirectory may require implementations to change the way they treat the `"format"`keyword (particularly on older drafts which did not have a notion of vocabularies).
+
+### Invariants & Guarantees
+
+The test suite guarantees a number of things about tests it defines.
+Any deviation from the below is generally considered a bug.
+If you suspect one, please [file an issue](https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/new):
+
+1. All files containing test cases are valid JSON.
+2. The contents of the `"schema"` property in a test case are always valid
+   JSON Schemas under the corresponding specification.
+
+   The rationale behind this is that we are testing instances in a test's `"data"` element, and not the schema itself.
+   A number of tests *do* test the validity of a schema itself, but do so by representing the schema as an instance inside a test, with the associated meta-schema in the `"schema"` property (via the `"$ref"` keyword):
+
+   ```json
+   {
+       "description": "Test the \"type\" schema keyword",
+       "schema": {
+           "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+       "tests": [
+           {
+               "description": "Valid: string",
+               "data": {
+                   "type": "string"
+               },
+               "valid": true
+           },
+           {
+               "description": "Invalid: null",
+               "data": {
+                   "type": null
+               },
+               "valid": false
+           }
+       ]
+   }
+   ```
+   See below for some [known limitations](#known-limitations).
+
+## Known Limitations
+
+This suite expresses its assertions about the behavior of an implementation *within* JSON Schema itself.
+Each test is the application of a schema to a particular instance.
+This means that the suite of tests can test against any behavior a schema can describe, and conversely cannot test against any behavior which a schema is incapable of representing, even if the behavior is mandated by the specification.
+
+For example, a schema can require that a string is a _URI-reference_ and even that it matches a certain pattern, but even though the specification contains [recommendations about URIs being normalized](https://json-schema.org/draft/2020-12/json-schema-core.html#name-the-id-keyword), a JSON schema cannot today represent this assertion within the core vocabularies of the specifications, so no test covers this behavior.
+
+## Who Uses the Test Suite
+
+This suite is being used by:
+
+### Clojure
+
+* [jinx](https://github.com/juxt/jinx)
+* [json-schema](https://github.com/tatut/json-schema)
+
+### Coffeescript
+
+* [jsck](https://github.com/pandastrike/jsck)
+
+### Common Lisp
+
+* [json-schema](https://github.com/fisxoj/json-schema)
+
+### C++
+
+* [Modern C++ JSON schema validator](https://github.com/pboettch/json-schema-validator)
+* [Valijson](https://github.com/tristanpenman/valijson)
+
+### Dart
+
+* [json\_schema](https://github.com/patefacio/json_schema)
+
+### Elixir
+
+* [ex\_json\_schema](https://github.com/jonasschmidt/ex_json_schema)
+
+### Erlang
+
+* [jesse](https://github.com/for-GET/jesse)
+
+### Go
+
+* [gojsonschema](https://github.com/sigu-399/gojsonschema)
+* [validate-json](https://github.com/cesanta/validate-json)
+
+### Haskell
+
+* [aeson-schema](https://github.com/timjb/aeson-schema)
+* [hjsonschema](https://github.com/seagreen/hjsonschema)
+
+### Java
+
+* [json-schema-validator](https://github.com/daveclayton/json-schema-validator)
+* [everit-org/json-schema](https://github.com/everit-org/json-schema)
+* [networknt/json-schema-validator](https://github.com/networknt/json-schema-validator)
+* [Justify](https://github.com/leadpony/justify)
+* [Snow](https://github.com/ssilverman/snowy-json)
+* [jsonschemafriend](https://github.com/jimblackler/jsonschemafriend)
+
+### JavaScript
+
+* [json-schema-benchmark](https://github.com/Muscula/json-schema-benchmark)
+* [direct-schema](https://github.com/IreneKnapp/direct-schema)
+* [is-my-json-valid](https://github.com/mafintosh/is-my-json-valid)
+* [jassi](https://github.com/iclanzan/jassi)
+* [JaySchema](https://github.com/natesilva/jayschema)
+* [json-schema-valid](https://github.com/ericgj/json-schema-valid)
+* [Jsonary](https://github.com/jsonary-js/jsonary)
+* [jsonschema](https://github.com/tdegrunt/jsonschema)
+* [request-validator](https://github.com/bugventure/request-validator)
+* [skeemas](https://github.com/Prestaul/skeemas)
+* [tv4](https://github.com/geraintluff/tv4)
+* [z-schema](https://github.com/zaggino/z-schema)
+* [jsen](https://github.com/bugventure/jsen)
+* [ajv](https://github.com/epoberezkin/ajv)
+* [djv](https://github.com/korzio/djv)
+
+### Node.js
+
+For node.js developers, the suite is also available as an [npm](https://www.npmjs.com/package/@json-schema-org/tests) package.
+
+Node-specific support is maintained in a [separate repository](https://github.com/json-schema-org/json-schema-test-suite-npm) which also welcomes your contributions!
+
+### .NET
+
+* [JsonSchema.Net](https://github.com/gregsdennis/json-everything)
+* [Newtonsoft.Json.Schema](https://github.com/JamesNK/Newtonsoft.Json.Schema)
+
+### Perl
+
+* [Test::JSON::Schema::Acceptance](https://github.com/karenetheridge/Test-JSON-Schema-Acceptance) (a wrapper of this test suite)
+* [JSON::Schema::Modern](https://github.com/karenetheridge/JSON-Schema-Modern)
+* [JSON::Schema::Tiny](https://github.com/karenetheridge/JSON-Schema-Tiny)
+
+### PHP
+
+* [opis/json-schema](https://github.com/opis/json-schema)
+* [json-schema](https://github.com/justinrainbow/json-schema)
+* [json-guard](https://github.com/thephpleague/json-guard)
+
+### PostgreSQL
+
+* [postgres-json-schema](https://github.com/gavinwahl/postgres-json-schema)
+* [is\_jsonb\_valid](https://github.com/furstenheim/is_jsonb_valid)
+
+### Python
+
+* [jsonschema](https://github.com/Julian/jsonschema)
+* [fastjsonschema](https://github.com/seznam/python-fastjsonschema)
+* [hypothesis-jsonschema](https://github.com/Zac-HD/hypothesis-jsonschema)
+* [jschon](https://github.com/marksparkza/jschon)
+* [python-experimental, OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/python-experimental.md)
+
+### Ruby
+
+* [json-schema](https://github.com/hoxworth/json-schema)
+* [json\_schemer](https://github.com/davishmcclurg/json_schemer)
+
+### Rust
+
+* [jsonschema](https://github.com/Stranger6667/jsonschema-rs)
+* [valico](https://github.com/rustless/valico)
+
+### Scala
+
+* [typed-json](https://github.com/frawa/typed-json)
+
+### Swift
+
+* [JSONSchema](https://github.com/kylef/JSONSchema.swift)
+
+If you use it as well, please fork and send a pull request adding yourself to
+the list :).
+
+## Contributing
+
+If you see something missing or incorrect, a pull request is most welcome!
+
+There are some sanity checks in place for testing the test suite. You can run
+them with `bin/jsonschema_suite check` or `tox`. They will be run automatically
+by [GitHub Actions](https://github.com/json-schema-org/JSON-Schema-Test-Suite/actions?query=workflow%3A%22Test+Suite+Sanity+Checking%22)
+as well.
+
+This repository is maintained by the JSON Schema organization, and will be governed by the JSON Schema steering committee (once it exists).

--- a/asdf/_jsonschema/json/bin/jsonschema_suite
+++ b/asdf/_jsonschema/json/bin/jsonschema_suite
@@ -1,0 +1,351 @@
+#! /usr/bin/env python3
+from pathlib import Path
+from urllib.parse import urljoin
+import argparse
+import json
+import os
+import random
+import shutil
+import sys
+import textwrap
+import unittest
+import warnings
+
+try:
+    import asdf._jsonschema.validators
+    jsonschema = asdf._jsonschema
+except ImportError:
+    jsonschema = None
+    VALIDATORS = {}
+else:
+    VALIDATORS = {
+        "draft3": asdf._jsonschema.validators.Draft3Validator,
+        "draft4": asdf._jsonschema.validators.Draft4Validator,
+        "draft6": asdf._jsonschema.validators.Draft6Validator,
+        "draft7": asdf._jsonschema.validators.Draft7Validator,
+        "draft2019-09": asdf._jsonschema.validators.Draft201909Validator,
+        "draft2020-12": asdf._jsonschema.validators.Draft202012Validator,
+        "latest": asdf._jsonschema.validators.Draft202012Validator,
+    }
+
+
+ROOT_DIR = Path(__file__).parent.parent
+SUITE_ROOT_DIR = ROOT_DIR / "tests"
+
+REMOTES_DIR = ROOT_DIR / "remotes"
+REMOTES_BASE_URL = "http://localhost:1234/"
+
+TESTSUITE_SCHEMA = json.loads((ROOT_DIR / "test-schema.json").read_text())
+
+
+def files(paths):
+    """
+    Each test file in the provided paths, as an array of test cases.
+    """
+    for path in paths:
+        yield path, json.loads(path.read_text())
+
+
+def cases(paths):
+    """
+    Each test case within each file in the provided paths.
+    """
+    for _, test_file in files(paths):
+        yield from test_file
+
+
+def tests(paths):
+    """
+    Each individual test within all cases within the provided paths.
+    """
+    for case in cases(paths):
+        for test in case["tests"]:
+            test["schema"] = case["schema"]
+            yield test
+
+
+def collect(root_dir):
+    """
+    All of the test file paths within the given root directory, recursively.
+    """
+    return root_dir.glob("**/*.json")
+
+
+def url_for_path(path):
+    """
+    Return the assumed remote URL for a file in the remotes/ directory.
+
+    Tests in the refRemote.json file reference this URL, and assume the
+    corresponding contents are available at the URL.
+    """
+
+    return urljoin(
+        REMOTES_BASE_URL,
+        str(path.relative_to(REMOTES_DIR)).replace("\\", "/")  # Windows...
+    )
+
+
+class SanityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print(f"Looking for tests in {SUITE_ROOT_DIR}")
+        print(f"Looking for remotes in {REMOTES_DIR}")
+
+        cls.test_files = list(collect(SUITE_ROOT_DIR))
+        assert cls.test_files, "Didn't find the test files!"
+        print(f"Found {len(cls.test_files)} test files")
+
+        cls.remote_files = list(collect(REMOTES_DIR))
+        assert cls.remote_files, "Didn't find the remote files!"
+        print(f"Found {len(cls.remote_files)} remote files")
+
+    def assertUnique(self, iterable):
+        """
+        Assert that the elements of an iterable are unique.
+        """
+
+        seen, duplicated = set(), set()
+        for each in iterable:
+            if each in seen:
+                duplicated.add(each)
+            seen.add(each)
+        self.assertFalse(duplicated, "Elements are not unique.")
+
+    def assertFollowsDescriptionStyle(self, description):
+        """
+        Instead of saying "test that X frobs" or "X should frob" use "X frobs".
+
+        See e.g. https://jml.io/pages/test-docstrings.html
+
+        This test isn't comprehensive (it doesn't catch all the extra
+        verbiage there), but it's just to catch whatever it manages to
+        cover.
+        """
+
+        message = (
+            "In descriptions, don't say 'Test that X frobs' or 'X should "
+            "frob' or 'X should be valid'. Just say 'X frobs' or 'X is "
+            "valid'. It's shorter, and the test suite is entirely about "
+            "what *should* be already. "
+            "See https://jml.io/pages/test-docstrings.html for help."
+        )
+        self.assertNotRegex(description, r"\bshould\b", message)
+        self.assertNotRegex(description, r"(?i)\btest(s)? that\b", message)
+
+    def test_all_test_files_are_valid_json(self):
+        """
+        All test files contain valid JSON.
+        """
+        for path in self.test_files:
+            with self.subTest(path=path):
+                try:
+                    json.loads(path.read_text())
+                except ValueError as error:
+                    self.fail(f"{path} contains invalid JSON ({error})")
+
+    def test_all_remote_files_are_valid_json(self):
+        """
+        All remote files contain valid JSON.
+        """
+        for path in self.remote_files:
+            with self.subTest(path=path):
+                try:
+                    json.loads(path.read_text())
+                except ValueError as error:
+                    self.fail(f"{path} contains invalid JSON ({error})")
+
+    def test_all_case_descriptions_have_reasonable_length(self):
+        """
+        All cases have reasonably long descriptions.
+        """
+        for case in cases(self.test_files):
+            with self.subTest(description=case["description"]):
+                self.assertLess(
+                    len(case["description"]),
+                    150,
+                    "Description is too long (keep it to less than 150 chars)."
+                )
+
+    def test_all_test_descriptions_have_reasonable_length(self):
+        """
+        All tests have reasonably long descriptions.
+        """
+        for count, test in enumerate(tests(self.test_files)):
+            with self.subTest(description=test["description"]):
+                self.assertLess(
+                    len(test["description"]),
+                    70,
+                    "Description is too long (keep it to less than 70 chars)."
+                )
+        print(f"Found {count} tests.")
+
+    def test_all_case_descriptions_are_unique(self):
+        """
+        All cases have unique descriptions in their files.
+        """
+        for path, cases in files(self.test_files):
+            with self.subTest(path=path):
+                self.assertUnique(case["description"] for case in cases)
+
+    def test_all_test_descriptions_are_unique(self):
+        """
+        All test cases have unique test descriptions in their tests.
+        """
+        for count, case in enumerate(cases(self.test_files)):
+            with self.subTest(description=case["description"]):
+                self.assertUnique(
+                    test["description"] for test in case["tests"]
+                )
+        print(f"Found {count} test cases.")
+
+    def test_case_descriptions_do_not_use_modal_verbs(self):
+        for case in cases(self.test_files):
+            with self.subTest(description=case["description"]):
+                self.assertFollowsDescriptionStyle(case["description"])
+
+    def test_test_descriptions_do_not_use_modal_verbs(self):
+        for test in tests(self.test_files):
+            with self.subTest(description=test["description"]):
+                self.assertFollowsDescriptionStyle(test["description"])
+
+    @unittest.skipIf(jsonschema is None, "Validation library not present!")
+    def test_all_schemas_are_valid(self):
+        """
+        All schemas are valid under their metaschemas.
+        """
+        for version in SUITE_ROOT_DIR.iterdir():
+            if not version.is_dir():
+                continue
+
+            Validator = VALIDATORS.get(version.name)
+            if Validator is not None:
+                test_files = collect(version)
+                for case in cases(test_files):
+                    with self.subTest(case=case):
+                        try:
+                            Validator.check_schema(case["schema"])
+                        except asdf._jsonschema.SchemaError:
+                            self.fail(
+                                "Found an invalid schema."
+                                "See the traceback for details on why."
+                            )
+            else:
+                warnings.warn(f"No schema validator for {version.name}")
+
+    @unittest.skipIf(jsonschema is None, "Validation library not present!")
+    def test_suites_are_valid(self):
+        """
+        All test files are valid under test-schema.json.
+        """
+        Validator = asdf._jsonschema.validators.validator_for(TESTSUITE_SCHEMA)
+        validator = Validator(TESTSUITE_SCHEMA)
+        for path, cases in files(self.test_files):
+            with self.subTest(path=path):
+                try:
+                    validator.validate(cases)
+                except asdf._jsonschema.ValidationError as error:
+                    self.fail(str(error))
+
+
+def main(arguments):
+    if arguments.command == "check":
+        suite = unittest.TestLoader().loadTestsFromTestCase(SanityTests)
+        result = unittest.TextTestRunner().run(suite)
+        sys.exit(not result.wasSuccessful())
+    elif arguments.command == "flatten":
+        selected_cases = [case for case in cases(collect(arguments.version))]
+
+        if arguments.randomize:
+            random.shuffle(selected_cases)
+
+        json.dump(selected_cases, sys.stdout, indent=4, sort_keys=True)
+    elif arguments.command == "remotes":
+        remotes = {
+            url_for_path(path): json.loads(path.read_text())
+            for path in collect(REMOTES_DIR)
+        }
+        json.dump(remotes, sys.stdout, indent=4, sort_keys=True)
+    elif arguments.command == "dump_remotes":
+        if arguments.update:
+            shutil.rmtree(arguments.out_dir, ignore_errors=True)
+
+        try:
+            shutil.copytree(REMOTES_DIR, arguments.out_dir)
+        except FileExistsError:
+            print(f"{arguments.out_dir} already exists. Aborting.")
+            sys.exit(1)
+    elif arguments.command == "serve":
+        try:
+            import flask
+        except ImportError:
+            print(textwrap.dedent("""
+                The Flask library is required to serve the remote schemas.
+
+                You can install it by running `pip install Flask`.
+
+                Alternatively, see the `jsonschema_suite remotes` or
+                `jsonschema_suite dump_remotes` commands to create static files
+                that can be served with your own web server.
+            """.strip("\n")))
+            sys.exit(1)
+
+        app = flask.Flask(__name__)
+
+        @app.route("/<path:path>")
+        def serve_path(path):
+            return flask.send_from_directory(REMOTES_DIR, path)
+
+        app.run(port=1234)
+
+
+parser = argparse.ArgumentParser(
+    description="JSON Schema Test Suite utilities",
+)
+subparsers = parser.add_subparsers(
+    help="utility commands", dest="command", metavar="COMMAND"
+)
+subparsers.required = True
+
+check = subparsers.add_parser("check", help="Sanity check the test suite.")
+
+flatten = subparsers.add_parser(
+    "flatten",
+    help="Output a flattened file containing a selected version's test cases."
+)
+flatten.add_argument(
+    "--randomize",
+    action="store_true",
+    help="Randomize the order of the outputted cases.",
+)
+flatten.add_argument(
+    "version", help="The directory containing the version to output",
+)
+
+remotes = subparsers.add_parser(
+    "remotes",
+    help="Output the expected URLs and their associated schemas for remote "
+         "ref tests as a JSON object."
+)
+
+dump_remotes = subparsers.add_parser(
+    "dump_remotes", help="Dump the remote ref schemas into a file tree",
+)
+dump_remotes.add_argument(
+    "--update",
+    action="store_true",
+    help="Update the remotes in an existing directory.",
+)
+dump_remotes.add_argument(
+    "--out-dir",
+    default=REMOTES_DIR,
+    type=os.path.abspath,
+    help="The output directory to create as the root of the file tree",
+)
+
+serve = subparsers.add_parser(
+    "serve",
+    help="Start a webserver to serve schemas used by remote ref tests."
+)
+
+if __name__ == "__main__":
+    main(parser.parse_args())

--- a/asdf/_jsonschema/json/package.json
+++ b/asdf/_jsonschema/json/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "json-schema-test-suite",
+  "version": "0.1.0",
+  "description": "A language agnostic test suite for the JSON Schema specifications",
+  "repository": "github:json-schema-org/JSON-Schema-Test-Suite",
+  "keywords": [
+    "json-schema",
+    "tests"
+  ],
+  "author": "http://json-schema.org",
+  "license": "MIT"
+}

--- a/asdf/_jsonschema/json/remotes/baseUriChange/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/baseUriChange/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/baseUriChangeFolder/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/baseUriChangeFolder/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/different-id-ref-string.json
+++ b/asdf/_jsonschema/json/remotes/different-id-ref-string.json
@@ -1,0 +1,5 @@
+{
+    "$id": "http://localhost:1234/real-id-ref-string.json",
+    "$defs": {"bar": {"type": "string"}},
+    "$ref": "#/$defs/bar"
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/baseUriChange/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/baseUriChange/folderInteger.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/baseUriChangeFolder/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/baseUriChangeFolder/folderInteger.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/extendible-dynamic-ref.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/extendible-dynamic-ref.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "description": "extendible array",
+    "$id": "http://localhost:1234/draft-next/extendible-dynamic-ref.json",
+    "type": "object",
+    "properties": {
+        "elements": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#elements"
+            }
+        }
+    },
+    "required": ["elements"],
+    "additionalProperties": false,
+    "$defs": {
+        "elements": {
+            "$dynamicAnchor": "elements"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/format-assertion-false.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/format-assertion-false.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft-next/format-assertion-false.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/format-assertion": false
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/meta/core" },
+        { "$ref": "https://json-schema.org/draft/next/meta/format-assertion" }
+    ]
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/format-assertion-true.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/format-assertion-true.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft-next/format-assertion-true.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/format-assertion": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/meta/core" },
+        { "$ref": "https://json-schema.org/draft/next/meta/format-assertion" }
+    ]
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/integer.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/integer.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/locationIndependentIdentifier.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/locationIndependentIdentifier.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$defs": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$anchor": "foo",
+            "type": "integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/metaschema-no-validation.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/metaschema-no-validation.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$id": "http://localhost:1234/draft-next/metaschema-no-validation.json",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/applicator": true,
+        "https://json-schema.org/draft/next/vocab/core": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/meta/applicator" },
+        { "$ref": "https://json-schema.org/draft/next/meta/core" }
+    ]
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/name-defs.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/name-defs.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$defs": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/nested/foo-ref-string.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/nested/foo-ref-string.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "type": "object",
+    "properties": {
+        "foo": {"$ref": "string.json"}
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/nested/string.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/nested/string.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "type": "string"
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/ref-and-defs.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/ref-and-defs.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$id": "http://localhost:1234/draft-next/ref-and-defs.json",
+    "$defs": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "$ref": "#/$defs/inner"
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/subSchemas-defs.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/subSchemas-defs.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$defs": {
+        "integer": {
+            "type": "integer"
+        },
+        "refToInteger": {
+            "$ref": "#/$defs/integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/subSchemas.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/subSchemas.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "integer": {
+        "type": "integer"
+    },
+    "refToInteger": {
+        "$ref": "#/integer"
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft-next/tree.json
+++ b/asdf/_jsonschema/json/remotes/draft-next/tree.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "description": "tree schema, extensible",
+    "$id": "http://localhost:1234/draft-next/tree.json",
+    "$dynamicAnchor": "node",
+
+    "type": "object",
+    "properties": {
+        "data": true,
+        "children": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#node"
+            }
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/baseUriChange/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/baseUriChange/folderInteger.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/baseUriChangeFolder/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/baseUriChangeFolder/folderInteger.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/dependentRequired.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/dependentRequired.json
@@ -1,0 +1,7 @@
+{
+    "$id": "http://localhost:1234/draft2019-09/dependentRequired.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "dependentRequired": {
+        "foo": ["bar"]
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/extendible-dynamic-ref.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/extendible-dynamic-ref.json
@@ -1,0 +1,21 @@
+{
+    "description": "extendible array",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "http://localhost:1234/draft2019-09/extendible-dynamic-ref.json",
+    "type": "object",
+    "properties": {
+        "elements": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#elements"
+            }
+        }
+    },
+    "required": ["elements"],
+    "additionalProperties": false,
+    "$defs": {
+        "elements": {
+            "$dynamicAnchor": "elements"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/ignore-prefixItems.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/ignore-prefixItems.json
@@ -1,0 +1,7 @@
+{
+    "$id": "http://localhost:1234/draft2019-09/ignore-prefixItems.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "prefixItems": [
+        {"type": "string"}
+    ]
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/integer.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/integer.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/locationIndependentIdentifier.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/locationIndependentIdentifier.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$anchor": "foo",
+            "type": "integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/metaschema-no-validation.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/metaschema-no-validation.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "http://localhost:1234/draft2019-09/metaschema-no-validation.json",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-09/vocab/core": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/2019-09/meta/applicator" },
+        { "$ref": "https://json-schema.org/draft/2019-09/meta/core" }
+    ]
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/name-defs.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/name-defs.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/nested/foo-ref-string.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/nested/foo-ref-string.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "object",
+    "properties": {
+        "foo": {"$ref": "string.json"}
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/nested/string.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/nested/string.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "string"
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/ref-and-defs.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/ref-and-defs.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "http://localhost:1234/draft2019-09/ref-and-defs.json",
+    "$defs": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "$ref": "#/$defs/inner"
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/subSchemas-defs.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/subSchemas-defs.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+        "integer": {
+            "type": "integer"
+        },
+        "refToInteger": {
+            "$ref": "#/$defs/integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/subSchemas.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/subSchemas.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "integer": {
+        "type": "integer"
+    },
+    "refToInteger": {
+        "$ref": "#/integer"
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2019-09/tree.json
+++ b/asdf/_jsonschema/json/remotes/draft2019-09/tree.json
@@ -1,0 +1,17 @@
+{
+    "description": "tree schema, extensible",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "http://localhost:1234/draft2019-09/tree.json",
+    "$dynamicAnchor": "node",
+
+    "type": "object",
+    "properties": {
+        "data": true,
+        "children": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#node"
+            }
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/baseUriChange/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/baseUriChange/folderInteger.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/baseUriChangeFolder/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/baseUriChangeFolder/folderInteger.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/baseUriChangeFolderInSubschema/folderInteger.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/baseUriChangeFolderInSubschema/folderInteger.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/extendible-dynamic-ref.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/extendible-dynamic-ref.json
@@ -1,0 +1,21 @@
+{
+    "description": "extendible array",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "http://localhost:1234/draft2020-12/extendible-dynamic-ref.json",
+    "type": "object",
+    "properties": {
+        "elements": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#elements"
+            }
+        }
+    },
+    "required": ["elements"],
+    "additionalProperties": false,
+    "$defs": {
+        "elements": {
+            "$dynamicAnchor": "elements"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/format-assertion-false.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/format-assertion-false.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft2020-12/format-assertion-false.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-assertion": false
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/core" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/format-assertion" }
+    ]
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/format-assertion-true.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/format-assertion-true.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft2020-12/format-assertion-true.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-assertion": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/core" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/format-assertion" }
+    ]
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/integer.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/integer.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/locationIndependentIdentifier.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/locationIndependentIdentifier.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$anchor": "foo",
+            "type": "integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/metaschema-no-validation.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/metaschema-no-validation.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "http://localhost:1234/draft2020-12/metaschema-no-validation.json",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+        "https://json-schema.org/draft/2020-12/vocab/core": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/applicator" },
+        { "$ref": "https://json-schema.org/draft/2020-12/meta/core" }
+    ]
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/name-defs.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/name-defs.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/nested/foo-ref-string.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/nested/foo-ref-string.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "foo": {"$ref": "string.json"}
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/nested/string.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/nested/string.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/prefixItems.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/prefixItems.json
@@ -1,0 +1,7 @@
+{
+    "$id": "http://localhost:1234/draft2020-12/prefixItems.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "prefixItems": [
+        {"type": "string"}
+    ]
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/ref-and-defs.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/ref-and-defs.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "http://localhost:1234/draft2020-12/ref-and-defs.json",
+    "$defs": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "$ref": "#/$defs/inner"
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/subSchemas-defs.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/subSchemas-defs.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "integer": {
+            "type": "integer"
+        },
+        "refToInteger": {
+            "$ref": "#/$defs/integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/subSchemas.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/subSchemas.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "integer": {
+        "type": "integer"
+    },
+    "refToInteger": {
+        "$ref": "#/integer"
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft2020-12/tree.json
+++ b/asdf/_jsonschema/json/remotes/draft2020-12/tree.json
@@ -1,0 +1,17 @@
+{
+    "description": "tree schema, extensible",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "http://localhost:1234/draft2020-12/tree.json",
+    "$dynamicAnchor": "node",
+
+    "type": "object",
+    "properties": {
+        "data": true,
+        "children": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#node"
+            }
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/draft7/ignore-dependentRequired.json
+++ b/asdf/_jsonschema/json/remotes/draft7/ignore-dependentRequired.json
@@ -1,0 +1,7 @@
+{
+    "$id": "http://localhost:1234/draft7/integer.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "dependentRequired": {
+        "foo": ["bar"]
+    }
+}

--- a/asdf/_jsonschema/json/remotes/extendible-dynamic-ref.json
+++ b/asdf/_jsonschema/json/remotes/extendible-dynamic-ref.json
@@ -1,0 +1,20 @@
+{
+    "description": "extendible array",
+    "$id": "http://localhost:1234/extendible-dynamic-ref.json",
+    "type": "object",
+    "properties": {
+        "elements": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#elements"
+            }
+        }
+    },
+    "required": ["elements"],
+    "additionalProperties": false,
+    "$defs": {
+        "elements": {
+            "$dynamicAnchor": "elements"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/integer.json
+++ b/asdf/_jsonschema/json/remotes/integer.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/asdf/_jsonschema/json/remotes/locationIndependentIdentifier.json
+++ b/asdf/_jsonschema/json/remotes/locationIndependentIdentifier.json
@@ -1,0 +1,11 @@
+{
+    "$defs": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$anchor": "foo",
+            "type": "integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/locationIndependentIdentifierDraft4.json
+++ b/asdf/_jsonschema/json/remotes/locationIndependentIdentifierDraft4.json
@@ -1,0 +1,11 @@
+{
+    "definitions": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "id": "#foo",
+            "type": "integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/locationIndependentIdentifierPre2019.json
+++ b/asdf/_jsonschema/json/remotes/locationIndependentIdentifierPre2019.json
@@ -1,0 +1,11 @@
+{
+    "definitions": {
+        "refToInteger": {
+            "$ref": "#foo"
+        },
+        "A": {
+            "$id": "#foo",
+            "type": "integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/name-defs.json
+++ b/asdf/_jsonschema/json/remotes/name-defs.json
@@ -1,0 +1,15 @@
+{
+    "$defs": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/asdf/_jsonschema/json/remotes/name.json
+++ b/asdf/_jsonschema/json/remotes/name.json
@@ -1,0 +1,15 @@
+{
+    "definitions": {
+        "orNull": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "$ref": "#"
+                }
+            ]
+        }
+    },
+    "type": "string"
+}

--- a/asdf/_jsonschema/json/remotes/nested-absolute-ref-to-string.json
+++ b/asdf/_jsonschema/json/remotes/nested-absolute-ref-to-string.json
@@ -1,0 +1,9 @@
+{
+    "$defs": {
+        "bar": {
+            "$id": "http://localhost:1234/the-nested-id.json",
+            "type": "string"
+        }
+    },
+    "$ref": "http://localhost:1234/the-nested-id.json"
+}

--- a/asdf/_jsonschema/json/remotes/nested/foo-ref-string.json
+++ b/asdf/_jsonschema/json/remotes/nested/foo-ref-string.json
@@ -1,0 +1,6 @@
+{
+    "type": "object",
+    "properties": {
+        "foo": {"$ref": "string.json"}
+    }
+}

--- a/asdf/_jsonschema/json/remotes/nested/string.json
+++ b/asdf/_jsonschema/json/remotes/nested/string.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/asdf/_jsonschema/json/remotes/ref-and-definitions.json
+++ b/asdf/_jsonschema/json/remotes/ref-and-definitions.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/ref-and-definitions.json",
+    "definitions": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "allOf": [ { "$ref": "#/definitions/inner" } ]
+}

--- a/asdf/_jsonschema/json/remotes/ref-and-defs.json
+++ b/asdf/_jsonschema/json/remotes/ref-and-defs.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/ref-and-defs.json",
+    "$defs": {
+        "inner": {
+            "properties": {
+                "bar": { "type": "string" }
+            }
+        }
+    },
+    "$ref": "#/$defs/inner"
+}

--- a/asdf/_jsonschema/json/remotes/subSchemas-defs.json
+++ b/asdf/_jsonschema/json/remotes/subSchemas-defs.json
@@ -1,0 +1,10 @@
+{
+    "$defs": {
+        "integer": {
+            "type": "integer"
+        },
+        "refToInteger": {
+            "$ref": "#/$defs/integer"
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/subSchemas.json
+++ b/asdf/_jsonschema/json/remotes/subSchemas.json
@@ -1,0 +1,8 @@
+{
+    "integer": {
+        "type": "integer"
+    },
+    "refToInteger": {
+        "$ref": "#/integer"
+    }
+}

--- a/asdf/_jsonschema/json/remotes/tree.json
+++ b/asdf/_jsonschema/json/remotes/tree.json
@@ -1,0 +1,16 @@
+{
+    "description": "tree schema, extensible",
+    "$id": "http://localhost:1234/tree.json",
+    "$dynamicAnchor": "node",
+
+    "type": "object",
+    "properties": {
+        "data": true,
+        "children": {
+            "type": "array",
+            "items": {
+                "$dynamicRef": "#node"
+            }
+        }
+    }
+}

--- a/asdf/_jsonschema/json/remotes/urn-ref-string.json
+++ b/asdf/_jsonschema/json/remotes/urn-ref-string.json
@@ -1,0 +1,5 @@
+{
+    "$id": "urn:uuid:feebdaed-ffff-0000-ffff-0000deadbeef",
+    "$defs": {"bar": {"type": "string"}},
+    "$ref": "#/$defs/bar"
+}

--- a/asdf/_jsonschema/json/test-schema.json
+++ b/asdf/_jsonschema/json/test-schema.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "A schema for files contained within this suite",
+
+    "type": "array",
+    "minItems": 1,
+    "items": {
+        "description": "An individual test case, containing multiple tests of a single schema's behavior",
+
+        "type": "object",
+        "required": [ "description", "schema", "tests" ],
+        "properties": {
+            "description": {
+                "description": "The test case description",
+                "type": "string"
+            },
+            "comment": {
+                "description": "Any additional comments about the test case",
+                "type": "string"
+            },
+            "schema": {
+                "description": "A valid JSON Schema (one written for the corresponding version directory that the file sits within)."
+            },
+            "tests": {
+                "description": "A set of related tests all using the same schema",
+                "type": "array",
+                "items": { "$ref": "#/$defs/test" },
+                "minItems": 1
+            }
+        },
+        "additionalProperties": false
+    },
+
+    "$defs": {
+        "test": {
+            "description": "A single test",
+
+            "type": "object",
+            "required": [ "description", "data", "valid" ],
+            "properties": {
+                "description": {
+                    "description": "The test description, briefly explaining which behavior it exercises",
+                    "type": "string"
+                },
+                "comment": {
+                    "description": "Any additional comments about the test",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "The instance which should be validated against the schema in \"schema\"."
+                },
+                "valid": {
+                    "description": "Whether the validation process of this instance should consider the instance valid or not",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/asdf/_jsonschema/json/tests/draft-next/additionalProperties.json
+++ b/asdf/_jsonschema/json/tests/draft-next/additionalProperties.json
@@ -1,0 +1,156 @@
+[
+    {
+        "description":
+            "additionalProperties being false does not allow other properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {"foo": {}, "bar": {}},
+            "patternProperties": { "^v": {} },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "patternProperties are not additional properties",
+                "data": {"foo":1, "vroom": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "non-ASCII pattern with additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "patternProperties": {"^á": {}},
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "matching the pattern is valid",
+                "data": {"ármányos": 2},
+                "valid": true
+            },
+            {
+                "description": "not matching the pattern is invalid",
+                "data": {"élmény": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {"foo": {}, "bar": {}},
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties can exist by itself",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties are allowed by default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {"foo": {}, "bar": {}}
+        },
+        "tests": [
+            {
+                "description": "additional properties are allowed",
+                "data": {"foo": 1, "bar": 2, "quux": true},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties does not look in applicators",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not examined",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "additionalProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/allOf.json
+++ b/asdf/_jsonschema/json/tests/draft-next/allOf.json
@@ -1,0 +1,312 @@
+[
+    {
+        "description": "allOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allOf",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "mismatch second",
+                "data": {"foo": "baz"},
+                "valid": false
+            },
+            {
+                "description": "mismatch first",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "baz", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {"bar": {"type": "integer"}},
+            "required": ["bar"],
+            "allOf" : [
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                },
+                {
+                    "properties": {
+                        "baz": {"type": "null"}
+                    },
+                    "required": ["baz"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "valid": true
+            },
+            {
+                "description": "mismatch base schema",
+                "data": {"foo": "quux", "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch first allOf",
+                "data": {"bar": 2, "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch second allOf",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "mismatch both",
+                "data": {"bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf simple types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {"maximum": 30},
+                {"minimum": 20}
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": 25,
+                "valid": true
+            },
+            {
+                "description": "mismatch one",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, some false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf combined with anyOf, oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [ { "multipleOf": 2 } ],
+            "anyOf": [ { "multipleOf": 3 } ],
+            "oneOf": [ { "multipleOf": 5 } ]
+        },
+        "tests": [
+            {
+                "description": "allOf: false, anyOf: false, oneOf: false",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: false, oneOf: true",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: false",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: true",
+                "data": 15,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: false",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: true",
+                "data": 10,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: false",
+                "data": 6,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: true",
+                "data": 30,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/anchor.json
+++ b/asdf/_jsonschema/json/tests/draft-next/anchor.json
@@ -1,0 +1,234 @@
+[
+    {
+        "description": "Location-independent identifier",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "#foo",
+            "$defs": {
+                "A": {
+                    "$anchor": "foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with absolute URI",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/bar#foo",
+            "$defs": {
+                "A": {
+                    "$id": "http://localhost:1234/draft-next/bar",
+                    "$anchor": "foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with base URI change in subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/root",
+            "$ref": "http://localhost:1234/draft-next/nested.json#foo",
+            "$defs": {
+                "A": {
+                    "$id": "nested.json",
+                    "$defs": {
+                        "B": {
+                            "$anchor": "foo",
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$anchor inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $anchor buried in the enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "anchor_in_enum": {
+                    "enum": [
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "null"
+                        }
+                    ]
+                },
+                "real_identifier_in_schema": {
+                    "$anchor": "my_anchor",
+                    "type": "string"
+                },
+                "zzz_anchor_in_const": {
+                    "const": {
+                        "$anchor": "my_anchor",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/anchor_in_enum" },
+                { "$ref": "#my_anchor" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$anchor": "my_anchor",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "in implementations that strip $anchor, this may match either $def",
+                "data": {
+                    "type": "null"
+                },
+                "valid": false
+            },
+            {
+                "description": "match $ref to $anchor",
+                "data": "a string to match #/$defs/anchor_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $anchor",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "same $anchor with different base uri",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/foobar",
+            "$defs": {
+                "A": {
+                    "$id": "child1",
+                    "allOf": [
+                        {
+                            "$id": "child2",
+                            "$anchor": "my_anchor",
+                            "type": "number"
+                        },
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "$ref": "child1#my_anchor"
+        },
+        "tests": [
+            {
+                "description": "$ref resolves to /$defs/A/allOf/1",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "$ref does not resolve to /$defs/A/allOf/0",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $anchor property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "const_not_anchor": {
+                    "const": {
+                        "$anchor": "not_a_real_anchor"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_anchor"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/$defs/const_not_anchor"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_anchor",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_anchor does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "invalid anchors",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
+        "tests": [
+            {
+                "description": "MUST start with a letter (and not #)",
+                "data": { "$anchor" : "#foo" },
+                "valid": false
+            },
+            {
+                "description": "JSON pointers are not valid",
+                "data": { "$anchor" : "/a/b" },
+                "valid": false
+            },
+            {
+                "description": "invalid with valid beginning",
+                "data": { "$anchor" : "foo#something" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/anyOf.json
+++ b/asdf/_jsonschema/json/tests/draft-next/anyOf.json
@@ -1,0 +1,203 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid",
+                "data": 3,
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one anyOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, some true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/boolean_schema.json
+++ b/asdf/_jsonschema/json/tests/draft-next/boolean_schema.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "boolean schema 'true'",
+        "schema": true,
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "boolean true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "boolean false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean schema 'false'",
+        "schema": false,
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "boolean true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "boolean false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/const.json
+++ b/asdf/_jsonschema/json/tests/draft-next/const.json
@@ -1,0 +1,387 @@
+[
+    {
+        "description": "const validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": 2
+        },
+        "tests": [
+            {
+                "description": "same value is valid",
+                "data": 2,
+                "valid": true
+            },
+            {
+                "description": "another value is invalid",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": {"foo": "bar", "baz": "bax"}
+        },
+        "tests": [
+            {
+                "description": "same object is valid",
+                "data": {"foo": "bar", "baz": "bax"},
+                "valid": true
+            },
+            {
+                "description": "same object with different property order is valid",
+                "data": {"baz": "bax", "foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "another object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": [1, 2],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": [{ "foo": "bar" }]
+        },
+        "tests": [
+            {
+                "description": "same array is valid",
+                "data": [{"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "another array item is invalid",
+                "data": [2],
+                "valid": false
+            },
+            {
+                "description": "array with additional items is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with null",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": null
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "not null is invalid",
+                "data": 0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with false does not match 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": false
+        },
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with true does not match 1",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": true
+        },
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": [false]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": [true]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": false} does not match {\"a\": 0}",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": {"a": false}
+        },
+        "tests": [
+            {
+                "description": "{\"a\": false} is valid",
+                "data": {"a": false},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 0} is invalid",
+                "data": {"a": 0},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 0.0} is invalid",
+                "data": {"a": 0.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": true} does not match {\"a\": 1}",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": {"a": true}
+        },
+        "tests": [
+            {
+                "description": "{\"a\": true} is valid",
+                "data": {"a": true},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 1} is invalid",
+                "data": {"a": 1},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 1.0} is invalid",
+                "data": {"a": 1.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 0 does not match other zero-like types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": 0
+        },
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
+                "data": "",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 1 does not match true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": 1
+        },
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "const with -2.0 matches integer and float types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": -2.0
+        },
+        "tests": [
+            {
+                "description": "integer -2 is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "integer 2 is invalid",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "float -2.0 is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float 2.0 is invalid",
+                "data": 2.0,
+                "valid": false
+            },
+            {
+                "description": "float -2.00001 is invalid",
+                "data": -2.00001,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float and integers are equal up to 64-bit representation limits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": 9007199254740992
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 9007199254740992,
+                "valid": true
+            },
+            {
+                "description": "integer minus one is invalid",
+                "data": 9007199254740991,
+                "valid": false
+            },
+            {
+                "description": "float is valid",
+                "data": 9007199254740992.0,
+                "valid": true
+            },
+            {
+                "description": "float minus one is invalid",
+                "data": 9007199254740991.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "const": "hello\u0000there"
+        },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/contains.json
+++ b/asdf/_jsonschema/json/tests/draft-next/contains.json
@@ -1,0 +1,267 @@
+[
+    {
+        "description": "contains keyword validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": { "minimum": 5 }
+        },
+        "tests": [
+            {
+                "description": "array with item matching schema (5) is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with item matching schema (6) is valid",
+                "data": [3, 4, 6],
+                "valid": true
+            },
+            {
+                "description": "array with two items matching schema (5, 6) is valid",
+                "data": [3, 4, 5, 6],
+                "valid": true
+            },
+            {
+                "description": "array without items matching schema is invalid",
+                "data": [2, 3, 4],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "object with property matching schema (5) is valid",
+                "data": { "a": 3, "b": 4, "c": 5 },
+                "valid": true
+            },
+            {
+                "description": "object with property matching schema (6) is valid",
+                "data": { "a": 3, "b": 4, "c": 6 },
+                "valid": true
+            },
+            {
+                "description": "object with two properties matching schema (5, 6) is valid",
+                "data": { "a": 3, "b": 4, "c": 5, "d": 6 },
+                "valid": true
+            },
+            {
+                "description": "object without properties matching schema is invalid",
+                "data": { "a": 2, "b": 3, "c": 4 },
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "not array or object is valid",
+                "data": 42,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with const keyword",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": { "const": 5 }
+        },
+        "tests": [
+            {
+                "description": "array with item 5 is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with two items 5 is valid",
+                "data": [3, 4, 5, 5],
+                "valid": true
+            },
+            {
+                "description": "array without item 5 is invalid",
+                "data": [1, 2, 3, 4],
+                "valid": false
+            },
+            {
+                "description": "object with property 5 is valid",
+                "data": { "a": 3, "b": 4, "c": 5 },
+                "valid": true
+            },
+            {
+                "description": "object with two properties 5 is valid",
+                "data": { "a": 3, "b": 4, "c": 5, "d": 5 },
+                "valid": true
+            },
+            {
+                "description": "object without property 5 is invalid",
+                "data": { "a": 1, "b": 2, "c": 3, "d": 4 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": true
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "any non-empty object is valid",
+                "data": { "a": "foo" },
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": false
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "any non-empty object is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "non-arrays/objects are valid",
+                "data": "contains does not apply to strings",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items + contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "additionalProperties": { "multipleOf": 2 },
+            "items": { "multipleOf": 2 },
+            "contains": { "multipleOf": 3 }
+        },
+        "tests": [
+            {
+                "description": "matches items, does not match contains",
+                "data": [2, 4, 8],
+                "valid": false
+            },
+            {
+                "description": "does not match items, matches contains",
+                "data": [3, 6, 9],
+                "valid": false
+            },
+            {
+                "description": "matches both items and contains",
+                "data": [6, 12],
+                "valid": true
+            },
+            {
+                "description": "matches neither items nor contains",
+                "data": [1, 5],
+                "valid": false
+            },
+            {
+                "description": "matches additionalProperties, does not match contains",
+                "data": { "a": 2, "b": 4, "c": 8 },
+                "valid": false
+            },
+            {
+                "description": "does not match additionalProperties, matches contains",
+                "data": { "a": 3, "b": 6, "c": 9 },
+                "valid": false
+            },
+            {
+                "description": "matches both additionalProperties and contains",
+                "data": { "a": 6, "b": 12 },
+                "valid": true
+            },
+            {
+                "description": "matches neither additionalProperties nor contains",
+                "data": { "a": 1, "b": 5 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with false if subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": {
+                "if": false,
+                "else": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "any non-empty object is valid",
+                "data": { "a": "foo" },
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null items",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/content.json
+++ b/asdf/_jsonschema/json/tests/draft-next/content.json
@@ -1,0 +1,131 @@
+[
+    {
+        "description": "validation of string-encoded content based on media type",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contentMediaType": "application/json"
+        },
+        "tests": [
+            {
+                "description": "a valid JSON document",
+                "data": "{\"foo\": \"bar\"}",
+                "valid": true
+            },
+            {
+                "description": "an invalid JSON document; validates true",
+                "data": "{:}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary string-encoding",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64 string",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string (% is not a valid character); validates true",
+                "data": "eyJmb28iOi%iYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary-encoded media type documents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64-encoded JSON document",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "a validly-encoded invalid JSON document; validates true",
+                "data": "ezp9Cg==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string that is valid JSON; validates true",
+                "data": "{}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary-encoded media type documents with schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64",
+            "contentSchema": { "type": "object", "required": ["foo"], "properties": { "foo": { "type": "string" } } }
+        },
+        "tests": [
+            {
+                "description": "a valid base64-encoded JSON document",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "another valid base64-encoded JSON document",
+                "data": "eyJib28iOiAyMCwgImZvbyI6ICJiYXoifQ==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64-encoded JSON document; validates true",
+                "data": "eyJib28iOiAyMH0=",
+                "valid": true
+            },
+            {
+                "description": "an empty object as a base64-encoded JSON document; validates true",
+                "data": "e30=",
+                "valid": true
+            },
+            {
+                "description": "an empty array as a base64-encoded JSON document",
+                "data": "W10=",
+                "valid": true
+            },
+            {
+                "description": "a validly-encoded invalid JSON document; validates true",
+                "data": "ezp9Cg==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string that is valid JSON; validates true",
+                "data": "{}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/default.json
+++ b/asdf/_jsonschema/json/tests/draft-next/default.json
@@ -1,0 +1,82 @@
+[
+    {
+        "description": "invalid type for default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {
+                    "type": "integer",
+                    "default": []
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"foo": 13},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid string value for default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "minLength": 4,
+                    "default": "bad"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"bar": "good"},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/defs.json
+++ b/asdf/_jsonschema/json/tests/draft-next/defs.json
@@ -1,0 +1,21 @@
+[
+    {
+        "description": "validate definition against metaschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
+        "tests": [
+            {
+                "description": "valid definition schema",
+                "data": {"$defs": {"foo": {"type": "integer"}}},
+                "valid": true
+            },
+            {
+                "description": "invalid definition schema",
+                "data": {"$defs": {"foo": {"type": 1}}},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/dependentRequired.json
+++ b/asdf/_jsonschema/json/tests/draft-next/dependentRequired.json
@@ -1,0 +1,152 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentRequired": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "empty dependents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentRequired": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependents required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentRequired": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentRequired": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "CRLF",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quotes",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "CRLF missing dependent",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quotes missing dependent",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/dependentSchemas.json
+++ b/asdf/_jsonschema/json/tests/draft-next/dependentSchemas.json
@@ -1,0 +1,132 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentSchemas": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean subschemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentSchemas": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependentSchemas": {
+                "foo\tbar": {"minProperties": 4},
+                "foo'bar": {"required": ["foo\"bar"]}
+            }
+        },
+        "tests": [
+            {
+                "description": "quoted tab",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quote",
+                "data": {
+                    "foo'bar": {"foo\"bar": 1}
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted tab invalid under dependent schema",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quote invalid under dependent schema",
+                "data": {"foo'bar": 1},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/dynamicRef.json
+++ b/asdf/_jsonschema/json/tests/draft-next/dynamicRef.json
@@ -1,0 +1,577 @@
+[
+    {
+        "description": "A $dynamicRef to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "https://test.json-schema.org/dynamicRef-dynamicAnchor-same-schema/root",
+            "type": "array",
+            "items": { "$dynamicRef": "#items" },
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $ref to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "https://test.json-schema.org/ref-dynamicAnchor-same-schema/root",
+            "type": "array",
+            "items": { "$ref": "#items" },
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef resolves to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "https://test.json-schema.org/typical-dynamic-resolution/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef with intermediate scopes that don't include a matching $dynamicAnchor does not affect dynamic scope resolution",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "https://test.json-schema.org/dynamic-resolution-with-intermediate-scopes/root",
+            "$ref": "intermediate-scope",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "intermediate-scope": {
+                    "$id": "intermediate-scope",
+                    "$ref": "list"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "An $anchor with the same name as a $dynamicAnchor is not used for dynamic scope resolution",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "https://test.json-schema.org/dynamic-resolution-ignores-anchors/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$anchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                      "items": {
+                          "$dynamicAnchor": "items"
+                      }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "Any array is valid",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef that initially resolves to a schema with a matching $dynamicAnchor resolves to the first $dynamicAnchor in the dynamic scope",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "https://test.json-schema.org/relative-dynamic-reference/root",
+            "$dynamicAnchor": "meta",
+            "type": "object",
+            "properties": {
+                "foo": { "const": "pass" }
+            },
+            "$ref": "extended",
+            "$defs": {
+                "extended": {
+                    "$id": "extended",
+                    "$dynamicAnchor": "meta",
+                    "type": "object",
+                    "properties": {
+                        "bar": { "$ref": "bar" }
+                    }
+                },
+                "bar": {
+                    "$id": "bar",
+                    "type": "object",
+                    "properties": {
+                        "baz": { "$dynamicRef": "extended#meta" }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "The recursive part is valid against the root",
+                "data": {
+                    "foo": "pass",
+                    "bar": {
+                        "baz": { "foo": "pass" }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "The recursive part is not valid against the root",
+                "data": {
+                    "foo": "pass",
+                    "bar": {
+                        "baz": { "foo": "fail" }
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple dynamic paths to the $dynamicRef keyword",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "https://test.json-schema.org/dynamic-ref-with-multiple-paths/main",
+            "$defs": {
+                "inner": {
+                    "$id": "inner",
+                    "$dynamicAnchor": "foo",
+                    "title": "inner",
+                    "additionalProperties": {
+                        "$dynamicRef": "#foo"
+                    }
+                }
+            },
+            "if": {
+                "propertyNames": {
+                    "pattern": "^[a-m]"
+                }
+            },
+            "then": {
+                "title": "any type of node",
+                "$id": "anyLeafNode",
+                "$dynamicAnchor": "foo",
+                "$ref": "inner"
+            },
+            "else": {
+                "title": "integer node",
+                "$id": "integerNode",
+                "$dynamicAnchor": "foo",
+                "type": [ "object", "integer" ],
+                "$ref": "inner"
+            }
+        },
+        "tests": [
+            {
+                "description": "recurse to anyLeafNode - floats are allowed",
+                "data": { "alpha": 1.1 },
+                "valid": true
+            },
+            {
+                "description": "recurse to integerNode - floats are not allowed",
+                "data": { "november": 1.1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "after leaving a dynamic scope, it is not used by a $dynamicRef",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main",
+            "if": {
+                "$id": "first_scope",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is first_scope#thingy",
+                        "$dynamicAnchor": "thingy",
+                        "type": "number"
+                    }
+                }
+            },
+            "then": {
+                "$id": "second_scope",
+                "$ref": "start",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is second_scope#thingy, the final destination of the $dynamicRef",
+                        "$dynamicAnchor": "thingy",
+                        "type": "null"
+                    }
+                }
+            },
+            "$defs": {
+                "start": {
+                    "$comment": "this is the landing spot from $ref",
+                    "$id": "start",
+                    "$dynamicRef": "inner_scope#thingy"
+                },
+                "thingy": {
+                    "$comment": "this is the first stop for the $dynamicRef",
+                    "$id": "inner_scope",
+                    "$dynamicAnchor": "thingy",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "string matches /$defs/thingy, but the $dynamicRef does not stop here",
+                "data": "a string",
+                "valid": false
+            },
+            {
+                "description": "first_scope is not in dynamic scope for the $dynamicRef",
+                "data": 42,
+                "valid": false
+            },
+            {
+                "description": "/then/$defs/thingy is the final stop for the $dynamicRef",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "strict-tree schema, guards against misspelled properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/strict-tree.json",
+            "$dynamicAnchor": "node",
+
+            "$ref": "tree.json",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "instance with misspelled field",
+                "data": {
+                    "children": [{
+                            "daat": 1
+                        }]
+                },
+                "valid": false
+            },
+            {
+                "description": "instance with correct field",
+                "data": {
+                    "children": [{
+                            "data": 1
+                        }]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "tests for implementation dynamic anchor and reference link",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/strict-extendible.json",
+            "$ref": "extendible-dynamic-ref.json",
+            "$defs": {
+                "elements": {
+                    "$dynamicAnchor": "elements",
+                    "properties": {
+                        "a": true
+                    },
+                    "required": ["a"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "incorrect parent schema",
+                "data": {
+                    "a": true
+                },
+                "valid": false
+            },
+            {
+                "description": "incorrect extended schema",
+                "data": {
+                    "elements": [
+                        { "b": 1 }
+                    ]
+                },
+                "valid": false
+            },
+            {
+                "description": "correct extended schema",
+                "data": {
+                    "elements": [
+                        { "a": 1 }
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref and $dynamicAnchor are independent of order - $defs first",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/strict-extendible-allof-defs-first.json",
+            "allOf": [
+                {
+                    "$ref": "extendible-dynamic-ref.json"
+                },
+                {
+                    "$defs": {
+                        "elements": {
+                            "$dynamicAnchor": "elements",
+                            "properties": {
+                                "a": true
+                            },
+                            "required": ["a"],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "incorrect parent schema",
+                "data": {
+                    "a": true
+                },
+                "valid": false
+            },
+            {
+                "description": "incorrect extended schema",
+                "data": {
+                    "elements": [
+                        { "b": 1 }
+                    ]
+                },
+                "valid": false
+            },
+            {
+                "description": "correct extended schema",
+                "data": {
+                    "elements": [
+                        { "a": 1 }
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref and $dynamicAnchor are independent of order - $ref first",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/strict-extendible-allof-ref-first.json",
+            "allOf": [
+                {
+                    "$defs": {
+                        "elements": {
+                            "$dynamicAnchor": "elements",
+                            "properties": {
+                                "a": true
+                            },
+                            "required": ["a"],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                {
+                    "$ref": "extendible-dynamic-ref.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "incorrect parent schema",
+                "data": {
+                    "a": true
+                },
+                "valid": false
+            },
+            {
+                "description": "incorrect extended schema",
+                "data": {
+                    "elements": [
+                        { "b": 1 }
+                    ]
+                },
+                "valid": false
+            },
+            {
+                "description": "correct extended schema",
+                "data": {
+                    "elements": [
+                        { "a": 1 }
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$dynamicAnchor inside propertyDependencies",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/dynamicanchor-in-propertydependencies.json",
+            "$defs": {
+                "inner": {
+                    "$id": "inner",
+                    "$dynamicAnchor": "foo",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$dynamicRef": "#foo"
+                    }
+                }
+            },
+            "propertyDependencies": {
+                "expectedTypes": {
+                    "strings": {
+                        "$id": "east",
+                        "$ref": "inner",
+                        "$defs": {
+                            "foo": {
+                                "$dynamicAnchor": "foo",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "integers": {
+                        "$id": "west",
+                        "$ref": "inner",
+                        "$defs": {
+                            "foo": {
+                                "$dynamicAnchor": "foo",
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "expected strings - additional property as string is valid",
+                "data": {
+                    "expectedTypes": "strings",
+                    "anotherProperty": "also a string"
+                },
+                "valid": true
+            },
+            {
+                "description": "expected strings - additional property as not string is invalid",
+                "data": {
+                    "expectedTypes": "strings",
+                    "anotherProperty": 42
+                },
+                "valid": false
+            },
+            {
+                "description": "expected integers - additional property as integer is valid",
+                "data": {
+                    "expectedTypes": "integers",
+                    "anotherProperty": 42
+                },
+                "valid": true
+            },
+            {
+                "description": "expected integers - additional property as not integer is invalid",
+                "data": {
+                    "expectedTypes": "integers",
+                    "anotherProperty": "a string"
+                },
+                "valid": false
+            },
+            {
+                "description": "expected missing - additional property as an object is valid",
+                "data": {
+                    "anotherProperty": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "expected missing - additional property as not object is invalid",
+                "data": {
+                    "anotherProperty": 42
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/enum.json
+++ b/asdf/_jsonschema/json/tests/draft-next/enum.json
@@ -1,0 +1,262 @@
+[
+    {
+        "description": "simple enum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [1, 2, 3]
+        },
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": 4,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [6, "foo", [], true, {"foo": 12}]
+        },
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": {"foo": false},
+                "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum-with-null validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [6, null]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 6,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": "test",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enums in properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type":"object",
+            "properties": {
+                "foo": {"enum":["foo"]},
+                "bar": {"enum":["bar"]}
+            },
+            "required": ["bar"]
+        },
+        "tests": [
+            {
+                "description": "both properties are valid",
+                "data": {"foo":"foo", "bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "wrong foo value",
+                "data": {"foo":"foot", "bar":"bar"},
+                "valid": false
+            },
+            {
+                "description": "wrong bar value",
+                "data": {"foo":"foo", "bar":"bart"},
+                "valid": false
+            },
+            {
+                "description": "missing optional property is valid",
+                "data": {"bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing required property is invalid",
+                "data": {"foo":"foo"},
+                "valid": false
+            },
+            {
+                "description": "missing all properties is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": ["foo\nbar", "foo\rbar"]
+        },
+        "tests": [
+            {
+                "description": "member 1 is valid",
+                "data": "foo\nbar",
+                "valid": true
+            },
+            {
+                "description": "member 2 is valid",
+                "data": "foo\rbar",
+                "valid": true
+            },
+            {
+                "description": "another string is invalid",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [false]
+        },
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [true]
+        },
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [0]
+        },
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [1]
+        },
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "enum": [ "hello\u0000there" ]
+        },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/exclusiveMaximum.json
+++ b/asdf/_jsonschema/json/tests/draft-next/exclusiveMaximum.json
@@ -1,0 +1,31 @@
+[
+    {
+        "description": "exclusiveMaximum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "exclusiveMaximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the exclusiveMaximum is valid",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 3.0,
+                "valid": false
+            },
+            {
+                "description": "above the exclusiveMaximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/exclusiveMinimum.json
+++ b/asdf/_jsonschema/json/tests/draft-next/exclusiveMinimum.json
@@ -1,0 +1,31 @@
+[
+    {
+        "description": "exclusiveMinimum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "exclusiveMinimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the exclusiveMinimum is valid",
+                "data": 1.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "below the exclusiveMinimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/format.json
+++ b/asdf/_jsonschema/json/tests/draft-next/format.json
@@ -1,0 +1,743 @@
+[
+    {
+        "description": "email format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-email format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "idn-email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "regex format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv4 format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv6 format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "ipv6"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-hostname format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "hostname format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "date"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date-time format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "date-time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "time format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "json-pointer format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative-json-pointer format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "relative-json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "iri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri-reference format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "iri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-reference format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-template format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri-template"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uuid format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uuid"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "duration format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "duration"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/id.json
+++ b/asdf/_jsonschema/json/tests/draft-next/id.json
@@ -1,0 +1,294 @@
+[
+    {
+        "description": "Invalid use of fragments in location-independent $id",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
+        "tests": [
+            {
+                "description": "Identifier name",
+                "data": {
+                    "$ref": "#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "#foo",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name and no ref",
+                "data": {
+                    "$defs": {
+                        "A": { "$id": "#foo" }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path",
+                "data": {
+                    "$ref": "#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "#/a/b",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft-next/bar#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft-next/bar#foo",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft-next/bar#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft-next/bar#/a/b",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft-next/root",
+                    "$ref": "http://localhost:1234/draft-next/nested.json#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#foo",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft-next/root",
+                    "$ref": "http://localhost:1234/draft-next/nested.json#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#/a/b",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Valid use of empty fragments in location-independent $id",
+        "comment": "These are allowed but discouraged",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
+        "tests": [
+            {
+                "description": "Identifier name with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft-next/bar",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft-next/bar#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Identifier name with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft-next/root",
+                    "$ref": "http://localhost:1234/draft-next/nested.json#/$defs/B",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Unnormalized $ids are allowed but discouraged",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
+        "tests": [
+            {
+                "description": "Unnormalized identifier",
+                "data": {
+                    "$ref": "http://localhost:1234/draft-next/foo/baz",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft-next/foo/bar/../baz",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier and no ref",
+                "data": {
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft-next/foo/bar/../baz",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier with empty fragment",
+                "data": {
+                    "$ref": "http://localhost:1234/draft-next/foo/baz",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft-next/foo/bar/../baz#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier with empty fragment and no ref",
+                "data": {
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft-next/foo/bar/../baz#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $id buried in the enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "$id": "https://localhost:1234/draft-next/id/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/draft-next/id/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "$id": "https://localhost:1234/draft-next/id/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_enum" },
+                { "$ref": "https://localhost:1234/draft-next/id/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$id": "https://localhost:1234/draft-next/id/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to $id",
+                "data": "a string to match #/$defs/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $id property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "const_not_id": {
+                    "const": {
+                        "$id": "not_a_real_id"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_id"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/$defs/const_not_id"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_id",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_id does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/if-then-else.json
+++ b/asdf/_jsonschema/json/tests/draft-next/if-then-else.json
@@ -1,0 +1,268 @@
+[
+    {
+        "description": "ignore if without then or else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "if": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone if",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone if",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore then without if",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "then": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone then",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone then",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore else without if",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "else": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone else",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone else",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and then without else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid when if test fails",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and else without then",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when if test passes",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validate against correct branch, then vs else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-interference across combined schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {
+                    "if": {
+                        "exclusiveMaximum": 0
+                    }
+                },
+                {
+                    "then": {
+                        "minimum": -10
+                    }
+                },
+                {
+                    "else": {
+                        "multipleOf": 2
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid, but would have been invalid through then",
+                "data": -100,
+                "valid": true
+            },
+            {
+                "description": "valid, but would have been invalid through else",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "if": true,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema true in if always chooses the then path (valid)",
+                "data": "then",
+                "valid": true
+            },
+            {
+                "description": "boolean schema true in if always chooses the then path (invalid)",
+                "data": "else",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "if": false,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema false in if always chooses the else path (invalid)",
+                "data": "then",
+                "valid": false
+            },
+            {
+                "description": "boolean schema false in if always chooses the else path (valid)",
+                "data": "else",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if appears at the end when serialized (keyword processing sequence)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "then": { "const": "yes" },
+            "else": { "const": "other" },
+            "if": { "maxLength": 4 }
+        },
+        "tests": [
+            {
+                "description": "yes redirects to then and passes",
+                "data": "yes",
+                "valid": true
+            },
+            {
+                "description": "other redirects to else and passes",
+                "data": "other",
+                "valid": true
+            },
+            {
+                "description": "no redirects to then and fails",
+                "data": "no",
+                "valid": false
+            },
+            {
+                "description": "invalid redirects to else and fails",
+                "data": "invalid",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/infinite-loop-detection.json
+++ b/asdf/_jsonschema/json/tests/draft-next/infinite-loop-detection.json
@@ -1,0 +1,37 @@
+[
+    {
+        "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "int": { "type": "integer" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "$ref": "#/$defs/int"
+                        }
+                    }
+                },
+                {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/int"
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "passing case",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "failing case",
+                "data": { "foo": "a string" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/items.json
+++ b/asdf/_jsonschema/json/tests/draft-next/items.json
@@ -1,0 +1,284 @@
+[
+    {
+        "description": "a schema given for items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "items": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of items",
+                "data": [1, "x"],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "length": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (true)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "items": true
+        },
+        "tests": [
+            {
+                "description": "any array is valid",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (false)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": [ 1, "foo", true ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "item": {
+                    "type": "array",
+                    "items": false,
+                    "prefixItems": [
+                        { "$ref": "#/$defs/sub-item" },
+                        { "$ref": "#/$defs/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "items": false,
+            "prefixItems": [
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "prefixItems with no additional items allowed",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [{}, {}, {}],
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "additional items are not permitted",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items does not look in applicators, valid case",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                { "prefixItems": [ { "minimum": 3 } ] }
+            ],
+            "items": { "minimum": 5 }
+        },
+        "tests": [
+            {
+                "description": "prefixItems in allOf does not constrain items, invalid case",
+                "data": [ 3, 5 ],
+                "valid": false
+            },
+            {
+                "description": "prefixItems in allOf does not constrain items, valid case",
+                "data": [ 5, 5 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "prefixItems validation adjusts the starting index for items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [ { "type": "string" } ],
+            "items": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "items": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/maxContains.json
+++ b/asdf/_jsonschema/json/tests/draft-next/maxContains.json
@@ -1,0 +1,152 @@
+[
+    {
+        "description": "maxContains without contains is ignored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "one item valid against lone maxContains",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "two items still valid against lone maxContains",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "one property valid against lone maxContains",
+                "data": { "a": 1 },
+                "valid": true
+            },
+            {
+                "description": "two properties still valid against lone maxContains",
+                "data": { "a": 1, "b": 2 },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": { "const": 1 },
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid maxContains",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "all elements match, invalid maxContains",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "some elements match, valid maxContains",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "some elements match, invalid maxContains",
+                "data": [1, 2, 1],
+                "valid": false
+            },
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "all properties match, valid maxContains",
+                "data": { "a": 1 },
+                "valid": true
+            },
+            {
+                "description": "all properties match, invalid maxContains",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "some properties match, valid maxContains",
+                "data": { "a": 1, "b": 2 },
+                "valid": true
+            },
+            {
+                "description": "some properties match, invalid maxContains",
+                "data": { "a": 1, "b": 2, "c": 1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxContains with contains, value with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": {"const": 1},
+            "maxContains": 1.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minContains < maxContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": { "const": 1 },
+            "minContains": 1,
+            "maxContains": 3
+        },
+        "tests": [
+            {
+                "description": "array with actual < minContains < maxContains",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "array with minContains < actual < maxContains",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "array with minContains < maxContains < actual",
+                "data": [1, 1, 1, 1],
+                "valid": false
+            },
+            {
+                "description": "object with actual < minContains < maxContains",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "object with minContains < actual < maxContains",
+                "data": { "a": 1, "b": 1 },
+                "valid": true
+            },
+            {
+                "description": "object with minContains < maxContains < actual",
+                "data": { "a": 1, "b": 1, "c": 1, "d": 1 },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/maxItems.json
+++ b/asdf/_jsonschema/json/tests/draft-next/maxItems.json
@@ -1,0 +1,50 @@
+[
+    {
+        "description": "maxItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxItems": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "foobar",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxItems": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/maxLength.json
+++ b/asdf/_jsonschema/json/tests/draft-next/maxLength.json
@@ -1,0 +1,55 @@
+[
+    {
+        "description": "maxLength validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxLength": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxLength": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/maxProperties.json
+++ b/asdf/_jsonschema/json/tests/draft-next/maxProperties.json
@@ -1,0 +1,79 @@
+[
+    {
+        "description": "maxProperties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxProperties": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxProperties validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxProperties": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxProperties = 0 means the object is empty",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maxProperties": 0
+        },
+        "tests": [
+            {
+                "description": "no properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "one property is invalid",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/maximum.json
+++ b/asdf/_jsonschema/json/tests/draft-next/maximum.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "maximum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maximum validation with unsigned integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maximum": 300
+        },
+        "tests":  [
+            {
+                "description": "below the maximum is invalid",
+                "data": 299.97,
+                "valid": true
+            },
+            {
+                "description": "boundary point integer is valid",
+                "data": 300,
+                "valid": true
+            },
+            {
+                "description": "boundary point float is valid",
+                "data": 300.00,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 300.5,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/minContains.json
+++ b/asdf/_jsonschema/json/tests/draft-next/minContains.json
@@ -1,0 +1,224 @@
+[
+    {
+        "description": "minContains without contains is ignored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minContains": 1
+        },
+        "tests": [
+            {
+                "description": "one item valid against lone minContains",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "zero items still valid against lone minContains",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=1 with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": { "const": 1 },
+            "minContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "no elements match",
+                "data": [2],
+                "valid": false
+            },
+            {
+                "description": "single element matches, valid minContains",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "some elements match, valid minContains",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "all elements match, valid minContains",
+                "data": [1, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=2 with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": { "const": 1 },
+            "minContains": 2
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid minContains",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "some elements match, invalid minContains",
+                "data": [1, 2],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid minContains (exactly as needed)",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "all elements match, valid minContains (more than needed)",
+                "data": [1, 1, 1],
+                "valid": true
+            },
+            {
+                "description": "some elements match, valid minContains",
+                "data": [1, 2, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=2 with contains with a decimal value",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": {"const": 1},
+            "minContains": 2.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "both elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains = minContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": { "const": 1 },
+            "maxContains": 2,
+            "minContains": 2
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid minContains",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid maxContains",
+                "data": [1, 1, 1],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid maxContains and minContains",
+                "data": [1, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains < minContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": { "const": 1 },
+            "maxContains": 1,
+            "minContains": 3
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "invalid minContains",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "invalid maxContains",
+                "data": [1, 1, 1],
+                "valid": false
+            },
+            {
+                "description": "invalid maxContains and minContains",
+                "data": [1, 1],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minContains = 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": { "const": 1 },
+            "minContains": 0
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "minContains = 0 makes contains always pass",
+                "data": [2],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains = 0 with maxContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "contains": {"const": 1},
+            "minContains": 0,
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "not more than maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/minItems.json
+++ b/asdf/_jsonschema/json/tests/draft-next/minItems.json
@@ -1,0 +1,50 @@
+[
+    {
+        "description": "minItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minItems": 1
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minItems": 1.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/minLength.json
+++ b/asdf/_jsonschema/json/tests/draft-next/minLength.json
@@ -1,0 +1,55 @@
+[
+    {
+        "description": "minLength validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minLength": 2
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minLength": 2.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/minProperties.json
+++ b/asdf/_jsonschema/json/tests/draft-next/minProperties.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "minProperties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minProperties": 1
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minProperties": 1.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/minimum.json
+++ b/asdf/_jsonschema/json/tests/draft-next/minimum.json
@@ -1,0 +1,75 @@
+[
+    {
+        "description": "minimum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minimum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minimum": -2
+        },
+        "tests": [
+            {
+                "description": "negative above the minimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the minimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point with float is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float below the minimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the minimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/multipleOf.json
+++ b/asdf/_jsonschema/json/tests/draft-next/multipleOf.json
@@ -1,0 +1,84 @@
+[
+    {
+        "description": "by int",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "multipleOf": 2
+        },
+        "tests": [
+            {
+                "description": "int by int",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "int by int fail",
+                "data": 7,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "by number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "multipleOf": 1.5
+        },
+        "tests": [
+            {
+                "description": "zero is multiple of anything",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "4.5 is multiple of 1.5",
+                "data": 4.5,
+                "valid": true
+            },
+            {
+                "description": "35 is not multiple of 1.5",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "by small number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "multipleOf": 0.0001
+        },
+        "tests": [
+            {
+                "description": "0.0075 is multiple of 0.0001",
+                "data": 0.0075,
+                "valid": true
+            },
+            {
+                "description": "0.00751 is not multiple of 0.0001",
+                "data": 0.00751,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float division = inf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "integer",
+            "multipleOf": 0.123456789
+        },
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/not.json
+++ b/asdf/_jsonschema/json/tests/draft-next/not.json
@@ -1,0 +1,127 @@
+[
+    {
+        "description": "not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "not": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "allowed",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "disallowed",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not multiple types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "not": {"type": ["integer", "boolean"]}
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": true,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not more complex schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "not": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+             }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "other match",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "forbidden property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": { 
+                    "not": {}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property present",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "property absent",
+                "data": {"bar": 1, "baz": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "not": true
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "not": false
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/oneOf.json
+++ b/asdf/_jsonschema/json/tests/draft-next/oneOf.json
@@ -1,0 +1,293 @@
+[
+    {
+        "description": "oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "oneOf" : [
+                {
+                    "minLength": 2
+                },
+                {
+                    "maxLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one oneOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [true, true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, one true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [true, false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, more than one true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [true, true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [false, false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf complex types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+	{
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": true,
+                        "baz": true
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/bignum.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/bignum.json
@@ -1,0 +1,110 @@
+[
+    {
+        "description": "integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "a bignum is an integer",
+                "data": 12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is an integer",
+                "data": -12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "number"
+        },
+        "tests": [
+            {
+                "description": "a bignum is a number",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is a number",
+                "data": -98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "string",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string"
+        },
+        "tests": [
+            {
+                "description": "a bignum is not a string",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum integer comparison",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "maximum": 18446744073709551615
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "exclusiveMaximum": 972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum integer comparison",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "minimum": -18446744073709551615
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision on negative numbers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "exclusiveMinimum": -972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/dependencies-compatibility.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/dependencies-compatibility.json
@@ -1,0 +1,282 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "empty dependents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependents required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "CRLF",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quotes",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "CRLF missing dependent",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quotes missing dependent",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "single schema dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean subschemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "schema dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "dependencies": {
+                "foo\tbar": {"minProperties": 4},
+                "foo'bar": {"required": ["foo\"bar"]}
+            }
+        },
+        "tests": [
+            {
+                "description": "quoted tab",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quote",
+                "data": {
+                    "foo'bar": {"foo\"bar": 1}
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted tab invalid under dependent schema",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quote invalid under dependent schema",
+                "data": {"foo'bar": 1},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/ecmascript-regex.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/ecmascript-regex.json
@@ -1,0 +1,596 @@
+[
+    {
+        "description": "ECMA 262 regex $ does not match trailing newline",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^abc$"
+        },
+        "tests": [
+            {
+                "description": "matches in Python, but not in ECMA 262",
+                "data": "abc\\n",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "abc",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^\\t$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\t",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0009",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\W matches everything but ascii letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches whitespace",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
+                "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but whitespace",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
+                "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with pattern",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "\\p{Letter}cole"
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "\\wcole"
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with ASCII ranges",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "[a-z]cole"
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in pattern matches [0-9], not unicode digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "^\\d+$"
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": { "pattern": "\\a" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with non-ASCII digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "^\\p{digit}+$"
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "patternProperties": {
+                "\\p{Letter}cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with ASCII ranges",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in patternProperties matches [0-9], not unicode digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with non-ASCII digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "patternProperties": {
+                "^\\p{digit}+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/float-overflow.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/float-overflow.json
@@ -1,0 +1,17 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "integer",
+            "multipleOf": 0.5
+        },
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format-assertion.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format-assertion.json
@@ -1,0 +1,42 @@
+[
+    {
+        "description": "schema that uses custom metaschema with format-assertion: false",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/false",
+            "$schema": "http://localhost:1234/draft-next/format-assertion-false.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: false: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: false: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "schema that uses custom metaschema with format-assertion: true",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/true",
+            "$schema": "http://localhost:1234/draft-next/format-assertion-true.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: true: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: true: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/date-time.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/date-time.json
@@ -1,0 +1,136 @@
+[
+    {
+        "description": "validation of date-time strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "date-time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
+                "data": "1990-02-31T15:59:59.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:59-24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid closing Z after time-zone offset",
+                "data": "1963-06-19T08:30:06.28123+01:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "case-insensitive T and Z",
+                "data": "1963-06-19t08:30:06.283185z",
+                "valid": true
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
+                "data": "1963-06-1৪T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
+                "data": "1963-06-11T0৪:00:00Z",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/date.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/date.json
@@ -1,0 +1,226 @@
+[
+    {
+        "description": "validation of date strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "date"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date string",
+                "data": "1963-06-19",
+                "valid": true
+            },
+            {
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
+                "data": "06/19/1963",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350",
+                "valid": false
+            },
+            {
+                "description": "non-padded month dates are not valid",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "non-padded day dates are not valid",
+                "data": "1998-01-1",
+                "valid": false
+            },
+            {
+                "description": "invalid month",
+                "data": "1998-13-01",
+                "valid": false
+            },
+            {
+                "description": "invalid month-day combination",
+                "data": "1998-04-31",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1963-06-1৪",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/duration.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/duration.json
@@ -1,0 +1,136 @@
+[
+    {
+        "description": "validation of duration strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "duration"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "P4DT12H30M5S",
+                "valid": true
+            },
+            {
+                "description": "an invalid duration string",
+                "data": "PT1D",
+                "valid": false
+            },
+            {
+                "description": "no elements present",
+                "data": "P",
+                "valid": false
+            },
+            {
+                "description": "no time elements present",
+                "data": "P1YT",
+                "valid": false
+            },
+            {
+                "description": "no date or time elements present",
+                "data": "PT",
+                "valid": false
+            },
+            {
+                "description": "elements out of order",
+                "data": "P2D1Y",
+                "valid": false
+            },
+            {
+                "description": "missing time separator",
+                "data": "P1D2H",
+                "valid": false
+            },
+            {
+                "description": "time element in the date position",
+                "data": "P2S",
+                "valid": false
+            },
+            {
+                "description": "four years duration",
+                "data": "P4Y",
+                "valid": true
+            },
+            {
+                "description": "zero time, in seconds",
+                "data": "PT0S",
+                "valid": true
+            },
+            {
+                "description": "zero time, in days",
+                "data": "P0D",
+                "valid": true
+            },
+            {
+                "description": "one month duration",
+                "data": "P1M",
+                "valid": true
+            },
+            {
+                "description": "one minute duration",
+                "data": "PT1M",
+                "valid": true
+            },
+            {
+                "description": "one and a half days, in hours",
+                "data": "PT36H",
+                "valid": true
+            },
+            {
+                "description": "one and a half days, in days and hours",
+                "data": "P1DT12H",
+                "valid": true
+            },
+            {
+                "description": "two weeks",
+                "data": "P2W",
+                "valid": true
+            },
+            {
+                "description": "weeks cannot be combined with other units",
+                "data": "P1Y2W",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "P২Y",
+                "valid": false
+            },
+            {
+                "description": "element without unit",
+                "data": "P1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/email.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/email.json
@@ -1,0 +1,121 @@
+[
+    {
+        "description": "validation of e-mail addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a space in the local part is valid",
+                "data": "\"joe bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a double dot in the local part is valid",
+                "data": "\"joe..bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a @ in the local part is valid",
+                "data": "\"joe@bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "an IPv4-address-literal after the @ is valid",
+                "data": "joe.bloggs@[127.0.0.1]",
+                "valid": true
+            },
+            {
+                "description": "an IPv6-address-literal after the @ is valid",
+                "data": "joe.bloggs@[IPv6:::1]",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid domain",
+                "data": "joe.bloggs@invalid=domain.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid IPv4-address-literal",
+                "data": "joe.bloggs@[127.0.0.300]",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/hostname.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/hostname.json
@@ -1,0 +1,101 @@
+[
+    {
+        "description": "validation of host names",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name",
+                "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid punycoded IDN hostname",
+                "data": "xn--4gbwdl.xn--wgbh1c",
+                "valid": true
+            },
+            {
+                "description": "a host name starting with an illegal character",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": false
+            },
+            {
+                "description": "a host name containing illegal characters",
+                "data": "not_a_valid_host_name",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+                "valid": false
+            },
+            {
+                "description": "starts with hyphen",
+                "data": "-hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with hyphen",
+                "data": "hostname-",
+                "valid": false
+            },
+            {
+                "description": "starts with underscore",
+                "data": "_hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with underscore",
+                "data": "hostname_",
+                "valid": false
+            },
+            {
+                "description": "contains underscore",
+                "data": "host_name",
+                "valid": false
+            },
+            {
+                "description": "maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": true
+            },
+            {
+                "description": "exceeds maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/idn-email.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/idn-email.json
@@ -1,0 +1,61 @@
+[
+    {
+        "description": "validation of an internationalized e-mail addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "idn-email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid idn e-mail (example@example.test in Hangul)",
+                "data": "실례@실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "an invalid idn e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/idn-hostname.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/idn-hostname.json
@@ -1,0 +1,307 @@
+[
+    {
+        "description": "validation of internationalized host names",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name (example.test in Hangul)",
+                "data": "실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "illegal first char U+302E Hangul single dot tone mark",
+                "data": "〮실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "contains illegal char U+302E Hangul single dot tone mark",
+                "data": "실〮례.테스트",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "invalid label, correct Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc3492#section-7.1",
+                "data": "-> $1.00 <--",
+                "valid": false
+            },
+            {
+                "description": "valid Chinese Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4",
+                "data": "xn--ihqwcrb4cv8a8dqg056pqjye",
+                "valid": true
+            },
+            {
+                "description": "invalid Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "xn--X",
+                "valid": false
+            },
+            {
+                "description": "U-label contains \"--\" in the 3rd and 4th position",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "XN--aa---o47jg78q",
+                "valid": false
+            },
+            {
+                "description": "U-label starts with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello",
+                "valid": false
+            },
+            {
+                "description": "U-label ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "hello-",
+                "valid": false
+            },
+            {
+                "description": "U-label starts and ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello-",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Spacing Combining Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0903hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Nonspacing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0300hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with an Enclosing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0488hello",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are PVALID, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u00df\u03c2\u0f0b\u3007",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are PVALID, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u06fd\u06fe",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u0640\u07fa",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6 Note: The two combining marks (U+302E and U+302F) are in the middle and not at the start",
+                "data": "\u3031\u3032\u3033\u3034\u3035\u302e\u302f\u303b",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no preceding 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "a\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing preceding",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no following 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7a",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing following",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with surrounding 'l's",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7l",
+                "valid": true
+            },
+            {
+                "description": "Greek KERAIA not followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375S",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA not followed by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375\u03b2",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERESH not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "A\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05d0\u05f3\u05d1",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "A\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05d0\u05f4\u05d1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no Hiragana, Katakana, or Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "def\u30fbabc",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no other characters",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Hiragana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u3041",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Katakana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u30a1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u4e08",
+                "valid": true
+            },
+            {
+                "description": "Arabic-Indic digits mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0660\u06f0",
+                "valid": false
+            },
+            {
+                "description": "Arabic-Indic digits not mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0628\u0660\u0628",
+                "valid": true
+            },
+            {
+                "description": "Extended Arabic-Indic digits not mixed with Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.9",
+                "data": "\u06f00",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u094d\u200d\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER not preceded by Virama but matches regexp",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
+                "data": "\u0628\u064a\u200c\u0628\u064a",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/ipv4.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/ipv4.json
@@ -1,0 +1,87 @@
+[
+    {
+        "description": "validation of IP addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IP address",
+                "data": "192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "an IP address with too many components",
+                "data": "127.0.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "an IP address with out-of-range values",
+                "data": "256.256.256.256",
+                "valid": false
+            },
+            {
+                "description": "an IP address without 4 components",
+                "data": "127.0",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer",
+                "data": "0x7f000001",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
+            },
+            {
+                "description": "invalid leading zeroes, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২7.0.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/ipv6.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/ipv6.json
@@ -1,0 +1,211 @@
+[
+    {
+        "description": "validation of IPv6 addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "ipv6"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IPv6 address",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "an IPv6 address with out-of-range values",
+                "data": "12345::",
+                "valid": false
+            },
+            {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address with too many components",
+                "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address containing illegal characters",
+                "data": "::laptop",
+                "valid": false
+            },
+            {
+                "description": "no digits is valid",
+                "data": "::",
+                "valid": true
+            },
+            {
+                "description": "leading colons is valid",
+                "data": "::42:ff:1",
+                "valid": true
+            },
+            {
+                "description": "trailing colons is valid",
+                "data": "d6::",
+                "valid": true
+            },
+            {
+                "description": "missing leading octet is invalid",
+                "data": ":2:3:4:5:6:7:8",
+                "valid": false
+            },
+            {
+                "description": "missing trailing octet is invalid",
+                "data": "1:2:3:4:5:6:7:",
+                "valid": false
+            },
+            {
+                "description": "missing leading octet with omitted octets later",
+                "data": ":2:3:4::8",
+                "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
+            },
+            {
+                "description": "two sets of double colons is invalid",
+                "data": "1::d6::42",
+                "valid": false
+            },
+            {
+                "description": "mixed format with the ipv4 section as decimal octets",
+                "data": "1::d6:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with double colons between the sections",
+                "data": "1:2::192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with ipv4 section with octet out of range",
+                "data": "1::2:192.168.256.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with ipv4 section with a hex octet",
+                "data": "1::2:192.168.ff.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with leading double colons (ipv4-mapped ipv6 address)",
+                "data": "::ffff:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "triple colons is invalid",
+                "data": "1:2:3:4:5:::8",
+                "valid": false
+            },
+            {
+                "description": "8 octets",
+                "data": "1:2:3:4:5:6:7:8",
+                "valid": true
+            },
+            {
+                "description": "insufficient octets without double colons",
+                "data": "1:2:3:4:5:6:7",
+                "valid": false
+            },
+            {
+                "description": "no colons is invalid",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 is not ipv6",
+                "data": "127.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 segment must have 4 octets",
+                "data": "1:2:3:4:1.2.3",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1:2:3:4:5:6:7:৪",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
+                "data": "1:2::192.16৪.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/iri-reference.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/iri-reference.json
@@ -1,0 +1,76 @@
+[
+    {
+        "description": "validation of IRI References",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "iri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference",
+                "data": "//ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid relative IRI Reference",
+                "data": "/âππ",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI Reference",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "a valid IRI Reference",
+                "data": "âππ",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI fragment",
+                "data": "#ƒrägmênt",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI fragment",
+                "data": "#ƒräg\\mênt",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/iri.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/iri.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "validation of IRIs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "iri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag and parentheses",
+                "data": "http://ƒøø.com/blah_(wîkïpédiå)_blah#ßité-1",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with URL-encoded stuff",
+                "data": "http://ƒøø.ßår/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI based on IPv6",
+                "data": "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI based on IPv6",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative IRI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI though valid IRI reference",
+                "data": "âππ",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/json-pointer.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/json-pointer.json
@@ -1,0 +1,201 @@
+[
+    {
+        "description": "validation of JSON-pointers (JSON String Representation)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid JSON-pointer",
+                "data": "/foo/bar~0/baz~1/%a",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (~ not escaped)",
+                "data": "/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "valid JSON-pointer with empty segment",
+                "data": "/foo//bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer with the last empty segment",
+                "data": "/foo/bar/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #1",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #2",
+                "data": "/foo",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #3",
+                "data": "/foo/0",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #4",
+                "data": "/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #5",
+                "data": "/a~1b",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #6",
+                "data": "/c%d",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #7",
+                "data": "/e^f",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #8",
+                "data": "/g|h",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #9",
+                "data": "/i\\j",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #10",
+                "data": "/k\"l",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #11",
+                "data": "/ ",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #12",
+                "data": "/m~0n",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer used adding to the last array position",
+                "data": "/foo/-",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (- used as object member name)",
+                "data": "/foo/-/bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (multiple escaped characters)",
+                "data": "/~1~0~0~1~1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #1",
+                "data": "/~1.1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #2",
+                "data": "/~0.1",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #1",
+                "data": "#",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #2",
+                "data": "#/",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #3",
+                "data": "#a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #1",
+                "data": "/~0~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #2",
+                "data": "/~0/~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #1",
+                "data": "/~2",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #2",
+                "data": "/~-1",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (multiple characters not escaped)",
+                "data": "/~~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #1",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #2",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #3",
+                "data": "a/a",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/regex.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/regex.json
@@ -1,0 +1,51 @@
+[
+    {
+        "description": "validation of regular expressions",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid regular expression",
+                "data": "([abc])+\\s+$",
+                "valid": true
+            },
+            {
+                "description": "a regular expression with unclosed parens is invalid",
+                "data": "^(abc]",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/relative-json-pointer.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/relative-json-pointer.json
@@ -1,0 +1,101 @@
+[
+    {
+        "description": "validation of Relative JSON Pointers (RJP)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "relative-json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid upwards RJP",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "a valid downwards RJP",
+                "data": "0/foo/bar",
+                "valid": true
+            },
+            {
+                "description": "a valid up and then down RJP, with array index",
+                "data": "2/0/baz/1/zip",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP taking the member or index name",
+                "data": "0#",
+                "valid": true
+            },
+            {
+                "description": "an invalid RJP that is a valid JSON Pointer",
+                "data": "/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "negative prefix",
+                "data": "-1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "explicit positive prefix",
+                "data": "+1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "## is not a valid json-pointer",
+                "data": "0##",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus json-pointer",
+                "data": "01/a",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus octothorpe",
+                "data": "01#",
+                "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "multi-digit integer prefix",
+                "data": "120/foo/bar",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/time.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/time.json
@@ -1,0 +1,216 @@
+[
+    {
+        "description": "validation of time strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid time string",
+                "data": "08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with leap second, Zulu",
+                "data": "23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, zero time-offset",
+                "data": "23:59:60+00:00",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong hour)",
+                "data": "22:59:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong minute)",
+                "data": "23:58:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, positive time-offset",
+                "data": "01:29:60+01:30",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large positive time-offset",
+                "data": "23:29:60+23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong hour)",
+                "data": "23:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong minute)",
+                "data": "23:59:60+00:30",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, negative time-offset",
+                "data": "15:59:60-08:00",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large negative time-offset",
+                "data": "00:29:60-23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong hour)",
+                "data": "23:59:60-01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong minute)",
+                "data": "23:59:60-00:30",
+                "valid": false
+            },
+            {
+                "description": "a valid time string with second fraction",
+                "data": "23:20:50.52Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with precise second fraction",
+                "data": "08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with plus offset",
+                "data": "08:30:06+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with minus offset",
+                "data": "08:30:06-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with case-insensitive Z",
+                "data": "08:30:06z",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string with invalid hour",
+                "data": "24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid minute",
+                "data": "00:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid second",
+                "data": "00:00:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset hour",
+                "data": "01:02:03+24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset minute",
+                "data": "01:02:03+00:60",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time with both Z and numoffset",
+                "data": "01:02:03Z+00:30",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset indicator",
+                "data": "08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "01:01:01,1111",
+                "valid": false
+            },
+            {
+                "description": "no time offset",
+                "data": "12:00:00",
+                "valid": false
+            },
+            {
+                "description": "no time offset with second fraction",
+                "data": "12:00:00.52",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "offset not starting with plus or minus",
+                "data": "08:30:06#00:20",
+                "valid": false
+            },
+            {
+                "description": "contains letters",
+                "data": "ab:cd:ef",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/uri-reference.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/uri-reference.json
@@ -1,0 +1,76 @@
+[
+    {
+        "description": "validation of URI References",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URI",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid relative URI Reference",
+                "data": "/abc",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI Reference",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "a valid URI Reference",
+                "data": "abc",
+                "valid": true
+            },
+            {
+                "description": "a valid URI fragment",
+                "data": "#fragment",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI fragment",
+                "data": "#frag\\ment",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/uri-template.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/uri-template.json
@@ -1,0 +1,61 @@
+[
+    {
+        "description": "format: uri-template",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri-template"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term}",
+                "valid": true
+            },
+            {
+                "description": "an invalid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": false
+            },
+            {
+                "description": "a valid uri-template without variables",
+                "data": "http://example.com/dictionary",
+                "valid": true
+            },
+            {
+                "description": "a valid relative uri-template",
+                "data": "dictionary/{term:1}/{term}",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/uri.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/uri.json
@@ -1,0 +1,141 @@
+[
+    {
+        "description": "validation of URIs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag and parentheses",
+                "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with URL-encoded stuff",
+                "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid puny-coded URL ",
+                "data": "http://xn--nw2a.xn--j6w193g/",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid URL based on IPv4",
+                "data": "http://223.255.255.254",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with ftp scheme",
+                "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL for a simple text file",
+                "data": "http://www.ietf.org/rfc/rfc2396.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL ",
+                "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+                "valid": true
+            },
+            {
+                "description": "a valid mailto URI",
+                "data": "mailto:John.Doe@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid newsgroup URI",
+                "data": "news:comp.infosystems.www.servers.unix",
+                "valid": true
+            },
+            {
+                "description": "a valid tel URI",
+                "data": "tel:+1-816-555-1212",
+                "valid": true
+            },
+            {
+                "description": "a valid URN",
+                "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+                "valid": true
+            },
+            {
+                "description": "an invalid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative URI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI though valid URI reference",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces",
+                "data": "http:// shouldfail.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces and missing scheme",
+                "data": ":// should fail",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/format/uuid.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/format/uuid.json
@@ -1,0 +1,116 @@
+[
+    {
+        "description": "uuid format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "format": "uuid"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "all upper-case",
+                "data": "2EB8AA08-AA98-11EA-B4AA-73B441D16380",
+                "valid": true
+            },
+            {
+                "description": "all lower-case",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": true
+            },
+            {
+                "description": "mixed case",
+                "data": "2eb8aa08-AA98-11ea-B4Aa-73B441D16380",
+                "valid": true
+            },
+            {
+                "description": "all zeroes is valid",
+                "data": "00000000-0000-0000-0000-000000000000",
+                "valid": true
+            },
+            {
+                "description": "wrong length",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
+                "valid": false
+            },
+            {
+                "description": "missing section",
+                "data": "2eb8aa08-aa98-11ea-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "bad characters (not hex)",
+                "data": "2eb8aa08-aa98-11ea-b4ga-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "no dashes",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too few dashes",
+                "data": "2eb8aa08aa98-11ea-b4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too many dashes",
+                "data": "2eb8-aa08-aa98-11ea-b4aa73b44-1d16380",
+                "valid": false
+            },
+            {
+                "description": "dashes in the wrong spot",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380----",
+                "valid": false
+            },
+            {
+                "description": "valid version 4",
+                "data": "98d80576-482e-427f-8434-7f86890ab222",
+                "valid": true
+            },
+            {
+                "description": "valid version 5",
+                "data": "99c17cbb-656f-564a-940f-1a4568f03487",
+                "valid": true
+            },
+            {
+                "description": "hypothetical version 6",
+                "data": "99c17cbb-656f-664a-940f-1a4568f03487",
+                "valid": true
+            },
+            {
+                "description": "hypothetical version 15",
+                "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/non-bmp-regex.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/non-bmp-regex.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "Proper UTF-16 surrogate pair handling: pattern",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "^🐲*$"
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Proper UTF-16 surrogate pair handling: patternProperties",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐲": "hello" },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐲🐲": "hello" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/optional/refOfUnknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/draft-next/optional/refOfUnknownKeyword.json
@@ -1,0 +1,46 @@
+[
+    {
+        "description": "reference of a root arbitrary keyword ",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unknown-keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference of an arbitrary keyword of a sub-schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {"unknown-keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/pattern.json
+++ b/asdf/_jsonschema/json/tests/draft-next/pattern.json
@@ -1,0 +1,65 @@
+[
+    {
+        "description": "pattern validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "^a*$"
+        },
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "aaa",
+                "valid": true
+            },
+            {
+                "description": "a non-matching pattern is invalid",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "pattern": "a+"
+        },
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/patternProperties.json
+++ b/asdf/_jsonschema/json/tests/draft-next/patternProperties.json
@@ -1,0 +1,176 @@
+[
+    {
+        "description":
+            "patternProperties validates properties matching a regex",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "patternProperties": {
+                "f.*o": {"type": "integer"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "multiple valid matches is valid",
+                "data": {"foo": 1, "foooooo" : 2},
+                "valid": true
+            },
+            {
+                "description": "a single invalid match is invalid",
+                "data": {"foo": "bar", "fooooo": 2},
+                "valid": false
+            },
+            {
+                "description": "multiple invalid matches is invalid",
+                "data": {"foo": "bar", "foooooo" : "baz"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple simultaneous patternProperties are validated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "patternProperties": {
+                "a*": {"type": "integer"},
+                "aaa*": {"maximum": 20}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"a": 21},
+                "valid": true
+            },
+            {
+                "description": "a simultaneous match is valid",
+                "data": {"aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "multiple matches is valid",
+                "data": {"a": 21, "aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "an invalid due to one is invalid",
+                "data": {"a": "bar"},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to the other is invalid",
+                "data": {"aaaa": 31},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to both is invalid",
+                "data": {"aaa": "foo", "aaaa": 31},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "regexes are not anchored by default and are case sensitive",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "patternProperties": {
+                "[0-9]{2,}": { "type": "boolean" },
+                "X_": { "type": "string" }
+            }
+        },
+        "tests": [
+            {
+                "description": "non recognized members are ignored",
+                "data": { "answer 1": "42" },
+                "valid": true
+            },
+            {
+                "description": "recognized members are accounted for",
+                "data": { "a31b": null },
+                "valid": false
+            },
+            {
+                "description": "regexes are case sensitive",
+                "data": { "a_x_3": 3 },
+                "valid": true
+            },
+            {
+                "description": "regexes are case sensitive, 2",
+                "data": { "a_X_3": 3 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "patternProperties": {
+                "f.*": true,
+                "b.*": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property matching schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property matching schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with a property matching both true and false is invalid",
+                "data": {"foobar":1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/prefixItems.json
+++ b/asdf/_jsonschema/json/tests/draft-next/prefixItems.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "a schema given for prefixItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                {"type": "integer"},
+                {"type": "string"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "correct types",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "wrong types",
+                "data": [ "foo", 1 ],
+                "valid": false
+            },
+            {
+                "description": "incomplete array of items",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with additional items",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "1": "valid",
+                    "length": 2
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "prefixItems with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [true, false]
+        },
+        "tests": [
+            {
+                "description": "array with one item is valid",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with two items is invalid",
+                "data": [ 1, "foo" ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additional items are allowed by default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [{"type": "integer"}]
+        },
+        "tests": [
+            {
+                "description": "only the first item is validated",
+                "data": [1, "foo", false],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "prefixItems with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/properties.json
+++ b/asdf/_jsonschema/json/tests/draft-next/properties.json
@@ -1,0 +1,242 @@
+[
+    {
+        "description": "object properties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties present and valid is valid",
+                "data": {"foo": 1, "bar": "baz"},
+                "valid": true
+            },
+            {
+                "description": "one property invalid is invalid",
+                "data": {"foo": 1, "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "both properties invalid is invalid",
+                "data": {"foo": [], "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "doesn't invalidate other properties",
+                "data": {"quux": []},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description":
+            "properties, patternProperties, additionalProperties interaction",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {"type": "array", "maxItems": 3},
+                "bar": {"type": "array"}
+            },
+            "patternProperties": {"f.o": {"minItems": 2}},
+            "additionalProperties": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "property validates property",
+                "data": {"foo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "property invalidates property",
+                "data": {"foo": [1, 2, 3, 4]},
+                "valid": false
+            },
+            {
+                "description": "patternProperty invalidates property",
+                "data": {"foo": []},
+                "valid": false
+            },
+            {
+                "description": "patternProperty validates nonproperty",
+                "data": {"fxo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "patternProperty invalidates nonproperty",
+                "data": {"fxo": []},
+                "valid": false
+            },
+            {
+                "description": "additionalProperty ignores property",
+                "data": {"bar": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty validates others",
+                "data": {"quux": 3},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty invalidates others",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with boolean schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no property present is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "only 'true' property present is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "only 'false' property present is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "both properties present is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo\nbar": {"type": "number"},
+                "foo\"bar": {"type": "number"},
+                "foo\\bar": {"type": "number"},
+                "foo\rbar": {"type": "number"},
+                "foo\tbar": {"type": "number"},
+                "foo\fbar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with all numbers is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1",
+                    "foo\\bar": "1",
+                    "foo\rbar": "1",
+                    "foo\tbar": "1",
+                    "foo\fbar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "__proto__": {"type": "number"},
+                "toString": {
+                    "properties": { "length": { "type": "string" } }
+                },
+                "constructor": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "__proto__ not valid",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString not valid",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor not valid",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present and valid",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/propertyDependencies.json
+++ b/asdf/_jsonschema/json/tests/draft-next/propertyDependencies.json
@@ -1,0 +1,161 @@
+[
+    {
+        "description": "propertyDependencies doesn't act on non-objects",
+        "schema": {
+            "propertyDependencies": {
+                "foo": {"bar": false}
+            }
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "abc",
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyDependencies doesn't act on non-string property values",
+        "schema": {
+            "propertyDependencies": {
+                "foo": {"bar": false}
+            }
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": {"foo": 2},
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": {"foo": 1.1},
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {"foo": {}},
+                "valid": true
+            },
+            {
+                "description": "ignores objects wth a key of the expected value",
+                "data": {"foo": {"bar": "baz"}},
+                "valid": true
+            },
+            {
+                "description": "ignores objects with the expected value nested in structure",
+                "data": {"foo": {"baz": "bar"}},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": {"foo": []},
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple options selects the right one",
+        "schema": {
+            "propertyDependencies": {
+                "foo": {
+                    "bar": {
+                        "minProperties": 2,
+                        "maxProperties": 2
+                    },
+                    "baz": {"maxProperties": 1},
+                    "qux": true,
+                    "quux": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "bar with exactly 2 properties is valid",
+                "data": {
+                    "foo": "bar",
+                    "other-foo": "other-bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "bar with more than 2 properties is invalid",
+                "data": {
+                    "foo": "bar",
+                    "other-foo": "other-bar",
+                    "too": "many"
+                },
+                "valid": false
+            },
+            {
+                "description": "bar with fewer than 2 properties is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "baz alone is valid",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "baz with other properties is invalid",
+                "data": {
+                    "foo": "baz",
+                    "other-foo": "other-bar"
+                },
+                "valid": false
+            },
+            {
+                "description": "anything allowed with qux",
+                "data": {
+                    "foo": "qux",
+                    "blah": ["some other property"],
+                    "more": "properties"
+                },
+                "valid": true
+            },
+            {
+                "description": "quux is disallowed",
+                "data": {
+                    "foo": "quux"
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/propertyNames.json
+++ b/asdf/_jsonschema/json/tests/draft-next/propertyNames.json
@@ -1,0 +1,85 @@
+[
+    {
+        "description": "propertyNames validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "propertyNames": {"maxLength": 3}
+        },
+        "tests": [
+            {
+                "description": "all property names valid",
+                "data": {
+                    "f": {},
+                    "foo": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "some property names invalid",
+                "data": {
+                    "foo": {},
+                    "foobar": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3, 4],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "propertyNames": true
+        },
+        "tests": [
+            {
+                "description": "object with any properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "propertyNames": false
+        },
+        "tests": [
+            {
+                "description": "object with any properties is invalid",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/ref.json
+++ b/asdf/_jsonschema/json/tests/draft-next/ref.json
@@ -1,0 +1,887 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                {"type": "integer"},
+                {"$ref": "#/prefixItems/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
+            },
+            "properties": {
+                "tilde": {"$ref": "#/$defs/tilde~0field"},
+                "slash": {"$ref": "#/$defs/slash~1field"},
+                "percent": {"$ref": "#/$defs/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilde invalid",
+                "data": {"tilde": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilde valid",
+                "data": {"tilde": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/$defs/a"},
+                "c": {"$ref": "#/$defs/b"}
+            },
+            "$ref": "#/$defs/c"
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref applies alongside sibling keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "ref valid, maxItems valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "ref valid, maxItems invalid",
+                "data": { "foo": [1, 2, 3] },
+                "valid": false
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"minLength": 1},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"minLength": -1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "$ref": {"$ref": "#/$defs/is-string"}
+            },
+            "$defs": {
+                "is-string": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": false
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {
+                    "type": "array",
+                    "items": {"$ref": "node"}
+                }
+            },
+            "required": ["meta", "nodes"],
+            "$defs": {
+                "node": {
+                    "$id": "http://localhost:1234/draft-next/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "subtree": {"$ref": "tree"}
+                    },
+                    "required": ["value"]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 1.1},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": "string is invalid"},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
+            },
+            "$defs": {
+                "foo\"bar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with numbers is valid",
+                "data": {
+                    "foo\"bar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref creates new scope when adjacent to keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "A": {
+                    "unevaluatedProperties": false
+                }
+            },
+            "properties": {
+                "prop1": {
+                    "type": "string"
+                }
+            },
+            "$ref": "#/$defs/A"
+        },
+        "tests": [
+            {
+                "description": "referenced subschema doesn't see annotations from properties",
+                "data": {
+                    "prop1": "match"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/$defs/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "do not evaluate the $ref inside the enum, definition exact match",
+                "data": { "type": "string" },
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/$defs/a_string" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "refs with relative uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://example.com/schema-relative-uri-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "schema-relative-uri-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-relative-uri-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative refs with absolute uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "http://example.com/schema-refs-absolute-uris-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-refs-absolute-uris-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://example.com/a.json",
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "$defs": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$id": "/draft/next/ref-and-id1/base.json",
+            "$ref": "int.json",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id1/int.json",
+                    "$id": "int.json",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /ref-and-id1-int.json",
+                    "$id": "/draft/next/ref-and-id1-int.json",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $anchor and $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$id": "/draft/next/ref-and-id2/base.json",
+            "$ref": "#bigint",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "$anchor": "bigint",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
+                    "$id": "/draft/next/ref-and-id2/",
+                    "$anchor": "bigint",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with $ref via the URN",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "minimum": 30,
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
+            }
+        },
+        "tests": [
+            {
+                "description": "valid under the URN IDed schema",
+                "data": {"foo": 37},
+                "valid": true
+            },
+            {
+                "description": "invalid under the URN IDed schema",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with JSON pointer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with NSS",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$comment": "RFC 8141 §2.2",
+            "$id": "urn:example:1/406/47452/2",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with r-component",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$comment": "RFC 8141 §2.3.1",
+            "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with q-component",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$comment": "RFC 8141 §2.3.2",
+            "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with f-component",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
+            "$ref": "https://json-schema.org/draft/next/schema"
+        },
+        "tests": [
+            {
+                "description": "is invalid",
+                "data": {"$id": "urn:example:foo-bar-baz-qux#somepart"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and JSON pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and anchor ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
+            },
+            "$defs": {
+                "bar": {
+                    "$anchor": "something",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN ref with nested pointer ref",
+        "schema": {
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+            "$defs": {
+                "foo": {
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$defs": {"bar": {"type": "string"}},
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": "bar",
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": 12,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/refRemote.json
+++ b/asdf/_jsonschema/json/tests/draft-next/refRemote.json
@@ -1,0 +1,295 @@
+[
+    {
+        "description": "remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/integer.json"
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "fragment within remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/subSchemas-defs.json#/$defs/integer"
+        },
+        "tests": [
+            {
+                "description": "remote fragment valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote fragment invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/subSchemas-defs.json#/$defs/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "ref within ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "ref within ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/",
+            "items": {
+                "$id": "baseUriChange/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "base URI change ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "base URI change ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/scope_change_defs1.json",
+            "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolder/",
+                    "type": "array",
+                    "items": {"$ref": "folderInteger.json"}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema/",
+                    "$defs": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "root ref in remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/object",
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "name-defs.json#/$defs/orNull"}
+            }
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": {
+                    "name": null
+                },
+                "valid": true
+            },
+            {
+                "description": "object is invalid",
+                "data": {
+                    "name": {
+                        "name": null
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref with ref to defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/schema-remote-ref-ref-defs1.json",
+            "$ref": "ref-and-defs.json"
+        },
+        "tests": [
+            {
+                "description": "invalid",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid",
+                "data": {
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier in remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "http://localhost:1234/draft-next/locationIndependentIdentifier.json#/$defs/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "retrieved nested refs resolve relative to their URI not $id",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$id": "http://localhost:1234/draft-next/some-id",
+            "properties": {
+                "name": {"$ref": "nested/foo-ref-string.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": {
+                    "name": {"foo":  1}
+                },
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different $id",
+        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different URN $id",
+        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with nested absolute ref",
+        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/required.json
+++ b/asdf/_jsonschema/json/tests/draft-next/required.json
@@ -1,0 +1,158 @@
+[
+    {
+        "description": "required validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "required": ["foo"]
+        },
+        "tests": [
+            {
+                "description": "present required property is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "non-present required property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required default validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required by default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with empty array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {}
+            },
+            "required": []
+        },
+        "tests": [
+            {
+                "description": "property not required",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "required": [
+                "foo\nbar",
+                "foo\"bar",
+                "foo\\bar",
+                "foo\rbar",
+                "foo\tbar",
+                "foo\fbar"
+            ]
+        },
+        "tests": [
+            {
+                "description": "object with all properties present is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with some properties missing is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "required properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "required": ["__proto__", "toString", "constructor"]
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "__proto__ present",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString present",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor present",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/type.json
+++ b/asdf/_jsonschema/json/tests/draft-next/type.json
@@ -1,0 +1,501 @@
+[
+    {
+        "description": "integer type matches integers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "an integer is an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is an integer",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is not an integer",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an integer",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not an integer, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not an integer",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not an integer",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an integer",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an integer",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "number type matches numbers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "number"
+        },
+        "tests": [
+            {
+                "description": "an integer is a number",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is a number (and an integer)",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is a number",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "a string is not a number",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not a number, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not a number",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a number",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a number",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a number",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "string type matches strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "string"
+        },
+        "tests": [
+            {
+                "description": "1 is not a string",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a string",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a string is still a string, even if it looks like a number",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an object is not a string",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a string",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a string",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a string",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "object type matches objects",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object"
+        },
+        "tests": [
+            {
+                "description": "an integer is not an object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an object",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an object",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is not an object",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an object",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an object",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "array type matches arrays",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "array"
+        },
+        "tests": [
+            {
+                "description": "an integer is not an array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an array",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an array",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not an array",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is not an array",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an array",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "boolean type matches booleans",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "boolean"
+        },
+        "tests": [
+            {
+                "description": "an integer is not a boolean",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a float is not a boolean",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not a boolean",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not a boolean",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a boolean",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is a boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is not a boolean",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "null type matches only the null object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "null"
+        },
+        "tests": [
+            {
+                "description": "an integer is not null",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not null",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a string is not null",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not null",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not null",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is not null",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple types can be specified in an array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": ["integer", "string"]
+        },
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/unevaluatedItems.json
+++ b/asdf/_jsonschema/json/tests/draft-next/unevaluatedItems.json
@@ -1,0 +1,675 @@
+[
+    {
+        "description": "unevaluatedItems true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": true
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems as schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": { "type": "string" }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with valid unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with invalid unevaluated items",
+                "data": [42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with uniform items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "items": { "type": "string" },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "unevaluatedItems doesn't apply",
+                "data": ["foo", "bar"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with tuple",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "items": true,
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "unevaluatedItems doesn't apply",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested tuple",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "allOf": [
+                {
+                    "prefixItems": [
+                        true,
+                        { "type": "number" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", 42],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", 42, true],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": {"type": "boolean"},
+            "anyOf": [
+                { "items": {"type": "string"} },
+                true
+            ]
+        },
+        "tests": [
+            {
+                "description": "with only (valid) additional items",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "with no additional items",
+                "data": ["yes", "no"],
+                "valid": true
+            },
+            {
+                "description": "with invalid additional item",
+                "data": ["yes", false],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested prefixItems and items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {
+                    "prefixItems": [
+                        { "type": "string" }
+                    ],
+                    "items": true
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no additional items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with additional items",
+                "data": ["foo", 42, true],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested unevaluatedItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {
+                    "prefixItems": [
+                        { "type": "string" }
+                    ]
+                },
+                { "unevaluatedItems": true }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no additional items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with additional items",
+                "data": ["foo", 42, true],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "anyOf": [
+                {
+                    "prefixItems": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                },
+                {
+                    "prefixItems": [
+                        true,
+                        true,
+                        { "const": "baz" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "when one schema matches and has no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "when one schema matches and has unevaluated items",
+                "data": ["foo", "bar", 42],
+                "valid": false
+            },
+            {
+                "description": "when two schemas match and has no unevaluated items",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "when two schemas match and has unevaluated items",
+                "data": ["foo", "bar", "baz", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "oneOf": [
+                {
+                    "prefixItems": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                },
+                {
+                    "prefixItems": [
+                        true,
+                        { "const": "baz" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "not": {
+                "not": {
+                    "prefixItems": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                }
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with if/then/else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "if": {
+                "prefixItems": [
+                    true,
+                    { "const": "bar" }
+                ]
+            },
+            "then": {
+                "prefixItems": [
+                    true,
+                    true,
+                    { "const": "then" }
+                ]
+            },
+            "else": {
+                "prefixItems": [
+                    true,
+                    true,
+                    true,
+                    { "const": "else" }
+                ]
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "when if matches and it has no unevaluated items",
+                "data": ["foo", "bar", "then"],
+                "valid": true
+            },
+            {
+                "description": "when if matches and it has unevaluated items",
+                "data": ["foo", "bar", "then", "else"],
+                "valid": false
+            },
+            {
+                "description": "when if doesn't match and it has no unevaluated items",
+                "data": ["foo", 42, 42, "else"],
+                "valid": true
+            },
+            {
+                "description": "when if doesn't match and it has unevaluated items",
+                "data": ["foo", 42, 42, "else", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [true],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$ref": "#/$defs/bar",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "unevaluatedItems": false,
+            "$defs": {
+              "bar": {
+                  "prefixItems": [
+                      true,
+                      { "type": "string" }
+                  ]
+              }
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar", "baz"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems can't see inside cousins",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {
+                    "prefixItems": [ true ]
+                },
+                { "unevaluatedItems": false }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": [ 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "item is evaluated in an uncle schema to unevaluatedItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+                "foo": {
+                    "prefixItems": [
+                        { "type": "string" }
+                    ],
+                    "unevaluatedItems": false
+                  }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "prefixItems": [
+                                true,
+                                { "type": "string" }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "no extra items",
+                "data": {
+                    "foo": [
+                        "test"
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "uncle keyword evaluation is not significant",
+                "data": {
+                    "foo": [
+                        "test",
+                        "test"
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems depends on adjacent contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [true],
+            "contains": {"type": "string"},
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "second item is evaluated by contains",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "contains fails, second item is not evaluated",
+                "data": [ 1, 2 ],
+                "valid": false
+            },
+            {
+                "description": "contains passes, second item is not evaluated",
+                "data": [ 1, 2, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems depends on multiple nested contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                { "contains": { "multipleOf": 2 } },
+                { "contains": { "multipleOf": 3 } }
+            ],
+            "unevaluatedItems": { "multipleOf": 5 }
+        },
+        "tests": [
+            {
+                "description": "5 not evaluated, passes unevaluatedItems",
+                "data": [ 2, 3, 4, 5, 6 ],
+                "valid": true
+            },
+            {
+                "description": "7 not evaluated, fails unevaluatedItems",
+                "data": [ 2, 3, 4, 7, 8 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems and contains interact to control item dependency relationship",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "if": {
+                "contains": {"const": "a"}
+            },
+            "then": {
+                "if": {
+                    "contains": {"const": "b"}
+                },
+                "then": {
+                    "if": {
+                        "contains": {"const": "c"}
+                    }
+                }
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "only a's are valid",
+                "data": [ "a", "a" ],
+                "valid": true
+            },
+            {
+                "description": "a's and b's are valid",
+                "data": [ "a", "b", "a", "b", "a" ],
+                "valid": true
+            },
+            {
+                "description": "a's, b's and c's are valid",
+                "data": [ "c", "a", "c", "c", "b", "a" ],
+                "valid": true
+            },
+            {
+                "description": "only b's are invalid",
+                "data": [ "b", "b" ],
+                "valid": false
+            },
+            {
+                "description": "only c's are invalid",
+                "data": [ "c", "c" ],
+                "valid": false
+            },
+            {
+                "description": "only b's and c's are invalid",
+                "data": [ "c", "b", "c", "b", "c" ],
+                "valid": false
+            },
+            {
+                "description": "only a's and c's are invalid",
+                "data": [ "c", "a", "c", "a", "c" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-array instances are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedItems": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/unevaluatedProperties.json
+++ b/asdf/_jsonschema/json/tests/draft-next/unevaluatedProperties.json
@@ -1,0 +1,1515 @@
+[
+    {
+        "description": "unevaluatedProperties true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "unevaluatedProperties": {
+                "type": "string",
+                "minLength": 3
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with valid unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with invalid unevaluated properties",
+                "data": {
+                    "foo": "fo"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "patternProperties": {
+                "^foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "additionalProperties": true,
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": { "type": "string" }
+                    }
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+              {
+                  "patternProperties": {
+                      "^bar": { "type": "string" }
+                  }
+              }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "additionalProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested unevaluatedProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": {
+                "type": "string",
+                "maxLength": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "baz": { "const": "baz" }
+                    },
+                    "required": ["baz"]
+                },
+                {
+                    "properties": {
+                        "quux": { "const": "quux" }
+                    },
+                    "required": ["quux"]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when one matches and has no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when one matches and has unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "not-baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when two match and has no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when two match and has unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz",
+                    "quux": "not-quux"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "baz": { "const": "baz" }
+                    },
+                    "required": ["baz"]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "quux": "quux"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "not": {
+                "not": {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "then": {
+                "properties": {
+                    "bar": { "type": "string" }
+                },
+                "required": ["bar"]
+            },
+            "else": {
+                "properties": {
+                    "baz": { "type": "string" }
+                },
+                "required": ["baz"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else, then not defined",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "else": {
+                "properties": {
+                    "baz": { "type": "string" }
+                },
+                "required": ["baz"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else, else not defined",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "then": {
+                "properties": {
+                    "bar": { "type": "string" }
+                },
+                "required": ["bar"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with dependentSchemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "dependentSchemas": {
+                "foo": {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [true],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "$ref": "#/$defs/bar",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false,
+            "$defs": {
+                "bar": {
+                    "properties": {
+                        "bar": { "type": "string" }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties can't see inside cousins",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                },
+                {
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties can't see inside cousins (reverse order)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer false, inner true, properties inside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer true, inner false, properties outside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                }
+            ],
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer true, inner false, properties inside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            ],
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "cousin unevaluatedProperties, true and false, true with properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": true
+                },
+                {
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "cousin unevaluatedProperties, true and false, false with properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                },
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property is evaluated in an uncle schema to unevaluatedProperties",
+        "comment": "see https://stackoverflow.com/questions/66936884/deeply-nested-unevaluatedproperties-and-their-expectations",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "object",
+                    "properties": {
+                        "bar": {
+                            "type": "string"
+                        }
+                    },
+                    "unevaluatedProperties": false
+                  }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "properties": {
+                                "faz": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "no extra properties",
+                "data": {
+                    "foo": {
+                        "bar": "test"
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "uncle keyword evaluation is not significant",
+                "data": {
+                    "foo": {
+                        "bar": "test",
+                        "faz": "test"
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "in-place applicator siblings, allOf has unevaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "unevaluatedProperties": false
+                }
+            ],
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "base case: both properties present",
+                "data": {
+                    "foo": 1,
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, bar is missing",
+                "data": {
+                    "foo": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "in place applicator siblings, foo is missing",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "in-place applicator siblings, anyOf has unevaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ],
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": true
+                    },
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "base case: both properties present",
+                "data": {
+                    "foo": 1,
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, bar is missing",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, foo is missing",
+                "data": {
+                    "bar": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties + single cyclic ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "type": "object",
+            "properties": {
+                "x": { "$ref": "#" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "Single is valid",
+                "data": { "x": {} },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 1st level is invalid",
+                "data": { "x": {}, "y": {} },
+                "valid": false
+            },
+            {
+                "description": "Nested is valid",
+                "data": { "x": { "x": {} } },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 2nd level is invalid",
+                "data": { "x": { "x": {}, "y": {} } },
+                "valid": false
+            },
+            {
+                "description": "Deep nested is valid",
+                "data": { "x": { "x": { "x": {} } } },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 3rd level is invalid",
+                "data": { "x": { "x": { "x": {}, "y": {} } } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties + ref inside allOf / oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "one": {
+                    "properties": { "a": true }
+                },
+                "two": {
+                    "required": ["x"],
+                    "properties": { "x": true }
+                }
+            },
+            "allOf": [
+                { "$ref": "#/$defs/one" },
+                { "properties": { "b": true } },
+                {
+                    "oneOf": [
+                        { "$ref": "#/$defs/two" },
+                        {
+                            "required": ["y"],
+                            "properties": { "y": true }
+                        }
+                    ]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is invalid (no x or y)",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "a and b are invalid (no x or y)",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "x and y are invalid",
+                "data": { "x": 1, "y": 1 },
+                "valid": false
+            },
+            {
+                "description": "a and x are valid",
+                "data": { "a": 1, "x": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and y are valid",
+                "data": { "a": 1, "y": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and x are valid",
+                "data": { "a": 1, "b": 1, "x": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and y are valid",
+                "data": { "a": 1, "b": 1, "y": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and x and y are invalid",
+                "data": { "a": 1, "b": 1, "x": 1, "y": 1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dynamic evalation inside nested refs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "one": {
+                    "oneOf": [
+                        { "$ref": "#/$defs/two" },
+                        { "required": ["b"], "properties": { "b": true } },
+                        { "required": ["xx"], "patternProperties": { "x": true } },
+                        { "required": ["all"], "unevaluatedProperties": true }
+                    ]
+                },
+                "two": {
+                    "oneOf": [
+                        { "required": ["c"], "properties": { "c": true } },
+                        { "required": ["d"], "properties": { "d": true } }
+                    ]
+                }
+            },
+            "oneOf": [
+                { "$ref": "#/$defs/one" },
+                { "required": ["a"], "properties": { "a": true } }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "a is valid",
+                "data": { "a": 1 },
+                "valid": true
+            },
+            {
+                "description": "b is valid",
+                "data": { "b": 1 },
+                "valid": true
+            },
+            {
+                "description": "c is valid",
+                "data": { "c": 1 },
+                "valid": true
+            },
+            {
+                "description": "d is valid",
+                "data": { "d": 1 },
+                "valid": true
+            },
+            {
+                "description": "a + b is invalid",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "a + c is invalid",
+                "data": { "a": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "a + d is invalid",
+                "data": { "a": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "b + c is invalid",
+                "data": { "b": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "b + d is invalid",
+                "data": { "b": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "c + d is invalid",
+                "data": { "c": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx is valid",
+                "data": { "xx": 1 },
+                "valid": true
+            },
+            {
+                "description": "xx + foox is valid",
+                "data": { "xx": 1, "foox": 1 },
+                "valid": true
+            },
+            {
+                "description": "xx + foo is invalid",
+                "data": { "xx": 1, "foo": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + a is invalid",
+                "data": { "xx": 1, "a": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + b is invalid",
+                "data": { "xx": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + c is invalid",
+                "data": { "xx": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + d is invalid",
+                "data": { "xx": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "all is valid",
+                "data": { "all": 1 },
+                "valid": true
+            },
+            {
+                "description": "all + foo is valid",
+                "data": { "all": 1, "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "all + a is invalid",
+                "data": { "all": 1, "a": 1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties depends on adjacent contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "properties": {
+              "foo": { "type": "number" }
+            },
+            "contains": { "type": "string" },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "bar is evaluated by contains",
+                "data": { "foo": 1, "bar": "foo" },
+                "valid": true
+            },
+            {
+                "description": "contains fails, bar is not evaluated",
+                "data": { "foo": 1, "bar": 2 },
+                "valid": false
+            },
+            {
+                "description": "contains passes, bar is not evaluated",
+                "data": { "foo": 1, "bar": 2, "baz": "foo" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties depends on multiple nested contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "allOf": [
+                { "contains": { "multipleOf": 2 } },
+                { "contains": { "multipleOf": 3 } }
+            ],
+            "unevaluatedProperties": { "multipleOf": 5 }
+        },
+        "tests": [
+            {
+                "description": "5 not evaluated, passes unevaluatedItems",
+                "data": { "a": 2, "b": 3, "c": 4, "d": 5, "e": 6 },
+                "valid": true
+            },
+            {
+                "description": "7 not evaluated, fails unevaluatedItems",
+                "data": { "a": 2, "b": 3, "c": 4, "d": 7, "e": 8 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-object instances are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "unevaluatedProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null valued properties",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties can see inside propertyDependencies",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "propertyDependencies": {
+                "foo": {
+                    "foo1": { 
+                        "properties": {
+                            "bar": true
+                        }
+                    }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "allows bar if foo = foo1",
+                "data": {
+                    "foo": "foo1",
+                    "bar": 42
+                },
+                "valid": true
+            },
+            {
+                "description": "disallows bar if foo != foo1",
+                "data": {
+                    "foo": "foo2",
+                    "bar": 42
+                },
+                "valid": false
+            },
+            {
+                "description": "disallows bar if foo is absent",
+                "data": {
+                    "bar": 42
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/uniqueItems.json
+++ b/asdf/_jsonschema/json/tests/draft-next/uniqueItems.json
@@ -1,0 +1,414 @@
+[
+    {
+        "description": "uniqueItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
+                "data": [1, 2, 1],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is invalid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": false
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is invalid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": false
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
+                "data": [["foo"], ["bar"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "[1] and [true] are unique",
+                "data": [[1], [true]],
+                "valid": true
+            },
+            {
+                "description": "[0] and [false] are unique",
+                "data": [[0], [false]],
+                "valid": true
+            },
+            {
+                "description": "nested [1] and [true] are unique",
+                "data": [[[1], "foo"], [[true], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "nested [0] and [false] are unique",
+                "data": [[[0], "foo"], [[false], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1, "{}"],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are invalid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
+                "valid": false
+            },
+            {
+                "description": "{\"a\": false} and {\"a\": 0} are unique",
+                "data": [{"a": false}, {"a": 0}],
+                "valid": true
+            },
+            {
+                "description": "{\"a\": true} and {\"a\": 1} are unique",
+                "data": [{"a": true}, {"a": 1}],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is not valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": false
+            },
+            {
+                "description": "non-unique array extended from [true, false] is not valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items and additionalItems=false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/unknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/draft-next/unknownKeyword.json
@@ -1,0 +1,57 @@
+[
+    {
+        "description": "$id inside an unknown keyword is not a real identifier",
+        "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/next/schema",
+            "$defs": {
+                "id_in_unknown0": {
+                    "not": {
+                        "array_of_schemas": [
+                            {
+                              "$id": "https://localhost:1234/draft-next/unknownKeyword/my_identifier.json",
+                              "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/draft-next/unknownKeyword/my_identifier.json",
+                    "type": "string"
+                },
+                "id_in_unknown1": {
+                    "not": {
+                        "object_of_schemas": {
+                            "foo": {
+                              "$id": "https://localhost:1234/draft-next/unknownKeyword/my_identifier.json",
+                              "type": "integer"
+                            }
+                        }
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_unknown0" },
+                { "$ref": "#/$defs/id_in_unknown1" },
+                { "$ref": "https://localhost:1234/draft-next/unknownKeyword/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "type matches second anyOf, which has a real schema in it",
+                "data": "a string",
+                "valid": true
+            },
+            {
+                "description": "type matches non-schema in first anyOf",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "type matches non-schema in third anyOf",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft-next/vocabulary.json
+++ b/asdf/_jsonschema/json/tests/draft-next/vocabulary.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "schema that uses custom metaschema with with no validation vocabulary",
+        "schema": {
+            "$id": "https://schema/using/no/validation",
+            "$schema": "http://localhost:1234/draft-next/metaschema-no-validation.json",
+            "properties": {
+                "badProperty": false,
+                "numberProperty": {
+                    "minimum": 10
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "applicator vocabulary still works",
+                "data": {
+                    "badProperty": "this property should not exist"
+                },
+                "valid": false
+            },
+            {
+                "description": "no validation: valid number",
+                "data": {
+                    "numberProperty": 20
+                },
+                "valid": true
+            },
+            {
+                "description": "no validation: invalid number, but it still validates",
+                "data": {
+                    "numberProperty": 1
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/additionalItems.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/additionalItems.json
@@ -1,0 +1,177 @@
+[
+    {
+        "description": "additionalItems as schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [{}],
+            "additionalItems": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "additional items match schema",
+                "data": [ null, 2, 3, 4 ],
+                "valid": true
+            },
+            {
+                "description": "additional items do not match schema",
+                "data": [ null, 2, 3, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "when items is schema, additionalItems does nothing",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": {},
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "all items match schema",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array of items with no additionalItems permitted",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [{}, {}, {}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "additional items are not permitted",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems as false without items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description":
+                    "items defaults to empty schema so everything is valid",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems are allowed by default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [{"type": "integer"}]
+        },
+        "tests": [
+            {
+                "description": "only the first item is validated",
+                "data": [1, "foo", false],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems does not look in applicators, valid case",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                { "items": [ { "type": "integer" } ] }
+            ],
+            "additionalItems": { "type": "boolean" }
+        },
+        "tests": [
+            {
+                "description": "items defined in allOf are not examined",
+                "data": [ 1, null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems does not look in applicators, invalid case",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                { "items": [ { "type": "integer" }, { "type": "string" } ] }
+            ],
+            "items": [ {"type": "integer" } ],
+            "additionalItems": { "type": "boolean" }
+        },
+        "tests": [
+            {
+                "description": "items defined in allOf are not examined",
+                "data": [ 1, "hello" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items validation adjusts the starting index for additionalItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [ { "type": "string" } ],
+            "additionalItems": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "additionalItems": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/additionalProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/additionalProperties.json
@@ -1,0 +1,156 @@
+[
+    {
+        "description":
+            "additionalProperties being false does not allow other properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {"foo": {}, "bar": {}},
+            "patternProperties": { "^v": {} },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "patternProperties are not additional properties",
+                "data": {"foo":1, "vroom": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "non-ASCII pattern with additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "patternProperties": {"^á": {}},
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "matching the pattern is valid",
+                "data": {"ármányos": 2},
+                "valid": true
+            },
+            {
+                "description": "not matching the pattern is invalid",
+                "data": {"élmény": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {"foo": {}, "bar": {}},
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties can exist by itself",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties are allowed by default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {"foo": {}, "bar": {}}
+        },
+        "tests": [
+            {
+                "description": "additional properties are allowed",
+                "data": {"foo": 1, "bar": 2, "quux": true},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties does not look in applicators",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not examined",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "additionalProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/allOf.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/allOf.json
@@ -1,0 +1,312 @@
+[
+    {
+        "description": "allOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allOf",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "mismatch second",
+                "data": {"foo": "baz"},
+                "valid": false
+            },
+            {
+                "description": "mismatch first",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "baz", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {"bar": {"type": "integer"}},
+            "required": ["bar"],
+            "allOf" : [
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                },
+                {
+                    "properties": {
+                        "baz": {"type": "null"}
+                    },
+                    "required": ["baz"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "valid": true
+            },
+            {
+                "description": "mismatch base schema",
+                "data": {"foo": "quux", "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch first allOf",
+                "data": {"bar": 2, "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch second allOf",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "mismatch both",
+                "data": {"bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf simple types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {"maximum": 30},
+                {"minimum": 20}
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": 25,
+                "valid": true
+            },
+            {
+                "description": "mismatch one",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, some false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf combined with anyOf, oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [ { "multipleOf": 2 } ],
+            "anyOf": [ { "multipleOf": 3 } ],
+            "oneOf": [ { "multipleOf": 5 } ]
+        },
+        "tests": [
+            {
+                "description": "allOf: false, anyOf: false, oneOf: false",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: false, oneOf: true",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: false",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: true",
+                "data": 15,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: false",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: true",
+                "data": 10,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: false",
+                "data": 6,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: true",
+                "data": 30,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/anchor.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/anchor.json
@@ -1,0 +1,235 @@
+[
+    {
+        "description": "Location-independent identifier",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "#foo",
+            "$defs": {
+                "A": {
+                    "$anchor": "foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with absolute URI",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/draft2019-09/bar#foo",
+            "$defs": {
+                "A": {
+                    "$id": "http://localhost:1234/draft2019-09/bar",
+                    "$anchor": "foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with base URI change in subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:1234/draft2019-09/root",
+            "$ref": "http://localhost:1234/draft2019-09/nested.json#foo",
+            "$defs": {
+                "A": {
+                    "$id": "nested.json",
+                    "$defs": {
+                        "B": {
+                            "$anchor": "foo",
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$anchor inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $anchor buried in the enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "anchor_in_enum": {
+                    "enum": [
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "null"
+                        }
+                    ]
+                },
+                "real_identifier_in_schema": {
+                    "$anchor": "my_anchor",
+                    "type": "string"
+                },
+                "zzz_anchor_in_const": {
+                    "const": {
+                        "$anchor": "my_anchor",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/anchor_in_enum" },
+                { "$ref": "#my_anchor" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$anchor": "my_anchor",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "in implementations that strip $anchor, this may match either $def",
+                "data": {
+                    "type": "null"
+                },
+                "valid": false
+            },
+            {
+                "description": "match $ref to $anchor",
+                "data": "a string to match #/$defs/anchor_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $anchor",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "same $anchor with different base uri",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:1234/draft2019-09/foobar",
+            "$defs": {
+                "A": {
+                    "$id": "child1",
+                    "allOf": [
+                        {
+                            "$id": "child2",
+                            "$anchor": "my_anchor",
+                            "type": "number"
+                        },
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "$ref": "child1#my_anchor"
+        },
+        "tests": [
+            {
+                "description": "$ref resolves to /$defs/A/allOf/1",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "$ref does not resolve to /$defs/A/allOf/0",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $anchor property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "const_not_anchor": {
+                    "const": {
+                        "$anchor": "not_a_real_anchor"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_anchor"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/$defs/const_not_anchor"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_anchor",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_anchor does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "invalid anchors",
+        "comment": "Section 8.2.3",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "MUST start with a letter (and not #)",
+                "data": { "$anchor" : "#foo" },
+                "valid": false
+            },
+            {
+                "description": "JSON pointers are not valid",
+                "data": { "$anchor" : "/a/b" },
+                "valid": false
+            },
+            {
+                "description": "invalid with valid beginning",
+                "data": { "$anchor" : "foo#something" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/anyOf.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/anyOf.json
@@ -1,0 +1,203 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid",
+                "data": 3,
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one anyOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, some true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/boolean_schema.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/boolean_schema.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "boolean schema 'true'",
+        "schema": true,
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "boolean true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "boolean false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean schema 'false'",
+        "schema": false,
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "boolean true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "boolean false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/const.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/const.json
@@ -1,0 +1,387 @@
+[
+    {
+        "description": "const validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": 2
+        },
+        "tests": [
+            {
+                "description": "same value is valid",
+                "data": 2,
+                "valid": true
+            },
+            {
+                "description": "another value is invalid",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": {"foo": "bar", "baz": "bax"}
+        },
+        "tests": [
+            {
+                "description": "same object is valid",
+                "data": {"foo": "bar", "baz": "bax"},
+                "valid": true
+            },
+            {
+                "description": "same object with different property order is valid",
+                "data": {"baz": "bax", "foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "another object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": [1, 2],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": [{ "foo": "bar" }]
+        },
+        "tests": [
+            {
+                "description": "same array is valid",
+                "data": [{"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "another array item is invalid",
+                "data": [2],
+                "valid": false
+            },
+            {
+                "description": "array with additional items is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with null",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": null
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "not null is invalid",
+                "data": 0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with false does not match 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": false
+        },
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with true does not match 1",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": true
+        },
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": [false]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": [true]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": false} does not match {\"a\": 0}",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": {"a": false}
+        },
+        "tests": [
+            {
+                "description": "{\"a\": false} is valid",
+                "data": {"a": false},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 0} is invalid",
+                "data": {"a": 0},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 0.0} is invalid",
+                "data": {"a": 0.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": true} does not match {\"a\": 1}",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": {"a": true}
+        },
+        "tests": [
+            {
+                "description": "{\"a\": true} is valid",
+                "data": {"a": true},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 1} is invalid",
+                "data": {"a": 1},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 1.0} is invalid",
+                "data": {"a": 1.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 0 does not match other zero-like types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": 0
+        },
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
+                "data": "",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 1 does not match true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": 1
+        },
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "const with -2.0 matches integer and float types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": -2.0
+        },
+        "tests": [
+            {
+                "description": "integer -2 is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "integer 2 is invalid",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "float -2.0 is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float 2.0 is invalid",
+                "data": 2.0,
+                "valid": false
+            },
+            {
+                "description": "float -2.00001 is invalid",
+                "data": -2.00001,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float and integers are equal up to 64-bit representation limits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": 9007199254740992
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 9007199254740992,
+                "valid": true
+            },
+            {
+                "description": "integer minus one is invalid",
+                "data": 9007199254740991,
+                "valid": false
+            },
+            {
+                "description": "float is valid",
+                "data": 9007199254740992.0,
+                "valid": true
+            },
+            {
+                "description": "float minus one is invalid",
+                "data": 9007199254740991.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "const": "hello\u0000there"
+        },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/contains.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/contains.json
@@ -1,0 +1,176 @@
+[
+    {
+        "description": "contains keyword validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"minimum": 5}
+        },
+        "tests": [
+            {
+                "description": "array with item matching schema (5) is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with item matching schema (6) is valid",
+                "data": [3, 4, 6],
+                "valid": true
+            },
+            {
+                "description": "array with two items matching schema (5, 6) is valid",
+                "data": [3, 4, 5, 6],
+                "valid": true
+            },
+            {
+                "description": "array without items matching schema is invalid",
+                "data": [2, 3, 4],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "not array is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with const keyword",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": { "const": 5 }
+        },
+        "tests": [
+            {
+                "description": "array with item 5 is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with two items 5 is valid",
+                "data": [3, 4, 5, 5],
+                "valid": true
+            },
+            {
+                "description": "array without item 5 is invalid",
+                "data": [1, 2, 3, 4],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": true
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": false
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "non-arrays are valid",
+                "data": "contains does not apply to strings",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items + contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": { "multipleOf": 2 },
+            "contains": { "multipleOf": 3 }
+        },
+        "tests": [
+            {
+                "description": "matches items, does not match contains",
+                "data": [ 2, 4, 8 ],
+                "valid": false
+            },
+            {
+                "description": "does not match items, matches contains",
+                "data": [ 3, 6, 9 ],
+                "valid": false
+            },
+            {
+                "description": "matches both items and contains",
+                "data": [ 6, 12 ],
+                "valid": true
+            },
+            {
+                "description": "matches neither items nor contains",
+                "data": [ 1, 5 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with false if subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {
+                "if": false,
+                "else": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null items",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/content.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/content.json
@@ -1,0 +1,131 @@
+[
+    {
+        "description": "validation of string-encoded content based on media type",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contentMediaType": "application/json"
+        },
+        "tests": [
+            {
+                "description": "a valid JSON document",
+                "data": "{\"foo\": \"bar\"}",
+                "valid": true
+            },
+            {
+                "description": "an invalid JSON document; validates true",
+                "data": "{:}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary string-encoding",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64 string",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string (% is not a valid character); validates true",
+                "data": "eyJmb28iOi%iYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary-encoded media type documents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64-encoded JSON document",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "a validly-encoded invalid JSON document; validates true",
+                "data": "ezp9Cg==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string that is valid JSON; validates true",
+                "data": "{}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary-encoded media type documents with schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64",
+            "contentSchema": { "type": "object", "required": ["foo"], "properties": { "foo": { "type": "string" } } }
+        },
+        "tests": [
+            {
+                "description": "a valid base64-encoded JSON document",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "another valid base64-encoded JSON document",
+                "data": "eyJib28iOiAyMCwgImZvbyI6ICJiYXoifQ==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64-encoded JSON document; validates true",
+                "data": "eyJib28iOiAyMH0=",
+                "valid": true
+            },
+            {
+                "description": "an empty object as a base64-encoded JSON document; validates true",
+                "data": "e30=",
+                "valid": true
+            },
+            {
+                "description": "an empty array as a base64-encoded JSON document",
+                "data": "W10=",
+                "valid": true
+            },
+            {
+                "description": "a validly-encoded invalid JSON document; validates true",
+                "data": "ezp9Cg==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string that is valid JSON; validates true",
+                "data": "{}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/default.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/default.json
@@ -1,0 +1,82 @@
+[
+    {
+        "description": "invalid type for default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {
+                    "type": "integer",
+                    "default": []
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"foo": 13},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid string value for default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "minLength": 4,
+                    "default": "bad"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"bar": "good"},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/defs.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/defs.json
@@ -1,0 +1,21 @@
+[
+    {
+        "description": "validate definition against metaschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "valid definition schema",
+                "data": {"$defs": {"foo": {"type": "integer"}}},
+                "valid": true
+            },
+            {
+                "description": "invalid definition schema",
+                "data": {"$defs": {"foo": {"type": 1}}},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/dependentRequired.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/dependentRequired.json
@@ -1,0 +1,152 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentRequired": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "empty dependents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentRequired": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependents required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentRequired": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentRequired": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "CRLF",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quotes",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "CRLF missing dependent",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quotes missing dependent",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/dependentSchemas.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/dependentSchemas.json
@@ -1,0 +1,132 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentSchemas": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean subschemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentSchemas": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependentSchemas": {
+                "foo\tbar": {"minProperties": 4},
+                "foo'bar": {"required": ["foo\"bar"]}
+            }
+        },
+        "tests": [
+            {
+                "description": "quoted tab",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quote",
+                "data": {
+                    "foo'bar": {"foo\"bar": 1}
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted tab invalid under dependent schema",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quote invalid under dependent schema",
+                "data": {"foo'bar": 1},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/enum.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/enum.json
@@ -1,0 +1,262 @@
+[
+    {
+        "description": "simple enum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [1, 2, 3]
+        },
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": 4,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [6, "foo", [], true, {"foo": 12}]
+        },
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": {"foo": false},
+                "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum-with-null validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [6, null]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 6,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": "test",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enums in properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type":"object",
+            "properties": {
+                "foo": {"enum":["foo"]},
+                "bar": {"enum":["bar"]}
+            },
+            "required": ["bar"]
+        },
+        "tests": [
+            {
+                "description": "both properties are valid",
+                "data": {"foo":"foo", "bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "wrong foo value",
+                "data": {"foo":"foot", "bar":"bar"},
+                "valid": false
+            },
+            {
+                "description": "wrong bar value",
+                "data": {"foo":"foo", "bar":"bart"},
+                "valid": false
+            },
+            {
+                "description": "missing optional property is valid",
+                "data": {"bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing required property is invalid",
+                "data": {"foo":"foo"},
+                "valid": false
+            },
+            {
+                "description": "missing all properties is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": ["foo\nbar", "foo\rbar"]
+        },
+        "tests": [
+            {
+                "description": "member 1 is valid",
+                "data": "foo\nbar",
+                "valid": true
+            },
+            {
+                "description": "member 2 is valid",
+                "data": "foo\rbar",
+                "valid": true
+            },
+            {
+                "description": "another string is invalid",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [false]
+        },
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [true]
+        },
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [0]
+        },
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [1]
+        },
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "enum": [ "hello\u0000there" ]
+        },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/exclusiveMaximum.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/exclusiveMaximum.json
@@ -1,0 +1,31 @@
+[
+    {
+        "description": "exclusiveMaximum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "exclusiveMaximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the exclusiveMaximum is valid",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 3.0,
+                "valid": false
+            },
+            {
+                "description": "above the exclusiveMaximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/exclusiveMinimum.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/exclusiveMinimum.json
@@ -1,0 +1,31 @@
+[
+    {
+        "description": "exclusiveMinimum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "exclusiveMinimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the exclusiveMinimum is valid",
+                "data": 1.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "below the exclusiveMinimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/format.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/format.json
@@ -1,0 +1,743 @@
+[
+    {
+        "description": "email format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-email format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "idn-email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "regex format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv4 format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv6 format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "ipv6"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-hostname format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "hostname format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "date"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date-time format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "date-time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "time format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "json-pointer format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative-json-pointer format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "relative-json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "iri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri-reference format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "iri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-reference format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-template format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri-template"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uuid format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uuid"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "duration format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "duration"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/id.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/id.json
@@ -1,0 +1,294 @@
+[
+    {
+        "description": "Invalid use of fragments in location-independent $id",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Identifier name",
+                "data": {
+                    "$ref": "#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "#foo",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name and no ref",
+                "data": {
+                    "$defs": {
+                        "A": { "$id": "#foo" }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path",
+                "data": {
+                    "$ref": "#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "#/a/b",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2019-09/bar#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2019-09/bar#foo",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2019-09/bar#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2019-09/bar#/a/b",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft2019-09/root",
+                    "$ref": "http://localhost:1234/draft2019-09/nested.json#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#foo",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft2019-09/root",
+                    "$ref": "http://localhost:1234/draft2019-09/nested.json#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#/a/b",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Valid use of empty fragments in location-independent $id",
+        "comment": "These are allowed but discouraged",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Identifier name with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2019-09/bar",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2019-09/bar#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Identifier name with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft2019-09/root",
+                    "$ref": "http://localhost:1234/draft2019-09/nested.json#/$defs/B",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Unnormalized $ids are allowed but discouraged",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "Unnormalized identifier",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2019-09/foo/baz",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2019-09/foo/bar/../baz",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier and no ref",
+                "data": {
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2019-09/foo/bar/../baz",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier with empty fragment",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2019-09/foo/baz",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2019-09/foo/bar/../baz#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier with empty fragment and no ref",
+                "data": {
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2019-09/foo/bar/../baz#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $id buried in the enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "$id": "https://localhost:1234/draft2019-09/id/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/draft2019-09/id/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "$id": "https://localhost:1234/draft2019-09/id/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_enum" },
+                { "$ref": "https://localhost:1234/draft2019-09/id/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$id": "https://localhost:1234/draft2019-09/id/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to $id",
+                "data": "a string to match #/$defs/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $id property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "const_not_id": {
+                    "const": {
+                        "$id": "not_a_real_id"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_id"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/$defs/const_not_id"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_id",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_id does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/if-then-else.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/if-then-else.json
@@ -1,0 +1,268 @@
+[
+    {
+        "description": "ignore if without then or else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "if": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone if",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone if",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore then without if",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "then": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone then",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone then",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore else without if",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "else": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone else",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone else",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and then without else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid when if test fails",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and else without then",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when if test passes",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validate against correct branch, then vs else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-interference across combined schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {
+                    "if": {
+                        "exclusiveMaximum": 0
+                    }
+                },
+                {
+                    "then": {
+                        "minimum": -10
+                    }
+                },
+                {
+                    "else": {
+                        "multipleOf": 2
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid, but would have been invalid through then",
+                "data": -100,
+                "valid": true
+            },
+            {
+                "description": "valid, but would have been invalid through else",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "if": true,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema true in if always chooses the then path (valid)",
+                "data": "then",
+                "valid": true
+            },
+            {
+                "description": "boolean schema true in if always chooses the then path (invalid)",
+                "data": "else",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "if": false,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema false in if always chooses the else path (invalid)",
+                "data": "then",
+                "valid": false
+            },
+            {
+                "description": "boolean schema false in if always chooses the else path (valid)",
+                "data": "else",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if appears at the end when serialized (keyword processing sequence)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "then": { "const": "yes" },
+            "else": { "const": "other" },
+            "if": { "maxLength": 4 }
+        },
+        "tests": [
+            {
+                "description": "yes redirects to then and passes",
+                "data": "yes",
+                "valid": true
+            },
+            {
+                "description": "other redirects to else and passes",
+                "data": "other",
+                "valid": true
+            },
+            {
+                "description": "no redirects to then and fails",
+                "data": "no",
+                "valid": false
+            },
+            {
+                "description": "invalid redirects to else and fails",
+                "data": "invalid",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/infinite-loop-detection.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/infinite-loop-detection.json
@@ -1,0 +1,37 @@
+[
+    {
+        "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "int": { "type": "integer" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "$ref": "#/$defs/int"
+                        }
+                    }
+                },
+                {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/int"
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "passing case",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "failing case",
+                "data": { "foo": "a string" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/items.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/items.json
@@ -1,0 +1,295 @@
+[
+    {
+        "description": "a schema given for items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of items",
+                "data": [1, "x"],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "length": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "an array of schemas for items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                {"type": "integer"},
+                {"type": "string"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "correct types",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "wrong types",
+                "data": [ "foo", 1 ],
+                "valid": false
+            },
+            {
+                "description": "incomplete array of items",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with additional items",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "1": "valid",
+                    "length": 2
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (true)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": true
+        },
+        "tests": [
+            {
+                "description": "any array is valid",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (false)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": [ 1, "foo", true ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [true, false]
+        },
+        "tests": [
+            {
+                "description": "array with one item is valid",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with two items is invalid",
+                "data": [ 1, "foo" ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "item": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "items": [
+                        { "$ref": "#/$defs/sub-item" },
+                        { "$ref": "#/$defs/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "additionalItems": false,
+            "items": [
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "single-form items with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/maxContains.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/maxContains.json
@@ -1,0 +1,102 @@
+[
+    {
+        "description": "maxContains without contains is ignored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "one item valid against lone maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "two items still valid against lone maxContains",
+                "data": [ 1, 2 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "all elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            },
+            {
+                "description": "some elements match, valid maxContains",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "some elements match, invalid maxContains",
+                "data": [ 1, 2, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxContains with contains, value with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "maxContains": 1.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minContains < maxContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "minContains": 1,
+            "maxContains": 3
+        },
+        "tests": [
+            {
+                "description": "actual < minContains < maxContains",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "minContains < actual < maxContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            },
+            {
+                "description": "minContains < maxContains < actual",
+                "data": [ 1, 1, 1, 1 ],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/maxItems.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/maxItems.json
@@ -1,0 +1,50 @@
+[
+    {
+        "description": "maxItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxItems": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "foobar",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxItems": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/maxLength.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/maxLength.json
@@ -1,0 +1,55 @@
+[
+    {
+        "description": "maxLength validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxLength": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxLength": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/maxProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/maxProperties.json
@@ -1,0 +1,79 @@
+[
+    {
+        "description": "maxProperties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxProperties": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxProperties validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxProperties": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxProperties = 0 means the object is empty",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maxProperties": 0
+        },
+        "tests": [
+            {
+                "description": "no properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "one property is invalid",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/maximum.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/maximum.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "maximum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maximum validation with unsigned integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maximum": 300
+        },
+        "tests":  [
+            {
+                "description": "below the maximum is invalid",
+                "data": 299.97,
+                "valid": true
+            },
+            {
+                "description": "boundary point integer is valid",
+                "data": 300,
+                "valid": true
+            },
+            {
+                "description": "boundary point float is valid",
+                "data": 300.00,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 300.5,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/minContains.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/minContains.json
@@ -1,0 +1,224 @@
+[
+    {
+        "description": "minContains without contains is ignored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minContains": 1
+        },
+        "tests": [
+            {
+                "description": "one item valid against lone minContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "zero items still valid against lone minContains",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=1 with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "minContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "no elements match",
+                "data": [ 2 ],
+                "valid": false
+            },
+            {
+                "description": "single element matches, valid minContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "some elements match, valid minContains",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "all elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=2 with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "minContains": 2
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "some elements match, invalid minContains",
+                "data": [ 1, 2 ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid minContains (exactly as needed)",
+                "data": [ 1, 1 ],
+                "valid": true
+            },
+            {
+                "description": "all elements match, valid minContains (more than needed)",
+                "data": [ 1, 1, 1 ],
+                "valid": true
+            },
+            {
+                "description": "some elements match, valid minContains",
+                "data": [ 1, 2, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=2 with contains with a decimal value",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "minContains": 2.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "both elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains = minContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "maxContains": 2,
+            "minContains": 2
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid maxContains",
+                "data": [ 1, 1, 1 ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid maxContains and minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains < minContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "maxContains": 1,
+            "minContains": 3
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "invalid maxContains",
+                "data": [ 1, 1, 1 ],
+                "valid": false
+            },
+            {
+                "description": "invalid maxContains and minContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minContains = 0 with no maxContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "minContains": 0
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "minContains = 0 makes contains always pass",
+                "data": [ 2 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains = 0 with maxContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "contains": {"const": 1},
+            "minContains": 0,
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "not more than maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/minItems.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/minItems.json
@@ -1,0 +1,50 @@
+[
+    {
+        "description": "minItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minItems": 1
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minItems": 1.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/minLength.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/minLength.json
@@ -1,0 +1,55 @@
+[
+    {
+        "description": "minLength validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minLength": 2
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minLength": 2.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/minProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/minProperties.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "minProperties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minProperties": 1
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minProperties": 1.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/minimum.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/minimum.json
@@ -1,0 +1,75 @@
+[
+    {
+        "description": "minimum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minimum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minimum": -2
+        },
+        "tests": [
+            {
+                "description": "negative above the minimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the minimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point with float is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float below the minimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the minimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/multipleOf.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/multipleOf.json
@@ -1,0 +1,83 @@
+[
+    {
+        "description": "by int",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "multipleOf": 2
+        },
+        "tests": [
+            {
+                "description": "int by int",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "int by int fail",
+                "data": 7,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "by number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "multipleOf": 1.5
+        },
+        "tests": [
+            {
+                "description": "zero is multiple of anything",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "4.5 is multiple of 1.5",
+                "data": 4.5,
+                "valid": true
+            },
+            {
+                "description": "35 is not multiple of 1.5",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "by small number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "multipleOf": 0.0001
+        },
+        "tests": [
+            {
+                "description": "0.0075 is multiple of 0.0001",
+                "data": 0.0075,
+                "valid": true
+            },
+            {
+                "description": "0.00751 is not multiple of 0.0001",
+                "data": 0.00751,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float division = inf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "integer", "multipleOf": 0.123456789
+        },
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/not.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/not.json
@@ -1,0 +1,127 @@
+[
+    {
+        "description": "not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "not": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "allowed",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "disallowed",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not multiple types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "not": {"type": ["integer", "boolean"]}
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": true,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not more complex schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "not": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+             }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "other match",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "forbidden property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": { 
+                    "not": {}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property present",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "property absent",
+                "data": {"bar": 1, "baz": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "not": true
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "not": false
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/oneOf.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/oneOf.json
@@ -1,0 +1,293 @@
+[
+    {
+        "description": "oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "oneOf" : [
+                {
+                    "minLength": 2
+                },
+                {
+                    "maxLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one oneOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [true, true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, one true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [true, false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, more than one true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [true, true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [false, false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf complex types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+	{
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": true,
+                        "baz": true
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/bignum.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/bignum.json
@@ -1,0 +1,110 @@
+[
+    {
+        "description": "integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "a bignum is an integer",
+                "data": 12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is an integer",
+                "data": -12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "number"
+        },
+        "tests": [
+            {
+                "description": "a bignum is a number",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is a number",
+                "data": -98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "string",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string"
+        },
+        "tests": [
+            {
+                "description": "a bignum is not a string",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum integer comparison",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "maximum": 18446744073709551615
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "exclusiveMaximum": 972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum integer comparison",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "minimum": -18446744073709551615
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision on negative numbers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "exclusiveMinimum": -972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/cross-draft.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/cross-draft.json
@@ -1,0 +1,41 @@
+[
+    {
+        "description": "refs to future drafts are processed as future drafts",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "array",
+            "$ref": "http://localhost:1234/draft2020-12/prefixItems.json"
+        },
+        "tests": [
+            {
+                "description": "first item not a string is invalid",
+                "comment": "if the implementation is not processing the $ref as a 2020-12 schema, this test will fail",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "first item is a string is valid",
+                "data": ["a string", 1, 2, 3],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "refs to historic drafts are processed as historic drafts",
+        "schema": {
+            "type": "object",
+            "allOf": [
+                { "properties": { "foo": true } },
+                { "$ref": "http://localhost:1234/draft7/ignore-dependentRequired.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "missing bar is valid",
+                "comment": "if the implementation is not processing the $ref as a draft 7 schema, this test will fail",
+                "data": {"foo": "any value"},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/dependencies-compatibility.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/dependencies-compatibility.json
@@ -1,0 +1,282 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "empty dependents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependents required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "CRLF",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quotes",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "CRLF missing dependent",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quotes missing dependent",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "single schema dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean subschemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "schema dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "dependencies": {
+                "foo\tbar": {"minProperties": 4},
+                "foo'bar": {"required": ["foo\"bar"]}
+            }
+        },
+        "tests": [
+            {
+                "description": "quoted tab",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quote",
+                "data": {
+                    "foo'bar": {"foo\"bar": 1}
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted tab invalid under dependent schema",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quote invalid under dependent schema",
+                "data": {"foo'bar": 1},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/ecmascript-regex.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/ecmascript-regex.json
@@ -1,0 +1,582 @@
+[
+    {
+        "description": "ECMA 262 regex $ does not match trailing newline",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^abc$"
+        },
+        "tests": [
+            {
+                "description": "matches in Python, but not in ECMA 262",
+                "data": "abc\\n",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "abc",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^\\t$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\t",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0009",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\W matches everything but ascii letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches whitespace",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
+                "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but whitespace",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
+                "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with pattern",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "\\p{Letter}cole"
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "\\wcole"
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with ASCII ranges",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "[a-z]cole"
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in pattern matches [0-9], not unicode digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "^\\d+$"
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with non-ASCII digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "^\\p{digit}+$"
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "patternProperties": {
+                "\\p{Letter}cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with ASCII ranges",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in patternProperties matches [0-9], not unicode digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with non-ASCII digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "patternProperties": {
+                "^\\p{digit}+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/float-overflow.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/float-overflow.json
@@ -1,0 +1,16 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "integer", "multipleOf": 0.5
+        },
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/date-time.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/date-time.json
@@ -1,0 +1,136 @@
+[
+    {
+        "description": "validation of date-time strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "date-time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
+                "data": "1990-02-31T15:59:59.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:59-24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid closing Z after time-zone offset",
+                "data": "1963-06-19T08:30:06.28123+01:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "case-insensitive T and Z",
+                "data": "1963-06-19t08:30:06.283185z",
+                "valid": true
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
+                "data": "1963-06-1৪T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
+                "data": "1963-06-11T0৪:00:00Z",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/date.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/date.json
@@ -1,0 +1,226 @@
+[
+    {
+        "description": "validation of date strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "date"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date string",
+                "data": "1963-06-19",
+                "valid": true
+            },
+            {
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
+                "data": "06/19/1963",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350",
+                "valid": false
+            },
+            {
+                "description": "non-padded month dates are not valid",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "non-padded day dates are not valid",
+                "data": "1998-01-1",
+                "valid": false
+            },
+            {
+                "description": "invalid month",
+                "data": "1998-13-01",
+                "valid": false
+            },
+            {
+                "description": "invalid month-day combination",
+                "data": "1998-04-31",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1963-06-1৪",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/duration.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/duration.json
@@ -1,0 +1,136 @@
+[
+    {
+        "description": "validation of duration strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "duration"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "P4DT12H30M5S",
+                "valid": true
+            },
+            {
+                "description": "an invalid duration string",
+                "data": "PT1D",
+                "valid": false
+            },
+            {
+                "description": "no elements present",
+                "data": "P",
+                "valid": false
+            },
+            {
+                "description": "no time elements present",
+                "data": "P1YT",
+                "valid": false
+            },
+            {
+                "description": "no date or time elements present",
+                "data": "PT",
+                "valid": false
+            },
+            {
+                "description": "elements out of order",
+                "data": "P2D1Y",
+                "valid": false
+            },
+            {
+                "description": "missing time separator",
+                "data": "P1D2H",
+                "valid": false
+            },
+            {
+                "description": "time element in the date position",
+                "data": "P2S",
+                "valid": false
+            },
+            {
+                "description": "four years duration",
+                "data": "P4Y",
+                "valid": true
+            },
+            {
+                "description": "zero time, in seconds",
+                "data": "PT0S",
+                "valid": true
+            },
+            {
+                "description": "zero time, in days",
+                "data": "P0D",
+                "valid": true
+            },
+            {
+                "description": "one month duration",
+                "data": "P1M",
+                "valid": true
+            },
+            {
+                "description": "one minute duration",
+                "data": "PT1M",
+                "valid": true
+            },
+            {
+                "description": "one and a half days, in hours",
+                "data": "PT36H",
+                "valid": true
+            },
+            {
+                "description": "one and a half days, in days and hours",
+                "data": "P1DT12H",
+                "valid": true
+            },
+            {
+                "description": "two weeks",
+                "data": "P2W",
+                "valid": true
+            },
+            {
+                "description": "weeks cannot be combined with other units",
+                "data": "P1Y2W",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "P২Y",
+                "valid": false
+            },
+            {
+                "description": "element without unit",
+                "data": "P1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/email.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/email.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "validation of e-mail addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/hostname.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/hostname.json
@@ -1,0 +1,101 @@
+[
+    {
+        "description": "validation of host names",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name",
+                "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid punycoded IDN hostname",
+                "data": "xn--4gbwdl.xn--wgbh1c",
+                "valid": true
+            },
+            {
+                "description": "a host name starting with an illegal character",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": false
+            },
+            {
+                "description": "a host name containing illegal characters",
+                "data": "not_a_valid_host_name",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+                "valid": false
+            },
+            {
+                "description": "starts with hyphen",
+                "data": "-hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with hyphen",
+                "data": "hostname-",
+                "valid": false
+            },
+            {
+                "description": "starts with underscore",
+                "data": "_hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with underscore",
+                "data": "hostname_",
+                "valid": false
+            },
+            {
+                "description": "contains underscore",
+                "data": "host_name",
+                "valid": false
+            },
+            {
+                "description": "maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": true
+            },
+            {
+                "description": "exceeds maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/idn-email.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/idn-email.json
@@ -1,0 +1,61 @@
+[
+    {
+        "description": "validation of an internationalized e-mail addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "idn-email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid idn e-mail (example@example.test in Hangul)",
+                "data": "실례@실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "an invalid idn e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/idn-hostname.json
@@ -1,0 +1,307 @@
+[
+    {
+        "description": "validation of internationalized host names",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name (example.test in Hangul)",
+                "data": "실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "illegal first char U+302E Hangul single dot tone mark",
+                "data": "〮실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "contains illegal char U+302E Hangul single dot tone mark",
+                "data": "실〮례.테스트",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "invalid label, correct Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc3492#section-7.1",
+                "data": "-> $1.00 <--",
+                "valid": false
+            },
+            {
+                "description": "valid Chinese Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4",
+                "data": "xn--ihqwcrb4cv8a8dqg056pqjye",
+                "valid": true
+            },
+            {
+                "description": "invalid Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "xn--X",
+                "valid": false
+            },
+            {
+                "description": "U-label contains \"--\" in the 3rd and 4th position",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "XN--aa---o47jg78q",
+                "valid": false
+            },
+            {
+                "description": "U-label starts with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello",
+                "valid": false
+            },
+            {
+                "description": "U-label ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "hello-",
+                "valid": false
+            },
+            {
+                "description": "U-label starts and ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello-",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Spacing Combining Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0903hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Nonspacing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0300hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with an Enclosing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0488hello",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are PVALID, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u00df\u03c2\u0f0b\u3007",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are PVALID, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u06fd\u06fe",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u0640\u07fa",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6 Note: The two combining marks (U+302E and U+302F) are in the middle and not at the start",
+                "data": "\u3031\u3032\u3033\u3034\u3035\u302e\u302f\u303b",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no preceding 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "a\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing preceding",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no following 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7a",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing following",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with surrounding 'l's",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7l",
+                "valid": true
+            },
+            {
+                "description": "Greek KERAIA not followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375S",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA not followed by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375\u03b2",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERESH not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "A\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05d0\u05f3\u05d1",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "A\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05d0\u05f4\u05d1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no Hiragana, Katakana, or Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "def\u30fbabc",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no other characters",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Hiragana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u3041",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Katakana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u30a1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u4e08",
+                "valid": true
+            },
+            {
+                "description": "Arabic-Indic digits mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0660\u06f0",
+                "valid": false
+            },
+            {
+                "description": "Arabic-Indic digits not mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0628\u0660\u0628",
+                "valid": true
+            },
+            {
+                "description": "Extended Arabic-Indic digits not mixed with Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.9",
+                "data": "\u06f00",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u094d\u200d\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER not preceded by Virama but matches regexp",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
+                "data": "\u0628\u064a\u200c\u0628\u064a",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/ipv4.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/ipv4.json
@@ -1,0 +1,87 @@
+[
+    {
+        "description": "validation of IP addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IP address",
+                "data": "192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "an IP address with too many components",
+                "data": "127.0.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "an IP address with out-of-range values",
+                "data": "256.256.256.256",
+                "valid": false
+            },
+            {
+                "description": "an IP address without 4 components",
+                "data": "127.0",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer",
+                "data": "0x7f000001",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
+            },
+            {
+                "description": "invalid leading zeroes, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২7.0.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/ipv6.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/ipv6.json
@@ -1,0 +1,211 @@
+[
+    {
+        "description": "validation of IPv6 addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "ipv6"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IPv6 address",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "an IPv6 address with out-of-range values",
+                "data": "12345::",
+                "valid": false
+            },
+            {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address with too many components",
+                "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address containing illegal characters",
+                "data": "::laptop",
+                "valid": false
+            },
+            {
+                "description": "no digits is valid",
+                "data": "::",
+                "valid": true
+            },
+            {
+                "description": "leading colons is valid",
+                "data": "::42:ff:1",
+                "valid": true
+            },
+            {
+                "description": "trailing colons is valid",
+                "data": "d6::",
+                "valid": true
+            },
+            {
+                "description": "missing leading octet is invalid",
+                "data": ":2:3:4:5:6:7:8",
+                "valid": false
+            },
+            {
+                "description": "missing trailing octet is invalid",
+                "data": "1:2:3:4:5:6:7:",
+                "valid": false
+            },
+            {
+                "description": "missing leading octet with omitted octets later",
+                "data": ":2:3:4::8",
+                "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
+            },
+            {
+                "description": "two sets of double colons is invalid",
+                "data": "1::d6::42",
+                "valid": false
+            },
+            {
+                "description": "mixed format with the ipv4 section as decimal octets",
+                "data": "1::d6:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with double colons between the sections",
+                "data": "1:2::192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with ipv4 section with octet out of range",
+                "data": "1::2:192.168.256.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with ipv4 section with a hex octet",
+                "data": "1::2:192.168.ff.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with leading double colons (ipv4-mapped ipv6 address)",
+                "data": "::ffff:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "triple colons is invalid",
+                "data": "1:2:3:4:5:::8",
+                "valid": false
+            },
+            {
+                "description": "8 octets",
+                "data": "1:2:3:4:5:6:7:8",
+                "valid": true
+            },
+            {
+                "description": "insufficient octets without double colons",
+                "data": "1:2:3:4:5:6:7",
+                "valid": false
+            },
+            {
+                "description": "no colons is invalid",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 is not ipv6",
+                "data": "127.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 segment must have 4 octets",
+                "data": "1:2:3:4:1.2.3",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1:2:3:4:5:6:7:৪",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
+                "data": "1:2::192.16৪.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/iri-reference.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/iri-reference.json
@@ -1,0 +1,76 @@
+[
+    {
+        "description": "validation of IRI References",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "iri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference",
+                "data": "//ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid relative IRI Reference",
+                "data": "/âππ",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI Reference",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "a valid IRI Reference",
+                "data": "âππ",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI fragment",
+                "data": "#ƒrägmênt",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI fragment",
+                "data": "#ƒräg\\mênt",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/iri.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/iri.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "validation of IRIs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "iri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag and parentheses",
+                "data": "http://ƒøø.com/blah_(wîkïpédiå)_blah#ßité-1",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with URL-encoded stuff",
+                "data": "http://ƒøø.ßår/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI based on IPv6",
+                "data": "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI based on IPv6",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative IRI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI though valid IRI reference",
+                "data": "âππ",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/json-pointer.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/json-pointer.json
@@ -1,0 +1,201 @@
+[
+    {
+        "description": "validation of JSON-pointers (JSON String Representation)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid JSON-pointer",
+                "data": "/foo/bar~0/baz~1/%a",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (~ not escaped)",
+                "data": "/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "valid JSON-pointer with empty segment",
+                "data": "/foo//bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer with the last empty segment",
+                "data": "/foo/bar/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #1",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #2",
+                "data": "/foo",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #3",
+                "data": "/foo/0",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #4",
+                "data": "/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #5",
+                "data": "/a~1b",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #6",
+                "data": "/c%d",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #7",
+                "data": "/e^f",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #8",
+                "data": "/g|h",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #9",
+                "data": "/i\\j",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #10",
+                "data": "/k\"l",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #11",
+                "data": "/ ",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #12",
+                "data": "/m~0n",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer used adding to the last array position",
+                "data": "/foo/-",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (- used as object member name)",
+                "data": "/foo/-/bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (multiple escaped characters)",
+                "data": "/~1~0~0~1~1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #1",
+                "data": "/~1.1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #2",
+                "data": "/~0.1",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #1",
+                "data": "#",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #2",
+                "data": "#/",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #3",
+                "data": "#a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #1",
+                "data": "/~0~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #2",
+                "data": "/~0/~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #1",
+                "data": "/~2",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #2",
+                "data": "/~-1",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (multiple characters not escaped)",
+                "data": "/~~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #1",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #2",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #3",
+                "data": "a/a",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/regex.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/regex.json
@@ -1,0 +1,51 @@
+[
+    {
+        "description": "validation of regular expressions",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid regular expression",
+                "data": "([abc])+\\s+$",
+                "valid": true
+            },
+            {
+                "description": "a regular expression with unclosed parens is invalid",
+                "data": "^(abc]",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/relative-json-pointer.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/relative-json-pointer.json
@@ -1,0 +1,101 @@
+[
+    {
+        "description": "validation of Relative JSON Pointers (RJP)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "relative-json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid upwards RJP",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "a valid downwards RJP",
+                "data": "0/foo/bar",
+                "valid": true
+            },
+            {
+                "description": "a valid up and then down RJP, with array index",
+                "data": "2/0/baz/1/zip",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP taking the member or index name",
+                "data": "0#",
+                "valid": true
+            },
+            {
+                "description": "an invalid RJP that is a valid JSON Pointer",
+                "data": "/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "negative prefix",
+                "data": "-1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "explicit positive prefix",
+                "data": "+1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "## is not a valid json-pointer",
+                "data": "0##",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus json-pointer",
+                "data": "01/a",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus octothorpe",
+                "data": "01#",
+                "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "multi-digit integer prefix",
+                "data": "120/foo/bar",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/time.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/time.json
@@ -1,0 +1,216 @@
+[
+    {
+        "description": "validation of time strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid time string",
+                "data": "08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with leap second, Zulu",
+                "data": "23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, zero time-offset",
+                "data": "23:59:60+00:00",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong hour)",
+                "data": "22:59:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong minute)",
+                "data": "23:58:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, positive time-offset",
+                "data": "01:29:60+01:30",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large positive time-offset",
+                "data": "23:29:60+23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong hour)",
+                "data": "23:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong minute)",
+                "data": "23:59:60+00:30",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, negative time-offset",
+                "data": "15:59:60-08:00",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large negative time-offset",
+                "data": "00:29:60-23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong hour)",
+                "data": "23:59:60-01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong minute)",
+                "data": "23:59:60-00:30",
+                "valid": false
+            },
+            {
+                "description": "a valid time string with second fraction",
+                "data": "23:20:50.52Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with precise second fraction",
+                "data": "08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with plus offset",
+                "data": "08:30:06+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with minus offset",
+                "data": "08:30:06-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with case-insensitive Z",
+                "data": "08:30:06z",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string with invalid hour",
+                "data": "24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid minute",
+                "data": "00:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid second",
+                "data": "00:00:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset hour",
+                "data": "01:02:03+24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset minute",
+                "data": "01:02:03+00:60",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time with both Z and numoffset",
+                "data": "01:02:03Z+00:30",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset indicator",
+                "data": "08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "01:01:01,1111",
+                "valid": false
+            },
+            {
+                "description": "no time offset",
+                "data": "12:00:00",
+                "valid": false
+            },
+            {
+                "description": "no time offset with second fraction",
+                "data": "12:00:00.52",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "offset not starting with plus or minus",
+                "data": "08:30:06#00:20",
+                "valid": false
+            },
+            {
+                "description": "contains letters",
+                "data": "ab:cd:ef",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/unknown.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/unknown.json
@@ -1,0 +1,46 @@
+[
+    {
+        "description": "unknown format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "unknown"
+        },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/uri-reference.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/uri-reference.json
@@ -1,0 +1,76 @@
+[
+    {
+        "description": "validation of URI References",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URI",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid relative URI Reference",
+                "data": "/abc",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI Reference",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "a valid URI Reference",
+                "data": "abc",
+                "valid": true
+            },
+            {
+                "description": "a valid URI fragment",
+                "data": "#fragment",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI fragment",
+                "data": "#frag\\ment",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/uri-template.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/uri-template.json
@@ -1,0 +1,61 @@
+[
+    {
+        "description": "format: uri-template",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri-template"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term}",
+                "valid": true
+            },
+            {
+                "description": "an invalid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": false
+            },
+            {
+                "description": "a valid uri-template without variables",
+                "data": "http://example.com/dictionary",
+                "valid": true
+            },
+            {
+                "description": "a valid relative uri-template",
+                "data": "dictionary/{term:1}/{term}",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/uri.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/uri.json
@@ -1,0 +1,141 @@
+[
+    {
+        "description": "validation of URIs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag and parentheses",
+                "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with URL-encoded stuff",
+                "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid puny-coded URL ",
+                "data": "http://xn--nw2a.xn--j6w193g/",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid URL based on IPv4",
+                "data": "http://223.255.255.254",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with ftp scheme",
+                "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL for a simple text file",
+                "data": "http://www.ietf.org/rfc/rfc2396.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL ",
+                "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+                "valid": true
+            },
+            {
+                "description": "a valid mailto URI",
+                "data": "mailto:John.Doe@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid newsgroup URI",
+                "data": "news:comp.infosystems.www.servers.unix",
+                "valid": true
+            },
+            {
+                "description": "a valid tel URI",
+                "data": "tel:+1-816-555-1212",
+                "valid": true
+            },
+            {
+                "description": "a valid URN",
+                "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+                "valid": true
+            },
+            {
+                "description": "an invalid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative URI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI though valid URI reference",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces",
+                "data": "http:// shouldfail.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces and missing scheme",
+                "data": ":// should fail",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/format/uuid.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/format/uuid.json
@@ -1,0 +1,116 @@
+[
+    {
+        "description": "uuid format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "uuid"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "all upper-case",
+                "data": "2EB8AA08-AA98-11EA-B4AA-73B441D16380",
+                "valid": true
+            },
+            {
+                "description": "all lower-case",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": true
+            },
+            {
+                "description": "mixed case",
+                "data": "2eb8aa08-AA98-11ea-B4Aa-73B441D16380",
+                "valid": true
+            },
+            {
+                "description": "all zeroes is valid",
+                "data": "00000000-0000-0000-0000-000000000000",
+                "valid": true
+            },
+            {
+                "description": "wrong length",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
+                "valid": false
+            },
+            {
+                "description": "missing section",
+                "data": "2eb8aa08-aa98-11ea-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "bad characters (not hex)",
+                "data": "2eb8aa08-aa98-11ea-b4ga-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "no dashes",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too few dashes",
+                "data": "2eb8aa08aa98-11ea-b4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too many dashes",
+                "data": "2eb8-aa08-aa98-11ea-b4aa73b44-1d16380",
+                "valid": false
+            },
+            {
+                "description": "dashes in the wrong spot",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380----",
+                "valid": false
+            },
+            {
+                "description": "valid version 4",
+                "data": "98d80576-482e-427f-8434-7f86890ab222",
+                "valid": true
+            },
+            {
+                "description": "valid version 5",
+                "data": "99c17cbb-656f-564a-940f-1a4568f03487",
+                "valid": true
+            },
+            {
+                "description": "hypothetical version 6",
+                "data": "99c17cbb-656f-664a-940f-1a4568f03487",
+                "valid": true
+            },
+            {
+                "description": "hypothetical version 15",
+                "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/no-schema.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/no-schema.json
@@ -1,0 +1,26 @@
+[
+    {
+        "description": "validation without $schema",
+        "comment": "minLength is the same across all drafts",
+        "schema": {
+            "minLength": 2
+        },
+        "tests": [
+            {
+                "description": "a 3-character string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a 1-character string is not valid",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "a non-string is valid",
+                "data": 5,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/non-bmp-regex.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/non-bmp-regex.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "Proper UTF-16 surrogate pair handling: pattern",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "^🐲*$"
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Proper UTF-16 surrogate pair handling: patternProperties",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐲": "hello" },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐲🐲": "hello" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/optional/refOfUnknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/optional/refOfUnknownKeyword.json
@@ -1,0 +1,46 @@
+[
+    {
+        "description": "reference of a root arbitrary keyword ",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unknown-keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference of an arbitrary keyword of a sub-schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {"unknown-keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/pattern.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/pattern.json
@@ -1,0 +1,65 @@
+[
+    {
+        "description": "pattern validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "^a*$"
+        },
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "aaa",
+                "valid": true
+            },
+            {
+                "description": "a non-matching pattern is invalid",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "pattern": "a+"
+        },
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/patternProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/patternProperties.json
@@ -1,0 +1,176 @@
+[
+    {
+        "description":
+            "patternProperties validates properties matching a regex",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "patternProperties": {
+                "f.*o": {"type": "integer"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "multiple valid matches is valid",
+                "data": {"foo": 1, "foooooo" : 2},
+                "valid": true
+            },
+            {
+                "description": "a single invalid match is invalid",
+                "data": {"foo": "bar", "fooooo": 2},
+                "valid": false
+            },
+            {
+                "description": "multiple invalid matches is invalid",
+                "data": {"foo": "bar", "foooooo" : "baz"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple simultaneous patternProperties are validated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "patternProperties": {
+                "a*": {"type": "integer"},
+                "aaa*": {"maximum": 20}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"a": 21},
+                "valid": true
+            },
+            {
+                "description": "a simultaneous match is valid",
+                "data": {"aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "multiple matches is valid",
+                "data": {"a": 21, "aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "an invalid due to one is invalid",
+                "data": {"a": "bar"},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to the other is invalid",
+                "data": {"aaaa": 31},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to both is invalid",
+                "data": {"aaa": "foo", "aaaa": 31},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "regexes are not anchored by default and are case sensitive",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "patternProperties": {
+                "[0-9]{2,}": { "type": "boolean" },
+                "X_": { "type": "string" }
+            }
+        },
+        "tests": [
+            {
+                "description": "non recognized members are ignored",
+                "data": { "answer 1": "42" },
+                "valid": true
+            },
+            {
+                "description": "recognized members are accounted for",
+                "data": { "a31b": null },
+                "valid": false
+            },
+            {
+                "description": "regexes are case sensitive",
+                "data": { "a_x_3": 3 },
+                "valid": true
+            },
+            {
+                "description": "regexes are case sensitive, 2",
+                "data": { "a_X_3": 3 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "patternProperties": {
+                "f.*": true,
+                "b.*": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property matching schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property matching schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with a property matching both true and false is invalid",
+                "data": {"foobar":1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/properties.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/properties.json
@@ -1,0 +1,242 @@
+[
+    {
+        "description": "object properties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties present and valid is valid",
+                "data": {"foo": 1, "bar": "baz"},
+                "valid": true
+            },
+            {
+                "description": "one property invalid is invalid",
+                "data": {"foo": 1, "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "both properties invalid is invalid",
+                "data": {"foo": [], "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "doesn't invalidate other properties",
+                "data": {"quux": []},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description":
+            "properties, patternProperties, additionalProperties interaction",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {"type": "array", "maxItems": 3},
+                "bar": {"type": "array"}
+            },
+            "patternProperties": {"f.o": {"minItems": 2}},
+            "additionalProperties": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "property validates property",
+                "data": {"foo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "property invalidates property",
+                "data": {"foo": [1, 2, 3, 4]},
+                "valid": false
+            },
+            {
+                "description": "patternProperty invalidates property",
+                "data": {"foo": []},
+                "valid": false
+            },
+            {
+                "description": "patternProperty validates nonproperty",
+                "data": {"fxo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "patternProperty invalidates nonproperty",
+                "data": {"fxo": []},
+                "valid": false
+            },
+            {
+                "description": "additionalProperty ignores property",
+                "data": {"bar": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty validates others",
+                "data": {"quux": 3},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty invalidates others",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with boolean schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no property present is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "only 'true' property present is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "only 'false' property present is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "both properties present is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo\nbar": {"type": "number"},
+                "foo\"bar": {"type": "number"},
+                "foo\\bar": {"type": "number"},
+                "foo\rbar": {"type": "number"},
+                "foo\tbar": {"type": "number"},
+                "foo\fbar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with all numbers is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1",
+                    "foo\\bar": "1",
+                    "foo\rbar": "1",
+                    "foo\tbar": "1",
+                    "foo\fbar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "__proto__": {"type": "number"},
+                "toString": {
+                    "properties": { "length": { "type": "string" } }
+                },
+                "constructor": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "__proto__ not valid",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString not valid",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor not valid",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present and valid",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/propertyNames.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/propertyNames.json
@@ -1,0 +1,115 @@
+[
+    {
+        "description": "propertyNames validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "propertyNames": {"maxLength": 3}
+        },
+        "tests": [
+            {
+                "description": "all property names valid",
+                "data": {
+                    "f": {},
+                    "foo": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "some property names invalid",
+                "data": {
+                    "foo": {},
+                    "foobar": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3, 4],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames validation with pattern",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "propertyNames": { "pattern": "^a+$" }
+        },
+        "tests": [
+            {
+                "description": "matching property names valid",
+                "data": {
+                    "a": {},
+                    "aa": {},
+                    "aaa": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "non-matching property name is invalid",
+                "data": {
+                    "aaA": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "propertyNames": true
+        },
+        "tests": [
+            {
+                "description": "object with any properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "propertyNames": false
+        },
+        "tests": [
+            {
+                "description": "object with any properties is invalid",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/recursiveRef.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/recursiveRef.json
@@ -1,0 +1,408 @@
+[
+    {
+        "description": "$recursiveRef without $recursiveAnchor works like $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": { "$recursiveRef": "#" }
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": { "foo": { "foo": false } },
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": { "bar": false },
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": { "foo": { "bar": false } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$recursiveRef without using nesting",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef2/schema.json",
+            "$defs": {
+                "myobject": {
+                    "$id": "myobject.json",
+                    "$recursiveAnchor": true,
+                    "anyOf": [
+                        { "type": "string" },
+                        {
+                            "type": "object",
+                            "additionalProperties": { "$recursiveRef": "#" }
+                        }
+                    ]
+                }
+            },
+            "anyOf": [
+                { "type": "integer" },
+                { "$ref": "#/$defs/myobject" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "integer matches at the outer level",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "single level match",
+                "data": { "foo": "hi" },
+                "valid": true
+            },
+            {
+                "description": "integer does not match as a property value",
+                "data": { "foo": 1 },
+                "valid": false
+            },
+            {
+                "description": "two levels, properties match with inner definition",
+                "data": { "foo": { "bar": "hi" } },
+                "valid": true
+            },
+            {
+                "description": "two levels, no match",
+                "data": { "foo": { "bar": 1 } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$recursiveRef with nesting",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef3/schema.json",
+            "$recursiveAnchor": true,
+            "$defs": {
+                "myobject": {
+                    "$id": "myobject.json",
+                    "$recursiveAnchor": true,
+                    "anyOf": [
+                        { "type": "string" },
+                        {
+                            "type": "object",
+                            "additionalProperties": { "$recursiveRef": "#" }
+                        }
+                    ]
+                }
+            },
+            "anyOf": [
+                { "type": "integer" },
+                { "$ref": "#/$defs/myobject" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "integer matches at the outer level",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "single level match",
+                "data": { "foo": "hi" },
+                "valid": true
+            },
+            {
+                "description": "integer now matches as a property value",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "two levels, properties match with inner definition",
+                "data": { "foo": { "bar": "hi" } },
+                "valid": true
+            },
+            {
+                "description": "two levels, properties match with $recursiveRef",
+                "data": { "foo": { "bar": 1 } },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$recursiveRef with $recursiveAnchor: false works like $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef4/schema.json",
+            "$recursiveAnchor": false,
+            "$defs": {
+                "myobject": {
+                    "$id": "myobject.json",
+                    "$recursiveAnchor": false,
+                    "anyOf": [
+                        { "type": "string" },
+                        {
+                            "type": "object",
+                            "additionalProperties": { "$recursiveRef": "#" }
+                        }
+                    ]
+                }
+            },
+            "anyOf": [
+                { "type": "integer" },
+                { "$ref": "#/$defs/myobject" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "integer matches at the outer level",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "single level match",
+                "data": { "foo": "hi" },
+                "valid": true
+            },
+            {
+                "description": "integer does not match as a property value",
+                "data": { "foo": 1 },
+                "valid": false
+            },
+            {
+                "description": "two levels, properties match with inner definition",
+                "data": { "foo": { "bar": "hi" } },
+                "valid": true
+            },
+            {
+                "description": "two levels, integer does not match as a property value",
+                "data": { "foo": { "bar": 1 } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$recursiveRef with no $recursiveAnchor works like $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef5/schema.json",
+            "$defs": {
+                "myobject": {
+                    "$id": "myobject.json",
+                    "$recursiveAnchor": false,
+                    "anyOf": [
+                        { "type": "string" },
+                        {
+                            "type": "object",
+                            "additionalProperties": { "$recursiveRef": "#" }
+                        }
+                    ]
+                }
+            },
+            "anyOf": [
+                { "type": "integer" },
+                { "$ref": "#/$defs/myobject" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "integer matches at the outer level",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "single level match",
+                "data": { "foo": "hi" },
+                "valid": true
+            },
+            {
+                "description": "integer does not match as a property value",
+                "data": { "foo": 1 },
+                "valid": false
+            },
+            {
+                "description": "two levels, properties match with inner definition",
+                "data": { "foo": { "bar": "hi" } },
+                "valid": true
+            },
+            {
+                "description": "two levels, integer does not match as a property value",
+                "data": { "foo": { "bar": 1 } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$recursiveRef with no $recursiveAnchor in the initial target schema resource",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef6/base.json",
+            "$recursiveAnchor": true,
+            "anyOf": [
+                { "type": "boolean" },
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$id": "http://localhost:4242/draft2019-09/recursiveRef6/inner.json",
+                        "$comment": "there is no $recursiveAnchor: true here, so we do NOT recurse to the base",
+                        "anyOf": [
+                            { "type": "integer" },
+                            { "type": "object", "additionalProperties": { "$recursiveRef": "#" } }
+                        ]
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "leaf node does not match; no recursion",
+                "data": { "foo": true },
+                "valid": false
+            },
+            {
+                "description": "leaf node matches: recursion uses the inner schema",
+                "data": { "foo": { "bar": 1 } },
+                "valid": true
+            },
+            {
+                "description": "leaf node does not match: recursion uses the inner schema",
+                "data": { "foo": { "bar": true } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$recursiveRef with no $recursiveAnchor in the outer schema resource",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:4242/draft2019-09/recursiveRef7/base.json",
+            "anyOf": [
+                { "type": "boolean" },
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$id": "http://localhost:4242/draft2019-09/recursiveRef7/inner.json",
+                        "$recursiveAnchor": true,
+                        "anyOf": [
+                            { "type": "integer" },
+                            { "type": "object", "additionalProperties": { "$recursiveRef": "#" } }
+                        ]
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "leaf node does not match; no recursion",
+                "data": { "foo": true },
+                "valid": false
+            },
+            {
+                "description": "leaf node matches: recursion only uses inner schema",
+                "data": { "foo": { "bar": 1 } },
+                "valid": true
+            },
+            {
+                "description": "leaf node does not match: recursion only uses inner schema",
+                "data": { "foo": { "bar": true } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple dynamic paths to the $recursiveRef keyword",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "recursiveRef8_main.json",
+            "$defs": {
+                "inner": {
+                    "$id": "recursiveRef8_inner.json",
+                    "$recursiveAnchor": true,
+                    "title": "inner",
+                    "additionalProperties": {
+                        "$recursiveRef": "#"
+                    }
+                }
+            },
+            "if": {
+                "propertyNames": {
+                    "pattern": "^[a-m]"
+                }
+            },
+            "then": {
+                "title": "any type of node",
+                "$id": "recursiveRef8_anyLeafNode.json",
+                "$recursiveAnchor": true,
+                "$ref": "recursiveRef8_inner.json"
+            },
+            "else": {
+                "title": "integer node",
+                "$id": "recursiveRef8_integerNode.json",
+                "$recursiveAnchor": true,
+                "type": [ "object", "integer" ],
+                "$ref": "recursiveRef8_inner.json"
+            }
+        },
+        "tests": [
+            {
+                "description": "recurse to anyLeafNode - floats are allowed",
+                "data": { "alpha": 1.1 },
+                "valid": true
+            },
+            {
+                "description": "recurse to integerNode - floats are not allowed",
+                "data": { "november": 1.1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dynamic $recursiveRef destination (not predictable at schema compile time)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "main.json",
+            "$defs": {
+                "inner": {
+                    "$id": "inner.json",
+                    "$recursiveAnchor": true,
+                    "title": "inner",
+                    "additionalProperties": {
+                        "$recursiveRef": "#"
+                    }
+                }
+
+            },
+            "if": { "propertyNames": { "pattern": "^[a-m]" } },
+            "then": {
+                "title": "any type of node",
+                "$id": "anyLeafNode.json",
+                "$recursiveAnchor": true,
+                "$ref": "main.json#/$defs/inner"
+            },
+            "else": {
+                "title": "integer node",
+                "$id": "integerNode.json",
+                "$recursiveAnchor": true,
+                "type": [ "object", "integer" ],
+                "$ref": "main.json#/$defs/inner"
+            }
+        },
+        "tests": [
+            {
+                "description": "numeric node",
+                "data": { "alpha": 1.1 },
+                "valid": true
+            },
+            {
+                "description": "integer node",
+                "data": { "november": 1.1 },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/ref.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/ref.json
@@ -1,0 +1,887 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                {"type": "integer"},
+                {"$ref": "#/items/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
+            },
+            "properties": {
+                "tilde": {"$ref": "#/$defs/tilde~0field"},
+                "slash": {"$ref": "#/$defs/slash~1field"},
+                "percent": {"$ref": "#/$defs/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilde invalid",
+                "data": {"tilde": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilde valid",
+                "data": {"tilde": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/$defs/a"},
+                "c": {"$ref": "#/$defs/b"}
+            },
+            "$ref": "#/$defs/c"
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref applies alongside sibling keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "ref valid, maxItems valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "ref valid, maxItems invalid",
+                "data": { "foo": [1, 2, 3] },
+                "valid": false
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"minLength": 1},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"minLength": -1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "$ref": {"$ref": "#/$defs/is-string"}
+            },
+            "$defs": {
+                "is-string": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": false
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:1234/draft2019-09/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {
+                    "type": "array",
+                    "items": {"$ref": "node"}
+                }
+            },
+            "required": ["meta", "nodes"],
+            "$defs": {
+                "node": {
+                    "$id": "http://localhost:1234/draft2019-09/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "subtree": {"$ref": "tree"}
+                    },
+                    "required": ["value"]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 1.1},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": "string is invalid"},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
+            },
+            "$defs": {
+                "foo\"bar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with numbers is valid",
+                "data": {
+                    "foo\"bar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref creates new scope when adjacent to keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "A": {
+                    "unevaluatedProperties": false
+                }
+            },
+            "properties": {
+                "prop1": {
+                    "type": "string"
+                }
+            },
+            "$ref": "#/$defs/A"
+        },
+        "tests": [
+            {
+                "description": "referenced subschema doesn't see annotations from properties",
+                "data": {
+                    "prop1": "match"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/$defs/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "do not evaluate the $ref inside the enum, definition exact match",
+                "data": { "type": "string" },
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/$defs/a_string" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "refs with relative uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://example.com/schema-relative-uri-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "schema-relative-uri-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-relative-uri-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative refs with absolute uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "http://example.com/schema-refs-absolute-uris-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-refs-absolute-uris-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://example.com/a.json",
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "$defs": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$id": "/draft2019-09/ref-and-id1/base.json",
+            "$ref": "int.json",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /draft2019-09/ref-and-id1/int.json",
+                    "$id": "int.json",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /draft2019-09/ref-and-id1-int.json",
+                    "$id": "/draft2019-09/ref-and-id1-int.json",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $anchor and $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$id": "/draft2019-09/ref-and-id2/base.json",
+            "$ref": "#bigint",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /draft2019-09/ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "$anchor": "bigint",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /draft2019-09/ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
+                    "$id": "/draft2019-09/ref-and-id2/",
+                    "$anchor": "bigint",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with $ref via the URN",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "minimum": 30,
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
+            }
+        },
+        "tests": [
+            {
+                "description": "valid under the URN IDed schema",
+                "data": {"foo": 37},
+                "valid": true
+            },
+            {
+                "description": "invalid under the URN IDed schema",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with JSON pointer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with NSS",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$comment": "RFC 8141 §2.2",
+            "$id": "urn:example:1/406/47452/2",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with r-component",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$comment": "RFC 8141 §2.3.1",
+            "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with q-component",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$comment": "RFC 8141 §2.3.2",
+            "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with f-component",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
+            "$ref": "https://json-schema.org/draft/2019-09/schema"
+        },
+        "tests": [
+            {
+                "description": "is invalid",
+                "data": {"$id": "urn:example:foo-bar-baz-qux#somepart"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and JSON pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and anchor ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
+            },
+            "$defs": {
+                "bar": {
+                    "$anchor": "something",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN ref with nested pointer ref",
+        "schema": {
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+            "$defs": {
+                "foo": {
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$defs": {"bar": {"type": "string"}},
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": "bar",
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": 12,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/refRemote.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/refRemote.json
@@ -1,0 +1,295 @@
+[
+    {
+        "description": "remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/draft2019-09/integer.json"
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "fragment within remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/draft2019-09/subSchemas-defs.json#/$defs/integer"
+        },
+        "tests": [
+            {
+                "description": "remote fragment valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote fragment invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/draft2019-09/subSchemas-defs.json#/$defs/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "ref within ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "ref within ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:1234/draft2019-09/",
+            "items": {
+                "$id": "baseUriChange/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "base URI change ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "base URI change ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:1234/draft2019-09/scope_change_defs1.json",
+            "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolder/",
+                    "type": "array",
+                    "items": {"$ref": "folderInteger.json"}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:1234/draft2019-09/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema/",
+                    "$defs": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "root ref in remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:1234/draft2019-09/object",
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "name-defs.json#/$defs/orNull"}
+            }
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": {
+                    "name": null
+                },
+                "valid": true
+            },
+            {
+                "description": "object is invalid",
+                "data": {
+                    "name": {
+                        "name": null
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref with ref to defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:1234/draft2019-09/schema-remote-ref-ref-defs1.json",
+            "$ref": "ref-and-defs.json"
+        },
+        "tests": [
+            {
+                "description": "invalid",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid",
+                "data": {
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier in remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "http://localhost:1234/draft2019-09/locationIndependentIdentifier.json#/$defs/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "retrieved nested refs resolve relative to their URI not $id",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://localhost:1234/draft2019-09/some-id",
+            "properties": {
+                "name": {"$ref": "nested/foo-ref-string.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": {
+                    "name": {"foo":  1}
+                },
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different $id",
+        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different URN $id",
+        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with nested absolute ref",
+        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/required.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/required.json
@@ -1,0 +1,158 @@
+[
+    {
+        "description": "required validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "required": ["foo"]
+        },
+        "tests": [
+            {
+                "description": "present required property is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "non-present required property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required default validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required by default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with empty array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {}
+            },
+            "required": []
+        },
+        "tests": [
+            {
+                "description": "property not required",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "required": [
+                "foo\nbar",
+                "foo\"bar",
+                "foo\\bar",
+                "foo\rbar",
+                "foo\tbar",
+                "foo\fbar"
+            ]
+        },
+        "tests": [
+            {
+                "description": "object with all properties present is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with some properties missing is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "required properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "required": ["__proto__", "toString", "constructor"]
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "__proto__ present",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString present",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor present",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/type.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/type.json
@@ -1,0 +1,501 @@
+[
+    {
+        "description": "integer type matches integers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "an integer is an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is an integer",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is not an integer",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an integer",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not an integer, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not an integer",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not an integer",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an integer",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an integer",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "number type matches numbers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "number"
+        },
+        "tests": [
+            {
+                "description": "an integer is a number",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is a number (and an integer)",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is a number",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "a string is not a number",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not a number, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not a number",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a number",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a number",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a number",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "string type matches strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "string"
+        },
+        "tests": [
+            {
+                "description": "1 is not a string",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a string",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a string is still a string, even if it looks like a number",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an object is not a string",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a string",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a string",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a string",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "object type matches objects",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object"
+        },
+        "tests": [
+            {
+                "description": "an integer is not an object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an object",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an object",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is not an object",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an object",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an object",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "array type matches arrays",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "array"
+        },
+        "tests": [
+            {
+                "description": "an integer is not an array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an array",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an array",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not an array",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is not an array",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an array",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "boolean type matches booleans",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "boolean"
+        },
+        "tests": [
+            {
+                "description": "an integer is not a boolean",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a float is not a boolean",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not a boolean",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not a boolean",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a boolean",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is a boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is not a boolean",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "null type matches only the null object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "null"
+        },
+        "tests": [
+            {
+                "description": "an integer is not null",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not null",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a string is not null",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not null",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not null",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is not null",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple types can be specified in an array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": ["integer", "string"]
+        },
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/unevaluatedItems.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/unevaluatedItems.json
@@ -1,0 +1,562 @@
+[
+    {
+        "description": "unevaluatedItems true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": true
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems as schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": { "type": "string" }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with valid unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with invalid unevaluated items",
+                "data": [42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with uniform items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": { "type": "string" },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "unevaluatedItems doesn't apply",
+                "data": ["foo", "bar"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with tuple",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                { "type": "string" }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with additionalItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                { "type": "string" }
+            ],
+            "additionalItems": true,
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "unevaluatedItems doesn't apply",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested tuple",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                { "type": "string" }
+            ],
+            "allOf": [
+                {
+                    "items": [
+                        true,
+                        { "type": "number" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", 42],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", 42, true],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": {"type": "boolean"},
+            "anyOf": [
+                { "items": {"type": "string"} },
+                true
+            ]
+        },
+        "tests": [
+            {
+                "description": "with only (valid) additional items",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "with no additional items",
+                "data": ["yes", "no"],
+                "valid": true
+            },
+            {
+                "description": "with invalid additional item",
+                "data": ["yes", false],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested items and additionalItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {
+                    "items": [
+                        { "type": "string" }
+                    ],
+                    "additionalItems": true
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no additional items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with additional items",
+                "data": ["foo", 42, true],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested unevaluatedItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {
+                    "items": [
+                        { "type": "string" }
+                    ]
+                },
+                { "unevaluatedItems": true }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no additional items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with additional items",
+                "data": ["foo", 42, true],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                { "const": "foo" }
+            ],
+            "anyOf": [
+                {
+                    "items": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                },
+                {
+                    "items": [
+                        true,
+                        true,
+                        { "const": "baz" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "when one schema matches and has no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "when one schema matches and has unevaluated items",
+                "data": ["foo", "bar", 42],
+                "valid": false
+            },
+            {
+                "description": "when two schemas match and has no unevaluated items",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "when two schemas match and has unevaluated items",
+                "data": ["foo", "bar", "baz", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                { "const": "foo" }
+            ],
+            "oneOf": [
+                {
+                    "items": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                },
+                {
+                    "items": [
+                        true,
+                        { "const": "baz" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                { "const": "foo" }
+            ],
+            "not": {
+                "not": {
+                    "items": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                }
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with if/then/else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [ { "const": "foo" } ],
+            "if": {
+                "items": [
+                    true,
+                    { "const": "bar" }
+                ]
+            },
+            "then": {
+                "items": [
+                    true,
+                    true,
+                    { "const": "then" }
+                ]
+            },
+            "else": {
+                "items": [
+                    true,
+                    true,
+                    true,
+                    { "const": "else" }
+                ]
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "when if matches and it has no unevaluated items",
+                "data": ["foo", "bar", "then"],
+                "valid": true
+            },
+            {
+                "description": "when if matches and it has unevaluated items",
+                "data": ["foo", "bar", "then", "else"],
+                "valid": false
+            },
+            {
+                "description": "when if doesn't match and it has no unevaluated items",
+                "data": ["foo", 42, 42, "else"],
+                "valid": true
+            },
+            {
+                "description": "when if doesn't match and it has unevaluated items",
+                "data": ["foo", 42, 42, "else", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [true],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$ref": "#/$defs/bar",
+            "items": [
+                { "type": "string" }
+            ],
+            "unevaluatedItems": false,
+            "$defs": {
+              "bar": {
+                  "items": [
+                      true,
+                      { "type": "string" }
+                  ]
+              }
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar", "baz"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems can't see inside cousins",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {
+                    "items": [ true ]
+                },
+                { "unevaluatedItems": false }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": [ 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "item is evaluated in an uncle schema to unevaluatedItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "properties": {
+                "foo": {
+                    "items": [
+                        { "type": "string" }
+                    ],
+                    "unevaluatedItems": false
+                  }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "items": [
+                                true,
+                                { "type": "string" }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "no extra items",
+                "data": {
+                    "foo": [
+                        "test"
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "uncle keyword evaluation is not significant",
+                "data": {
+                    "foo": [
+                        "test",
+                        "test"
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-array instances are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedItems": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/unevaluatedProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/unevaluatedProperties.json
@@ -1,0 +1,1423 @@
+[
+    {
+        "description": "unevaluatedProperties true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "unevaluatedProperties": {
+                "type": "string",
+                "minLength": 3
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with valid unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with invalid unevaluated properties",
+                "data": {
+                    "foo": "fo"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "patternProperties": {
+                "^foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "additionalProperties": true,
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": { "type": "string" }
+                    }
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+              {
+                  "patternProperties": {
+                      "^bar": { "type": "string" }
+                  }
+              }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "additionalProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested unevaluatedProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": {
+                "type": "string",
+                "maxLength": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "baz": { "const": "baz" }
+                    },
+                    "required": ["baz"]
+                },
+                {
+                    "properties": {
+                        "quux": { "const": "quux" }
+                    },
+                    "required": ["quux"]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when one matches and has no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when one matches and has unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "not-baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when two match and has no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when two match and has unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz",
+                    "quux": "not-quux"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "baz": { "const": "baz" }
+                    },
+                    "required": ["baz"]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "quux": "quux"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "not": {
+                "not": {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "then": {
+                "properties": {
+                    "bar": { "type": "string" }
+                },
+                "required": ["bar"]
+            },
+            "else": {
+                "properties": {
+                    "baz": { "type": "string" }
+                },
+                "required": ["baz"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else, then not defined",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "else": {
+                "properties": {
+                    "baz": { "type": "string" }
+                },
+                "required": ["baz"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else, else not defined",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "then": {
+                "properties": {
+                    "bar": { "type": "string" }
+                },
+                "required": ["bar"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with dependentSchemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "dependentSchemas": {
+                "foo": {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [true],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "$ref": "#/$defs/bar",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false,
+            "$defs": {
+                "bar": {
+                    "properties": {
+                        "bar": { "type": "string" }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties can't see inside cousins",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                },
+                {
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties can't see inside cousins (reverse order)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer false, inner true, properties inside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer true, inner false, properties outside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                }
+            ],
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer true, inner false, properties inside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            ],
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "cousin unevaluatedProperties, true and false, true with properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": true
+                },
+                {
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "cousin unevaluatedProperties, true and false, false with properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                },
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property is evaluated in an uncle schema to unevaluatedProperties",
+        "comment": "see https://stackoverflow.com/questions/66936884/deeply-nested-unevaluatedproperties-and-their-expectations",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "object",
+                    "properties": {
+                        "bar": {
+                            "type": "string"
+                        }
+                    },
+                    "unevaluatedProperties": false
+                  }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "properties": {
+                                "faz": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "no extra properties",
+                "data": {
+                    "foo": {
+                        "bar": "test"
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "uncle keyword evaluation is not significant",
+                "data": {
+                    "foo": {
+                        "bar": "test",
+                        "faz": "test"
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "in-place applicator siblings, allOf has unevaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "unevaluatedProperties": false
+                }
+            ],
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "base case: both properties present",
+                "data": {
+                    "foo": 1,
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, bar is missing",
+                "data": {
+                    "foo": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "in place applicator siblings, foo is missing",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "in-place applicator siblings, anyOf has unevaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ],
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": true
+                    },
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "base case: both properties present",
+                "data": {
+                    "foo": 1,
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, bar is missing",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, foo is missing",
+                "data": {
+                    "bar": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties + single cyclic ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "type": "object",
+            "properties": {
+                "x": { "$ref": "#" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "Single is valid",
+                "data": { "x": {} },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 1st level is invalid",
+                "data": { "x": {}, "y": {} },
+                "valid": false
+            },
+            {
+                "description": "Nested is valid",
+                "data": { "x": { "x": {} } },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 2nd level is invalid",
+                "data": { "x": { "x": {}, "y": {} } },
+                "valid": false
+            },
+            {
+                "description": "Deep nested is valid",
+                "data": { "x": { "x": { "x": {} } } },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 3rd level is invalid",
+                "data": { "x": { "x": { "x": {}, "y": {} } } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties + ref inside allOf / oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "one": {
+                    "properties": { "a": true }
+                },
+                "two": {
+                    "required": ["x"],
+                    "properties": { "x": true }
+                }
+            },
+            "allOf": [
+                { "$ref": "#/$defs/one" },
+                { "properties": { "b": true } },
+                {
+                    "oneOf": [
+                        { "$ref": "#/$defs/two" },
+                        {
+                            "required": ["y"],
+                            "properties": { "y": true }
+                        }
+                    ]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is invalid (no x or y)",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "a and b are invalid (no x or y)",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "x and y are invalid",
+                "data": { "x": 1, "y": 1 },
+                "valid": false
+            },
+            {
+                "description": "a and x are valid",
+                "data": { "a": 1, "x": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and y are valid",
+                "data": { "a": 1, "y": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and x are valid",
+                "data": { "a": 1, "b": 1, "x": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and y are valid",
+                "data": { "a": 1, "b": 1, "y": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and x and y are invalid",
+                "data": { "a": 1, "b": 1, "x": 1, "y": 1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dynamic evalation inside nested refs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "one": {
+                    "oneOf": [
+                        { "$ref": "#/$defs/two" },
+                        { "required": ["b"], "properties": { "b": true } },
+                        { "required": ["xx"], "patternProperties": { "x": true } },
+                        { "required": ["all"], "unevaluatedProperties": true }
+                    ]
+                },
+                "two": {
+                    "oneOf": [
+                        { "required": ["c"], "properties": { "c": true } },
+                        { "required": ["d"], "properties": { "d": true } }
+                    ]
+                }
+            },
+            "oneOf": [
+                { "$ref": "#/$defs/one" },
+                { "required": ["a"], "properties": { "a": true } }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "a is valid",
+                "data": { "a": 1 },
+                "valid": true
+            },
+            {
+                "description": "b is valid",
+                "data": { "b": 1 },
+                "valid": true
+            },
+            {
+                "description": "c is valid",
+                "data": { "c": 1 },
+                "valid": true
+            },
+            {
+                "description": "d is valid",
+                "data": { "d": 1 },
+                "valid": true
+            },
+            {
+                "description": "a + b is invalid",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "a + c is invalid",
+                "data": { "a": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "a + d is invalid",
+                "data": { "a": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "b + c is invalid",
+                "data": { "b": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "b + d is invalid",
+                "data": { "b": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "c + d is invalid",
+                "data": { "c": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx is valid",
+                "data": { "xx": 1 },
+                "valid": true
+            },
+            {
+                "description": "xx + foox is valid",
+                "data": { "xx": 1, "foox": 1 },
+                "valid": true
+            },
+            {
+                "description": "xx + foo is invalid",
+                "data": { "xx": 1, "foo": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + a is invalid",
+                "data": { "xx": 1, "a": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + b is invalid",
+                "data": { "xx": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + c is invalid",
+                "data": { "xx": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + d is invalid",
+                "data": { "xx": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "all is valid",
+                "data": { "all": 1 },
+                "valid": true
+            },
+            {
+                "description": "all + foo is valid",
+                "data": { "all": 1, "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "all + a is invalid",
+                "data": { "all": 1, "a": 1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-object instances are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "unevaluatedProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null valued properties",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/uniqueItems.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/uniqueItems.json
@@ -1,0 +1,414 @@
+[
+    {
+        "description": "uniqueItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
+                "data": [1, 2, 1],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is invalid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": false
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is invalid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": false
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
+                "data": [["foo"], ["bar"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "[1] and [true] are unique",
+                "data": [[1], [true]],
+                "valid": true
+            },
+            {
+                "description": "[0] and [false] are unique",
+                "data": [[0], [false]],
+                "valid": true
+            },
+            {
+                "description": "nested [1] and [true] are unique",
+                "data": [[[1], "foo"], [[true], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "nested [0] and [false] are unique",
+                "data": [[[0], "foo"], [[false], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1, "{}"],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are invalid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
+                "valid": false
+            },
+            {
+                "description": "{\"a\": false} and {\"a\": 0} are unique",
+                "data": [{"a": false}, {"a": 0}],
+                "valid": true
+            },
+            {
+                "description": "{\"a\": true} and {\"a\": 1} are unique",
+                "data": [{"a": true}, {"a": 1}],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is not valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": false
+            },
+            {
+                "description": "non-unique array extended from [true, false] is not valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items and additionalItems=false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/unknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/unknownKeyword.json
@@ -1,0 +1,57 @@
+[
+    {
+        "description": "$id inside an unknown keyword is not a real identifier",
+        "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$defs": {
+                "id_in_unknown0": {
+                    "not": {
+                        "array_of_schemas": [
+                            {
+                              "$id": "https://localhost:1234/draft2019-09/unknownKeyword/my_identifier.json",
+                              "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/draft2019-09/unknownKeyword/my_identifier.json",
+                    "type": "string"
+                },
+                "id_in_unknown1": {
+                    "not": {
+                        "object_of_schemas": {
+                            "foo": {
+                              "$id": "https://localhost:1234/draft2019-09/unknownKeyword/my_identifier.json",
+                              "type": "integer"
+                            }
+                        }
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_unknown0" },
+                { "$ref": "#/$defs/id_in_unknown1" },
+                { "$ref": "https://localhost:1234/draft2019-09/unknownKeyword/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "type matches second anyOf, which has a real schema in it",
+                "data": "a string",
+                "valid": true
+            },
+            {
+                "description": "type matches non-schema in first anyOf",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "type matches non-schema in third anyOf",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2019-09/vocabulary.json
+++ b/asdf/_jsonschema/json/tests/draft2019-09/vocabulary.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "schema that uses custom metaschema with with no validation vocabulary",
+        "schema": {
+            "$id": "https://schema/using/no/validation",
+            "$schema": "http://localhost:1234/draft2019-09/metaschema-no-validation.json",
+            "properties": {
+                "badProperty": false,
+                "numberProperty": {
+                    "minimum": 10
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "applicator vocabulary still works",
+                "data": {
+                    "badProperty": "this property should not exist"
+                },
+                "valid": false
+            },
+            {
+                "description": "no validation: valid number",
+                "data": {
+                    "numberProperty": 20
+                },
+                "valid": true
+            },
+            {
+                "description": "no validation: invalid number, but it still validates",
+                "data": {
+                    "numberProperty": 1
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/additionalProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/additionalProperties.json
@@ -1,0 +1,156 @@
+[
+    {
+        "description":
+            "additionalProperties being false does not allow other properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"foo": {}, "bar": {}},
+            "patternProperties": { "^v": {} },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "patternProperties are not additional properties",
+                "data": {"foo":1, "vroom": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "non-ASCII pattern with additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {"^á": {}},
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "matching the pattern is valid",
+                "data": {"ármányos": 2},
+                "valid": true
+            },
+            {
+                "description": "not matching the pattern is invalid",
+                "data": {"élmény": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"foo": {}, "bar": {}},
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties can exist by itself",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties are allowed by default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"foo": {}, "bar": {}}
+        },
+        "tests": [
+            {
+                "description": "additional properties are allowed",
+                "data": {"foo": 1, "bar": 2, "quux": true},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties does not look in applicators",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not examined",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/allOf.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/allOf.json
@@ -1,0 +1,312 @@
+[
+    {
+        "description": "allOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allOf",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "mismatch second",
+                "data": {"foo": "baz"},
+                "valid": false
+            },
+            {
+                "description": "mismatch first",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "baz", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"bar": {"type": "integer"}},
+            "required": ["bar"],
+            "allOf" : [
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                },
+                {
+                    "properties": {
+                        "baz": {"type": "null"}
+                    },
+                    "required": ["baz"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "valid": true
+            },
+            {
+                "description": "mismatch base schema",
+                "data": {"foo": "quux", "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch first allOf",
+                "data": {"bar": 2, "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch second allOf",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "mismatch both",
+                "data": {"bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf simple types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {"maximum": 30},
+                {"minimum": 20}
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": 25,
+                "valid": true
+            },
+            {
+                "description": "mismatch one",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, some false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf combined with anyOf, oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [ { "multipleOf": 2 } ],
+            "anyOf": [ { "multipleOf": 3 } ],
+            "oneOf": [ { "multipleOf": 5 } ]
+        },
+        "tests": [
+            {
+                "description": "allOf: false, anyOf: false, oneOf: false",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: false, oneOf: true",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: false",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: true",
+                "data": 15,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: false",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: true",
+                "data": 10,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: false",
+                "data": 6,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: true",
+                "data": 30,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/anchor.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/anchor.json
@@ -1,0 +1,235 @@
+[
+    {
+        "description": "Location-independent identifier",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#foo",
+            "$defs": {
+                "A": {
+                    "$anchor": "foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with absolute URI",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/bar#foo",
+            "$defs": {
+                "A": {
+                    "$id": "http://localhost:1234/draft2020-12/bar",
+                    "$anchor": "foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with base URI change in subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/root",
+            "$ref": "http://localhost:1234/draft2020-12/nested.json#foo",
+            "$defs": {
+                "A": {
+                    "$id": "nested.json",
+                    "$defs": {
+                        "B": {
+                            "$anchor": "foo",
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$anchor inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $anchor buried in the enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "anchor_in_enum": {
+                    "enum": [
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "null"
+                        }
+                    ]
+                },
+                "real_identifier_in_schema": {
+                    "$anchor": "my_anchor",
+                    "type": "string"
+                },
+                "zzz_anchor_in_const": {
+                    "const": {
+                        "$anchor": "my_anchor",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/anchor_in_enum" },
+                { "$ref": "#my_anchor" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$anchor": "my_anchor",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "in implementations that strip $anchor, this may match either $def",
+                "data": {
+                    "type": "null"
+                },
+                "valid": false
+            },
+            {
+                "description": "match $ref to $anchor",
+                "data": "a string to match #/$defs/anchor_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $anchor",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "same $anchor with different base uri",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/foobar",
+            "$defs": {
+                "A": {
+                    "$id": "child1",
+                    "allOf": [
+                        {
+                            "$id": "child2",
+                            "$anchor": "my_anchor",
+                            "type": "number"
+                        },
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "$ref": "child1#my_anchor"
+        },
+        "tests": [
+            {
+                "description": "$ref resolves to /$defs/A/allOf/1",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "$ref does not resolve to /$defs/A/allOf/0",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $anchor property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "const_not_anchor": {
+                    "const": {
+                        "$anchor": "not_a_real_anchor"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_anchor"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/$defs/const_not_anchor"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_anchor",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_anchor does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "invalid anchors",
+        "comment": "Section 8.2.2",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "MUST start with a letter (and not #)",
+                "data": { "$anchor" : "#foo" },
+                "valid": false
+            },
+            {
+                "description": "JSON pointers are not valid",
+                "data": { "$anchor" : "/a/b" },
+                "valid": false
+            },
+            {
+                "description": "invalid with valid beginning",
+                "data": { "$anchor" : "foo#something" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/anyOf.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/anyOf.json
@@ -1,0 +1,203 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid",
+                "data": 3,
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one anyOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, some true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/boolean_schema.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/boolean_schema.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "boolean schema 'true'",
+        "schema": true,
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "boolean true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "boolean false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean schema 'false'",
+        "schema": false,
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "boolean true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "boolean false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/const.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/const.json
@@ -1,0 +1,387 @@
+[
+    {
+        "description": "const validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 2
+        },
+        "tests": [
+            {
+                "description": "same value is valid",
+                "data": 2,
+                "valid": true
+            },
+            {
+                "description": "another value is invalid",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": {"foo": "bar", "baz": "bax"}
+        },
+        "tests": [
+            {
+                "description": "same object is valid",
+                "data": {"foo": "bar", "baz": "bax"},
+                "valid": true
+            },
+            {
+                "description": "same object with different property order is valid",
+                "data": {"baz": "bax", "foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "another object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": [1, 2],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": [{ "foo": "bar" }]
+        },
+        "tests": [
+            {
+                "description": "same array is valid",
+                "data": [{"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "another array item is invalid",
+                "data": [2],
+                "valid": false
+            },
+            {
+                "description": "array with additional items is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with null",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": null
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "not null is invalid",
+                "data": 0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with false does not match 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": false
+        },
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with true does not match 1",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": true
+        },
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": [false]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": [true]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": false} does not match {\"a\": 0}",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": {"a": false}
+        },
+        "tests": [
+            {
+                "description": "{\"a\": false} is valid",
+                "data": {"a": false},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 0} is invalid",
+                "data": {"a": 0},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 0.0} is invalid",
+                "data": {"a": 0.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": true} does not match {\"a\": 1}",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": {"a": true}
+        },
+        "tests": [
+            {
+                "description": "{\"a\": true} is valid",
+                "data": {"a": true},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 1} is invalid",
+                "data": {"a": 1},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 1.0} is invalid",
+                "data": {"a": 1.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 0 does not match other zero-like types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 0
+        },
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
+                "data": "",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 1 does not match true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 1
+        },
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "const with -2.0 matches integer and float types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": -2.0
+        },
+        "tests": [
+            {
+                "description": "integer -2 is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "integer 2 is invalid",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "float -2.0 is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float 2.0 is invalid",
+                "data": 2.0,
+                "valid": false
+            },
+            {
+                "description": "float -2.00001 is invalid",
+                "data": -2.00001,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float and integers are equal up to 64-bit representation limits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 9007199254740992
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 9007199254740992,
+                "valid": true
+            },
+            {
+                "description": "integer minus one is invalid",
+                "data": 9007199254740991,
+                "valid": false
+            },
+            {
+                "description": "float is valid",
+                "data": 9007199254740992.0,
+                "valid": true
+            },
+            {
+                "description": "float minus one is invalid",
+                "data": 9007199254740991.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": "hello\u0000there"
+        },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/contains.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/contains.json
@@ -1,0 +1,176 @@
+[
+    {
+        "description": "contains keyword validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"minimum": 5}
+        },
+        "tests": [
+            {
+                "description": "array with item matching schema (5) is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with item matching schema (6) is valid",
+                "data": [3, 4, 6],
+                "valid": true
+            },
+            {
+                "description": "array with two items matching schema (5, 6) is valid",
+                "data": [3, 4, 5, 6],
+                "valid": true
+            },
+            {
+                "description": "array without items matching schema is invalid",
+                "data": [2, 3, 4],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "not array is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with const keyword",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": { "const": 5 }
+        },
+        "tests": [
+            {
+                "description": "array with item 5 is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with two items 5 is valid",
+                "data": [3, 4, 5, 5],
+                "valid": true
+            },
+            {
+                "description": "array without item 5 is invalid",
+                "data": [1, 2, 3, 4],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": true
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": false
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "non-arrays are valid",
+                "data": "contains does not apply to strings",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items + contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": { "multipleOf": 2 },
+            "contains": { "multipleOf": 3 }
+        },
+        "tests": [
+            {
+                "description": "matches items, does not match contains",
+                "data": [ 2, 4, 8 ],
+                "valid": false
+            },
+            {
+                "description": "does not match items, matches contains",
+                "data": [ 3, 6, 9 ],
+                "valid": false
+            },
+            {
+                "description": "matches both items and contains",
+                "data": [ 6, 12 ],
+                "valid": true
+            },
+            {
+                "description": "matches neither items nor contains",
+                "data": [ 1, 5 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with false if subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {
+                "if": false,
+                "else": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null items",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/content.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/content.json
@@ -1,0 +1,131 @@
+[
+    {
+        "description": "validation of string-encoded content based on media type",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contentMediaType": "application/json"
+        },
+        "tests": [
+            {
+                "description": "a valid JSON document",
+                "data": "{\"foo\": \"bar\"}",
+                "valid": true
+            },
+            {
+                "description": "an invalid JSON document; validates true",
+                "data": "{:}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary string-encoding",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64 string",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string (% is not a valid character); validates true",
+                "data": "eyJmb28iOi%iYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary-encoded media type documents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64-encoded JSON document",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "a validly-encoded invalid JSON document; validates true",
+                "data": "ezp9Cg==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string that is valid JSON; validates true",
+                "data": "{}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary-encoded media type documents with schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64",
+            "contentSchema": { "type": "object", "required": ["foo"], "properties": { "foo": { "type": "string" } } }
+        },
+        "tests": [
+            {
+                "description": "a valid base64-encoded JSON document",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "another valid base64-encoded JSON document",
+                "data": "eyJib28iOiAyMCwgImZvbyI6ICJiYXoifQ==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64-encoded JSON document; validates true",
+                "data": "eyJib28iOiAyMH0=",
+                "valid": true
+            },
+            {
+                "description": "an empty object as a base64-encoded JSON document; validates true",
+                "data": "e30=",
+                "valid": true
+            },
+            {
+                "description": "an empty array as a base64-encoded JSON document",
+                "data": "W10=",
+                "valid": true
+            },
+            {
+                "description": "a validly-encoded invalid JSON document; validates true",
+                "data": "ezp9Cg==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string that is valid JSON; validates true",
+                "data": "{}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/default.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/default.json
@@ -1,0 +1,82 @@
+[
+    {
+        "description": "invalid type for default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "type": "integer",
+                    "default": []
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"foo": 13},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid string value for default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "minLength": 4,
+                    "default": "bad"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"bar": "good"},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/defs.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/defs.json
@@ -1,0 +1,21 @@
+[
+    {
+        "description": "validate definition against metaschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "valid definition schema",
+                "data": {"$defs": {"foo": {"type": "integer"}}},
+                "valid": true
+            },
+            {
+                "description": "invalid definition schema",
+                "data": {"$defs": {"foo": {"type": 1}}},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/dependentRequired.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/dependentRequired.json
@@ -1,0 +1,152 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "empty dependents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependents required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "CRLF",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quotes",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "CRLF missing dependent",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quotes missing dependent",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/dependentSchemas.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/dependentSchemas.json
@@ -1,0 +1,132 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentSchemas": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean subschemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentSchemas": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentSchemas": {
+                "foo\tbar": {"minProperties": 4},
+                "foo'bar": {"required": ["foo\"bar"]}
+            }
+        },
+        "tests": [
+            {
+                "description": "quoted tab",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quote",
+                "data": {
+                    "foo'bar": {"foo\"bar": 1}
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted tab invalid under dependent schema",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quote invalid under dependent schema",
+                "data": {"foo'bar": 1},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/dynamicRef.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/dynamicRef.json
@@ -1,0 +1,635 @@
+[
+    {
+        "description": "A $dynamicRef to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamicRef-dynamicAnchor-same-schema/root",
+            "type": "array",
+            "items": { "$dynamicRef": "#items" },
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef to an $anchor in the same schema resource behaves like a normal $ref to an $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamicRef-anchor-same-schema/root",
+            "type": "array",
+            "items": { "$dynamicRef": "#items" },
+            "$defs": {
+                "foo": {
+                    "$anchor": "items",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $ref to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/ref-dynamicAnchor-same-schema/root",
+            "type": "array",
+            "items": { "$ref": "#items" },
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef resolves to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/typical-dynamic-resolution/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                      "items": {
+                          "$comment": "This is only needed to satisfy the bookending requirement",
+                          "$dynamicAnchor": "items"
+                      }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef with intermediate scopes that don't include a matching $dynamicAnchor does not affect dynamic scope resolution",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-resolution-with-intermediate-scopes/root",
+            "$ref": "intermediate-scope",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "intermediate-scope": {
+                    "$id": "intermediate-scope",
+                    "$ref": "list"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                      "items": {
+                          "$comment": "This is only needed to satisfy the bookending requirement",
+                          "$dynamicAnchor": "items"
+                      }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "An $anchor with the same name as a $dynamicAnchor is not used for dynamic scope resolution",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-resolution-ignores-anchors/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$anchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                      "items": {
+                          "$comment": "This is only needed to satisfy the bookending requirement",
+                          "$dynamicAnchor": "items"
+                      }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "Any array is valid",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef without a matching $dynamicAnchor in the same schema resource behaves like a normal $ref to $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-resolution-without-bookend/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                        "items": {
+                            "$comment": "This is only needed to give the reference somewhere to resolve to when it behaves like $ref",
+                            "$anchor": "items"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "Any array is valid",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef with a non-matching $dynamicAnchor in the same schema resource behaves like a normal $ref to $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/unmatched-dynamic-anchor/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                        "items": {
+                            "$comment": "This is only needed to give the reference somewhere to resolve to when it behaves like $ref",
+                            "$anchor": "items",
+                            "$dynamicAnchor": "foo"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "Any array is valid",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef that initially resolves to a schema with a matching $dynamicAnchor resolves to the first $dynamicAnchor in the dynamic scope",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/relative-dynamic-reference/root",
+            "$dynamicAnchor": "meta",
+            "type": "object",
+            "properties": {
+                "foo": { "const": "pass" }
+            },
+            "$ref": "extended",
+            "$defs": {
+                "extended": {
+                    "$id": "extended",
+                    "$dynamicAnchor": "meta",
+                    "type": "object",
+                    "properties": {
+                        "bar": { "$ref": "bar" }
+                    }
+                },
+                "bar": {
+                    "$id": "bar",
+                    "type": "object",
+                    "properties": {
+                        "baz": { "$dynamicRef": "extended#meta" }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "The recursive part is valid against the root",
+                "data": {
+                    "foo": "pass",
+                    "bar": {
+                        "baz": { "foo": "pass" }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "The recursive part is not valid against the root",
+                "data": {
+                    "foo": "pass",
+                    "bar": {
+                        "baz": { "foo": "fail" }
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef that initially resolves to a schema without a matching $dynamicAnchor behaves like a normal $ref to $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/relative-dynamic-reference-without-bookend/root",
+            "$dynamicAnchor": "meta",
+            "type": "object",
+            "properties": {
+                "foo": { "const": "pass" }
+            },
+            "$ref": "extended",
+            "$defs": {
+                "extended": {
+                    "$id": "extended",
+                    "$anchor": "meta",
+                    "type": "object",
+                    "properties": {
+                        "bar": { "$ref": "bar" }
+                    }
+                },
+                "bar": {
+                    "$id": "bar",
+                    "type": "object",
+                    "properties": {
+                        "baz": { "$dynamicRef": "extended#meta" }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "The recursive part doesn't need to validate against the root",
+                "data": {
+                    "foo": "pass",
+                    "bar": {
+                        "baz": { "foo": "fail" }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dynamic paths to the $dynamicRef keyword",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-ref-with-multiple-paths/main",
+            "$defs": {
+                "inner": {
+                    "$id": "inner",
+                    "$dynamicAnchor": "foo",
+                    "title": "inner",
+                    "additionalProperties": {
+                        "$dynamicRef": "#foo"
+                    }
+                }
+            },
+            "if": {
+                "propertyNames": {
+                    "pattern": "^[a-m]"
+                }
+            },
+            "then": {
+                "title": "any type of node",
+                "$id": "anyLeafNode",
+                "$dynamicAnchor": "foo",
+                "$ref": "inner"
+            },
+            "else": {
+                "title": "integer node",
+                "$id": "integerNode",
+                "$dynamicAnchor": "foo",
+                "type": [ "object", "integer" ],
+                "$ref": "inner"
+            }
+        },
+        "tests": [
+            {
+                "description": "recurse to anyLeafNode - floats are allowed",
+                "data": { "alpha": 1.1 },
+                "valid": true
+            },
+            {
+                "description": "recurse to integerNode - floats are not allowed",
+                "data": { "november": 1.1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "after leaving a dynamic scope, it is not used by a $dynamicRef",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main",
+            "if": {
+                "$id": "first_scope",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is first_scope#thingy",
+                        "$dynamicAnchor": "thingy",
+                        "type": "number"
+                    }
+                }
+            },
+            "then": {
+                "$id": "second_scope",
+                "$ref": "start",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is second_scope#thingy, the final destination of the $dynamicRef",
+                        "$dynamicAnchor": "thingy",
+                        "type": "null"
+                    }
+                }
+            },
+            "$defs": {
+                "start": {
+                    "$comment": "this is the landing spot from $ref",
+                    "$id": "start",
+                    "$dynamicRef": "inner_scope#thingy"
+                },
+                "thingy": {
+                    "$comment": "this is the first stop for the $dynamicRef",
+                    "$id": "inner_scope",
+                    "$dynamicAnchor": "thingy",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "string matches /$defs/thingy, but the $dynamicRef does not stop here",
+                "data": "a string",
+                "valid": false
+            },
+            {
+                "description": "first_scope is not in dynamic scope for the $dynamicRef",
+                "data": 42,
+                "valid": false
+            },
+            {
+                "description": "/then/$defs/thingy is the final stop for the $dynamicRef",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "strict-tree schema, guards against misspelled properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/strict-tree.json",
+            "$dynamicAnchor": "node",
+
+            "$ref": "tree.json",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "instance with misspelled field",
+                "data": {
+                    "children": [{
+                            "daat": 1
+                        }]
+                },
+                "valid": false
+            },
+            {
+                "description": "instance with correct field",
+                "data": {
+                    "children": [{
+                            "data": 1
+                        }]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "tests for implementation dynamic anchor and reference link",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/strict-extendible.json",
+            "$ref": "extendible-dynamic-ref.json",
+            "$defs": {
+                "elements": {
+                    "$dynamicAnchor": "elements",
+                    "properties": {
+                        "a": true
+                    },
+                    "required": ["a"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "incorrect parent schema",
+                "data": {
+                    "a": true
+                },
+                "valid": false
+            },
+            {
+                "description": "incorrect extended schema",
+                "data": {
+                    "elements": [
+                        { "b": 1 }
+                    ]
+                },
+                "valid": false
+            },
+            {
+                "description": "correct extended schema",
+                "data": {
+                    "elements": [
+                        { "a": 1 }
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref and $dynamicAnchor are independent of order - $defs first",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/strict-extendible-allof-defs-first.json",
+            "allOf": [
+                {
+                    "$ref": "extendible-dynamic-ref.json"
+                },
+                {
+                    "$defs": {
+                        "elements": {
+                            "$dynamicAnchor": "elements",
+                            "properties": {
+                                "a": true
+                            },
+                            "required": ["a"],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "incorrect parent schema",
+                "data": {
+                    "a": true
+                },
+                "valid": false
+            },
+            {
+                "description": "incorrect extended schema",
+                "data": {
+                    "elements": [
+                        { "b": 1 }
+                    ]
+                },
+                "valid": false
+            },
+            {
+                "description": "correct extended schema",
+                "data": {
+                    "elements": [
+                        { "a": 1 }
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref and $dynamicAnchor are independent of order - $ref first",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/strict-extendible-allof-ref-first.json",
+            "allOf": [
+                {
+                    "$defs": {
+                        "elements": {
+                            "$dynamicAnchor": "elements",
+                            "properties": {
+                                "a": true
+                            },
+                            "required": ["a"],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                {
+                    "$ref": "extendible-dynamic-ref.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "incorrect parent schema",
+                "data": {
+                    "a": true
+                },
+                "valid": false
+            },
+            {
+                "description": "incorrect extended schema",
+                "data": {
+                    "elements": [
+                        { "b": 1 }
+                    ]
+                },
+                "valid": false
+            },
+            {
+                "description": "correct extended schema",
+                "data": {
+                    "elements": [
+                        { "a": 1 }
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/enum.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/enum.json
@@ -1,0 +1,262 @@
+[
+    {
+        "description": "simple enum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [1, 2, 3]
+        },
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": 4,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [6, "foo", [], true, {"foo": 12}]
+        },
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": {"foo": false},
+                "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum-with-null validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [6, null]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 6,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": "test",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enums in properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type":"object",
+            "properties": {
+                "foo": {"enum":["foo"]},
+                "bar": {"enum":["bar"]}
+            },
+            "required": ["bar"]
+        },
+        "tests": [
+            {
+                "description": "both properties are valid",
+                "data": {"foo":"foo", "bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "wrong foo value",
+                "data": {"foo":"foot", "bar":"bar"},
+                "valid": false
+            },
+            {
+                "description": "wrong bar value",
+                "data": {"foo":"foo", "bar":"bart"},
+                "valid": false
+            },
+            {
+                "description": "missing optional property is valid",
+                "data": {"bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing required property is invalid",
+                "data": {"foo":"foo"},
+                "valid": false
+            },
+            {
+                "description": "missing all properties is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": ["foo\nbar", "foo\rbar"]
+        },
+        "tests": [
+            {
+                "description": "member 1 is valid",
+                "data": "foo\nbar",
+                "valid": true
+            },
+            {
+                "description": "member 2 is valid",
+                "data": "foo\rbar",
+                "valid": true
+            },
+            {
+                "description": "another string is invalid",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [false]
+        },
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [true]
+        },
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [0]
+        },
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [1]
+        },
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [ "hello\u0000there" ]
+        },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/exclusiveMaximum.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/exclusiveMaximum.json
@@ -1,0 +1,31 @@
+[
+    {
+        "description": "exclusiveMaximum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMaximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the exclusiveMaximum is valid",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 3.0,
+                "valid": false
+            },
+            {
+                "description": "above the exclusiveMaximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/exclusiveMinimum.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/exclusiveMinimum.json
@@ -1,0 +1,31 @@
+[
+    {
+        "description": "exclusiveMinimum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMinimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the exclusiveMinimum is valid",
+                "data": 1.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "below the exclusiveMinimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/format.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/format.json
@@ -1,0 +1,743 @@
+[
+    {
+        "description": "email format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-email format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "regex format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv4 format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv6 format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv6"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-hostname format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "hostname format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date-time format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date-time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "time format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "json-pointer format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative-json-pointer format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "relative-json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri-reference format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-reference format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-template format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-template"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uuid format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uuid"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "duration format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "duration"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/id.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/id.json
@@ -1,0 +1,294 @@
+[
+    {
+        "description": "Invalid use of fragments in location-independent $id",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "Identifier name",
+                "data": {
+                    "$ref": "#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "#foo",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name and no ref",
+                "data": {
+                    "$defs": {
+                        "A": { "$id": "#foo" }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path",
+                "data": {
+                    "$ref": "#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "#/a/b",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/bar#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/bar#foo",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/bar#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/bar#/a/b",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft2020-12/root",
+                    "$ref": "http://localhost:1234/draft2020-12/nested.json#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#foo",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft2020-12/root",
+                    "$ref": "http://localhost:1234/draft2020-12/nested.json#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#/a/b",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Valid use of empty fragments in location-independent $id",
+        "comment": "These are allowed but discouraged",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "Identifier name with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/bar",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/bar#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Identifier name with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft2020-12/root",
+                    "$ref": "http://localhost:1234/draft2020-12/nested.json#/$defs/B",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Unnormalized $ids are allowed but discouraged",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "Unnormalized identifier",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/foo/baz",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier and no ref",
+                "data": {
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier with empty fragment",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/foo/baz",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier with empty fragment and no ref",
+                "data": {
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $id buried in the enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_enum" },
+                { "$ref": "https://localhost:1234/draft2020-12/id/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to $id",
+                "data": "a string to match #/$defs/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $id property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "const_not_id": {
+                    "const": {
+                        "$id": "not_a_real_id"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_id"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/$defs/const_not_id"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_id",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_id does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/if-then-else.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/if-then-else.json
@@ -1,0 +1,268 @@
+[
+    {
+        "description": "ignore if without then or else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone if",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone if",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore then without if",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "then": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone then",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone then",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore else without if",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "else": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone else",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone else",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and then without else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid when if test fails",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and else without then",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when if test passes",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validate against correct branch, then vs else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-interference across combined schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "if": {
+                        "exclusiveMaximum": 0
+                    }
+                },
+                {
+                    "then": {
+                        "minimum": -10
+                    }
+                },
+                {
+                    "else": {
+                        "multipleOf": 2
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid, but would have been invalid through then",
+                "data": -100,
+                "valid": true
+            },
+            {
+                "description": "valid, but would have been invalid through else",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": true,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema true in if always chooses the then path (valid)",
+                "data": "then",
+                "valid": true
+            },
+            {
+                "description": "boolean schema true in if always chooses the then path (invalid)",
+                "data": "else",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": false,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema false in if always chooses the else path (invalid)",
+                "data": "then",
+                "valid": false
+            },
+            {
+                "description": "boolean schema false in if always chooses the else path (valid)",
+                "data": "else",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if appears at the end when serialized (keyword processing sequence)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "then": { "const": "yes" },
+            "else": { "const": "other" },
+            "if": { "maxLength": 4 }
+        },
+        "tests": [
+            {
+                "description": "yes redirects to then and passes",
+                "data": "yes",
+                "valid": true
+            },
+            {
+                "description": "other redirects to else and passes",
+                "data": "other",
+                "valid": true
+            },
+            {
+                "description": "no redirects to then and fails",
+                "data": "no",
+                "valid": false
+            },
+            {
+                "description": "invalid redirects to else and fails",
+                "data": "invalid",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/infinite-loop-detection.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/infinite-loop-detection.json
@@ -1,0 +1,37 @@
+[
+    {
+        "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "int": { "type": "integer" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "$ref": "#/$defs/int"
+                        }
+                    }
+                },
+                {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/int"
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "passing case",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "failing case",
+                "data": { "foo": "a string" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/items.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/items.json
@@ -1,0 +1,284 @@
+[
+    {
+        "description": "a schema given for items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of items",
+                "data": [1, "x"],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "length": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (true)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": true
+        },
+        "tests": [
+            {
+                "description": "any array is valid",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (false)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": [ 1, "foo", true ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "item": {
+                    "type": "array",
+                    "items": false,
+                    "prefixItems": [
+                        { "$ref": "#/$defs/sub-item" },
+                        { "$ref": "#/$defs/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "items": false,
+            "prefixItems": [
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "prefixItems with no additional items allowed",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{}, {}, {}],
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "additional items are not permitted",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items does not look in applicators, valid case",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                { "prefixItems": [ { "minimum": 3 } ] }
+            ],
+            "items": { "minimum": 5 }
+        },
+        "tests": [
+            {
+                "description": "prefixItems in allOf does not constrain items, invalid case",
+                "data": [ 3, 5 ],
+                "valid": false
+            },
+            {
+                "description": "prefixItems in allOf does not constrain items, valid case",
+                "data": [ 5, 5 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "prefixItems validation adjusts the starting index for items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [ { "type": "string" } ],
+            "items": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/maxContains.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/maxContains.json
@@ -1,0 +1,102 @@
+[
+    {
+        "description": "maxContains without contains is ignored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "one item valid against lone maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "two items still valid against lone maxContains",
+                "data": [ 1, 2 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "all elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            },
+            {
+                "description": "some elements match, valid maxContains",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "some elements match, invalid maxContains",
+                "data": [ 1, 2, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxContains with contains, value with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "maxContains": 1.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minContains < maxContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 1,
+            "maxContains": 3
+        },
+        "tests": [
+            {
+                "description": "actual < minContains < maxContains",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "minContains < actual < maxContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            },
+            {
+                "description": "minContains < maxContains < actual",
+                "data": [ 1, 1, 1, 1 ],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/maxItems.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/maxItems.json
@@ -1,0 +1,50 @@
+[
+    {
+        "description": "maxItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxItems": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "foobar",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxItems": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/maxLength.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/maxLength.json
@@ -1,0 +1,55 @@
+[
+    {
+        "description": "maxLength validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxLength": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxLength": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/maxProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/maxProperties.json
@@ -1,0 +1,79 @@
+[
+    {
+        "description": "maxProperties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxProperties": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxProperties validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxProperties": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxProperties = 0 means the object is empty",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxProperties": 0
+        },
+        "tests": [
+            {
+                "description": "no properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "one property is invalid",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/maximum.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/maximum.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "maximum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maximum validation with unsigned integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maximum": 300
+        },
+        "tests":  [
+            {
+                "description": "below the maximum is invalid",
+                "data": 299.97,
+                "valid": true
+            },
+            {
+                "description": "boundary point integer is valid",
+                "data": 300,
+                "valid": true
+            },
+            {
+                "description": "boundary point float is valid",
+                "data": 300.00,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 300.5,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/minContains.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/minContains.json
@@ -1,0 +1,224 @@
+[
+    {
+        "description": "minContains without contains is ignored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minContains": 1
+        },
+        "tests": [
+            {
+                "description": "one item valid against lone minContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "zero items still valid against lone minContains",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=1 with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "no elements match",
+                "data": [ 2 ],
+                "valid": false
+            },
+            {
+                "description": "single element matches, valid minContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "some elements match, valid minContains",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "all elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=2 with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 2
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "some elements match, invalid minContains",
+                "data": [ 1, 2 ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid minContains (exactly as needed)",
+                "data": [ 1, 1 ],
+                "valid": true
+            },
+            {
+                "description": "all elements match, valid minContains (more than needed)",
+                "data": [ 1, 1, 1 ],
+                "valid": true
+            },
+            {
+                "description": "some elements match, valid minContains",
+                "data": [ 1, 2, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=2 with contains with a decimal value",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 2.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "both elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains = minContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "maxContains": 2,
+            "minContains": 2
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid maxContains",
+                "data": [ 1, 1, 1 ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid maxContains and minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains < minContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "maxContains": 1,
+            "minContains": 3
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "invalid maxContains",
+                "data": [ 1, 1, 1 ],
+                "valid": false
+            },
+            {
+                "description": "invalid maxContains and minContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minContains = 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 0
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "minContains = 0 makes contains always pass",
+                "data": [ 2 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains = 0 with maxContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 0,
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "not more than maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/minItems.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/minItems.json
@@ -1,0 +1,50 @@
+[
+    {
+        "description": "minItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minItems": 1
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minItems": 1.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/minLength.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/minLength.json
@@ -1,0 +1,55 @@
+[
+    {
+        "description": "minLength validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minLength": 2
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minLength": 2.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/minProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/minProperties.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "minProperties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minProperties": 1
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minProperties": 1.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/minimum.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/minimum.json
@@ -1,0 +1,75 @@
+[
+    {
+        "description": "minimum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minimum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": -2
+        },
+        "tests": [
+            {
+                "description": "negative above the minimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the minimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point with float is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float below the minimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the minimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/multipleOf.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/multipleOf.json
@@ -1,0 +1,83 @@
+[
+    {
+        "description": "by int",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "multipleOf": 2
+        },
+        "tests": [
+            {
+                "description": "int by int",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "int by int fail",
+                "data": 7,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "by number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "multipleOf": 1.5
+        },
+        "tests": [
+            {
+                "description": "zero is multiple of anything",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "4.5 is multiple of 1.5",
+                "data": 4.5,
+                "valid": true
+            },
+            {
+                "description": "35 is not multiple of 1.5",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "by small number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "multipleOf": 0.0001
+        },
+        "tests": [
+            {
+                "description": "0.0075 is multiple of 0.0001",
+                "data": 0.0075,
+                "valid": true
+            },
+            {
+                "description": "0.00751 is not multiple of 0.0001",
+                "data": 0.00751,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float division = inf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer", "multipleOf": 0.123456789
+        },
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/not.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/not.json
@@ -1,0 +1,127 @@
+[
+    {
+        "description": "not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "allowed",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "disallowed",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not multiple types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": {"type": ["integer", "boolean"]}
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": true,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not more complex schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+             }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "other match",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "forbidden property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": { 
+                    "not": {}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property present",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "property absent",
+                "data": {"bar": 1, "baz": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": true
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": false
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/oneOf.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/oneOf.json
@@ -1,0 +1,293 @@
+[
+    {
+        "description": "oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "oneOf" : [
+                {
+                    "minLength": 2
+                },
+                {
+                    "maxLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one oneOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [true, true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, one true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [true, false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, more than one true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [true, true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [false, false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf complex types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+	{
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": true,
+                        "baz": true
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/bignum.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/bignum.json
@@ -1,0 +1,110 @@
+[
+    {
+        "description": "integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "a bignum is an integer",
+                "data": 12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is an integer",
+                "data": -12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number"
+        },
+        "tests": [
+            {
+                "description": "a bignum is a number",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is a number",
+                "data": -98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "string",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string"
+        },
+        "tests": [
+            {
+                "description": "a bignum is not a string",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum integer comparison",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maximum": 18446744073709551615
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMaximum": 972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum integer comparison",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": -18446744073709551615
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision on negative numbers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMinimum": -972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/cross-draft.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/cross-draft.json
@@ -1,0 +1,18 @@
+[
+    {
+        "description": "refs to historic drafts are processed as historic drafts",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "$ref": "http://localhost:1234/draft2019-09/ignore-prefixItems.json"
+        },
+        "tests": [
+            {
+                "description": "first item not a string is valid",
+                "comment": "if the implementation is not processing the $ref as a 2019-09 schema, this test will fail",
+                "data": [1, 2, 3],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/dependencies-compatibility.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/dependencies-compatibility.json
@@ -1,0 +1,282 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "empty dependents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependents required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "CRLF",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quotes",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "CRLF missing dependent",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quotes missing dependent",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "single schema dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean subschemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "schema dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {
+                "foo\tbar": {"minProperties": 4},
+                "foo'bar": {"required": ["foo\"bar"]}
+            }
+        },
+        "tests": [
+            {
+                "description": "quoted tab",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quote",
+                "data": {
+                    "foo'bar": {"foo\"bar": 1}
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted tab invalid under dependent schema",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quote invalid under dependent schema",
+                "data": {"foo'bar": 1},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/ecmascript-regex.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/ecmascript-regex.json
@@ -1,0 +1,596 @@
+[
+    {
+        "description": "ECMA 262 regex $ does not match trailing newline",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^abc$"
+        },
+        "tests": [
+            {
+                "description": "matches in Python, but not in ECMA 262",
+                "data": "abc\\n",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "abc",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\t$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\t",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0009",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\W matches everything but ascii letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches whitespace",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
+                "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but whitespace",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
+                "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with pattern",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "\\p{Letter}cole"
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "\\wcole"
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with ASCII ranges",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "[a-z]cole"
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in pattern matches [0-9], not unicode digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^\\d+$"
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": { "pattern": "\\a" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with non-ASCII digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^\\p{digit}+$"
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "\\p{Letter}cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with ASCII ranges",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in patternProperties matches [0-9], not unicode digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with non-ASCII digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "^\\p{digit}+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/float-overflow.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/float-overflow.json
@@ -1,0 +1,17 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer",
+            "multipleOf": 0.5
+        },
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format-assertion.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format-assertion.json
@@ -1,0 +1,42 @@
+[
+    {
+        "description": "schema that uses custom metaschema with format-assertion: false",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/false",
+            "$schema": "http://localhost:1234/draft2020-12/format-assertion-false.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: false: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: false: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "schema that uses custom metaschema with format-assertion: true",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/true",
+            "$schema": "http://localhost:1234/draft2020-12/format-assertion-true.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: true: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: true: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/date-time.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/date-time.json
@@ -1,0 +1,136 @@
+[
+    {
+        "description": "validation of date-time strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date-time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
+                "data": "1990-02-31T15:59:59.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:59-24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid closing Z after time-zone offset",
+                "data": "1963-06-19T08:30:06.28123+01:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "case-insensitive T and Z",
+                "data": "1963-06-19t08:30:06.283185z",
+                "valid": true
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
+                "data": "1963-06-1৪T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
+                "data": "1963-06-11T0৪:00:00Z",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/date.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/date.json
@@ -1,0 +1,226 @@
+[
+    {
+        "description": "validation of date strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date string",
+                "data": "1963-06-19",
+                "valid": true
+            },
+            {
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
+                "data": "06/19/1963",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350",
+                "valid": false
+            },
+            {
+                "description": "non-padded month dates are not valid",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "non-padded day dates are not valid",
+                "data": "1998-01-1",
+                "valid": false
+            },
+            {
+                "description": "invalid month",
+                "data": "1998-13-01",
+                "valid": false
+            },
+            {
+                "description": "invalid month-day combination",
+                "data": "1998-04-31",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1963-06-1৪",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/duration.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/duration.json
@@ -1,0 +1,136 @@
+[
+    {
+        "description": "validation of duration strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "duration"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "P4DT12H30M5S",
+                "valid": true
+            },
+            {
+                "description": "an invalid duration string",
+                "data": "PT1D",
+                "valid": false
+            },
+            {
+                "description": "no elements present",
+                "data": "P",
+                "valid": false
+            },
+            {
+                "description": "no time elements present",
+                "data": "P1YT",
+                "valid": false
+            },
+            {
+                "description": "no date or time elements present",
+                "data": "PT",
+                "valid": false
+            },
+            {
+                "description": "elements out of order",
+                "data": "P2D1Y",
+                "valid": false
+            },
+            {
+                "description": "missing time separator",
+                "data": "P1D2H",
+                "valid": false
+            },
+            {
+                "description": "time element in the date position",
+                "data": "P2S",
+                "valid": false
+            },
+            {
+                "description": "four years duration",
+                "data": "P4Y",
+                "valid": true
+            },
+            {
+                "description": "zero time, in seconds",
+                "data": "PT0S",
+                "valid": true
+            },
+            {
+                "description": "zero time, in days",
+                "data": "P0D",
+                "valid": true
+            },
+            {
+                "description": "one month duration",
+                "data": "P1M",
+                "valid": true
+            },
+            {
+                "description": "one minute duration",
+                "data": "PT1M",
+                "valid": true
+            },
+            {
+                "description": "one and a half days, in hours",
+                "data": "PT36H",
+                "valid": true
+            },
+            {
+                "description": "one and a half days, in days and hours",
+                "data": "P1DT12H",
+                "valid": true
+            },
+            {
+                "description": "two weeks",
+                "data": "P2W",
+                "valid": true
+            },
+            {
+                "description": "weeks cannot be combined with other units",
+                "data": "P1Y2W",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "P২Y",
+                "valid": false
+            },
+            {
+                "description": "element without unit",
+                "data": "P1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/email.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/email.json
@@ -1,0 +1,121 @@
+[
+    {
+        "description": "validation of e-mail addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a space in the local part is valid",
+                "data": "\"joe bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a double dot in the local part is valid",
+                "data": "\"joe..bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a @ in the local part is valid",
+                "data": "\"joe@bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "an IPv4-address-literal after the @ is valid",
+                "data": "joe.bloggs@[127.0.0.1]",
+                "valid": true
+            },
+            {
+                "description": "an IPv6-address-literal after the @ is valid",
+                "data": "joe.bloggs@[IPv6:::1]",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid domain",
+                "data": "joe.bloggs@invalid=domain.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid IPv4-address-literal",
+                "data": "joe.bloggs@[127.0.0.300]",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/hostname.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/hostname.json
@@ -1,0 +1,101 @@
+[
+    {
+        "description": "validation of host names",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name",
+                "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid punycoded IDN hostname",
+                "data": "xn--4gbwdl.xn--wgbh1c",
+                "valid": true
+            },
+            {
+                "description": "a host name starting with an illegal character",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": false
+            },
+            {
+                "description": "a host name containing illegal characters",
+                "data": "not_a_valid_host_name",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+                "valid": false
+            },
+            {
+                "description": "starts with hyphen",
+                "data": "-hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with hyphen",
+                "data": "hostname-",
+                "valid": false
+            },
+            {
+                "description": "starts with underscore",
+                "data": "_hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with underscore",
+                "data": "hostname_",
+                "valid": false
+            },
+            {
+                "description": "contains underscore",
+                "data": "host_name",
+                "valid": false
+            },
+            {
+                "description": "maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": true
+            },
+            {
+                "description": "exceeds maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/idn-email.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/idn-email.json
@@ -1,0 +1,61 @@
+[
+    {
+        "description": "validation of an internationalized e-mail addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid idn e-mail (example@example.test in Hangul)",
+                "data": "실례@실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "an invalid idn e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/idn-hostname.json
@@ -1,0 +1,307 @@
+[
+    {
+        "description": "validation of internationalized host names",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name (example.test in Hangul)",
+                "data": "실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "illegal first char U+302E Hangul single dot tone mark",
+                "data": "〮실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "contains illegal char U+302E Hangul single dot tone mark",
+                "data": "실〮례.테스트",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "invalid label, correct Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc3492#section-7.1",
+                "data": "-> $1.00 <--",
+                "valid": false
+            },
+            {
+                "description": "valid Chinese Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4",
+                "data": "xn--ihqwcrb4cv8a8dqg056pqjye",
+                "valid": true
+            },
+            {
+                "description": "invalid Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "xn--X",
+                "valid": false
+            },
+            {
+                "description": "U-label contains \"--\" in the 3rd and 4th position",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "XN--aa---o47jg78q",
+                "valid": false
+            },
+            {
+                "description": "U-label starts with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello",
+                "valid": false
+            },
+            {
+                "description": "U-label ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "hello-",
+                "valid": false
+            },
+            {
+                "description": "U-label starts and ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello-",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Spacing Combining Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0903hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Nonspacing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0300hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with an Enclosing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0488hello",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are PVALID, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u00df\u03c2\u0f0b\u3007",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are PVALID, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u06fd\u06fe",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u0640\u07fa",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6 Note: The two combining marks (U+302E and U+302F) are in the middle and not at the start",
+                "data": "\u3031\u3032\u3033\u3034\u3035\u302e\u302f\u303b",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no preceding 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "a\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing preceding",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no following 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7a",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing following",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with surrounding 'l's",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7l",
+                "valid": true
+            },
+            {
+                "description": "Greek KERAIA not followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375S",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA not followed by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375\u03b2",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERESH not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "A\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05d0\u05f3\u05d1",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "A\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05d0\u05f4\u05d1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no Hiragana, Katakana, or Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "def\u30fbabc",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no other characters",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Hiragana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u3041",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Katakana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u30a1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u4e08",
+                "valid": true
+            },
+            {
+                "description": "Arabic-Indic digits mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0660\u06f0",
+                "valid": false
+            },
+            {
+                "description": "Arabic-Indic digits not mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0628\u0660\u0628",
+                "valid": true
+            },
+            {
+                "description": "Extended Arabic-Indic digits not mixed with Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.9",
+                "data": "\u06f00",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u094d\u200d\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER not preceded by Virama but matches regexp",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
+                "data": "\u0628\u064a\u200c\u0628\u064a",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/ipv4.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/ipv4.json
@@ -1,0 +1,87 @@
+[
+    {
+        "description": "validation of IP addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IP address",
+                "data": "192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "an IP address with too many components",
+                "data": "127.0.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "an IP address with out-of-range values",
+                "data": "256.256.256.256",
+                "valid": false
+            },
+            {
+                "description": "an IP address without 4 components",
+                "data": "127.0",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer",
+                "data": "0x7f000001",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
+            },
+            {
+                "description": "invalid leading zeroes, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২7.0.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/ipv6.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/ipv6.json
@@ -1,0 +1,211 @@
+[
+    {
+        "description": "validation of IPv6 addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv6"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IPv6 address",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "an IPv6 address with out-of-range values",
+                "data": "12345::",
+                "valid": false
+            },
+            {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address with too many components",
+                "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address containing illegal characters",
+                "data": "::laptop",
+                "valid": false
+            },
+            {
+                "description": "no digits is valid",
+                "data": "::",
+                "valid": true
+            },
+            {
+                "description": "leading colons is valid",
+                "data": "::42:ff:1",
+                "valid": true
+            },
+            {
+                "description": "trailing colons is valid",
+                "data": "d6::",
+                "valid": true
+            },
+            {
+                "description": "missing leading octet is invalid",
+                "data": ":2:3:4:5:6:7:8",
+                "valid": false
+            },
+            {
+                "description": "missing trailing octet is invalid",
+                "data": "1:2:3:4:5:6:7:",
+                "valid": false
+            },
+            {
+                "description": "missing leading octet with omitted octets later",
+                "data": ":2:3:4::8",
+                "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
+            },
+            {
+                "description": "two sets of double colons is invalid",
+                "data": "1::d6::42",
+                "valid": false
+            },
+            {
+                "description": "mixed format with the ipv4 section as decimal octets",
+                "data": "1::d6:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with double colons between the sections",
+                "data": "1:2::192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with ipv4 section with octet out of range",
+                "data": "1::2:192.168.256.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with ipv4 section with a hex octet",
+                "data": "1::2:192.168.ff.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with leading double colons (ipv4-mapped ipv6 address)",
+                "data": "::ffff:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "triple colons is invalid",
+                "data": "1:2:3:4:5:::8",
+                "valid": false
+            },
+            {
+                "description": "8 octets",
+                "data": "1:2:3:4:5:6:7:8",
+                "valid": true
+            },
+            {
+                "description": "insufficient octets without double colons",
+                "data": "1:2:3:4:5:6:7",
+                "valid": false
+            },
+            {
+                "description": "no colons is invalid",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 is not ipv6",
+                "data": "127.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 segment must have 4 octets",
+                "data": "1:2:3:4:1.2.3",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1:2:3:4:5:6:7:৪",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
+                "data": "1:2::192.16৪.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/iri-reference.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/iri-reference.json
@@ -1,0 +1,76 @@
+[
+    {
+        "description": "validation of IRI References",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference",
+                "data": "//ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid relative IRI Reference",
+                "data": "/âππ",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI Reference",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "a valid IRI Reference",
+                "data": "âππ",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI fragment",
+                "data": "#ƒrägmênt",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI fragment",
+                "data": "#ƒräg\\mênt",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/iri.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/iri.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "validation of IRIs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag and parentheses",
+                "data": "http://ƒøø.com/blah_(wîkïpédiå)_blah#ßité-1",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with URL-encoded stuff",
+                "data": "http://ƒøø.ßår/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI based on IPv6",
+                "data": "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI based on IPv6",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative IRI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI though valid IRI reference",
+                "data": "âππ",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/json-pointer.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/json-pointer.json
@@ -1,0 +1,201 @@
+[
+    {
+        "description": "validation of JSON-pointers (JSON String Representation)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid JSON-pointer",
+                "data": "/foo/bar~0/baz~1/%a",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (~ not escaped)",
+                "data": "/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "valid JSON-pointer with empty segment",
+                "data": "/foo//bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer with the last empty segment",
+                "data": "/foo/bar/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #1",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #2",
+                "data": "/foo",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #3",
+                "data": "/foo/0",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #4",
+                "data": "/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #5",
+                "data": "/a~1b",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #6",
+                "data": "/c%d",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #7",
+                "data": "/e^f",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #8",
+                "data": "/g|h",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #9",
+                "data": "/i\\j",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #10",
+                "data": "/k\"l",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #11",
+                "data": "/ ",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #12",
+                "data": "/m~0n",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer used adding to the last array position",
+                "data": "/foo/-",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (- used as object member name)",
+                "data": "/foo/-/bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (multiple escaped characters)",
+                "data": "/~1~0~0~1~1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #1",
+                "data": "/~1.1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #2",
+                "data": "/~0.1",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #1",
+                "data": "#",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #2",
+                "data": "#/",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #3",
+                "data": "#a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #1",
+                "data": "/~0~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #2",
+                "data": "/~0/~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #1",
+                "data": "/~2",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #2",
+                "data": "/~-1",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (multiple characters not escaped)",
+                "data": "/~~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #1",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #2",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #3",
+                "data": "a/a",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/regex.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/regex.json
@@ -1,0 +1,51 @@
+[
+    {
+        "description": "validation of regular expressions",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid regular expression",
+                "data": "([abc])+\\s+$",
+                "valid": true
+            },
+            {
+                "description": "a regular expression with unclosed parens is invalid",
+                "data": "^(abc]",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/relative-json-pointer.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/relative-json-pointer.json
@@ -1,0 +1,101 @@
+[
+    {
+        "description": "validation of Relative JSON Pointers (RJP)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "relative-json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid upwards RJP",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "a valid downwards RJP",
+                "data": "0/foo/bar",
+                "valid": true
+            },
+            {
+                "description": "a valid up and then down RJP, with array index",
+                "data": "2/0/baz/1/zip",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP taking the member or index name",
+                "data": "0#",
+                "valid": true
+            },
+            {
+                "description": "an invalid RJP that is a valid JSON Pointer",
+                "data": "/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "negative prefix",
+                "data": "-1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "explicit positive prefix",
+                "data": "+1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "## is not a valid json-pointer",
+                "data": "0##",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus json-pointer",
+                "data": "01/a",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus octothorpe",
+                "data": "01#",
+                "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "multi-digit integer prefix",
+                "data": "120/foo/bar",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/time.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/time.json
@@ -1,0 +1,216 @@
+[
+    {
+        "description": "validation of time strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid time string",
+                "data": "08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with leap second, Zulu",
+                "data": "23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, zero time-offset",
+                "data": "23:59:60+00:00",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong hour)",
+                "data": "22:59:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong minute)",
+                "data": "23:58:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, positive time-offset",
+                "data": "01:29:60+01:30",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large positive time-offset",
+                "data": "23:29:60+23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong hour)",
+                "data": "23:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong minute)",
+                "data": "23:59:60+00:30",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, negative time-offset",
+                "data": "15:59:60-08:00",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large negative time-offset",
+                "data": "00:29:60-23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong hour)",
+                "data": "23:59:60-01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong minute)",
+                "data": "23:59:60-00:30",
+                "valid": false
+            },
+            {
+                "description": "a valid time string with second fraction",
+                "data": "23:20:50.52Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with precise second fraction",
+                "data": "08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with plus offset",
+                "data": "08:30:06+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with minus offset",
+                "data": "08:30:06-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with case-insensitive Z",
+                "data": "08:30:06z",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string with invalid hour",
+                "data": "24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid minute",
+                "data": "00:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid second",
+                "data": "00:00:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset hour",
+                "data": "01:02:03+24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset minute",
+                "data": "01:02:03+00:60",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time with both Z and numoffset",
+                "data": "01:02:03Z+00:30",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset indicator",
+                "data": "08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "01:01:01,1111",
+                "valid": false
+            },
+            {
+                "description": "no time offset",
+                "data": "12:00:00",
+                "valid": false
+            },
+            {
+                "description": "no time offset with second fraction",
+                "data": "12:00:00.52",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "offset not starting with plus or minus",
+                "data": "08:30:06#00:20",
+                "valid": false
+            },
+            {
+                "description": "contains letters",
+                "data": "ab:cd:ef",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/unknown.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/unknown.json
@@ -1,0 +1,46 @@
+[
+    {
+        "description": "unknown format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "unknown"
+        },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/uri-reference.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/uri-reference.json
@@ -1,0 +1,76 @@
+[
+    {
+        "description": "validation of URI References",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URI",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid relative URI Reference",
+                "data": "/abc",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI Reference",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "a valid URI Reference",
+                "data": "abc",
+                "valid": true
+            },
+            {
+                "description": "a valid URI fragment",
+                "data": "#fragment",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI fragment",
+                "data": "#frag\\ment",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/uri-template.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/uri-template.json
@@ -1,0 +1,61 @@
+[
+    {
+        "description": "format: uri-template",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-template"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term}",
+                "valid": true
+            },
+            {
+                "description": "an invalid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": false
+            },
+            {
+                "description": "a valid uri-template without variables",
+                "data": "http://example.com/dictionary",
+                "valid": true
+            },
+            {
+                "description": "a valid relative uri-template",
+                "data": "dictionary/{term:1}/{term}",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/uri.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/uri.json
@@ -1,0 +1,141 @@
+[
+    {
+        "description": "validation of URIs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag and parentheses",
+                "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with URL-encoded stuff",
+                "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid puny-coded URL ",
+                "data": "http://xn--nw2a.xn--j6w193g/",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid URL based on IPv4",
+                "data": "http://223.255.255.254",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with ftp scheme",
+                "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL for a simple text file",
+                "data": "http://www.ietf.org/rfc/rfc2396.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL ",
+                "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+                "valid": true
+            },
+            {
+                "description": "a valid mailto URI",
+                "data": "mailto:John.Doe@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid newsgroup URI",
+                "data": "news:comp.infosystems.www.servers.unix",
+                "valid": true
+            },
+            {
+                "description": "a valid tel URI",
+                "data": "tel:+1-816-555-1212",
+                "valid": true
+            },
+            {
+                "description": "a valid URN",
+                "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+                "valid": true
+            },
+            {
+                "description": "an invalid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative URI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI though valid URI reference",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces",
+                "data": "http:// shouldfail.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces and missing scheme",
+                "data": ":// should fail",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/format/uuid.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/format/uuid.json
@@ -1,0 +1,116 @@
+[
+    {
+        "description": "uuid format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uuid"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "all upper-case",
+                "data": "2EB8AA08-AA98-11EA-B4AA-73B441D16380",
+                "valid": true
+            },
+            {
+                "description": "all lower-case",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": true
+            },
+            {
+                "description": "mixed case",
+                "data": "2eb8aa08-AA98-11ea-B4Aa-73B441D16380",
+                "valid": true
+            },
+            {
+                "description": "all zeroes is valid",
+                "data": "00000000-0000-0000-0000-000000000000",
+                "valid": true
+            },
+            {
+                "description": "wrong length",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
+                "valid": false
+            },
+            {
+                "description": "missing section",
+                "data": "2eb8aa08-aa98-11ea-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "bad characters (not hex)",
+                "data": "2eb8aa08-aa98-11ea-b4ga-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "no dashes",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too few dashes",
+                "data": "2eb8aa08aa98-11ea-b4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too many dashes",
+                "data": "2eb8-aa08-aa98-11ea-b4aa73b44-1d16380",
+                "valid": false
+            },
+            {
+                "description": "dashes in the wrong spot",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380----",
+                "valid": false
+            },
+            {
+                "description": "valid version 4",
+                "data": "98d80576-482e-427f-8434-7f86890ab222",
+                "valid": true
+            },
+            {
+                "description": "valid version 5",
+                "data": "99c17cbb-656f-564a-940f-1a4568f03487",
+                "valid": true
+            },
+            {
+                "description": "hypothetical version 6",
+                "data": "99c17cbb-656f-664a-940f-1a4568f03487",
+                "valid": true
+            },
+            {
+                "description": "hypothetical version 15",
+                "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/no-schema.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/no-schema.json
@@ -1,0 +1,26 @@
+[
+    {
+        "description": "validation without $schema",
+        "comment": "minLength is the same across all drafts",
+        "schema": {
+            "minLength": 2
+        },
+        "tests": [
+            {
+                "description": "a 3-character string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a 1-character string is not valid",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "a non-string is valid",
+                "data": 5,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/non-bmp-regex.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/non-bmp-regex.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "Proper UTF-16 surrogate pair handling: pattern",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^🐲*$"
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Proper UTF-16 surrogate pair handling: patternProperties",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐲": "hello" },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐲🐲": "hello" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/optional/refOfUnknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/optional/refOfUnknownKeyword.json
@@ -1,0 +1,46 @@
+[
+    {
+        "description": "reference of a root arbitrary keyword ",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unknown-keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference of an arbitrary keyword of a sub-schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"unknown-keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/pattern.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/pattern.json
@@ -1,0 +1,65 @@
+[
+    {
+        "description": "pattern validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^a*$"
+        },
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "aaa",
+                "valid": true
+            },
+            {
+                "description": "a non-matching pattern is invalid",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "a+"
+        },
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/patternProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/patternProperties.json
@@ -1,0 +1,176 @@
+[
+    {
+        "description":
+            "patternProperties validates properties matching a regex",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "f.*o": {"type": "integer"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "multiple valid matches is valid",
+                "data": {"foo": 1, "foooooo" : 2},
+                "valid": true
+            },
+            {
+                "description": "a single invalid match is invalid",
+                "data": {"foo": "bar", "fooooo": 2},
+                "valid": false
+            },
+            {
+                "description": "multiple invalid matches is invalid",
+                "data": {"foo": "bar", "foooooo" : "baz"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple simultaneous patternProperties are validated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "a*": {"type": "integer"},
+                "aaa*": {"maximum": 20}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"a": 21},
+                "valid": true
+            },
+            {
+                "description": "a simultaneous match is valid",
+                "data": {"aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "multiple matches is valid",
+                "data": {"a": 21, "aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "an invalid due to one is invalid",
+                "data": {"a": "bar"},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to the other is invalid",
+                "data": {"aaaa": 31},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to both is invalid",
+                "data": {"aaa": "foo", "aaaa": 31},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "regexes are not anchored by default and are case sensitive",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "[0-9]{2,}": { "type": "boolean" },
+                "X_": { "type": "string" }
+            }
+        },
+        "tests": [
+            {
+                "description": "non recognized members are ignored",
+                "data": { "answer 1": "42" },
+                "valid": true
+            },
+            {
+                "description": "recognized members are accounted for",
+                "data": { "a31b": null },
+                "valid": false
+            },
+            {
+                "description": "regexes are case sensitive",
+                "data": { "a_x_3": 3 },
+                "valid": true
+            },
+            {
+                "description": "regexes are case sensitive, 2",
+                "data": { "a_X_3": 3 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "f.*": true,
+                "b.*": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property matching schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property matching schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with a property matching both true and false is invalid",
+                "data": {"foobar":1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/prefixItems.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/prefixItems.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "a schema given for prefixItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                {"type": "integer"},
+                {"type": "string"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "correct types",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "wrong types",
+                "data": [ "foo", 1 ],
+                "valid": false
+            },
+            {
+                "description": "incomplete array of items",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with additional items",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "1": "valid",
+                    "length": 2
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "prefixItems with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [true, false]
+        },
+        "tests": [
+            {
+                "description": "array with one item is valid",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with two items is invalid",
+                "data": [ 1, "foo" ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additional items are allowed by default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "integer"}]
+        },
+        "tests": [
+            {
+                "description": "only the first item is validated",
+                "data": [1, "foo", false],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "prefixItems with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/properties.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/properties.json
@@ -1,0 +1,242 @@
+[
+    {
+        "description": "object properties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties present and valid is valid",
+                "data": {"foo": 1, "bar": "baz"},
+                "valid": true
+            },
+            {
+                "description": "one property invalid is invalid",
+                "data": {"foo": 1, "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "both properties invalid is invalid",
+                "data": {"foo": [], "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "doesn't invalidate other properties",
+                "data": {"quux": []},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description":
+            "properties, patternProperties, additionalProperties interaction",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"type": "array", "maxItems": 3},
+                "bar": {"type": "array"}
+            },
+            "patternProperties": {"f.o": {"minItems": 2}},
+            "additionalProperties": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "property validates property",
+                "data": {"foo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "property invalidates property",
+                "data": {"foo": [1, 2, 3, 4]},
+                "valid": false
+            },
+            {
+                "description": "patternProperty invalidates property",
+                "data": {"foo": []},
+                "valid": false
+            },
+            {
+                "description": "patternProperty validates nonproperty",
+                "data": {"fxo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "patternProperty invalidates nonproperty",
+                "data": {"fxo": []},
+                "valid": false
+            },
+            {
+                "description": "additionalProperty ignores property",
+                "data": {"bar": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty validates others",
+                "data": {"quux": 3},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty invalidates others",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with boolean schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no property present is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "only 'true' property present is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "only 'false' property present is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "both properties present is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo\nbar": {"type": "number"},
+                "foo\"bar": {"type": "number"},
+                "foo\\bar": {"type": "number"},
+                "foo\rbar": {"type": "number"},
+                "foo\tbar": {"type": "number"},
+                "foo\fbar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with all numbers is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1",
+                    "foo\\bar": "1",
+                    "foo\rbar": "1",
+                    "foo\tbar": "1",
+                    "foo\fbar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "__proto__": {"type": "number"},
+                "toString": {
+                    "properties": { "length": { "type": "string" } }
+                },
+                "constructor": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "__proto__ not valid",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString not valid",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor not valid",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present and valid",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/propertyNames.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/propertyNames.json
@@ -1,0 +1,85 @@
+[
+    {
+        "description": "propertyNames validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": {"maxLength": 3}
+        },
+        "tests": [
+            {
+                "description": "all property names valid",
+                "data": {
+                    "f": {},
+                    "foo": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "some property names invalid",
+                "data": {
+                    "foo": {},
+                    "foobar": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3, 4],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": true
+        },
+        "tests": [
+            {
+                "description": "object with any properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": false
+        },
+        "tests": [
+            {
+                "description": "object with any properties is invalid",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/ref.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/ref.json
@@ -1,0 +1,887 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                {"type": "integer"},
+                {"$ref": "#/prefixItems/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
+            },
+            "properties": {
+                "tilde": {"$ref": "#/$defs/tilde~0field"},
+                "slash": {"$ref": "#/$defs/slash~1field"},
+                "percent": {"$ref": "#/$defs/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilde invalid",
+                "data": {"tilde": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilde valid",
+                "data": {"tilde": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/$defs/a"},
+                "c": {"$ref": "#/$defs/b"}
+            },
+            "$ref": "#/$defs/c"
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref applies alongside sibling keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "ref valid, maxItems valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "ref valid, maxItems invalid",
+                "data": { "foo": [1, 2, 3] },
+                "valid": false
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"minLength": 1},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"minLength": -1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "$ref": {"$ref": "#/$defs/is-string"}
+            },
+            "$defs": {
+                "is-string": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": false
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {
+                    "type": "array",
+                    "items": {"$ref": "node"}
+                }
+            },
+            "required": ["meta", "nodes"],
+            "$defs": {
+                "node": {
+                    "$id": "http://localhost:1234/draft2020-12/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "subtree": {"$ref": "tree"}
+                    },
+                    "required": ["value"]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 1.1},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": "string is invalid"},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
+            },
+            "$defs": {
+                "foo\"bar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with numbers is valid",
+                "data": {
+                    "foo\"bar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref creates new scope when adjacent to keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "A": {
+                    "unevaluatedProperties": false
+                }
+            },
+            "properties": {
+                "prop1": {
+                    "type": "string"
+                }
+            },
+            "$ref": "#/$defs/A"
+        },
+        "tests": [
+            {
+                "description": "referenced subschema doesn't see annotations from properties",
+                "data": {
+                    "prop1": "match"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/$defs/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "do not evaluate the $ref inside the enum, definition exact match",
+                "data": { "type": "string" },
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/$defs/a_string" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "refs with relative uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/schema-relative-uri-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "schema-relative-uri-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-relative-uri-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative refs with absolute uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "http://example.com/schema-refs-absolute-uris-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-refs-absolute-uris-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/a.json",
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "$defs": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $ref",
+        "schema": {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "/draft2020-12/ref-and-id1/base.json",
+            "$ref": "int.json",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id1/int.json",
+                    "$id": "int.json",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /ref-and-id1-int.json",
+                    "$id": "/draft2020-12/ref-and-id1-int.json",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $anchor and $ref",
+        "schema": {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "/draft2020-12/ref-and-id2/base.json",
+            "$ref": "#bigint",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "$anchor": "bigint",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
+                    "$id": "/draft2020-12/ref-and-id2/",
+                    "$anchor": "bigint",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with $ref via the URN",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "minimum": 30,
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
+            }
+        },
+        "tests": [
+            {
+                "description": "valid under the URN IDed schema",
+                "data": {"foo": 37},
+                "valid": true
+            },
+            {
+                "description": "invalid under the URN IDed schema",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with JSON pointer",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with NSS",
+        "schema": {
+            "$comment": "RFC 8141 §2.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:1/406/47452/2",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with r-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.1",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with q-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with f-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "is invalid",
+                "data": {"$id": "urn:example:foo-bar-baz-qux#somepart"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and JSON pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and anchor ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
+            },
+            "$defs": {
+                "bar": {
+                    "$anchor": "something",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN ref with nested pointer ref",
+        "schema": {
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+            "$defs": {
+                "foo": {
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$defs": {"bar": {"type": "string"}},
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": "bar",
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": 12,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/refRemote.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/refRemote.json
@@ -1,0 +1,295 @@
+[
+    {
+        "description": "remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/integer.json"
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "fragment within remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/subSchemas-defs.json#/$defs/integer"
+        },
+        "tests": [
+            {
+                "description": "remote fragment valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote fragment invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/subSchemas-defs.json#/$defs/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "ref within ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "ref within ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/",
+            "items": {
+                "$id": "baseUriChange/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "base URI change ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "base URI change ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/scope_change_defs1.json",
+            "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolder/",
+                    "type": "array",
+                    "items": {"$ref": "folderInteger.json"}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema/",
+                    "$defs": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "root ref in remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/object",
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "name-defs.json#/$defs/orNull"}
+            }
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": {
+                    "name": null
+                },
+                "valid": true
+            },
+            {
+                "description": "object is invalid",
+                "data": {
+                    "name": {
+                        "name": null
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref with ref to defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/schema-remote-ref-ref-defs1.json",
+            "$ref": "ref-and-defs.json"
+        },
+        "tests": [
+            {
+                "description": "invalid",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid",
+                "data": {
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier in remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/locationIndependentIdentifier.json#/$defs/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "retrieved nested refs resolve relative to their URI not $id",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/some-id",
+            "properties": {
+                "name": {"$ref": "nested/foo-ref-string.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": {
+                    "name": {"foo":  1}
+                },
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different $id",
+        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different URN $id",
+        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with nested absolute ref",
+        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/required.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/required.json
@@ -1,0 +1,158 @@
+[
+    {
+        "description": "required validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "required": ["foo"]
+        },
+        "tests": [
+            {
+                "description": "present required property is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "non-present required property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required default validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required by default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with empty array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {}
+            },
+            "required": []
+        },
+        "tests": [
+            {
+                "description": "property not required",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "required": [
+                "foo\nbar",
+                "foo\"bar",
+                "foo\\bar",
+                "foo\rbar",
+                "foo\tbar",
+                "foo\fbar"
+            ]
+        },
+        "tests": [
+            {
+                "description": "object with all properties present is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with some properties missing is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "required properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "required": ["__proto__", "toString", "constructor"]
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "__proto__ present",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString present",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor present",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/type.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/type.json
@@ -1,0 +1,501 @@
+[
+    {
+        "description": "integer type matches integers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "an integer is an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is an integer",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is not an integer",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an integer",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not an integer, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not an integer",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not an integer",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an integer",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an integer",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "number type matches numbers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number"
+        },
+        "tests": [
+            {
+                "description": "an integer is a number",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is a number (and an integer)",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is a number",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "a string is not a number",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not a number, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not a number",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a number",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a number",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a number",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "string type matches strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string"
+        },
+        "tests": [
+            {
+                "description": "1 is not a string",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a string",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a string is still a string, even if it looks like a number",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an object is not a string",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a string",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a string",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a string",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "object type matches objects",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object"
+        },
+        "tests": [
+            {
+                "description": "an integer is not an object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an object",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an object",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is not an object",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an object",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an object",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "array type matches arrays",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array"
+        },
+        "tests": [
+            {
+                "description": "an integer is not an array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an array",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an array",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not an array",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is not an array",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an array",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "boolean type matches booleans",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "boolean"
+        },
+        "tests": [
+            {
+                "description": "an integer is not a boolean",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a float is not a boolean",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not a boolean",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not a boolean",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a boolean",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is a boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is not a boolean",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "null type matches only the null object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "null"
+        },
+        "tests": [
+            {
+                "description": "an integer is not null",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not null",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a string is not null",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not null",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not null",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is not null",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple types can be specified in an array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": ["integer", "string"]
+        },
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/unevaluatedItems.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/unevaluatedItems.json
@@ -1,0 +1,675 @@
+[
+    {
+        "description": "unevaluatedItems true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": true
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems as schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": { "type": "string" }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with valid unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with invalid unevaluated items",
+                "data": [42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with uniform items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": { "type": "string" },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "unevaluatedItems doesn't apply",
+                "data": ["foo", "bar"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with tuple",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "items": true,
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "unevaluatedItems doesn't apply",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested tuple",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "allOf": [
+                {
+                    "prefixItems": [
+                        true,
+                        { "type": "number" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", 42],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", 42, true],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": {"type": "boolean"},
+            "anyOf": [
+                { "items": {"type": "string"} },
+                true
+            ]
+        },
+        "tests": [
+            {
+                "description": "with only (valid) additional items",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "with no additional items",
+                "data": ["yes", "no"],
+                "valid": true
+            },
+            {
+                "description": "with invalid additional item",
+                "data": ["yes", false],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested prefixItems and items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "prefixItems": [
+                        { "type": "string" }
+                    ],
+                    "items": true
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no additional items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with additional items",
+                "data": ["foo", 42, true],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested unevaluatedItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "prefixItems": [
+                        { "type": "string" }
+                    ]
+                },
+                { "unevaluatedItems": true }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no additional items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with additional items",
+                "data": ["foo", 42, true],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "anyOf": [
+                {
+                    "prefixItems": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                },
+                {
+                    "prefixItems": [
+                        true,
+                        true,
+                        { "const": "baz" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "when one schema matches and has no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "when one schema matches and has unevaluated items",
+                "data": ["foo", "bar", 42],
+                "valid": false
+            },
+            {
+                "description": "when two schemas match and has no unevaluated items",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "when two schemas match and has unevaluated items",
+                "data": ["foo", "bar", "baz", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "oneOf": [
+                {
+                    "prefixItems": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                },
+                {
+                    "prefixItems": [
+                        true,
+                        { "const": "baz" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "not": {
+                "not": {
+                    "prefixItems": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                }
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with if/then/else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "if": {
+                "prefixItems": [
+                    true,
+                    { "const": "bar" }
+                ]
+            },
+            "then": {
+                "prefixItems": [
+                    true,
+                    true,
+                    { "const": "then" }
+                ]
+            },
+            "else": {
+                "prefixItems": [
+                    true,
+                    true,
+                    true,
+                    { "const": "else" }
+                ]
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "when if matches and it has no unevaluated items",
+                "data": ["foo", "bar", "then"],
+                "valid": true
+            },
+            {
+                "description": "when if matches and it has unevaluated items",
+                "data": ["foo", "bar", "then", "else"],
+                "valid": false
+            },
+            {
+                "description": "when if doesn't match and it has no unevaluated items",
+                "data": ["foo", 42, 42, "else"],
+                "valid": true
+            },
+            {
+                "description": "when if doesn't match and it has unevaluated items",
+                "data": ["foo", 42, 42, "else", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [true],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bar",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "unevaluatedItems": false,
+            "$defs": {
+              "bar": {
+                  "prefixItems": [
+                      true,
+                      { "type": "string" }
+                  ]
+              }
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar", "baz"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems can't see inside cousins",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "prefixItems": [ true ]
+                },
+                { "unevaluatedItems": false }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": [ 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "item is evaluated in an uncle schema to unevaluatedItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "prefixItems": [
+                        { "type": "string" }
+                    ],
+                    "unevaluatedItems": false
+                  }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "prefixItems": [
+                                true,
+                                { "type": "string" }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "no extra items",
+                "data": {
+                    "foo": [
+                        "test"
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "uncle keyword evaluation is not significant",
+                "data": {
+                    "foo": [
+                        "test",
+                        "test"
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems depends on adjacent contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [true],
+            "contains": {"type": "string"},
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "second item is evaluated by contains",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "contains fails, second item is not evaluated",
+                "data": [ 1, 2 ],
+                "valid": false
+            },
+            {
+                "description": "contains passes, second item is not evaluated",
+                "data": [ 1, 2, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems depends on multiple nested contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                { "contains": { "multipleOf": 2 } },
+                { "contains": { "multipleOf": 3 } }
+            ],
+            "unevaluatedItems": { "multipleOf": 5 }
+        },
+        "tests": [
+            {
+                "description": "5 not evaluated, passes unevaluatedItems",
+                "data": [ 2, 3, 4, 5, 6 ],
+                "valid": true
+            },
+            {
+                "description": "7 not evaluated, fails unevaluatedItems",
+                "data": [ 2, 3, 4, 7, 8 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems and contains interact to control item dependency relationship",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "contains": {"const": "a"}
+            },
+            "then": {
+                "if": {
+                    "contains": {"const": "b"}
+                },
+                "then": {
+                    "if": {
+                        "contains": {"const": "c"}
+                    }
+                }
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "only a's are valid",
+                "data": [ "a", "a" ],
+                "valid": true
+            },
+            {
+                "description": "a's and b's are valid",
+                "data": [ "a", "b", "a", "b", "a" ],
+                "valid": true
+            },
+            {
+                "description": "a's, b's and c's are valid",
+                "data": [ "c", "a", "c", "c", "b", "a" ],
+                "valid": true
+            },
+            {
+                "description": "only b's are invalid",
+                "data": [ "b", "b" ],
+                "valid": false
+            },
+            {
+                "description": "only c's are invalid",
+                "data": [ "c", "c" ],
+                "valid": false
+            },
+            {
+                "description": "only b's and c's are invalid",
+                "data": [ "c", "b", "c", "b", "c" ],
+                "valid": false
+            },
+            {
+                "description": "only a's and c's are invalid",
+                "data": [ "c", "a", "c", "a", "c" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-array instances are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/unevaluatedProperties.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/unevaluatedProperties.json
@@ -1,0 +1,1423 @@
+[
+    {
+        "description": "unevaluatedProperties true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "unevaluatedProperties": {
+                "type": "string",
+                "minLength": 3
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with valid unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with invalid unevaluated properties",
+                "data": {
+                    "foo": "fo"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "^foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "additionalProperties": true,
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": { "type": "string" }
+                    }
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+              {
+                  "patternProperties": {
+                      "^bar": { "type": "string" }
+                  }
+              }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "additionalProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested unevaluatedProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": {
+                "type": "string",
+                "maxLength": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "baz": { "const": "baz" }
+                    },
+                    "required": ["baz"]
+                },
+                {
+                    "properties": {
+                        "quux": { "const": "quux" }
+                    },
+                    "required": ["quux"]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when one matches and has no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when one matches and has unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "not-baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when two match and has no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when two match and has unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz",
+                    "quux": "not-quux"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "baz": { "const": "baz" }
+                    },
+                    "required": ["baz"]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "quux": "quux"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "not": {
+                "not": {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "then": {
+                "properties": {
+                    "bar": { "type": "string" }
+                },
+                "required": ["bar"]
+            },
+            "else": {
+                "properties": {
+                    "baz": { "type": "string" }
+                },
+                "required": ["baz"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else, then not defined",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "else": {
+                "properties": {
+                    "baz": { "type": "string" }
+                },
+                "required": ["baz"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else, else not defined",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "then": {
+                "properties": {
+                    "bar": { "type": "string" }
+                },
+                "required": ["bar"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with dependentSchemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "dependentSchemas": {
+                "foo": {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [true],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "$ref": "#/$defs/bar",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false,
+            "$defs": {
+                "bar": {
+                    "properties": {
+                        "bar": { "type": "string" }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties can't see inside cousins",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                },
+                {
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties can't see inside cousins (reverse order)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer false, inner true, properties inside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer true, inner false, properties outside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                }
+            ],
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer true, inner false, properties inside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            ],
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "cousin unevaluatedProperties, true and false, true with properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": true
+                },
+                {
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "cousin unevaluatedProperties, true and false, false with properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                },
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property is evaluated in an uncle schema to unevaluatedProperties",
+        "comment": "see https://stackoverflow.com/questions/66936884/deeply-nested-unevaluatedproperties-and-their-expectations",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "object",
+                    "properties": {
+                        "bar": {
+                            "type": "string"
+                        }
+                    },
+                    "unevaluatedProperties": false
+                  }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "properties": {
+                                "faz": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "no extra properties",
+                "data": {
+                    "foo": {
+                        "bar": "test"
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "uncle keyword evaluation is not significant",
+                "data": {
+                    "foo": {
+                        "bar": "test",
+                        "faz": "test"
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "in-place applicator siblings, allOf has unevaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "unevaluatedProperties": false
+                }
+            ],
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "base case: both properties present",
+                "data": {
+                    "foo": 1,
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, bar is missing",
+                "data": {
+                    "foo": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "in place applicator siblings, foo is missing",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "in-place applicator siblings, anyOf has unevaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ],
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": true
+                    },
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "base case: both properties present",
+                "data": {
+                    "foo": 1,
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, bar is missing",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, foo is missing",
+                "data": {
+                    "bar": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties + single cyclic ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "x": { "$ref": "#" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "Single is valid",
+                "data": { "x": {} },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 1st level is invalid",
+                "data": { "x": {}, "y": {} },
+                "valid": false
+            },
+            {
+                "description": "Nested is valid",
+                "data": { "x": { "x": {} } },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 2nd level is invalid",
+                "data": { "x": { "x": {}, "y": {} } },
+                "valid": false
+            },
+            {
+                "description": "Deep nested is valid",
+                "data": { "x": { "x": { "x": {} } } },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 3rd level is invalid",
+                "data": { "x": { "x": { "x": {}, "y": {} } } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties + ref inside allOf / oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "one": {
+                    "properties": { "a": true }
+                },
+                "two": {
+                    "required": ["x"],
+                    "properties": { "x": true }
+                }
+            },
+            "allOf": [
+                { "$ref": "#/$defs/one" },
+                { "properties": { "b": true } },
+                {
+                    "oneOf": [
+                        { "$ref": "#/$defs/two" },
+                        {
+                            "required": ["y"],
+                            "properties": { "y": true }
+                        }
+                    ]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is invalid (no x or y)",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "a and b are invalid (no x or y)",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "x and y are invalid",
+                "data": { "x": 1, "y": 1 },
+                "valid": false
+            },
+            {
+                "description": "a and x are valid",
+                "data": { "a": 1, "x": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and y are valid",
+                "data": { "a": 1, "y": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and x are valid",
+                "data": { "a": 1, "b": 1, "x": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and y are valid",
+                "data": { "a": 1, "b": 1, "y": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and x and y are invalid",
+                "data": { "a": 1, "b": 1, "x": 1, "y": 1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dynamic evalation inside nested refs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "one": {
+                    "oneOf": [
+                        { "$ref": "#/$defs/two" },
+                        { "required": ["b"], "properties": { "b": true } },
+                        { "required": ["xx"], "patternProperties": { "x": true } },
+                        { "required": ["all"], "unevaluatedProperties": true }
+                    ]
+                },
+                "two": {
+                    "oneOf": [
+                        { "required": ["c"], "properties": { "c": true } },
+                        { "required": ["d"], "properties": { "d": true } }
+                    ]
+                }
+            },
+            "oneOf": [
+                { "$ref": "#/$defs/one" },
+                { "required": ["a"], "properties": { "a": true } }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "a is valid",
+                "data": { "a": 1 },
+                "valid": true
+            },
+            {
+                "description": "b is valid",
+                "data": { "b": 1 },
+                "valid": true
+            },
+            {
+                "description": "c is valid",
+                "data": { "c": 1 },
+                "valid": true
+            },
+            {
+                "description": "d is valid",
+                "data": { "d": 1 },
+                "valid": true
+            },
+            {
+                "description": "a + b is invalid",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "a + c is invalid",
+                "data": { "a": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "a + d is invalid",
+                "data": { "a": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "b + c is invalid",
+                "data": { "b": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "b + d is invalid",
+                "data": { "b": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "c + d is invalid",
+                "data": { "c": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx is valid",
+                "data": { "xx": 1 },
+                "valid": true
+            },
+            {
+                "description": "xx + foox is valid",
+                "data": { "xx": 1, "foox": 1 },
+                "valid": true
+            },
+            {
+                "description": "xx + foo is invalid",
+                "data": { "xx": 1, "foo": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + a is invalid",
+                "data": { "xx": 1, "a": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + b is invalid",
+                "data": { "xx": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + c is invalid",
+                "data": { "xx": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + d is invalid",
+                "data": { "xx": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "all is valid",
+                "data": { "all": 1 },
+                "valid": true
+            },
+            {
+                "description": "all + foo is valid",
+                "data": { "all": 1, "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "all + a is invalid",
+                "data": { "all": 1, "a": 1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-object instances are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null valued properties",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/uniqueItems.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/uniqueItems.json
@@ -1,0 +1,414 @@
+[
+    {
+        "description": "uniqueItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
+                "data": [1, 2, 1],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is invalid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": false
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is invalid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": false
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
+                "data": [["foo"], ["bar"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "[1] and [true] are unique",
+                "data": [[1], [true]],
+                "valid": true
+            },
+            {
+                "description": "[0] and [false] are unique",
+                "data": [[0], [false]],
+                "valid": true
+            },
+            {
+                "description": "nested [1] and [true] are unique",
+                "data": [[[1], "foo"], [[true], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "nested [0] and [false] are unique",
+                "data": [[[0], "foo"], [[false], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1, "{}"],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are invalid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
+                "valid": false
+            },
+            {
+                "description": "{\"a\": false} and {\"a\": 0} are unique",
+                "data": [{"a": false}, {"a": 0}],
+                "valid": true
+            },
+            {
+                "description": "{\"a\": true} and {\"a\": 1} are unique",
+                "data": [{"a": true}, {"a": 1}],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is not valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": false
+            },
+            {
+                "description": "non-unique array extended from [true, false] is not valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items and additionalItems=false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/unknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/unknownKeyword.json
@@ -1,0 +1,57 @@
+[
+    {
+        "description": "$id inside an unknown keyword is not a real identifier",
+        "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "id_in_unknown0": {
+                    "not": {
+                        "array_of_schemas": [
+                            {
+                              "$id": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json",
+                              "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json",
+                    "type": "string"
+                },
+                "id_in_unknown1": {
+                    "not": {
+                        "object_of_schemas": {
+                            "foo": {
+                              "$id": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json",
+                              "type": "integer"
+                            }
+                        }
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_unknown0" },
+                { "$ref": "#/$defs/id_in_unknown1" },
+                { "$ref": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "type matches second anyOf, which has a real schema in it",
+                "data": "a string",
+                "valid": true
+            },
+            {
+                "description": "type matches non-schema in first anyOf",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "type matches non-schema in third anyOf",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft2020-12/vocabulary.json
+++ b/asdf/_jsonschema/json/tests/draft2020-12/vocabulary.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "schema that uses custom metaschema with with no validation vocabulary",
+        "schema": {
+            "$id": "https://schema/using/no/validation",
+            "$schema": "http://localhost:1234/draft2020-12/metaschema-no-validation.json",
+            "properties": {
+                "badProperty": false,
+                "numberProperty": {
+                    "minimum": 10
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "applicator vocabulary still works",
+                "data": {
+                    "badProperty": "this property should not exist"
+                },
+                "valid": false
+            },
+            {
+                "description": "no validation: valid number",
+                "data": {
+                    "numberProperty": 20
+                },
+                "valid": true
+            },
+            {
+                "description": "no validation: invalid number, but it still validates",
+                "data": {
+                    "numberProperty": 1
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/additionalItems.json
+++ b/asdf/_jsonschema/json/tests/draft3/additionalItems.json
@@ -1,0 +1,128 @@
+[
+    {
+        "description": "additionalItems as schema",
+        "schema": {
+            "items": [],
+            "additionalItems": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "additional items match schema",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": true
+            },
+            {
+                "description": "additional items do not match schema",
+                "data": [ 1, 2, 3, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "when items is schema, additionalItems does nothing",
+        "schema": {
+            "items": {},
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "all items match schema",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array of items with no additionalItems permitted",
+        "schema": {
+            "items": [{}, {}, {}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "additional items are not permitted",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems as false without items",
+        "schema": {"additionalItems": false},
+        "tests": [
+            {
+                "description":
+                    "items defaults to empty schema so everything is valid",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems are allowed by default",
+        "schema": {"items": [{"type": "integer"}]},
+        "tests": [
+            {
+                "description": "only the first item is validated",
+                "data": [1, "foo", false],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems does not look in applicators",
+        "schema": {
+            "extends": [
+                { "items": [ { "type": "integer" } ] }
+            ],
+            "additionalItems": { "type": "boolean" }
+        },
+        "tests": [
+            {
+                "description": "items defined in extends are not examined",
+                "data": [ 1, null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems with null instance elements",
+        "schema": {
+            "additionalItems": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/additionalProperties.json
+++ b/asdf/_jsonschema/json/tests/draft3/additionalProperties.json
@@ -1,0 +1,147 @@
+[
+    {
+        "description":
+            "additionalProperties being false does not allow other properties",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "patternProperties": { "^v": {} },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "patternProperties are not additional properties",
+                "data": {"foo":1, "vroom": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "non-ASCII pattern with additionalProperties",
+        "schema": {
+            "patternProperties": {"^á": {}},
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "matching the pattern is valid",
+                "data": {"ármányos": 2},
+                "valid": true
+            },
+            {
+                "description": "not matching the pattern is invalid",
+                "data": {"élmény": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with schema",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties can exist by itself",
+        "schema": {
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties are allowed by default",
+        "schema": {"properties": {"foo": {}, "bar": {}}},
+        "tests": [
+            {
+                "description": "additional properties are allowed",
+                "data": {"foo": 1, "bar": 2, "quux": true},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties does not look in applicators",
+        "schema": {
+            "extends": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in extends are not examined",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with null valued instance properties",
+        "schema": {
+            "additionalProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/default.json
+++ b/asdf/_jsonschema/json/tests/draft3/default.json
@@ -1,0 +1,79 @@
+[
+    {
+        "description": "invalid type for default",
+        "schema": {
+            "properties": {
+                "foo": {
+                    "type": "integer",
+                    "default": []
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"foo": 13},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid string value for default",
+        "schema": {
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "minLength": 4,
+                    "default": "bad"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"bar": "good"},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/dependencies.json
+++ b/asdf/_jsonschema/json/tests/draft3/dependencies.json
@@ -1,0 +1,123 @@
+[
+    {
+        "description": "dependencies",
+        "schema": {
+            "dependencies": {"bar": "foo"}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies",
+        "schema": {
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies subschema",
+        "schema": {
+            "dependencies": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/disallow.json
+++ b/asdf/_jsonschema/json/tests/draft3/disallow.json
@@ -1,0 +1,80 @@
+[
+    {
+        "description": "disallow",
+        "schema": {
+            "disallow": "integer"
+        },
+        "tests": [
+            {
+                "description": "allowed",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "disallowed",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple disallow",
+        "schema": {
+            "disallow": ["integer", "boolean"]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": true,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple disallow subschema",
+        "schema": {
+            "disallow":
+                ["string",
+                 {
+                    "type": "object",
+                    "properties": {
+                        "foo": {
+                            "type": "string"
+                        }
+                    }
+                 }]
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "other match",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/divisibleBy.json
+++ b/asdf/_jsonschema/json/tests/draft3/divisibleBy.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "by int",
+        "schema": {"divisibleBy": 2},
+        "tests": [
+            {
+                "description": "int by int",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "int by int fail",
+                "data": 7,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "by number",
+        "schema": {"divisibleBy": 1.5},
+        "tests": [
+            {
+                "description": "zero is divisible by anything (except 0)",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "4.5 is divisible by 1.5",
+                "data": 4.5,
+                "valid": true
+            },
+            {
+                "description": "35 is not divisible by 1.5",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "by small number",
+        "schema": {"divisibleBy": 0.0001},
+        "tests": [
+            {
+                "description": "0.0075 is divisible by 0.0001",
+                "data": 0.0075,
+                "valid": true
+            },
+            {
+                "description": "0.00751 is not divisible by 0.0001",
+                "data": 0.00751,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/enum.json
+++ b/asdf/_jsonschema/json/tests/draft3/enum.json
@@ -1,0 +1,118 @@
+[
+    {
+        "description": "simple enum validation",
+        "schema": {"enum": [1, 2, 3]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": 4,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum validation",
+        "schema": {"enum": [6, "foo", [], true, {"foo": 12}]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": {"foo": false},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum-with-null validation",
+        "schema": { "enum": [6, null] },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 6,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": "test",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enums in properties",
+        "schema": {
+            "type":"object",
+            "properties": {
+                "foo": {"enum":["foo"]},
+                "bar": {"enum":["bar"], "required":true}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties are valid",
+                "data": {"foo":"foo", "bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "wrong foo value",
+                "data": {"foo":"foot", "bar":"bar"},
+                "valid": false
+            },
+            {
+                "description": "wrong bar value",
+                "data": {"foo":"foo", "bar":"bart"},
+                "valid": false
+            },
+            {
+                "description": "missing optional property is valid",
+                "data": {"bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing required property is invalid",
+                "data": {"foo":"foo"},
+                "valid": false
+            },
+            {
+                "description": "missing all properties is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": { "enum": [ "hello\u0000there" ] },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/extends.json
+++ b/asdf/_jsonschema/json/tests/draft3/extends.json
@@ -1,0 +1,94 @@
+[
+    {
+        "description": "extends",
+        "schema": {
+            "properties": {"bar": {"type": "integer", "required": true}},
+            "extends": {
+                "properties": {
+                    "foo": {"type": "string", "required": true}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "extends",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "mismatch extends",
+                "data": {"foo": "baz"},
+                "valid": false
+            },
+            {
+                "description": "mismatch extended",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "baz", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple extends",
+        "schema": {
+            "properties": {"bar": {"type": "integer", "required": true}},
+            "extends" : [
+                {
+                    "properties": {
+                        "foo": {"type": "string", "required": true}
+                    }
+                },
+                {
+                    "properties": {
+                        "baz": {"type": "null", "required": true}
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "valid": true
+            },
+            {
+                "description": "mismatch first extends",
+                "data": {"bar": 2, "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch second extends",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "mismatch both",
+                "data": {"bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "extends simple types",
+        "schema": {
+            "minimum": 20,
+            "extends": {"maximum": 30}
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": 25,
+                "valid": true
+            },
+            {
+                "description": "mismatch extends",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/format.json
+++ b/asdf/_jsonschema/json/tests/draft3/format.json
@@ -1,0 +1,362 @@
+[
+    {
+        "description": "email format",
+        "schema": { "format": "email" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ip-address format",
+        "schema": { "format": "ip-address" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "host-name format",
+        "schema": { "format": "host-name" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "regex format",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date format",
+        "schema": { "format": "date" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "time format",
+        "schema": { "format": "time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "color format",
+        "schema": { "format": "color" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri format",
+        "schema": { "format": "uri" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/infinite-loop-detection.json
+++ b/asdf/_jsonschema/json/tests/draft3/infinite-loop-detection.json
@@ -1,0 +1,32 @@
+[
+    {
+        "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
+        "schema": {
+            "definitions": {
+                "int": { "type": "integer" }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/definitions/int"
+                }
+            },
+            "extends": {
+                "additionalProperties": {
+                    "$ref": "#/definitions/int"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "passing case",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "failing case",
+                "data": { "foo": "a string" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/items.json
+++ b/asdf/_jsonschema/json/tests/draft3/items.json
@@ -1,0 +1,78 @@
+[
+    {
+        "description": "a schema given for items",
+        "schema": {
+            "items": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of items",
+                "data": [1, "x"],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "an array of schemas for items",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"type": "string"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "correct types",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "wrong types",
+                "data": [ "foo", 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items with null instance elements",
+        "schema": {
+            "items": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items with null instance elements",
+        "schema": {
+            "items": [
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/maxItems.json
+++ b/asdf/_jsonschema/json/tests/draft3/maxItems.json
@@ -1,0 +1,28 @@
+[
+    {
+        "description": "maxItems validation",
+        "schema": {"maxItems": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "foobar",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/maxLength.json
+++ b/asdf/_jsonschema/json/tests/draft3/maxLength.json
@@ -1,0 +1,33 @@
+[
+    {
+        "description": "maxLength validation",
+        "schema": {"maxLength": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/maximum.json
+++ b/asdf/_jsonschema/json/tests/draft3/maximum.json
@@ -1,0 +1,99 @@
+[
+    {
+        "description": "maximum validation",
+        "schema": {"maximum": 3.0},
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maximum validation with unsigned integer",
+        "schema": {"maximum": 300},
+        "tests":  [
+            {
+                "description": "below the maximum is invalid",
+                "data": 299.97,
+                "valid": true
+            },
+            {
+                "description": "boundary point integer is valid",
+                "data": 300,
+                "valid": true
+            },
+            {
+                "description": "boundary point float is valid",
+                "data": 300.00,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 300.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum validation (explicit false exclusivity)",
+        "schema": {"maximum": 3.0, "exclusiveMaximum": false},
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMaximum validation",
+        "schema": {
+            "maximum": 3.0,
+            "exclusiveMaximum": true
+        },
+        "tests": [
+            {
+                "description": "below the maximum is still valid",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 3.0,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/minItems.json
+++ b/asdf/_jsonschema/json/tests/draft3/minItems.json
@@ -1,0 +1,28 @@
+[
+    {
+        "description": "minItems validation",
+        "schema": {"minItems": 1},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/minLength.json
+++ b/asdf/_jsonschema/json/tests/draft3/minLength.json
@@ -1,0 +1,33 @@
+[
+    {
+        "description": "minLength validation",
+        "schema": {"minLength": 2},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/minimum.json
+++ b/asdf/_jsonschema/json/tests/draft3/minimum.json
@@ -1,0 +1,88 @@
+[
+    {
+        "description": "minimum validation",
+        "schema": {"minimum": 1.1},
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMinimum validation",
+        "schema": {
+            "minimum": 1.1,
+            "exclusiveMinimum": true
+        },
+        "tests": [
+            {
+                "description": "above the minimum is still valid",
+                "data": 1.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 1.1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum validation with signed integer",
+        "schema": {"minimum": -2},
+        "tests": [
+            {
+                "description": "negative above the minimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the minimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point with float is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float below the minimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the minimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/bignum.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/bignum.json
@@ -1,0 +1,95 @@
+[
+    {
+        "description": "integer",
+        "schema": { "type": "integer" },
+        "tests": [
+            {
+                "description": "a bignum is an integer",
+                "data": 12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is an integer",
+                "data": -12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "number",
+        "schema": { "type": "number" },
+        "tests": [
+            {
+                "description": "a bignum is a number",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is a number",
+                "data": -98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "string",
+        "schema": { "type": "string" },
+        "tests": [
+            {
+                "description": "a bignum is not a string",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum integer comparison",
+        "schema": { "maximum": 18446744073709551615 },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision",
+        "schema": {
+            "maximum": 972783798187987123879878123.18878137,
+            "exclusiveMaximum": true
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum integer comparison",
+        "schema": { "minimum": -18446744073709551615 },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision on negative numbers",
+        "schema": {
+            "minimum": -972783798187987123879878123.18878137,
+            "exclusiveMinimum": true
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/ecmascript-regex.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/ecmascript-regex.json
@@ -1,0 +1,18 @@
+[
+    {
+        "description": "ECMA 262 regex dialect recognition",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "[^] is a valid regex",
+                "data": "[^]",
+                "valid": true
+            },
+            {
+                "description": "ECMA 262 has no support for lookbehind",
+                "data": "(?<=foo)bar",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/color.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/color.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "validation of CSS colors",
+        "schema": { "format": "color" },
+        "tests": [
+            {
+                "description": "a valid CSS color name",
+                "data": "fuchsia",
+                "valid": true
+            },
+            {
+                "description": "a valid six-digit CSS color code",
+                "data": "#CC8899",
+                "valid": true
+            },
+            {
+                "description": "a valid three-digit CSS color code",
+                "data": "#C89",
+                "valid": true
+            },
+            {
+                "description": "an invalid CSS color code",
+                "data": "#00332520",
+                "valid": false
+            },
+            {
+                "description": "an invalid CSS color name",
+                "data": "puce",
+                "valid": false
+            },
+            {
+                "description": "a CSS color name containing invalid characters",
+                "data": "light_grayish_red-violet",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/date-time.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/date-time.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "validation of date-time strings",
+        "schema": { "format": "date-time" },
+        "tests": [
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "case-insensitive T and Z",
+                "data": "1963-06-19t08:30:06.283185z",
+                "valid": true
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/date.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/date.json
@@ -1,0 +1,168 @@
+[
+    {
+        "description": "validation of date strings",
+        "schema": { "format": "date" },
+        "tests": [
+            {
+                "description": "a valid date string",
+                "data": "1963-06-19",
+                "valid": true
+            },
+            {
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
+                "data": "06/19/1963",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350",
+                "valid": false
+            },
+            {
+                "description": "invalidates non-padded month dates",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "invalidates non-padded day dates",
+                "data": "1998-01-1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/email.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/email.json
@@ -1,0 +1,53 @@
+[
+    {
+        "description": "validation of e-mail addresses",
+        "schema": { "format": "email" },
+        "tests": [
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/host-name.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/host-name.json
@@ -1,0 +1,63 @@
+[
+    {
+        "description": "validation of host names",
+        "schema": { "format": "host-name" },
+        "tests": [
+            {
+                "description": "a valid host name",
+                "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a host name starting with an illegal character",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": false
+            },
+            {
+                "description": "a host name containing illegal characters",
+                "data": "not_a_valid_host_name",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+                "valid": false
+            },
+            {
+                "description": "starts with hyphen",
+                "data": "-hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with hyphen",
+                "data": "hostname-",
+                "valid": false
+            },
+            {
+                "description": "starts with underscore",
+                "data": "_hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with underscore",
+                "data": "hostname_",
+                "valid": false
+            },
+            {
+                "description": "contains underscore",
+                "data": "host_name",
+                "valid": false
+            },
+            {
+                "description": "maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": true
+            },
+            {
+                "description": "exceeds maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/ip-address.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/ip-address.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "validation of IP addresses",
+        "schema": { "format": "ip-address" },
+        "tests": [
+            {
+                "description": "a valid IP address",
+                "data": "192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "an IP address with too many components",
+                "data": "127.0.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "an IP address with out-of-range values",
+                "data": "256.256.256.256",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/ipv6.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/ipv6.json
@@ -1,0 +1,68 @@
+[
+    {
+        "description": "validation of IPv6 addresses",
+        "schema": { "format": "ipv6" },
+        "tests": [
+            {
+                "description": "a valid IPv6 address",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "an IPv6 address with out-of-range values",
+                "data": "12345::",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address with too many components",
+                "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address containing illegal characters",
+                "data": "::laptop",
+                "valid": false
+            },
+            {
+                "description": "no digits is valid",
+                "data": "::",
+                "valid": true
+            },
+            {
+                "description": "leading colons is valid",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "trailing colons is valid",
+                "data": "d6::",
+                "valid": true
+            },
+            {
+                "description": "two sets of double colons is invalid",
+                "data": "1::d6::42",
+                "valid": false
+            },
+            {
+                "description": "mixed format with the ipv4 section as decimal octets",
+                "data": "1::d6:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with double colons between the sections",
+                "data": "1:2::192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with ipv4 section with octet out of range",
+                "data": "1::2:192.168.256.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with ipv4 section with a hex octet",
+                "data": "1::2:192.168.ff.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/regex.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/regex.json
@@ -1,0 +1,18 @@
+[
+    {
+        "description": "validation of regular expressions",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "a valid regular expression",
+                "data": "([abc])+\\s+$",
+                "valid": true
+            },
+            {
+                "description": "a regular expression with unclosed parens is invalid",
+                "data": "^(abc]",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/time.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/time.json
@@ -1,0 +1,18 @@
+[
+    {
+        "description": "validation of time strings",
+        "schema": { "format": "time" },
+        "tests": [
+            {
+                "description": "a valid time string",
+                "data": "08:30:06",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string",
+                "data": "8:30 AM",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/format/uri.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/format/uri.json
@@ -1,0 +1,28 @@
+[
+    {
+        "description": "validation of URIs",
+        "schema": { "format": "uri" },
+        "tests": [
+            {
+                "description": "a valid URI",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "an invalid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI though valid URI reference",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/non-bmp-regex.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/non-bmp-regex.json
@@ -1,0 +1,82 @@
+[
+    {
+        "description": "Proper UTF-16 surrogate pair handling: pattern",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": { "pattern": "^🐲*$" },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Proper UTF-16 surrogate pair handling: patternProperties",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐲": "hello" },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐲🐲": "hello" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/optional/zeroTerminatedFloats.json
+++ b/asdf/_jsonschema/json/tests/draft3/optional/zeroTerminatedFloats.json
@@ -1,0 +1,15 @@
+[
+    {
+        "description": "some languages do not distinguish between different types of numeric value",
+        "schema": {
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "a float is not an integer even without fractional part",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/pattern.json
+++ b/asdf/_jsonschema/json/tests/draft3/pattern.json
@@ -1,0 +1,59 @@
+[
+    {
+        "description": "pattern validation",
+        "schema": {"pattern": "^a*$"},
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "aaa",
+                "valid": true
+            },
+            {
+                "description": "a non-matching pattern is invalid",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {"pattern": "a+"},
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/patternProperties.json
+++ b/asdf/_jsonschema/json/tests/draft3/patternProperties.json
@@ -1,0 +1,130 @@
+[
+    {
+        "description":
+            "patternProperties validates properties matching a regex",
+        "schema": {
+            "patternProperties": {
+                "f.*o": {"type": "integer"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "multiple valid matches is valid",
+                "data": {"foo": 1, "foooooo" : 2},
+                "valid": true
+            },
+            {
+                "description": "a single invalid match is invalid",
+                "data": {"foo": "bar", "fooooo": 2},
+                "valid": false
+            },
+            {
+                "description": "multiple invalid matches is invalid",
+                "data": {"foo": "bar", "foooooo" : "baz"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple simultaneous patternProperties are validated",
+        "schema": {
+            "patternProperties": {
+                "a*": {"type": "integer"},
+                "aaa*": {"maximum": 20}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"a": 21},
+                "valid": true
+            },
+            {
+                "description": "a simultaneous match is valid",
+                "data": {"aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "multiple matches is valid",
+                "data": {"a": 21, "aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "an invalid due to one is invalid",
+                "data": {"a": "bar"},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to the other is invalid",
+                "data": {"aaaa": 31},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to both is invalid",
+                "data": {"aaa": "foo", "aaaa": 31},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "regexes are not anchored by default and are case sensitive",
+        "schema": {
+            "patternProperties": {
+                "[0-9]{2,}": { "type": "boolean" },
+                "X_": { "type": "string" }
+            }
+        },
+        "tests": [
+            {
+                "description": "non recognized members are ignored",
+                "data": { "answer 1": "42" },
+                "valid": true
+            },
+            {
+                "description": "recognized members are accounted for",
+                "data": { "a31b": null },
+                "valid": false
+            },
+            {
+                "description": "regexes are case sensitive",
+                "data": { "a_x_3": 3 },
+                "valid": true
+            },
+            {
+                "description": "regexes are case sensitive, 2",
+                "data": { "a_X_3": 3 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with null valued instance properties",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/properties.json
+++ b/asdf/_jsonschema/json/tests/draft3/properties.json
@@ -1,0 +1,112 @@
+[
+    {
+        "description": "object properties validation",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties present and valid is valid",
+                "data": {"foo": 1, "bar": "baz"},
+                "valid": true
+            },
+            {
+                "description": "one property invalid is invalid",
+                "data": {"foo": 1, "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "both properties invalid is invalid",
+                "data": {"foo": [], "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "doesn't invalidate other properties",
+                "data": {"quux": []},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description":
+            "properties, patternProperties, additionalProperties interaction",
+        "schema": {
+            "properties": {
+                "foo": {"type": "array", "maxItems": 3},
+                "bar": {"type": "array"}
+            },
+            "patternProperties": {"f.o": {"minItems": 2}},
+            "additionalProperties": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "property validates property",
+                "data": {"foo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "property invalidates property",
+                "data": {"foo": [1, 2, 3, 4]},
+                "valid": false
+            },
+            {
+                "description": "patternProperty invalidates property",
+                "data": {"foo": []},
+                "valid": false
+            },
+            {
+                "description": "patternProperty validates nonproperty",
+                "data": {"fxo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "patternProperty invalidates nonproperty",
+                "data": {"fxo": []},
+                "valid": false
+            },
+            {
+                "description": "additionalProperty ignores property",
+                "data": {"bar": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty validates others",
+                "data": {"quux": 3},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty invalidates others",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with null valued instance properties",
+        "schema": {
+            "properties": {
+                "foo": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/ref.json
+++ b/asdf/_jsonschema/json/tests/draft3/ref.json
@@ -1,0 +1,278 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"$ref": "#/items/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "definitions": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
+            },
+            "properties": {
+                "tilde": {"$ref": "#/definitions/tilde~0field"},
+                "slash": {"$ref": "#/definitions/slash~1field"},
+                "percent": {"$ref": "#/definitions/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilde invalid",
+                "data": {"tilde": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilde valid",
+                "data": {"tilde": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "definitions": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/definitions/a"},
+                "c": {"$ref": "#/definitions/b"}
+            },
+            "$ref": "#/definitions/c"
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref overrides any sibling keywords",
+        "schema": {
+            "definitions": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/definitions/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "remote ref valid, maxItems ignored",
+                "data": { "foo": [ 1, 2, 3] },
+                "valid": true
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "properties": {
+                "$ref": {"$ref": "#/definitions/is-string"}
+            },
+            "definitions": {
+                "is-string": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref prevents a sibling id from changing the base uri",
+        "schema": {
+            "id": "http://localhost:1234/sibling_id/base/",
+            "definitions": {
+                "foo": {
+                    "id": "http://localhost:1234/sibling_id/foo.json",
+                    "type": "string"
+                },
+                "base_foo": {
+                    "$comment": "this canonical uri is http://localhost:1234/sibling_id/base/foo.json",
+                    "id": "foo.json",
+                    "type": "number"
+                }
+            },
+            "allOf": [
+                {
+                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not http://localhost:1234/sibling_id/foo.json",
+                    "id": "http://localhost:1234/sibling_id/",
+                    "$ref": "foo.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "$ref resolves to /definitions/base_foo, data does not validate",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "$ref resolves to /definitions/base_foo, data validates",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {"$ref": "http://json-schema.org/draft-03/schema#"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"items": {"type": "integer"}},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"items": {"type": 1}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "definitions": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/definitions/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/definitions/a_string" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/refRemote.json
+++ b/asdf/_jsonschema/json/tests/draft3/refRemote.json
@@ -1,0 +1,74 @@
+[
+    {
+        "description": "remote ref",
+        "schema": {"$ref": "http://localhost:1234/integer.json"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "fragment within remote ref",
+        "schema": {"$ref": "http://localhost:1234/subSchemas.json#/integer"},
+        "tests": [
+            {
+                "description": "remote fragment valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote fragment invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within remote ref",
+        "schema": {
+            "$ref": "http://localhost:1234/subSchemas.json#/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "ref within ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "ref within ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "change resolution scope",
+        "schema": {
+            "id": "http://localhost:1234/",
+            "items": {
+                "id": "baseUriChange/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "changed scope ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "changed scope ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/required.json
+++ b/asdf/_jsonschema/json/tests/draft3/required.json
@@ -1,0 +1,53 @@
+[
+    {
+        "description": "required validation",
+        "schema": {
+            "properties": {
+                "foo": {"required" : true},
+                "bar": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "present required property is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "non-present required property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "required default validation",
+        "schema": {
+            "properties": {
+                "foo": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required by default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required explicitly false validation",
+        "schema": {
+            "properties": {
+                "foo": {"required": false}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required if required is false",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/type.json
+++ b/asdf/_jsonschema/json/tests/draft3/type.json
@@ -1,0 +1,493 @@
+[
+    {
+        "description": "integer type matches integers",
+        "schema": {"type": "integer"},
+        "tests": [
+            {
+                "description": "an integer is an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float is not an integer",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an integer",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not an integer, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not an integer",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not an integer",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an integer",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an integer",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "number type matches numbers",
+        "schema": {"type": "number"},
+        "tests": [
+            {
+                "description": "an integer is a number",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is a number",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is a number",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "a string is not a number",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not a number, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not a number",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a number",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a number",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a number",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "string type matches strings",
+        "schema": {"type": "string"},
+        "tests": [
+            {
+                "description": "1 is not a string",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a string",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a string is still a string, even if it looks like a number",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "an object is not a string",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a string",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a string",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a string",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "object type matches objects",
+        "schema": {"type": "object"},
+        "tests": [
+            {
+                "description": "an integer is not an object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an object",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an object",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is not an object",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an object",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an object",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "array type matches arrays",
+        "schema": {"type": "array"},
+        "tests": [
+            {
+                "description": "an integer is not an array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an array",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an array",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not an array",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is not an array",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an array",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "boolean type matches booleans",
+        "schema": {"type": "boolean"},
+        "tests": [
+            {
+                "description": "an integer is not a boolean",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a boolean",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not a boolean",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not a boolean",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a boolean",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is a boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "null is not a boolean",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "null type matches only the null object",
+        "schema": {"type": "null"},
+        "tests": [
+            {
+                "description": "an integer is not null",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not null",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not null",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not null",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not null",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not null",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "any type matches any type",
+        "schema": {"type": "any"},
+        "tests": [
+            {
+                "description": "any type includes integers",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "any type includes float",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "any type includes string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "any type includes object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "any type includes array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "any type includes boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "any type includes null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple types can be specified in an array",
+        "schema": {"type": ["integer", "string"]},
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "types can include schemas",
+        "schema": {
+            "type": [
+                "array",
+                {"type": "object"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "an integer is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "applies a nested schema",
+        "schema": {
+            "type": [
+                "integer",
+                {
+                    "properties": {
+                        "foo": {"type": "null"}
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "an object is valid only if it is fully valid",
+                "data": {"foo": null},
+                "valid": true
+            },
+            {
+                "description": "an object is invalid otherwise",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "types from separate schemas are merged",
+        "schema": {
+            "type": [
+                {"type": ["string"]},
+                {"type": ["array", "null"]}
+            ]
+        },
+        "tests": [
+            {
+                "description": "an integer is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "an array is valid",
+                "data": [1, 2, 3],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft3/uniqueItems.json
+++ b/asdf/_jsonschema/json/tests/draft3/uniqueItems.json
@@ -1,0 +1,374 @@
+[
+    {
+        "description": "uniqueItems validation",
+        "schema": {"uniqueItems": true},
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
+                "data": [1, 2, 1],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is invalid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": false
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is invalid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": false
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
+                "data": [["foo"], ["bar"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "[1] and [true] are unique",
+                "data": [[1], [true]],
+                "valid": true
+            },
+            {
+                "description": "[0] and [false] are unique",
+                "data": [[0], [false]],
+                "valid": true
+            },
+            {
+                "description": "nested [1] and [true] are unique",
+                "data": [[[1], "foo"], [[true], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "nested [0] and [false] are unique",
+                "data": [[[0], "foo"], [[false], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are invalid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "{\"a\": false} and {\"a\": 0} are unique",
+                "data": [{"a": false}, {"a": 0}],
+                "valid": true
+            },
+            {
+                "description": "{\"a\": true} and {\"a\": 1} are unique",
+                "data": [{"a": true}, {"a": 1}],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is not valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": false
+            },
+            {
+                "description": "non-unique array extended from [true, false] is not valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": { "uniqueItems": false },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/additionalItems.json
+++ b/asdf/_jsonschema/json/tests/draft4/additionalItems.json
@@ -1,0 +1,164 @@
+[
+    {
+        "description": "additionalItems as schema",
+        "schema": {
+            "items": [{}],
+            "additionalItems": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "additional items match schema",
+                "data": [ null, 2, 3, 4 ],
+                "valid": true
+            },
+            {
+                "description": "additional items do not match schema",
+                "data": [ null, 2, 3, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "when items is schema, additionalItems does nothing",
+        "schema": {
+            "items": {},
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "all items match schema",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array of items with no additionalItems permitted",
+        "schema": {
+            "items": [{}, {}, {}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "additional items are not permitted",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems as false without items",
+        "schema": {"additionalItems": false},
+        "tests": [
+            {
+                "description":
+                    "items defaults to empty schema so everything is valid",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems are allowed by default",
+        "schema": {"items": [{"type": "integer"}]},
+        "tests": [
+            {
+                "description": "only the first item is validated",
+                "data": [1, "foo", false],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems does not look in applicators, valid case",
+        "schema": {
+            "allOf": [
+                { "items": [ { "type": "integer" } ] }
+            ],
+            "additionalItems": { "type": "boolean" }
+        },
+        "tests": [
+            {
+                "description": "items defined in allOf are not examined",
+                "data": [ 1, null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems does not look in applicators, invalid case",
+        "schema": {
+            "allOf": [
+                { "items": [ { "type": "integer" }, { "type": "string" } ] }
+            ],
+            "items": [ {"type": "integer" } ],
+            "additionalItems": { "type": "boolean" }
+        },
+        "tests": [
+            {
+                "description": "items defined in allOf are not examined",
+                "data": [ 1, "hello" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items validation adjusts the starting index for additionalItems",
+        "schema": {
+            "items": [ { "type": "string" } ],
+            "additionalItems": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems with null instance elements",
+        "schema": {
+            "additionalItems": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/additionalProperties.json
+++ b/asdf/_jsonschema/json/tests/draft4/additionalProperties.json
@@ -1,0 +1,147 @@
+[
+    {
+        "description":
+            "additionalProperties being false does not allow other properties",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "patternProperties": { "^v": {} },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "patternProperties are not additional properties",
+                "data": {"foo":1, "vroom": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "non-ASCII pattern with additionalProperties",
+        "schema": {
+            "patternProperties": {"^á": {}},
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "matching the pattern is valid",
+                "data": {"ármányos": 2},
+                "valid": true
+            },
+            {
+                "description": "not matching the pattern is invalid",
+                "data": {"élmény": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with schema",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties can exist by itself",
+        "schema": {
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties are allowed by default",
+        "schema": {"properties": {"foo": {}, "bar": {}}},
+        "tests": [
+            {
+                "description": "additional properties are allowed",
+                "data": {"foo": 1, "bar": 2, "quux": true},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties does not look in applicators",
+        "schema": {
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not examined",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with null valued instance properties",
+        "schema": {
+            "additionalProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/allOf.json
+++ b/asdf/_jsonschema/json/tests/draft4/allOf.json
@@ -1,0 +1,261 @@
+[
+    {
+        "description": "allOf",
+        "schema": {
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allOf",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "mismatch second",
+                "data": {"foo": "baz"},
+                "valid": false
+            },
+            {
+                "description": "mismatch first",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "baz", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with base schema",
+        "schema": {
+            "properties": {"bar": {"type": "integer"}},
+            "required": ["bar"],
+            "allOf" : [
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                },
+                {
+                    "properties": {
+                        "baz": {"type": "null"}
+                    },
+                    "required": ["baz"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "valid": true
+            },
+            {
+                "description": "mismatch base schema",
+                "data": {"foo": "quux", "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch first allOf",
+                "data": {"bar": 2, "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch second allOf",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "mismatch both",
+                "data": {"bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf simple types",
+        "schema": {
+            "allOf": [
+                {"maximum": 30},
+                {"minimum": 20}
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": 25,
+                "valid": true
+            },
+            {
+                "description": "mismatch one",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf combined with anyOf, oneOf",
+        "schema": {
+            "allOf": [ { "multipleOf": 2 } ],
+            "anyOf": [ { "multipleOf": 3 } ],
+            "oneOf": [ { "multipleOf": 5 } ]
+        },
+        "tests": [
+            {
+                "description": "allOf: false, anyOf: false, oneOf: false",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: false, oneOf: true",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: false",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: true",
+                "data": 15,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: false",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: true",
+                "data": 10,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: false",
+                "data": 6,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: true",
+                "data": 30,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/anyOf.json
+++ b/asdf/_jsonschema/json/tests/draft4/anyOf.json
@@ -1,0 +1,156 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid",
+                "data": 3,
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one anyOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/default.json
+++ b/asdf/_jsonschema/json/tests/draft4/default.json
@@ -1,0 +1,79 @@
+[
+    {
+        "description": "invalid type for default",
+        "schema": {
+            "properties": {
+                "foo": {
+                    "type": "integer",
+                    "default": []
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"foo": 13},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid string value for default",
+        "schema": {
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "minLength": 4,
+                    "default": "bad"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"bar": "good"},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/definitions.json
+++ b/asdf/_jsonschema/json/tests/draft4/definitions.json
@@ -1,0 +1,26 @@
+[
+    {
+        "description": "validate definition against metaschema",
+        "schema": {"$ref": "http://json-schema.org/draft-04/schema#"},
+        "tests": [
+            {
+                "description": "valid definition schema",
+                "data": {
+                    "definitions": {
+                        "foo": {"type": "integer"}
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid definition schema",
+                "data": {
+                    "definitions": {
+                        "foo": {"type": 1}
+                    }
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/dependencies.json
+++ b/asdf/_jsonschema/json/tests/draft4/dependencies.json
@@ -1,0 +1,194 @@
+[
+    {
+        "description": "dependencies",
+        "schema": {
+            "dependencies": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies",
+        "schema": {
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies subschema",
+        "schema": {
+            "dependencies": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "dependencies": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\tbar": {
+                    "minProperties": 4
+                },
+                "foo'bar": {"required": ["foo\"bar"]},
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "valid object 1",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "valid object 2",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "valid object 3",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid object 1",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 2",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 3",
+                "data": {
+                    "foo'bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 4",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/enum.json
+++ b/asdf/_jsonschema/json/tests/draft4/enum.json
@@ -1,0 +1,236 @@
+[
+    {
+        "description": "simple enum validation",
+        "schema": {"enum": [1, 2, 3]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": 4,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum validation",
+        "schema": {"enum": [6, "foo", [], true, {"foo": 12}]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": {"foo": false},
+                "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum-with-null validation",
+        "schema": { "enum": [6, null] },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 6,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": "test",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enums in properties",
+        "schema": {
+            "type":"object",
+            "properties": {
+                "foo": {"enum":["foo"]},
+                "bar": {"enum":["bar"]}
+            },
+            "required": ["bar"]
+        },
+        "tests": [
+            {
+                "description": "both properties are valid",
+                "data": {"foo":"foo", "bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "wrong foo value",
+                "data": {"foo":"foot", "bar":"bar"},
+                "valid": false
+            },
+            {
+                "description": "wrong bar value",
+                "data": {"foo":"foo", "bar":"bart"},
+                "valid": false
+            },
+            {
+                "description": "missing optional property is valid",
+                "data": {"bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing required property is invalid",
+                "data": {"foo":"foo"},
+                "valid": false
+            },
+            {
+                "description": "missing all properties is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with escaped characters",
+        "schema": {
+            "enum": ["foo\nbar", "foo\rbar"]
+        },
+        "tests": [
+            {
+                "description": "member 1 is valid",
+                "data": "foo\nbar",
+                "valid": true
+            },
+            {
+                "description": "member 2 is valid",
+                "data": "foo\rbar",
+                "valid": true
+            },
+            {
+                "description": "another string is invalid",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {"enum": [false]},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {"enum": [true]},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {"enum": [0]},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {"enum": [1]},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": { "enum": [ "hello\u0000there" ] },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/format.json
+++ b/asdf/_jsonschema/json/tests/draft4/format.json
@@ -1,0 +1,218 @@
+[
+    {
+        "description": "email format",
+        "schema": { "format": "email" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv4 format",
+        "schema": { "format": "ipv4" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "hostname format",
+        "schema": { "format": "hostname" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri format",
+        "schema": { "format": "uri" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/id.json
+++ b/asdf/_jsonschema/json/tests/draft4/id.json
@@ -1,0 +1,53 @@
+[
+    {
+        "description": "id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an id buried in the enum",
+        "schema": {
+            "definitions": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "id": "https://localhost:1234/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "id": "https://localhost:1234/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "id": "https://localhost:1234/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/definitions/id_in_enum" },
+                { "$ref": "https://localhost:1234/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "id": "https://localhost:1234/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to id",
+                "data": "a string to match #/definitions/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+
+]

--- a/asdf/_jsonschema/json/tests/draft4/infinite-loop-detection.json
+++ b/asdf/_jsonschema/json/tests/draft4/infinite-loop-detection.json
@@ -1,0 +1,36 @@
+[
+    {
+        "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
+        "schema": {
+            "definitions": {
+                "int": { "type": "integer" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "$ref": "#/definitions/int"
+                        }
+                    }
+                },
+                {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/int"
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "passing case",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "failing case",
+                "data": { "foo": "a string" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/items.json
+++ b/asdf/_jsonschema/json/tests/draft4/items.json
@@ -1,0 +1,227 @@
+[
+    {
+        "description": "a schema given for items",
+        "schema": {
+            "items": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of items",
+                "data": [1, "x"],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "length": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "an array of schemas for items",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"type": "string"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "correct types",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "wrong types",
+                "data": [ "foo", 1 ],
+                "valid": false
+            },
+            {
+                "description": "incomplete array of items",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with additional items",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "1": "valid",
+                    "length": 2
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "definitions": {
+                "item": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "items": [
+                        { "$ref": "#/definitions/sub-item" },
+                        { "$ref": "#/definitions/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "additionalItems": false,
+            "items": [
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items with null instance elements",
+        "schema": {
+            "items": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items with null instance elements",
+        "schema": {
+            "items": [
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/maxItems.json
+++ b/asdf/_jsonschema/json/tests/draft4/maxItems.json
@@ -1,0 +1,28 @@
+[
+    {
+        "description": "maxItems validation",
+        "schema": {"maxItems": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "foobar",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/maxLength.json
+++ b/asdf/_jsonschema/json/tests/draft4/maxLength.json
@@ -1,0 +1,33 @@
+[
+    {
+        "description": "maxLength validation",
+        "schema": {"maxLength": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/maxProperties.json
+++ b/asdf/_jsonschema/json/tests/draft4/maxProperties.json
@@ -1,0 +1,54 @@
+[
+    {
+        "description": "maxProperties validation",
+        "schema": {"maxProperties": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxProperties = 0 means the object is empty",
+        "schema": { "maxProperties": 0 },
+        "tests": [
+            {
+                "description": "no properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "one property is invalid",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/maximum.json
+++ b/asdf/_jsonschema/json/tests/draft4/maximum.json
@@ -1,0 +1,99 @@
+[
+    {
+        "description": "maximum validation",
+        "schema": {"maximum": 3.0},
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maximum validation with unsigned integer",
+        "schema": {"maximum": 300},
+        "tests":  [
+            {
+                "description": "below the maximum is invalid",
+                "data": 299.97,
+                "valid": true
+            },
+            {
+                "description": "boundary point integer is valid",
+                "data": 300,
+                "valid": true
+            },
+            {
+                "description": "boundary point float is valid",
+                "data": 300.00,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 300.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum validation (explicit false exclusivity)",
+        "schema": {"maximum": 3.0, "exclusiveMaximum": false},
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMaximum validation",
+        "schema": {
+            "maximum": 3.0,
+            "exclusiveMaximum": true
+        },
+        "tests": [
+            {
+                "description": "below the maximum is still valid",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 3.0,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/minItems.json
+++ b/asdf/_jsonschema/json/tests/draft4/minItems.json
@@ -1,0 +1,28 @@
+[
+    {
+        "description": "minItems validation",
+        "schema": {"minItems": 1},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/minLength.json
+++ b/asdf/_jsonschema/json/tests/draft4/minLength.json
@@ -1,0 +1,33 @@
+[
+    {
+        "description": "minLength validation",
+        "schema": {"minLength": 2},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/minProperties.json
+++ b/asdf/_jsonschema/json/tests/draft4/minProperties.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "minProperties validation",
+        "schema": {"minProperties": 1},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/minimum.json
+++ b/asdf/_jsonschema/json/tests/draft4/minimum.json
@@ -1,0 +1,114 @@
+[
+    {
+        "description": "minimum validation",
+        "schema": {"minimum": 1.1},
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minimum validation (explicit false exclusivity)",
+        "schema": {"minimum": 1.1, "exclusiveMinimum": false},
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "exclusiveMinimum validation",
+        "schema": {
+            "minimum": 1.1,
+            "exclusiveMinimum": true
+        },
+        "tests": [
+            {
+                "description": "above the minimum is still valid",
+                "data": 1.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 1.1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum validation with signed integer",
+        "schema": {"minimum": -2},
+        "tests": [
+            {
+                "description": "negative above the minimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the minimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point with float is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float below the minimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the minimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/multipleOf.json
+++ b/asdf/_jsonschema/json/tests/draft4/multipleOf.json
@@ -1,0 +1,71 @@
+[
+    {
+        "description": "by int",
+        "schema": {"multipleOf": 2},
+        "tests": [
+            {
+                "description": "int by int",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "int by int fail",
+                "data": 7,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "by number",
+        "schema": {"multipleOf": 1.5},
+        "tests": [
+            {
+                "description": "zero is multiple of anything",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "4.5 is multiple of 1.5",
+                "data": 4.5,
+                "valid": true
+            },
+            {
+                "description": "35 is not multiple of 1.5",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "by small number",
+        "schema": {"multipleOf": 0.0001},
+        "tests": [
+            {
+                "description": "0.0075 is multiple of 0.0001",
+                "data": 0.0075,
+                "valid": true
+            },
+            {
+                "description": "0.00751 is not multiple of 0.0001",
+                "data": 0.00751,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float division = inf",
+        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "tests": [
+            {
+                "description": "invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/not.json
+++ b/asdf/_jsonschema/json/tests/draft4/not.json
@@ -1,0 +1,96 @@
+[
+    {
+        "description": "not",
+        "schema": {
+            "not": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "allowed",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "disallowed",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not multiple types",
+        "schema": {
+            "not": {"type": ["integer", "boolean"]}
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": true,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not more complex schema",
+        "schema": {
+            "not": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+             }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "other match",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "forbidden property",
+        "schema": {
+            "properties": {
+                "foo": { 
+                    "not": {}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property present",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "property absent",
+                "data": {"bar": 1, "baz": 2},
+                "valid": true
+            }
+        ]
+    }
+
+]

--- a/asdf/_jsonschema/json/tests/draft4/oneOf.json
+++ b/asdf/_jsonschema/json/tests/draft4/oneOf.json
@@ -1,0 +1,230 @@
+[
+    {
+        "description": "oneOf",
+        "schema": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with base schema",
+        "schema": {
+            "type": "string",
+            "oneOf" : [
+                {
+                    "minLength": 2
+                },
+                {
+                    "maxLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one oneOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf complex types",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+	{
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": {},
+                        "baz": {}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/bignum.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/bignum.json
@@ -1,0 +1,95 @@
+[
+    {
+        "description": "integer",
+        "schema": { "type": "integer" },
+        "tests": [
+            {
+                "description": "a bignum is an integer",
+                "data": 12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is an integer",
+                "data": -12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "number",
+        "schema": { "type": "number" },
+        "tests": [
+            {
+                "description": "a bignum is a number",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is a number",
+                "data": -98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "string",
+        "schema": { "type": "string" },
+        "tests": [
+            {
+                "description": "a bignum is not a string",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum integer comparison",
+        "schema": { "maximum": 18446744073709551615 },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision",
+        "schema": {
+            "maximum": 972783798187987123879878123.18878137,
+            "exclusiveMaximum": true
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum integer comparison",
+        "schema": { "minimum": -18446744073709551615 },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision on negative numbers",
+        "schema": {
+            "minimum": -972783798187987123879878123.18878137,
+            "exclusiveMinimum": true
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/ecmascript-regex.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/ecmascript-regex.json
@@ -1,0 +1,552 @@
+[
+    {
+        "description": "ECMA 262 regex $ does not match trailing newline",
+        "schema": {
+            "type": "string",
+            "pattern": "^abc$"
+        },
+        "tests": [
+            {
+                "description": "matches in Python, but not in ECMA 262",
+                "data": "abc\\n",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "abc",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\t$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\t",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0009",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\W matches everything but ascii letters",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
+                "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
+                "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with pattern",
+        "schema": { "pattern": "\\p{Letter}cole" },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
+        "schema": { "pattern": "\\wcole" },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with ASCII ranges",
+        "schema": { "pattern": "[a-z]cole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in pattern matches [0-9], not unicode digits",
+        "schema": { "pattern": "^\\d+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with non-ASCII digits",
+        "schema": { "pattern": "^\\p{digit}+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with patternProperties",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\p{Letter}cole": {}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": {}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with ASCII ranges",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": {}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in patternProperties matches [0-9], not unicode digits",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": {}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with non-ASCII digits",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\p{digit}+$": {}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/float-overflow.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/float-overflow.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {"type": "number", "multipleOf": 0.5},
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/format/date-time.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/format/date-time.json
@@ -1,0 +1,133 @@
+[
+    {
+        "description": "validation of date-time strings",
+        "schema": { "format": "date-time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
+                "data": "1990-02-31T15:59:59.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:59-24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid closing Z after time-zone offset",
+                "data": "1963-06-19T08:30:06.28123+01:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "case-insensitive T and Z",
+                "data": "1963-06-19t08:30:06.283185z",
+                "valid": true
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
+                "data": "1963-06-1৪T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
+                "data": "1963-06-11T0৪:00:00Z",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/format/email.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/format/email.json
@@ -1,0 +1,83 @@
+[
+    {
+        "description": "validation of e-mail addresses",
+        "schema": { "format": "email" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/format/hostname.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/format/hostname.json
@@ -1,0 +1,98 @@
+[
+    {
+        "description": "validation of host names",
+        "schema": { "format": "hostname" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name",
+                "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid punycoded IDN hostname",
+                "data": "xn--4gbwdl.xn--wgbh1c",
+                "valid": true
+            },
+            {
+                "description": "a host name starting with an illegal character",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": false
+            },
+            {
+                "description": "a host name containing illegal characters",
+                "data": "not_a_valid_host_name",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+                "valid": false
+            },
+            {
+                "description": "starts with hyphen",
+                "data": "-hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with hyphen",
+                "data": "hostname-",
+                "valid": false
+            },
+            {
+                "description": "starts with underscore",
+                "data": "_hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with underscore",
+                "data": "hostname_",
+                "valid": false
+            },
+            {
+                "description": "contains underscore",
+                "data": "host_name",
+                "valid": false
+            },
+            {
+                "description": "maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": true
+            },
+            {
+                "description": "exceeds maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/format/ipv4.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/format/ipv4.json
@@ -1,0 +1,84 @@
+[
+    {
+        "description": "validation of IP addresses",
+        "schema": { "format": "ipv4" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IP address",
+                "data": "192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "an IP address with too many components",
+                "data": "127.0.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "an IP address with out-of-range values",
+                "data": "256.256.256.256",
+                "valid": false
+            },
+            {
+                "description": "an IP address without 4 components",
+                "data": "127.0",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer",
+                "data": "0x7f000001",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
+            },
+            {
+                "description": "invalid leading zeroes, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২7.0.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/format/ipv6.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/format/ipv6.json
@@ -1,0 +1,208 @@
+[
+    {
+        "description": "validation of IPv6 addresses",
+        "schema": { "format": "ipv6" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IPv6 address",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "an IPv6 address with out-of-range values",
+                "data": "12345::",
+                "valid": false
+            },
+            {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address with too many components",
+                "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address containing illegal characters",
+                "data": "::laptop",
+                "valid": false
+            },
+            {
+                "description": "no digits is valid",
+                "data": "::",
+                "valid": true
+            },
+            {
+                "description": "leading colons is valid",
+                "data": "::42:ff:1",
+                "valid": true
+            },
+            {
+                "description": "trailing colons is valid",
+                "data": "d6::",
+                "valid": true
+            },
+            {
+                "description": "missing leading octet is invalid",
+                "data": ":2:3:4:5:6:7:8",
+                "valid": false
+            },
+            {
+                "description": "missing trailing octet is invalid",
+                "data": "1:2:3:4:5:6:7:",
+                "valid": false
+            },
+            {
+                "description": "missing leading octet with omitted octets later",
+                "data": ":2:3:4::8",
+                "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
+            },
+            {
+                "description": "two sets of double colons is invalid",
+                "data": "1::d6::42",
+                "valid": false
+            },
+            {
+                "description": "mixed format with the ipv4 section as decimal octets",
+                "data": "1::d6:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with double colons between the sections",
+                "data": "1:2::192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with ipv4 section with octet out of range",
+                "data": "1::2:192.168.256.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with ipv4 section with a hex octet",
+                "data": "1::2:192.168.ff.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with leading double colons (ipv4-mapped ipv6 address)",
+                "data": "::ffff:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "triple colons is invalid",
+                "data": "1:2:3:4:5:::8",
+                "valid": false
+            },
+            {
+                "description": "8 octets",
+                "data": "1:2:3:4:5:6:7:8",
+                "valid": true
+            },
+            {
+                "description": "insufficient octets without double colons",
+                "data": "1:2:3:4:5:6:7",
+                "valid": false
+            },
+            {
+                "description": "no colons is invalid",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 is not ipv6",
+                "data": "127.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 segment must have 4 octets",
+                "data": "1:2:3:4:1.2.3",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1:2:3:4:5:6:7:৪",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
+                "data": "1:2::192.16৪.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/format/unknown.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/format/uri.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/format/uri.json
@@ -1,0 +1,138 @@
+[
+    {
+        "description": "validation of URIs",
+        "schema": { "format": "uri" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag and parentheses",
+                "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with URL-encoded stuff",
+                "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid puny-coded URL ",
+                "data": "http://xn--nw2a.xn--j6w193g/",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid URL based on IPv4",
+                "data": "http://223.255.255.254",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with ftp scheme",
+                "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL for a simple text file",
+                "data": "http://www.ietf.org/rfc/rfc2396.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL ",
+                "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+                "valid": true
+            },
+            {
+                "description": "a valid mailto URI",
+                "data": "mailto:John.Doe@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid newsgroup URI",
+                "data": "news:comp.infosystems.www.servers.unix",
+                "valid": true
+            },
+            {
+                "description": "a valid tel URI",
+                "data": "tel:+1-816-555-1212",
+                "valid": true
+            },
+            {
+                "description": "a valid URN",
+                "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+                "valid": true
+            },
+            {
+                "description": "an invalid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative URI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI though valid URI reference",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces",
+                "data": "http:// shouldfail.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces and missing scheme",
+                "data": ":// should fail",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/non-bmp-regex.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/non-bmp-regex.json
@@ -1,0 +1,82 @@
+[
+    {
+        "description": "Proper UTF-16 surrogate pair handling: pattern",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": { "pattern": "^🐲*$" },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Proper UTF-16 surrogate pair handling: patternProperties",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐲": "hello" },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐲🐲": "hello" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/optional/zeroTerminatedFloats.json
+++ b/asdf/_jsonschema/json/tests/draft4/optional/zeroTerminatedFloats.json
@@ -1,0 +1,15 @@
+[
+    {
+        "description": "some languages do not distinguish between different types of numeric value",
+        "schema": {
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "a float is not an integer even without fractional part",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/pattern.json
+++ b/asdf/_jsonschema/json/tests/draft4/pattern.json
@@ -1,0 +1,59 @@
+[
+    {
+        "description": "pattern validation",
+        "schema": {"pattern": "^a*$"},
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "aaa",
+                "valid": true
+            },
+            {
+                "description": "a non-matching pattern is invalid",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {"pattern": "a+"},
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/patternProperties.json
+++ b/asdf/_jsonschema/json/tests/draft4/patternProperties.json
@@ -1,0 +1,135 @@
+[
+    {
+        "description":
+            "patternProperties validates properties matching a regex",
+        "schema": {
+            "patternProperties": {
+                "f.*o": {"type": "integer"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "multiple valid matches is valid",
+                "data": {"foo": 1, "foooooo" : 2},
+                "valid": true
+            },
+            {
+                "description": "a single invalid match is invalid",
+                "data": {"foo": "bar", "fooooo": 2},
+                "valid": false
+            },
+            {
+                "description": "multiple invalid matches is invalid",
+                "data": {"foo": "bar", "foooooo" : "baz"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple simultaneous patternProperties are validated",
+        "schema": {
+            "patternProperties": {
+                "a*": {"type": "integer"},
+                "aaa*": {"maximum": 20}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"a": 21},
+                "valid": true
+            },
+            {
+                "description": "a simultaneous match is valid",
+                "data": {"aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "multiple matches is valid",
+                "data": {"a": 21, "aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "an invalid due to one is invalid",
+                "data": {"a": "bar"},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to the other is invalid",
+                "data": {"aaaa": 31},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to both is invalid",
+                "data": {"aaa": "foo", "aaaa": 31},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "regexes are not anchored by default and are case sensitive",
+        "schema": {
+            "patternProperties": {
+                "[0-9]{2,}": { "type": "boolean" },
+                "X_": { "type": "string" }
+            }
+        },
+        "tests": [
+            {
+                "description": "non recognized members are ignored",
+                "data": { "answer 1": "42" },
+                "valid": true
+            },
+            {
+                "description": "recognized members are accounted for",
+                "data": { "a31b": null },
+                "valid": false
+            },
+            {
+                "description": "regexes are case sensitive",
+                "data": { "a_x_3": 3 },
+                "valid": true
+            },
+            {
+                "description": "regexes are case sensitive, 2",
+                "data": { "a_X_3": 3 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with null valued instance properties",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/properties.json
+++ b/asdf/_jsonschema/json/tests/draft4/properties.json
@@ -1,0 +1,205 @@
+[
+    {
+        "description": "object properties validation",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties present and valid is valid",
+                "data": {"foo": 1, "bar": "baz"},
+                "valid": true
+            },
+            {
+                "description": "one property invalid is invalid",
+                "data": {"foo": 1, "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "both properties invalid is invalid",
+                "data": {"foo": [], "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "doesn't invalidate other properties",
+                "data": {"quux": []},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description":
+            "properties, patternProperties, additionalProperties interaction",
+        "schema": {
+            "properties": {
+                "foo": {"type": "array", "maxItems": 3},
+                "bar": {"type": "array"}
+            },
+            "patternProperties": {"f.o": {"minItems": 2}},
+            "additionalProperties": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "property validates property",
+                "data": {"foo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "property invalidates property",
+                "data": {"foo": [1, 2, 3, 4]},
+                "valid": false
+            },
+            {
+                "description": "patternProperty invalidates property",
+                "data": {"foo": []},
+                "valid": false
+            },
+            {
+                "description": "patternProperty validates nonproperty",
+                "data": {"fxo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "patternProperty invalidates nonproperty",
+                "data": {"fxo": []},
+                "valid": false
+            },
+            {
+                "description": "additionalProperty ignores property",
+                "data": {"bar": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty validates others",
+                "data": {"quux": 3},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty invalidates others",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with escaped characters",
+        "schema": {
+            "properties": {
+                "foo\nbar": {"type": "number"},
+                "foo\"bar": {"type": "number"},
+                "foo\\bar": {"type": "number"},
+                "foo\rbar": {"type": "number"},
+                "foo\tbar": {"type": "number"},
+                "foo\fbar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with all numbers is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1",
+                    "foo\\bar": "1",
+                    "foo\rbar": "1",
+                    "foo\tbar": "1",
+                    "foo\fbar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with null valued instance properties",
+        "schema": {
+            "properties": {
+                "foo": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "properties": {
+                "__proto__": {"type": "number"},
+                "toString": {
+                    "properties": { "length": { "type": "string" } }
+                },
+                "constructor": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "__proto__ not valid",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString not valid",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor not valid",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present and valid",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/ref.json
+++ b/asdf/_jsonschema/json/tests/draft4/ref.json
@@ -1,0 +1,507 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"$ref": "#/items/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "definitions": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
+            },
+            "properties": {
+                "tilde": {"$ref": "#/definitions/tilde~0field"},
+                "slash": {"$ref": "#/definitions/slash~1field"},
+                "percent": {"$ref": "#/definitions/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilde invalid",
+                "data": {"tilde": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilde valid",
+                "data": {"tilde": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "definitions": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/definitions/a"},
+                "c": {"$ref": "#/definitions/b"}
+            },
+            "allOf": [{ "$ref": "#/definitions/c" }]
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref overrides any sibling keywords",
+        "schema": {
+            "definitions": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/definitions/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "ref valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "ref valid, maxItems ignored",
+                "data": { "foo": [ 1, 2, 3] },
+                "valid": true
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref prevents a sibling id from changing the base uri",
+        "schema": {
+            "id": "http://localhost:1234/sibling_id/base/",
+            "definitions": {
+                "foo": {
+                    "id": "http://localhost:1234/sibling_id/foo.json",
+                    "type": "string"
+                },
+                "base_foo": {
+                    "$comment": "this canonical uri is http://localhost:1234/sibling_id/base/foo.json",
+                    "id": "foo.json",
+                    "type": "number"
+                }
+            },
+            "allOf": [
+                {
+                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not http://localhost:1234/sibling_id/foo.json",
+                    "id": "http://localhost:1234/sibling_id/",
+                    "$ref": "foo.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "$ref resolves to /definitions/base_foo, data does not validate",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "$ref resolves to /definitions/base_foo, data validates",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {"$ref": "http://json-schema.org/draft-04/schema#"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"minLength": 1},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"minLength": -1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "properties": {
+                "$ref": {"$ref": "#/definitions/is-string"}
+            },
+            "definitions": {
+                "is-string": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "id": "http://localhost:1234/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {
+                    "type": "array",
+                    "items": {"$ref": "node"}
+                }
+            },
+            "required": ["meta", "nodes"],
+            "definitions": {
+                "node": {
+                    "id": "http://localhost:1234/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "subtree": {"$ref": "tree"}
+                    },
+                    "required": ["value"]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid tree",
+                "data": { 
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 1.1},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid tree",
+                "data": { 
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": "string is invalid"},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "properties": {
+                "foo\"bar": {"$ref": "#/definitions/foo%22bar"}
+            },
+            "definitions": {
+                "foo\"bar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with numbers is valid",
+                "data": {
+                    "foo\"bar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier",
+        "schema": {
+            "allOf": [{
+                "$ref": "#foo"
+            }],
+            "definitions": {
+                "A": {
+                    "id": "#foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with base URI change in subschema",
+        "schema": {
+            "id": "http://localhost:1234/root",
+            "allOf": [{
+                "$ref": "http://localhost:1234/nested.json#foo"
+            }],
+            "definitions": {
+                "A": {
+                    "id": "nested.json",
+                    "definitions": {
+                        "B": {
+                            "id": "#foo",
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "definitions": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/definitions/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/definitions/a_string" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "id": "http://example.com/a.json",
+            "definitions": {
+                "x": {
+                    "id": "http://example.com/b/c.json",
+                    "not": {
+                        "definitions": {
+                            "y": {
+                                "id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/refRemote.json
+++ b/asdf/_jsonschema/json/tests/draft4/refRemote.json
@@ -1,0 +1,189 @@
+[
+    {
+        "description": "remote ref",
+        "schema": {"$ref": "http://localhost:1234/integer.json"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "fragment within remote ref",
+        "schema": {"$ref": "http://localhost:1234/subSchemas.json#/integer"},
+        "tests": [
+            {
+                "description": "remote fragment valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote fragment invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within remote ref",
+        "schema": {
+            "$ref": "http://localhost:1234/subSchemas.json#/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "ref within ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "ref within ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change",
+        "schema": {
+            "id": "http://localhost:1234/",
+            "items": {
+                "id": "baseUriChange/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "base URI change ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "base URI change ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder",
+        "schema": {
+            "id": "http://localhost:1234/scope_change_defs1.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz"}
+            },
+            "definitions": {
+                "baz": {
+                    "id": "baseUriChangeFolder/",
+                    "type": "array",
+                    "items": {"$ref": "folderInteger.json"}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "id": "http://localhost:1234/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz/definitions/bar"}
+            },
+            "definitions": {
+                "baz": {
+                    "id": "baseUriChangeFolderInSubschema/",
+                    "definitions": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "root ref in remote ref",
+        "schema": {
+            "id": "http://localhost:1234/object",
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "name.json#/definitions/orNull"}
+            }
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": {
+                    "name": null
+                },
+                "valid": true
+            },
+            {
+                "description": "object is invalid",
+                "data": {
+                    "name": {
+                        "name": null
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier in remote ref",
+        "schema": {
+            "$ref": "http://localhost:1234/locationIndependentIdentifierDraft4.json#/definitions/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/required.json
+++ b/asdf/_jsonschema/json/tests/draft4/required.json
@@ -1,0 +1,135 @@
+[
+    {
+        "description": "required validation",
+        "schema": {
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "required": ["foo"]
+        },
+        "tests": [
+            {
+                "description": "present required property is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "non-present required property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required default validation",
+        "schema": {
+            "properties": {
+                "foo": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required by default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with escaped characters",
+        "schema": {
+            "required": [
+                "foo\nbar",
+                "foo\"bar",
+                "foo\\bar",
+                "foo\rbar",
+                "foo\tbar",
+                "foo\fbar"
+            ]
+        },
+        "tests": [
+            {
+                "description": "object with all properties present is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with some properties missing is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "required properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": { "required": ["__proto__", "toString", "constructor"] },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "__proto__ present",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString present",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor present",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/type.json
+++ b/asdf/_jsonschema/json/tests/draft4/type.json
@@ -1,0 +1,469 @@
+[
+    {
+        "description": "integer type matches integers",
+        "schema": {"type": "integer"},
+        "tests": [
+            {
+                "description": "an integer is an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float is not an integer",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an integer",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not an integer, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not an integer",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not an integer",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an integer",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an integer",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "number type matches numbers",
+        "schema": {"type": "number"},
+        "tests": [
+            {
+                "description": "an integer is a number",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is a number",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is a number",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "a string is not a number",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not a number, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not a number",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a number",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a number",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a number",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "string type matches strings",
+        "schema": {"type": "string"},
+        "tests": [
+            {
+                "description": "1 is not a string",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a string",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a string is still a string, even if it looks like a number",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an object is not a string",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a string",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a string",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a string",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "object type matches objects",
+        "schema": {"type": "object"},
+        "tests": [
+            {
+                "description": "an integer is not an object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an object",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an object",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is not an object",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an object",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an object",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "array type matches arrays",
+        "schema": {"type": "array"},
+        "tests": [
+            {
+                "description": "an integer is not an array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an array",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an array",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not an array",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is not an array",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an array",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "boolean type matches booleans",
+        "schema": {"type": "boolean"},
+        "tests": [
+            {
+                "description": "an integer is not a boolean",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a float is not a boolean",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not a boolean",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not a boolean",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a boolean",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is a boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is not a boolean",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "null type matches only the null object",
+        "schema": {"type": "null"},
+        "tests": [
+            {
+                "description": "an integer is not null",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not null",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a string is not null",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not null",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not null",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is not null",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple types can be specified in an array",
+        "schema": {"type": ["integer", "string"]},
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft4/uniqueItems.json
+++ b/asdf/_jsonschema/json/tests/draft4/uniqueItems.json
@@ -1,0 +1,404 @@
+[
+    {
+        "description": "uniqueItems validation",
+        "schema": {"uniqueItems": true},
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
+                "data": [1, 2, 1],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is invalid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": false
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is invalid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": false
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
+                "data": [["foo"], ["bar"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "[1] and [true] are unique",
+                "data": [[1], [true]],
+                "valid": true
+            },
+            {
+                "description": "[0] and [false] are unique",
+                "data": [[0], [false]],
+                "valid": true
+            },
+            {
+                "description": "nested [1] and [true] are unique",
+                "data": [[[1], "foo"], [[true], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "nested [0] and [false] are unique",
+                "data": [[[0], "foo"], [[false], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1, "{}"],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are invalid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
+                "valid": false
+            },
+            {
+                "description": "{\"a\": false} and {\"a\": 0} are unique",
+                "data": [{"a": false}, {"a": 0}],
+                "valid": true
+            },
+            {
+                "description": "{\"a\": true} and {\"a\": 1} are unique",
+                "data": [{"a": true}, {"a": 1}],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is not valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": false
+            },
+            {
+                "description": "non-unique array extended from [true, false] is not valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": { "uniqueItems": false },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/additionalItems.json
+++ b/asdf/_jsonschema/json/tests/draft6/additionalItems.json
@@ -1,0 +1,164 @@
+[
+    {
+        "description": "additionalItems as schema",
+        "schema": {
+            "items": [{}],
+            "additionalItems": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "additional items match schema",
+                "data": [ null, 2, 3, 4 ],
+                "valid": true
+            },
+            {
+                "description": "additional items do not match schema",
+                "data": [ null, 2, 3, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "when items is schema, additionalItems does nothing",
+        "schema": {
+            "items": {},
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "all items match schema",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array of items with no additionalItems permitted",
+        "schema": {
+            "items": [{}, {}, {}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "additional items are not permitted",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems as false without items",
+        "schema": {"additionalItems": false},
+        "tests": [
+            {
+                "description":
+                    "items defaults to empty schema so everything is valid",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems are allowed by default",
+        "schema": {"items": [{"type": "integer"}]},
+        "tests": [
+            {
+                "description": "only the first item is validated",
+                "data": [1, "foo", false],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems does not look in applicators, valid case",
+        "schema": {
+            "allOf": [
+                { "items": [ { "type": "integer" } ] }
+            ],
+            "additionalItems": { "type": "boolean" }
+        },
+        "tests": [
+            {
+                "description": "items defined in allOf are not examined",
+                "data": [ 1, null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems does not look in applicators, invalid case",
+        "schema": {
+            "allOf": [
+                { "items": [ { "type": "integer" }, { "type": "string" } ] }
+            ],
+            "items": [ {"type": "integer" } ],
+            "additionalItems": { "type": "boolean" }
+        },
+        "tests": [
+            {
+                "description": "items defined in allOf are not examined",
+                "data": [ 1, "hello" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items validation adjusts the starting index for additionalItems",
+        "schema": {
+            "items": [ { "type": "string" } ],
+            "additionalItems": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems with null instance elements",
+        "schema": {
+            "additionalItems": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/additionalProperties.json
+++ b/asdf/_jsonschema/json/tests/draft6/additionalProperties.json
@@ -1,0 +1,147 @@
+[
+    {
+        "description":
+            "additionalProperties being false does not allow other properties",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "patternProperties": { "^v": {} },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "patternProperties are not additional properties",
+                "data": {"foo":1, "vroom": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "non-ASCII pattern with additionalProperties",
+        "schema": {
+            "patternProperties": {"^á": {}},
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "matching the pattern is valid",
+                "data": {"ármányos": 2},
+                "valid": true
+            },
+            {
+                "description": "not matching the pattern is invalid",
+                "data": {"élmény": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with schema",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties can exist by itself",
+        "schema": {
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties are allowed by default",
+        "schema": {"properties": {"foo": {}, "bar": {}}},
+        "tests": [
+            {
+                "description": "additional properties are allowed",
+                "data": {"foo": 1, "bar": 2, "quux": true},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties does not look in applicators",
+        "schema": {
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not examined",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with null valued instance properties",
+        "schema": {
+            "additionalProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/allOf.json
+++ b/asdf/_jsonschema/json/tests/draft6/allOf.json
@@ -1,0 +1,294 @@
+[
+    {
+        "description": "allOf",
+        "schema": {
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allOf",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "mismatch second",
+                "data": {"foo": "baz"},
+                "valid": false
+            },
+            {
+                "description": "mismatch first",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "baz", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with base schema",
+        "schema": {
+            "properties": {"bar": {"type": "integer"}},
+            "required": ["bar"],
+            "allOf" : [
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                },
+                {
+                    "properties": {
+                        "baz": {"type": "null"}
+                    },
+                    "required": ["baz"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "valid": true
+            },
+            {
+                "description": "mismatch base schema",
+                "data": {"foo": "quux", "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch first allOf",
+                "data": {"bar": 2, "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch second allOf",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "mismatch both",
+                "data": {"bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf simple types",
+        "schema": {
+            "allOf": [
+                {"maximum": 30},
+                {"minimum": 20}
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": 25,
+                "valid": true
+            },
+            {
+                "description": "mismatch one",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all true",
+        "schema": {"allOf": [true, true]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, some false",
+        "schema": {"allOf": [true, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all false",
+        "schema": {"allOf": [false, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf combined with anyOf, oneOf",
+        "schema": {
+            "allOf": [ { "multipleOf": 2 } ],
+            "anyOf": [ { "multipleOf": 3 } ],
+            "oneOf": [ { "multipleOf": 5 } ]
+        },
+        "tests": [
+            {
+                "description": "allOf: false, anyOf: false, oneOf: false",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: false, oneOf: true",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: false",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: true",
+                "data": 15,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: false",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: true",
+                "data": 10,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: false",
+                "data": 6,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: true",
+                "data": 30,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/anyOf.json
+++ b/asdf/_jsonschema/json/tests/draft6/anyOf.json
@@ -1,0 +1,189 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid",
+                "data": 3,
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one anyOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all true",
+        "schema": {"anyOf": [true, true]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, some true",
+        "schema": {"anyOf": [true, false]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all false",
+        "schema": {"anyOf": [false, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/boolean_schema.json
+++ b/asdf/_jsonschema/json/tests/draft6/boolean_schema.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "boolean schema 'true'",
+        "schema": true,
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "boolean true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "boolean false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean schema 'false'",
+        "schema": false,
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "boolean true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "boolean false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/const.json
+++ b/asdf/_jsonschema/json/tests/draft6/const.json
@@ -1,0 +1,342 @@
+[
+    {
+        "description": "const validation",
+        "schema": {"const": 2},
+        "tests": [
+            {
+                "description": "same value is valid",
+                "data": 2,
+                "valid": true
+            },
+            {
+                "description": "another value is invalid",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with object",
+        "schema": {"const": {"foo": "bar", "baz": "bax"}},
+        "tests": [
+            {
+                "description": "same object is valid",
+                "data": {"foo": "bar", "baz": "bax"},
+                "valid": true
+            },
+            {
+                "description": "same object with different property order is valid",
+                "data": {"baz": "bax", "foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "another object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": [1, 2],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with array",
+        "schema": {"const": [{ "foo": "bar" }]},
+        "tests": [
+            {
+                "description": "same array is valid",
+                "data": [{"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "another array item is invalid",
+                "data": [2],
+                "valid": false
+            },
+            {
+                "description": "array with additional items is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with null",
+        "schema": {"const": null},
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "not null is invalid",
+                "data": 0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with false does not match 0",
+        "schema": {"const": false},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with true does not match 1",
+        "schema": {"const": true},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [false] does not match [0]",
+        "schema": {"const": [false]},
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [true] does not match [1]",
+        "schema": {"const": [true]},
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": false} does not match {\"a\": 0}",
+        "schema": {"const": {"a": false}},
+        "tests": [
+            {
+                "description": "{\"a\": false} is valid",
+                "data": {"a": false},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 0} is invalid",
+                "data": {"a": 0},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 0.0} is invalid",
+                "data": {"a": 0.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": true} does not match {\"a\": 1}",
+        "schema": {"const": {"a": true}},
+        "tests": [
+            {
+                "description": "{\"a\": true} is valid",
+                "data": {"a": true},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 1} is invalid",
+                "data": {"a": 1},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 1.0} is invalid",
+                "data": {"a": 1.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 0 does not match other zero-like types",
+        "schema": {"const": 0},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
+                "data": "",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 1 does not match true",
+        "schema": {"const": 1},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "const with -2.0 matches integer and float types",
+        "schema": {"const": -2.0},
+        "tests": [
+            {
+                "description": "integer -2 is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "integer 2 is invalid",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "float -2.0 is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float 2.0 is invalid",
+                "data": 2.0,
+                "valid": false
+            },
+            {
+                "description": "float -2.00001 is invalid",
+                "data": -2.00001,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float and integers are equal up to 64-bit representation limits",
+        "schema": {"const": 9007199254740992},
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 9007199254740992,
+                "valid": true
+            },
+            {
+                "description": "integer minus one is invalid",
+                "data": 9007199254740991,
+                "valid": false
+            },
+            {
+                "description": "float is valid",
+                "data": 9007199254740992.0,
+                "valid": true
+            },
+            {
+                "description": "float minus one is invalid",
+                "data": 9007199254740991.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": { "const": "hello\u0000there" },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/contains.json
+++ b/asdf/_jsonschema/json/tests/draft6/contains.json
@@ -1,0 +1,144 @@
+[
+    {
+        "description": "contains keyword validation",
+        "schema": {
+            "contains": {"minimum": 5}
+        },
+        "tests": [
+            {
+                "description": "array with item matching schema (5) is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with item matching schema (6) is valid",
+                "data": [3, 4, 6],
+                "valid": true
+            },
+            {
+                "description": "array with two items matching schema (5, 6) is valid",
+                "data": [3, 4, 5, 6],
+                "valid": true
+            },
+            {
+                "description": "array without items matching schema is invalid",
+                "data": [2, 3, 4],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "not array is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with const keyword",
+        "schema": {
+            "contains": { "const": 5 }
+        },
+        "tests": [
+            {
+                "description": "array with item 5 is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with two items 5 is valid",
+                "data": [3, 4, 5, 5],
+                "valid": true
+            },
+            {
+                "description": "array without item 5 is invalid",
+                "data": [1, 2, 3, 4],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema true",
+        "schema": {"contains": true},
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema false",
+        "schema": {"contains": false},
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "non-arrays are valid",
+                "data": "contains does not apply to strings",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items + contains",
+        "schema": {
+            "items": { "multipleOf": 2 },
+            "contains": { "multipleOf": 3 }
+        },
+        "tests": [
+            {
+                "description": "matches items, does not match contains",
+                "data": [ 2, 4, 8 ],
+                "valid": false
+            },
+            {
+                "description": "does not match items, matches contains",
+                "data": [ 3, 6, 9 ],
+                "valid": false
+            },
+            {
+                "description": "matches both items and contains",
+                "data": [ 6, 12 ],
+                "valid": true
+            },
+            {
+                "description": "matches neither items nor contains",
+                "data": [ 1, 5 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with null instance elements",
+        "schema": {
+            "contains": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null items",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/default.json
+++ b/asdf/_jsonschema/json/tests/draft6/default.json
@@ -1,0 +1,79 @@
+[
+    {
+        "description": "invalid type for default",
+        "schema": {
+            "properties": {
+                "foo": {
+                    "type": "integer",
+                    "default": []
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"foo": 13},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid string value for default",
+        "schema": {
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "minLength": 4,
+                    "default": "bad"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"bar": "good"},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/definitions.json
+++ b/asdf/_jsonschema/json/tests/draft6/definitions.json
@@ -1,0 +1,26 @@
+[
+    {
+        "description": "validate definition against metaschema",
+        "schema": {"$ref": "http://json-schema.org/draft-06/schema#"},
+        "tests": [
+            {
+                "description": "valid definition schema",
+                "data": {
+                    "definitions": {
+                        "foo": {"type": "integer"}
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid definition schema",
+                "data": {
+                    "definitions": {
+                        "foo": {"type": 1}
+                    }
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/dependencies.json
+++ b/asdf/_jsonschema/json/tests/draft6/dependencies.json
@@ -1,0 +1,248 @@
+[
+    {
+        "description": "dependencies",
+        "schema": {
+            "dependencies": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with empty array",
+        "schema": {
+            "dependencies": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies",
+        "schema": {
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies subschema",
+        "schema": {
+            "dependencies": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with boolean subschemas",
+        "schema": {
+            "dependencies": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "dependencies": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\tbar": {
+                    "minProperties": 4
+                },
+                "foo'bar": {"required": ["foo\"bar"]},
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "valid object 1",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "valid object 2",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "valid object 3",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid object 1",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 2",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 3",
+                "data": {
+                    "foo'bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 4",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/enum.json
+++ b/asdf/_jsonschema/json/tests/draft6/enum.json
@@ -1,0 +1,236 @@
+[
+    {
+        "description": "simple enum validation",
+        "schema": {"enum": [1, 2, 3]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": 4,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum validation",
+        "schema": {"enum": [6, "foo", [], true, {"foo": 12}]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": {"foo": false},
+                "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum-with-null validation",
+        "schema": { "enum": [6, null] },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 6,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": "test",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enums in properties",
+        "schema": {
+            "type":"object",
+            "properties": {
+                "foo": {"enum":["foo"]},
+                "bar": {"enum":["bar"]}
+            },
+            "required": ["bar"]
+        },
+        "tests": [
+            {
+                "description": "both properties are valid",
+                "data": {"foo":"foo", "bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "wrong foo value",
+                "data": {"foo":"foot", "bar":"bar"},
+                "valid": false
+            },
+            {
+                "description": "wrong bar value",
+                "data": {"foo":"foo", "bar":"bart"},
+                "valid": false
+            },
+            {
+                "description": "missing optional property is valid",
+                "data": {"bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing required property is invalid",
+                "data": {"foo":"foo"},
+                "valid": false
+            },
+            {
+                "description": "missing all properties is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with escaped characters",
+        "schema": {
+            "enum": ["foo\nbar", "foo\rbar"]
+        },
+        "tests": [
+            {
+                "description": "member 1 is valid",
+                "data": "foo\nbar",
+                "valid": true
+            },
+            {
+                "description": "member 2 is valid",
+                "data": "foo\rbar",
+                "valid": true
+            },
+            {
+                "description": "another string is invalid",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {"enum": [false]},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {"enum": [true]},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {"enum": [0]},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {"enum": [1]},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": { "enum": [ "hello\u0000there" ] },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/exclusiveMaximum.json
+++ b/asdf/_jsonschema/json/tests/draft6/exclusiveMaximum.json
@@ -1,0 +1,30 @@
+[
+    {
+        "description": "exclusiveMaximum validation",
+        "schema": {
+            "exclusiveMaximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the exclusiveMaximum is valid",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 3.0,
+                "valid": false
+            },
+            {
+                "description": "above the exclusiveMaximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/exclusiveMinimum.json
+++ b/asdf/_jsonschema/json/tests/draft6/exclusiveMinimum.json
@@ -1,0 +1,30 @@
+[
+    {
+        "description": "exclusiveMinimum validation",
+        "schema": {
+            "exclusiveMinimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the exclusiveMinimum is valid",
+                "data": 1.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "below the exclusiveMinimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/format.json
+++ b/asdf/_jsonschema/json/tests/draft6/format.json
@@ -1,0 +1,326 @@
+[
+    {
+        "description": "email format",
+        "schema": { "format": "email" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv4 format",
+        "schema": { "format": "ipv4" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "hostname format",
+        "schema": { "format": "hostname" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "json-pointer format",
+        "schema": { "format": "json-pointer" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri format",
+        "schema": { "format": "uri" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-reference format",
+        "schema": { "format": "uri-reference" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-template format",
+        "schema": { "format": "uri-template" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/id.json
+++ b/asdf/_jsonschema/json/tests/draft6/id.json
@@ -1,0 +1,134 @@
+[
+    {
+        "description": "id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an id buried in the enum",
+        "schema": {
+            "definitions": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "$id": "https://localhost:1234/id/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "$id": "https://localhost:1234/id/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/definitions/id_in_enum" },
+                { "$ref": "https://localhost:1234/id/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to id",
+                "data": "a string to match #/definitions/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing a plain-name $id property",
+        "schema": {
+            "definitions": {
+                "const_not_anchor": {
+                    "const": {
+                        "$id": "#not_a_real_anchor"
+                    }
+                }
+            },
+            "oneOf": [
+                {
+                    "const": "skip not_a_real_anchor"
+                },
+                {
+                    "allOf": [
+                        {
+                            "not": {
+                                "const": "skip not_a_real_anchor"
+                            }
+                        },
+                        {
+                            "$ref": "#/definitions/const_not_anchor"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_anchor",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_anchor does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $id property",
+        "schema": {
+            "definitions": {
+                "const_not_id": {
+                    "const": {
+                        "$id": "not_a_real_id"
+                    }
+                }
+            },
+            "oneOf": [
+                {
+                    "const":"skip not_a_real_id"
+                },
+                {
+                    "allOf": [
+                        {
+                            "not": {
+                                "const": "skip not_a_real_id"
+                            }
+                        },
+                        {
+                            "$ref": "#/definitions/const_not_id"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_id",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_id does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/infinite-loop-detection.json
+++ b/asdf/_jsonschema/json/tests/draft6/infinite-loop-detection.json
@@ -1,0 +1,36 @@
+[
+    {
+        "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
+        "schema": {
+            "definitions": {
+                "int": { "type": "integer" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "$ref": "#/definitions/int"
+                        }
+                    }
+                },
+                {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/int"
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "passing case",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "failing case",
+                "data": { "foo": "a string" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/items.json
+++ b/asdf/_jsonschema/json/tests/draft6/items.json
@@ -1,0 +1,282 @@
+[
+    {
+        "description": "a schema given for items",
+        "schema": {
+            "items": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of items",
+                "data": [1, "x"],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "length": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "an array of schemas for items",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"type": "string"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "correct types",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "wrong types",
+                "data": [ "foo", 1 ],
+                "valid": false
+            },
+            {
+                "description": "incomplete array of items",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with additional items",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "1": "valid",
+                    "length": 2
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (true)",
+        "schema": {"items": true},
+        "tests": [
+            {
+                "description": "any array is valid",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (false)",
+        "schema": {"items": false},
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": [ 1, "foo", true ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schemas",
+        "schema": {
+            "items": [true, false]
+        },
+        "tests": [
+            {
+                "description": "array with one item is valid",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with two items is invalid",
+                "data": [ 1, "foo" ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "definitions": {
+                "item": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "items": [
+                        { "$ref": "#/definitions/sub-item" },
+                        { "$ref": "#/definitions/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "additionalItems": false,
+            "items": [
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "single-form items with null instance elements",
+        "schema": {
+            "items": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items with null instance elements",
+        "schema": {
+            "items": [
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/maxItems.json
+++ b/asdf/_jsonschema/json/tests/draft6/maxItems.json
@@ -1,0 +1,44 @@
+[
+    {
+        "description": "maxItems validation",
+        "schema": {"maxItems": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "foobar",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {"maxItems": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/maxLength.json
+++ b/asdf/_jsonschema/json/tests/draft6/maxLength.json
@@ -1,0 +1,49 @@
+[
+    {
+        "description": "maxLength validation",
+        "schema": {"maxLength": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {"maxLength": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/maxProperties.json
+++ b/asdf/_jsonschema/json/tests/draft6/maxProperties.json
@@ -1,0 +1,70 @@
+[
+    {
+        "description": "maxProperties validation",
+        "schema": {"maxProperties": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxProperties validation with a decimal",
+        "schema": {"maxProperties": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxProperties = 0 means the object is empty",
+        "schema": { "maxProperties": 0 },
+        "tests": [
+            {
+                "description": "no properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "one property is invalid",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/maximum.json
+++ b/asdf/_jsonschema/json/tests/draft6/maximum.json
@@ -1,0 +1,54 @@
+[
+    {
+        "description": "maximum validation",
+        "schema": {"maximum": 3.0},
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maximum validation with unsigned integer",
+        "schema": {"maximum": 300},
+        "tests":  [
+            {
+                "description": "below the maximum is invalid",
+                "data": 299.97,
+                "valid": true
+            },
+            {
+                "description": "boundary point integer is valid",
+                "data": 300,
+                "valid": true
+            },
+            {
+                "description": "boundary point float is valid",
+                "data": 300.00,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 300.5,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/minItems.json
+++ b/asdf/_jsonschema/json/tests/draft6/minItems.json
@@ -1,0 +1,44 @@
+[
+    {
+        "description": "minItems validation",
+        "schema": {"minItems": 1},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {"minItems": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/minLength.json
+++ b/asdf/_jsonschema/json/tests/draft6/minLength.json
@@ -1,0 +1,49 @@
+[
+    {
+        "description": "minLength validation",
+        "schema": {"minLength": 2},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {"minLength": 2.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/minProperties.json
+++ b/asdf/_jsonschema/json/tests/draft6/minProperties.json
@@ -1,0 +1,54 @@
+[
+    {
+        "description": "minProperties validation",
+        "schema": {"minProperties": 1},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {"minProperties": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/minimum.json
+++ b/asdf/_jsonschema/json/tests/draft6/minimum.json
@@ -1,0 +1,69 @@
+[
+    {
+        "description": "minimum validation",
+        "schema": {"minimum": 1.1},
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minimum validation with signed integer",
+        "schema": {"minimum": -2},
+        "tests": [
+            {
+                "description": "negative above the minimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the minimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point with float is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float below the minimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the minimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/multipleOf.json
+++ b/asdf/_jsonschema/json/tests/draft6/multipleOf.json
@@ -1,0 +1,71 @@
+[
+    {
+        "description": "by int",
+        "schema": {"multipleOf": 2},
+        "tests": [
+            {
+                "description": "int by int",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "int by int fail",
+                "data": 7,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "by number",
+        "schema": {"multipleOf": 1.5},
+        "tests": [
+            {
+                "description": "zero is multiple of anything",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "4.5 is multiple of 1.5",
+                "data": 4.5,
+                "valid": true
+            },
+            {
+                "description": "35 is not multiple of 1.5",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "by small number",
+        "schema": {"multipleOf": 0.0001},
+        "tests": [
+            {
+                "description": "0.0075 is multiple of 0.0001",
+                "data": 0.0075,
+                "valid": true
+            },
+            {
+                "description": "0.00751 is not multiple of 0.0001",
+                "data": 0.00751,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float division = inf",
+        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/not.json
+++ b/asdf/_jsonschema/json/tests/draft6/not.json
@@ -1,0 +1,117 @@
+[
+    {
+        "description": "not",
+        "schema": {
+            "not": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "allowed",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "disallowed",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not multiple types",
+        "schema": {
+            "not": {"type": ["integer", "boolean"]}
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": true,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not more complex schema",
+        "schema": {
+            "not": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+             }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "other match",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "forbidden property",
+        "schema": {
+            "properties": {
+                "foo": { 
+                    "not": {}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property present",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "property absent",
+                "data": {"bar": 1, "baz": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema true",
+        "schema": {"not": true},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema false",
+        "schema": {"not": false},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/oneOf.json
+++ b/asdf/_jsonschema/json/tests/draft6/oneOf.json
@@ -1,0 +1,274 @@
+[
+    {
+        "description": "oneOf",
+        "schema": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with base schema",
+        "schema": {
+            "type": "string",
+            "oneOf" : [
+                {
+                    "minLength": 2
+                },
+                {
+                    "maxLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one oneOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all true",
+        "schema": {"oneOf": [true, true, true]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, one true",
+        "schema": {"oneOf": [true, false, false]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, more than one true",
+        "schema": {"oneOf": [true, true, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all false",
+        "schema": {"oneOf": [false, false, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf complex types",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+	{
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": true,
+                        "baz": true
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/bignum.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/bignum.json
@@ -1,0 +1,93 @@
+[
+    {
+        "description": "integer",
+        "schema": { "type": "integer" },
+        "tests": [
+            {
+                "description": "a bignum is an integer",
+                "data": 12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is an integer",
+                "data": -12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "number",
+        "schema": { "type": "number" },
+        "tests": [
+            {
+                "description": "a bignum is a number",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is a number",
+                "data": -98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "string",
+        "schema": { "type": "string" },
+        "tests": [
+            {
+                "description": "a bignum is not a string",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum integer comparison",
+        "schema": { "maximum": 18446744073709551615 },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision",
+        "schema": {
+            "exclusiveMaximum": 972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum integer comparison",
+        "schema": { "minimum": -18446744073709551615 },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision on negative numbers",
+        "schema": {
+            "exclusiveMinimum": -972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/ecmascript-regex.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/ecmascript-regex.json
@@ -1,0 +1,552 @@
+[
+    {
+        "description": "ECMA 262 regex $ does not match trailing newline",
+        "schema": {
+            "type": "string",
+            "pattern": "^abc$"
+        },
+        "tests": [
+            {
+                "description": "matches in Python, but not in ECMA 262",
+                "data": "abc\\n",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "abc",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\t$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\t",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0009",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\W matches everything but ascii letters",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
+                "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
+                "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with pattern",
+        "schema": { "pattern": "\\p{Letter}cole" },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
+        "schema": { "pattern": "\\wcole" },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with ASCII ranges",
+        "schema": { "pattern": "[a-z]cole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in pattern matches [0-9], not unicode digits",
+        "schema": { "pattern": "^\\d+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with non-ASCII digits",
+        "schema": { "pattern": "^\\p{digit}+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with patternProperties",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\p{Letter}cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with ASCII ranges",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in patternProperties matches [0-9], not unicode digits",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with non-ASCII digits",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\p{digit}+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/float-overflow.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/float-overflow.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {"type": "integer", "multipleOf": 0.5},
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/date-time.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/date-time.json
@@ -1,0 +1,133 @@
+[
+    {
+        "description": "validation of date-time strings",
+        "schema": { "format": "date-time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
+                "data": "1990-02-31T15:59:59.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:59-24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid closing Z after time-zone offset",
+                "data": "1963-06-19T08:30:06.28123+01:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "case-insensitive T and Z",
+                "data": "1963-06-19t08:30:06.283185z",
+                "valid": true
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
+                "data": "1963-06-1৪T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
+                "data": "1963-06-11T0৪:00:00Z",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/email.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/email.json
@@ -1,0 +1,83 @@
+[
+    {
+        "description": "validation of e-mail addresses",
+        "schema": { "format": "email" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/hostname.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/hostname.json
@@ -1,0 +1,98 @@
+[
+    {
+        "description": "validation of host names",
+        "schema": { "format": "hostname" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name",
+                "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid punycoded IDN hostname",
+                "data": "xn--4gbwdl.xn--wgbh1c",
+                "valid": true
+            },
+            {
+                "description": "a host name starting with an illegal character",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": false
+            },
+            {
+                "description": "a host name containing illegal characters",
+                "data": "not_a_valid_host_name",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+                "valid": false
+            },
+            {
+                "description": "starts with hyphen",
+                "data": "-hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with hyphen",
+                "data": "hostname-",
+                "valid": false
+            },
+            {
+                "description": "starts with underscore",
+                "data": "_hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with underscore",
+                "data": "hostname_",
+                "valid": false
+            },
+            {
+                "description": "contains underscore",
+                "data": "host_name",
+                "valid": false
+            },
+            {
+                "description": "maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": true
+            },
+            {
+                "description": "exceeds maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/ipv4.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/ipv4.json
@@ -1,0 +1,84 @@
+[
+    {
+        "description": "validation of IP addresses",
+        "schema": { "format": "ipv4" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IP address",
+                "data": "192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "an IP address with too many components",
+                "data": "127.0.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "an IP address with out-of-range values",
+                "data": "256.256.256.256",
+                "valid": false
+            },
+            {
+                "description": "an IP address without 4 components",
+                "data": "127.0",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer",
+                "data": "0x7f000001",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
+            },
+            {
+                "description": "invalid leading zeroes, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২7.0.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/ipv6.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/ipv6.json
@@ -1,0 +1,208 @@
+[
+    {
+        "description": "validation of IPv6 addresses",
+        "schema": { "format": "ipv6" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IPv6 address",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "an IPv6 address with out-of-range values",
+                "data": "12345::",
+                "valid": false
+            },
+            {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address with too many components",
+                "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address containing illegal characters",
+                "data": "::laptop",
+                "valid": false
+            },
+            {
+                "description": "no digits is valid",
+                "data": "::",
+                "valid": true
+            },
+            {
+                "description": "leading colons is valid",
+                "data": "::42:ff:1",
+                "valid": true
+            },
+            {
+                "description": "trailing colons is valid",
+                "data": "d6::",
+                "valid": true
+            },
+            {
+                "description": "missing leading octet is invalid",
+                "data": ":2:3:4:5:6:7:8",
+                "valid": false
+            },
+            {
+                "description": "missing trailing octet is invalid",
+                "data": "1:2:3:4:5:6:7:",
+                "valid": false
+            },
+            {
+                "description": "missing leading octet with omitted octets later",
+                "data": ":2:3:4::8",
+                "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
+            },
+            {
+                "description": "two sets of double colons is invalid",
+                "data": "1::d6::42",
+                "valid": false
+            },
+            {
+                "description": "mixed format with the ipv4 section as decimal octets",
+                "data": "1::d6:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with double colons between the sections",
+                "data": "1:2::192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with ipv4 section with octet out of range",
+                "data": "1::2:192.168.256.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with ipv4 section with a hex octet",
+                "data": "1::2:192.168.ff.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with leading double colons (ipv4-mapped ipv6 address)",
+                "data": "::ffff:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "triple colons is invalid",
+                "data": "1:2:3:4:5:::8",
+                "valid": false
+            },
+            {
+                "description": "8 octets",
+                "data": "1:2:3:4:5:6:7:8",
+                "valid": true
+            },
+            {
+                "description": "insufficient octets without double colons",
+                "data": "1:2:3:4:5:6:7",
+                "valid": false
+            },
+            {
+                "description": "no colons is invalid",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 is not ipv6",
+                "data": "127.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 segment must have 4 octets",
+                "data": "1:2:3:4:1.2.3",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1:2:3:4:5:6:7:৪",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
+                "data": "1:2::192.16৪.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/json-pointer.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/json-pointer.json
@@ -1,0 +1,198 @@
+[
+    {
+        "description": "validation of JSON-pointers (JSON String Representation)",
+        "schema": { "format": "json-pointer" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid JSON-pointer",
+                "data": "/foo/bar~0/baz~1/%a",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (~ not escaped)",
+                "data": "/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "valid JSON-pointer with empty segment",
+                "data": "/foo//bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer with the last empty segment",
+                "data": "/foo/bar/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #1",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #2",
+                "data": "/foo",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #3",
+                "data": "/foo/0",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #4",
+                "data": "/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #5",
+                "data": "/a~1b",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #6",
+                "data": "/c%d",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #7",
+                "data": "/e^f",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #8",
+                "data": "/g|h",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #9",
+                "data": "/i\\j",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #10",
+                "data": "/k\"l",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #11",
+                "data": "/ ",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #12",
+                "data": "/m~0n",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer used adding to the last array position",
+                "data": "/foo/-",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (- used as object member name)",
+                "data": "/foo/-/bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (multiple escaped characters)",
+                "data": "/~1~0~0~1~1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #1",
+                "data": "/~1.1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #2",
+                "data": "/~0.1",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #1",
+                "data": "#",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #2",
+                "data": "#/",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #3",
+                "data": "#a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #1",
+                "data": "/~0~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #2",
+                "data": "/~0/~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #1",
+                "data": "/~2",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #2",
+                "data": "/~-1",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (multiple characters not escaped)",
+                "data": "/~~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #1",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #2",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #3",
+                "data": "a/a",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/unknown.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/uri-reference.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/uri-reference.json
@@ -1,0 +1,73 @@
+[
+    {
+        "description": "validation of URI References",
+        "schema": { "format": "uri-reference" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URI",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid relative URI Reference",
+                "data": "/abc",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI Reference",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "a valid URI Reference",
+                "data": "abc",
+                "valid": true
+            },
+            {
+                "description": "a valid URI fragment",
+                "data": "#fragment",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI fragment",
+                "data": "#frag\\ment",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/uri-template.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/uri-template.json
@@ -1,0 +1,58 @@
+[
+    {
+        "description": "format: uri-template",
+        "schema": { "format": "uri-template" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term}",
+                "valid": true
+            },
+            {
+                "description": "an invalid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": false
+            },
+            {
+                "description": "a valid uri-template without variables",
+                "data": "http://example.com/dictionary",
+                "valid": true
+            },
+            {
+                "description": "a valid relative uri-template",
+                "data": "dictionary/{term:1}/{term}",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/format/uri.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/format/uri.json
@@ -1,0 +1,138 @@
+[
+    {
+        "description": "validation of URIs",
+        "schema": { "format": "uri" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag and parentheses",
+                "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with URL-encoded stuff",
+                "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid puny-coded URL ",
+                "data": "http://xn--nw2a.xn--j6w193g/",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid URL based on IPv4",
+                "data": "http://223.255.255.254",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with ftp scheme",
+                "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL for a simple text file",
+                "data": "http://www.ietf.org/rfc/rfc2396.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL ",
+                "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+                "valid": true
+            },
+            {
+                "description": "a valid mailto URI",
+                "data": "mailto:John.Doe@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid newsgroup URI",
+                "data": "news:comp.infosystems.www.servers.unix",
+                "valid": true
+            },
+            {
+                "description": "a valid tel URI",
+                "data": "tel:+1-816-555-1212",
+                "valid": true
+            },
+            {
+                "description": "a valid URN",
+                "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+                "valid": true
+            },
+            {
+                "description": "an invalid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative URI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI though valid URI reference",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces",
+                "data": "http:// shouldfail.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces and missing scheme",
+                "data": ":// should fail",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/optional/non-bmp-regex.json
+++ b/asdf/_jsonschema/json/tests/draft6/optional/non-bmp-regex.json
@@ -1,0 +1,82 @@
+[
+    {
+        "description": "Proper UTF-16 surrogate pair handling: pattern",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": { "pattern": "^🐲*$" },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Proper UTF-16 surrogate pair handling: patternProperties",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐲": "hello" },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐲🐲": "hello" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/pattern.json
+++ b/asdf/_jsonschema/json/tests/draft6/pattern.json
@@ -1,0 +1,59 @@
+[
+    {
+        "description": "pattern validation",
+        "schema": {"pattern": "^a*$"},
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "aaa",
+                "valid": true
+            },
+            {
+                "description": "a non-matching pattern is invalid",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {"pattern": "a+"},
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/patternProperties.json
+++ b/asdf/_jsonschema/json/tests/draft6/patternProperties.json
@@ -1,0 +1,171 @@
+[
+    {
+        "description":
+            "patternProperties validates properties matching a regex",
+        "schema": {
+            "patternProperties": {
+                "f.*o": {"type": "integer"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "multiple valid matches is valid",
+                "data": {"foo": 1, "foooooo" : 2},
+                "valid": true
+            },
+            {
+                "description": "a single invalid match is invalid",
+                "data": {"foo": "bar", "fooooo": 2},
+                "valid": false
+            },
+            {
+                "description": "multiple invalid matches is invalid",
+                "data": {"foo": "bar", "foooooo" : "baz"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple simultaneous patternProperties are validated",
+        "schema": {
+            "patternProperties": {
+                "a*": {"type": "integer"},
+                "aaa*": {"maximum": 20}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"a": 21},
+                "valid": true
+            },
+            {
+                "description": "a simultaneous match is valid",
+                "data": {"aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "multiple matches is valid",
+                "data": {"a": 21, "aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "an invalid due to one is invalid",
+                "data": {"a": "bar"},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to the other is invalid",
+                "data": {"aaaa": 31},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to both is invalid",
+                "data": {"aaa": "foo", "aaaa": 31},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "regexes are not anchored by default and are case sensitive",
+        "schema": {
+            "patternProperties": {
+                "[0-9]{2,}": { "type": "boolean" },
+                "X_": { "type": "string" }
+            }
+        },
+        "tests": [
+            {
+                "description": "non recognized members are ignored",
+                "data": { "answer 1": "42" },
+                "valid": true
+            },
+            {
+                "description": "recognized members are accounted for",
+                "data": { "a31b": null },
+                "valid": false
+            },
+            {
+                "description": "regexes are case sensitive",
+                "data": { "a_x_3": 3 },
+                "valid": true
+            },
+            {
+                "description": "regexes are case sensitive, 2",
+                "data": { "a_X_3": 3 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with boolean schemas",
+        "schema": {
+            "patternProperties": {
+                "f.*": true,
+                "b.*": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property matching schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property matching schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with a property matching both true and false is invalid",
+                "data": {"foobar":1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with null valued instance properties",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/properties.json
+++ b/asdf/_jsonschema/json/tests/draft6/properties.json
@@ -1,0 +1,236 @@
+[
+    {
+        "description": "object properties validation",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties present and valid is valid",
+                "data": {"foo": 1, "bar": "baz"},
+                "valid": true
+            },
+            {
+                "description": "one property invalid is invalid",
+                "data": {"foo": 1, "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "both properties invalid is invalid",
+                "data": {"foo": [], "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "doesn't invalidate other properties",
+                "data": {"quux": []},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description":
+            "properties, patternProperties, additionalProperties interaction",
+        "schema": {
+            "properties": {
+                "foo": {"type": "array", "maxItems": 3},
+                "bar": {"type": "array"}
+            },
+            "patternProperties": {"f.o": {"minItems": 2}},
+            "additionalProperties": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "property validates property",
+                "data": {"foo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "property invalidates property",
+                "data": {"foo": [1, 2, 3, 4]},
+                "valid": false
+            },
+            {
+                "description": "patternProperty invalidates property",
+                "data": {"foo": []},
+                "valid": false
+            },
+            {
+                "description": "patternProperty validates nonproperty",
+                "data": {"fxo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "patternProperty invalidates nonproperty",
+                "data": {"fxo": []},
+                "valid": false
+            },
+            {
+                "description": "additionalProperty ignores property",
+                "data": {"bar": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty validates others",
+                "data": {"quux": 3},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty invalidates others",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with boolean schema",
+        "schema": {
+            "properties": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no property present is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "only 'true' property present is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "only 'false' property present is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "both properties present is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with escaped characters",
+        "schema": {
+            "properties": {
+                "foo\nbar": {"type": "number"},
+                "foo\"bar": {"type": "number"},
+                "foo\\bar": {"type": "number"},
+                "foo\rbar": {"type": "number"},
+                "foo\tbar": {"type": "number"},
+                "foo\fbar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with all numbers is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1",
+                    "foo\\bar": "1",
+                    "foo\rbar": "1",
+                    "foo\tbar": "1",
+                    "foo\fbar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with null valued instance properties",
+        "schema": {
+            "properties": {
+                "foo": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "properties": {
+                "__proto__": {"type": "number"},
+                "toString": {
+                    "properties": { "length": { "type": "string" } }
+                },
+                "constructor": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "__proto__ not valid",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString not valid",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor not valid",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present and valid",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/propertyNames.json
+++ b/asdf/_jsonschema/json/tests/draft6/propertyNames.json
@@ -1,0 +1,107 @@
+[
+    {
+        "description": "propertyNames validation",
+        "schema": {
+            "propertyNames": {"maxLength": 3}
+        },
+        "tests": [
+            {
+                "description": "all property names valid",
+                "data": {
+                    "f": {},
+                    "foo": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "some property names invalid",
+                "data": {
+                    "foo": {},
+                    "foobar": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3, 4],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames validation with pattern",
+        "schema": {
+            "propertyNames": { "pattern": "^a+$" }
+        },
+        "tests": [
+            {
+                "description": "matching property names valid",
+                "data": {
+                    "a": {},
+                    "aa": {},
+                    "aaa": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "non-matching property name is invalid",
+                "data": {
+                    "aaA": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema true",
+        "schema": {"propertyNames": true},
+        "tests": [
+            {
+                "description": "object with any properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema false",
+        "schema": {"propertyNames": false},
+        "tests": [
+            {
+                "description": "object with any properties is invalid",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/ref.json
+++ b/asdf/_jsonschema/json/tests/draft6/ref.json
@@ -1,0 +1,786 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"$ref": "#/items/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "definitions": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
+            },
+            "properties": {
+                "tilde": {"$ref": "#/definitions/tilde~0field"},
+                "slash": {"$ref": "#/definitions/slash~1field"},
+                "percent": {"$ref": "#/definitions/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilde invalid",
+                "data": {"tilde": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilde valid",
+                "data": {"tilde": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "definitions": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/definitions/a"},
+                "c": {"$ref": "#/definitions/b"}
+            },
+            "allOf": [{ "$ref": "#/definitions/c" }]
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref overrides any sibling keywords",
+        "schema": {
+            "definitions": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/definitions/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "ref valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "ref valid, maxItems ignored",
+                "data": { "foo": [ 1, 2, 3] },
+                "valid": true
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref prevents a sibling $id from changing the base uri",
+        "schema": {
+            "$id": "http://localhost:1234/sibling_id/base/",
+            "definitions": {
+                "foo": {
+                    "$id": "http://localhost:1234/sibling_id/foo.json",
+                    "type": "string"
+                },
+                "base_foo": {
+                    "$comment": "this canonical uri is http://localhost:1234/sibling_id/base/foo.json",
+                    "$id": "foo.json",
+                    "type": "number"
+                }
+            },
+            "allOf": [
+                {
+                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not http://localhost:1234/sibling_id/foo.json",
+                    "$id": "http://localhost:1234/sibling_id/",
+                    "$ref": "foo.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "$ref resolves to /definitions/base_foo, data does not validate",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "$ref resolves to /definitions/base_foo, data validates",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {"$ref": "http://json-schema.org/draft-06/schema#"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"minLength": 1},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"minLength": -1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "properties": {
+                "$ref": {"$ref": "#/definitions/is-string"}
+            },
+            "definitions": {
+                "is-string": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema true",
+        "schema": {
+            "allOf": [{ "$ref": "#/definitions/bool" }],
+            "definitions": {
+                "bool": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema false",
+        "schema": {
+            "allOf": [{ "$ref": "#/definitions/bool" }],
+            "definitions": {
+                "bool": false
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "$id": "http://localhost:1234/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {
+                    "type": "array",
+                    "items": {"$ref": "node"}
+                }
+            },
+            "required": ["meta", "nodes"],
+            "definitions": {
+                "node": {
+                    "$id": "http://localhost:1234/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "subtree": {"$ref": "tree"}
+                    },
+                    "required": ["value"]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid tree",
+                "data": { 
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 1.1},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid tree",
+                "data": { 
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": "string is invalid"},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "properties": {
+                "foo\"bar": {"$ref": "#/definitions/foo%22bar"}
+            },
+            "definitions": {
+                "foo\"bar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with numbers is valid",
+                "data": {
+                    "foo\"bar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier",
+        "schema": {
+            "allOf": [{
+                "$ref": "#foo"
+            }],
+            "definitions": {
+                "A": {
+                    "$id": "#foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with base URI change in subschema",
+        "schema": {
+            "$id": "http://localhost:1234/root",
+            "allOf": [{
+                "$ref": "http://localhost:1234/nested.json#foo"
+            }],
+            "definitions": {
+                "A": {
+                    "$id": "nested.json",
+                    "definitions": {
+                        "B": {
+                            "$id": "#foo",
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "definitions": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/definitions/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "do not evaluate the $ref inside the enum, definition exact match",
+                "data": { "type": "string" },
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/definitions/a_string" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "refs with relative uris and defs",
+        "schema": {
+            "$id": "http://example.com/schema-relative-uri-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "schema-relative-uri-defs2.json",
+                    "definitions": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "allOf": [ { "$ref": "#/definitions/inner" } ]
+                }
+            },
+            "allOf": [ { "$ref": "schema-relative-uri-defs2.json" } ]
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative refs with absolute uris and defs",
+        "schema": {
+            "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "http://example.com/schema-refs-absolute-uris-defs2.json",
+                    "definitions": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "allOf": [ { "$ref": "#/definitions/inner" } ]
+                }
+            },
+            "allOf": [ { "$ref": "schema-refs-absolute-uris-defs2.json" } ]
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with $ref via the URN",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "minimum": 30,
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
+            }
+        },
+        "tests": [
+            {
+                "description": "valid under the URN IDed schema",
+                "data": {"foo": 37},
+                "valid": true
+            },
+            {
+                "description": "invalid under the URN IDed schema",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with JSON pointer",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with NSS",
+        "schema": {
+            "$comment": "RFC 8141 §2.2",
+            "$id": "urn:example:1/406/47452/2",
+            "properties": {
+                "foo": {"$ref": "#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with r-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.1",
+            "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
+            "properties": {
+                "foo": {"$ref": "#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with q-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.2",
+            "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
+            "properties": {
+                "foo": {"$ref": "#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and JSON pointer ref",
+        "schema": {
+            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and anchor ref",
+        "schema": {
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
+            },
+            "definitions": {
+                "bar": {
+                    "$id": "#something",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/refRemote.json
+++ b/asdf/_jsonschema/json/tests/draft6/refRemote.json
@@ -1,0 +1,239 @@
+[
+    {
+        "description": "remote ref",
+        "schema": {"$ref": "http://localhost:1234/integer.json"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "fragment within remote ref",
+        "schema": {"$ref": "http://localhost:1234/subSchemas.json#/integer"},
+        "tests": [
+            {
+                "description": "remote fragment valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote fragment invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within remote ref",
+        "schema": {
+            "$ref": "http://localhost:1234/subSchemas.json#/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "ref within ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "ref within ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change",
+        "schema": {
+            "$id": "http://localhost:1234/",
+            "items": {
+                "$id": "baseUriChange/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "base URI change ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "base URI change ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs1.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz"}
+            },
+            "definitions": {
+                "baz": {
+                    "$id": "baseUriChangeFolder/",
+                    "type": "array",
+                    "items": {"$ref": "folderInteger.json"}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz/definitions/bar"}
+            },
+            "definitions": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema/",
+                    "definitions": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "root ref in remote ref",
+        "schema": {
+            "$id": "http://localhost:1234/object",
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "name.json#/definitions/orNull"}
+            }
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": {
+                    "name": null
+                },
+                "valid": true
+            },
+            {
+                "description": "object is invalid",
+                "data": {
+                    "name": {
+                        "name": null
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref with ref to definitions",
+        "schema": {
+            "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
+            "allOf": [
+                { "$ref": "ref-and-definitions.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "invalid",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid",
+                "data": {
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier in remote ref",
+        "schema": {
+            "$ref": "http://localhost:1234/locationIndependentIdentifierPre2019.json#/definitions/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "retrieved nested refs resolve relative to their URI not $id",
+        "schema": {
+            "$id": "http://localhost:1234/some-id",
+            "properties": {
+                "name": {"$ref": "nested/foo-ref-string.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": {
+                    "name": {"foo":  1}
+                },
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/required.json
+++ b/asdf/_jsonschema/json/tests/draft6/required.json
@@ -1,0 +1,151 @@
+[
+    {
+        "description": "required validation",
+        "schema": {
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "required": ["foo"]
+        },
+        "tests": [
+            {
+                "description": "present required property is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "non-present required property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required default validation",
+        "schema": {
+            "properties": {
+                "foo": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required by default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with empty array",
+        "schema": {
+            "properties": {
+                "foo": {}
+            },
+            "required": []
+        },
+        "tests": [
+            {
+                "description": "property not required",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with escaped characters",
+        "schema": {
+            "required": [
+                "foo\nbar",
+                "foo\"bar",
+                "foo\\bar",
+                "foo\rbar",
+                "foo\tbar",
+                "foo\fbar"
+            ]
+        },
+        "tests": [
+            {
+                "description": "object with all properties present is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with some properties missing is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "required properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": { "required": ["__proto__", "toString", "constructor"] },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "__proto__ present",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString present",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor present",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/type.json
+++ b/asdf/_jsonschema/json/tests/draft6/type.json
@@ -1,0 +1,474 @@
+[
+    {
+        "description": "integer type matches integers",
+        "schema": {"type": "integer"},
+        "tests": [
+            {
+                "description": "an integer is an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is an integer",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is not an integer",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an integer",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not an integer, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not an integer",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not an integer",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an integer",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an integer",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "number type matches numbers",
+        "schema": {"type": "number"},
+        "tests": [
+            {
+                "description": "an integer is a number",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is a number (and an integer)",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is a number",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "a string is not a number",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not a number, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not a number",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a number",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a number",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a number",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "string type matches strings",
+        "schema": {"type": "string"},
+        "tests": [
+            {
+                "description": "1 is not a string",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a string",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a string is still a string, even if it looks like a number",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an object is not a string",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a string",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a string",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a string",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "object type matches objects",
+        "schema": {"type": "object"},
+        "tests": [
+            {
+                "description": "an integer is not an object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an object",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an object",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is not an object",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an object",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an object",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "array type matches arrays",
+        "schema": {"type": "array"},
+        "tests": [
+            {
+                "description": "an integer is not an array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an array",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an array",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not an array",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is not an array",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an array",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "boolean type matches booleans",
+        "schema": {"type": "boolean"},
+        "tests": [
+            {
+                "description": "an integer is not a boolean",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a float is not a boolean",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not a boolean",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not a boolean",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a boolean",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is a boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is not a boolean",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "null type matches only the null object",
+        "schema": {"type": "null"},
+        "tests": [
+            {
+                "description": "an integer is not null",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not null",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a string is not null",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not null",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not null",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is not null",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple types can be specified in an array",
+        "schema": {"type": ["integer", "string"]},
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/uniqueItems.json
+++ b/asdf/_jsonschema/json/tests/draft6/uniqueItems.json
@@ -1,0 +1,404 @@
+[
+    {
+        "description": "uniqueItems validation",
+        "schema": {"uniqueItems": true},
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
+                "data": [1, 2, 1],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is invalid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": false
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is invalid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": false
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
+                "data": [["foo"], ["bar"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "[1] and [true] are unique",
+                "data": [[1], [true]],
+                "valid": true
+            },
+            {
+                "description": "[0] and [false] are unique",
+                "data": [[0], [false]],
+                "valid": true
+            },
+            {
+                "description": "nested [1] and [true] are unique",
+                "data": [[[1], "foo"], [[true], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "nested [0] and [false] are unique",
+                "data": [[[0], "foo"], [[false], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1, "{}"],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are invalid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
+                "valid": false
+            },
+            {
+                "description": "{\"a\": false} and {\"a\": 0} are unique",
+                "data": [{"a": false}, {"a": 0}],
+                "valid": true
+            },
+            {
+                "description": "{\"a\": true} and {\"a\": 1} are unique",
+                "data": [{"a": true}, {"a": 1}],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is not valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": false
+            },
+            {
+                "description": "non-unique array extended from [true, false] is not valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": { "uniqueItems": false },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft6/unknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/draft6/unknownKeyword.json
@@ -1,0 +1,56 @@
+[
+    {
+        "description": "$id inside an unknown keyword is not a real identifier",
+        "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
+        "schema": {
+            "definitions": {
+                "id_in_unknown0": {
+                    "not": {
+                        "array_of_schemas": [
+                            {
+                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                    "type": "string"
+                },
+                "id_in_unknown1": {
+                    "not": {
+                        "object_of_schemas": {
+                            "foo": {
+                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "type": "integer"
+                            }
+                        }
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/definitions/id_in_unknown0" },
+                { "$ref": "#/definitions/id_in_unknown1" },
+                { "$ref": "https://localhost:1234/unknownKeyword/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "type matches second anyOf, which has a real schema in it",
+                "data": "a string",
+                "valid": true
+            },
+            {
+                "description": "type matches non-schema in first anyOf",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "type matches non-schema in third anyOf",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/additionalItems.json
+++ b/asdf/_jsonschema/json/tests/draft7/additionalItems.json
@@ -1,0 +1,164 @@
+[
+    {
+        "description": "additionalItems as schema",
+        "schema": {
+            "items": [{}],
+            "additionalItems": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "additional items match schema",
+                "data": [ null, 2, 3, 4 ],
+                "valid": true
+            },
+            {
+                "description": "additional items do not match schema",
+                "data": [ null, 2, 3, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "when items is schema, additionalItems does nothing",
+        "schema": {
+            "items": {},
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "all items match schema",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array of items with no additionalItems permitted",
+        "schema": {
+            "items": [{}, {}, {}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "additional items are not permitted",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems as false without items",
+        "schema": {"additionalItems": false},
+        "tests": [
+            {
+                "description":
+                    "items defaults to empty schema so everything is valid",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems are allowed by default",
+        "schema": {"items": [{"type": "integer"}]},
+        "tests": [
+            {
+                "description": "only the first item is validated",
+                "data": [1, "foo", false],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems does not look in applicators, valid case",
+        "schema": {
+            "allOf": [
+                { "items": [ { "type": "integer" } ] }
+            ],
+            "additionalItems": { "type": "boolean" }
+        },
+        "tests": [
+            {
+                "description": "items defined in allOf are not examined",
+                "data": [ 1, null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems does not look in applicators, invalid case",
+        "schema": {
+            "allOf": [
+                { "items": [ { "type": "integer" }, { "type": "string" } ] }
+            ],
+            "items": [ {"type": "integer" } ],
+            "additionalItems": { "type": "boolean" }
+        },
+        "tests": [
+            {
+                "description": "items defined in allOf are not examined",
+                "data": [ 1, "hello" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items validation adjusts the starting index for additionalItems",
+        "schema": {
+            "items": [ { "type": "string" } ],
+            "additionalItems": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems with null instance elements",
+        "schema": {
+            "additionalItems": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/additionalProperties.json
+++ b/asdf/_jsonschema/json/tests/draft7/additionalProperties.json
@@ -1,0 +1,147 @@
+[
+    {
+        "description":
+            "additionalProperties being false does not allow other properties",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "patternProperties": { "^v": {} },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "patternProperties are not additional properties",
+                "data": {"foo":1, "vroom": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "non-ASCII pattern with additionalProperties",
+        "schema": {
+            "patternProperties": {"^á": {}},
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "matching the pattern is valid",
+                "data": {"ármányos": 2},
+                "valid": true
+            },
+            {
+                "description": "not matching the pattern is invalid",
+                "data": {"élmény": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with schema",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties can exist by itself",
+        "schema": {
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties are allowed by default",
+        "schema": {"properties": {"foo": {}, "bar": {}}},
+        "tests": [
+            {
+                "description": "additional properties are allowed",
+                "data": {"foo": 1, "bar": 2, "quux": true},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties does not look in applicators",
+        "schema": {
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not examined",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with null valued instance properties",
+        "schema": {
+            "additionalProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/allOf.json
+++ b/asdf/_jsonschema/json/tests/draft7/allOf.json
@@ -1,0 +1,294 @@
+[
+    {
+        "description": "allOf",
+        "schema": {
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allOf",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "mismatch second",
+                "data": {"foo": "baz"},
+                "valid": false
+            },
+            {
+                "description": "mismatch first",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "baz", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with base schema",
+        "schema": {
+            "properties": {"bar": {"type": "integer"}},
+            "required": ["bar"],
+            "allOf" : [
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                },
+                {
+                    "properties": {
+                        "baz": {"type": "null"}
+                    },
+                    "required": ["baz"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "valid": true
+            },
+            {
+                "description": "mismatch base schema",
+                "data": {"foo": "quux", "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch first allOf",
+                "data": {"bar": 2, "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch second allOf",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "mismatch both",
+                "data": {"bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf simple types",
+        "schema": {
+            "allOf": [
+                {"maximum": 30},
+                {"minimum": 20}
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": 25,
+                "valid": true
+            },
+            {
+                "description": "mismatch one",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all true",
+        "schema": {"allOf": [true, true]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, some false",
+        "schema": {"allOf": [true, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all false",
+        "schema": {"allOf": [false, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf combined with anyOf, oneOf",
+        "schema": {
+            "allOf": [ { "multipleOf": 2 } ],
+            "anyOf": [ { "multipleOf": 3 } ],
+            "oneOf": [ { "multipleOf": 5 } ]
+        },
+        "tests": [
+            {
+                "description": "allOf: false, anyOf: false, oneOf: false",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: false, oneOf: true",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: false",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: true",
+                "data": 15,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: false",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: true",
+                "data": 10,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: false",
+                "data": 6,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: true",
+                "data": 30,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/anyOf.json
+++ b/asdf/_jsonschema/json/tests/draft7/anyOf.json
@@ -1,0 +1,189 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid",
+                "data": 3,
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one anyOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all true",
+        "schema": {"anyOf": [true, true]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, some true",
+        "schema": {"anyOf": [true, false]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all false",
+        "schema": {"anyOf": [false, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/boolean_schema.json
+++ b/asdf/_jsonschema/json/tests/draft7/boolean_schema.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "boolean schema 'true'",
+        "schema": true,
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "boolean true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "boolean false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean schema 'false'",
+        "schema": false,
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "boolean true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "boolean false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/const.json
+++ b/asdf/_jsonschema/json/tests/draft7/const.json
@@ -1,0 +1,342 @@
+[
+    {
+        "description": "const validation",
+        "schema": {"const": 2},
+        "tests": [
+            {
+                "description": "same value is valid",
+                "data": 2,
+                "valid": true
+            },
+            {
+                "description": "another value is invalid",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with object",
+        "schema": {"const": {"foo": "bar", "baz": "bax"}},
+        "tests": [
+            {
+                "description": "same object is valid",
+                "data": {"foo": "bar", "baz": "bax"},
+                "valid": true
+            },
+            {
+                "description": "same object with different property order is valid",
+                "data": {"baz": "bax", "foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "another object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": [1, 2],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with array",
+        "schema": {"const": [{ "foo": "bar" }]},
+        "tests": [
+            {
+                "description": "same array is valid",
+                "data": [{"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "another array item is invalid",
+                "data": [2],
+                "valid": false
+            },
+            {
+                "description": "array with additional items is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with null",
+        "schema": {"const": null},
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "not null is invalid",
+                "data": 0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with false does not match 0",
+        "schema": {"const": false},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with true does not match 1",
+        "schema": {"const": true},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [false] does not match [0]",
+        "schema": {"const": [false]},
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [true] does not match [1]",
+        "schema": {"const": [true]},
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": false} does not match {\"a\": 0}",
+        "schema": {"const": {"a": false}},
+        "tests": [
+            {
+                "description": "{\"a\": false} is valid",
+                "data": {"a": false},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 0} is invalid",
+                "data": {"a": 0},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 0.0} is invalid",
+                "data": {"a": 0.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": true} does not match {\"a\": 1}",
+        "schema": {"const": {"a": true}},
+        "tests": [
+            {
+                "description": "{\"a\": true} is valid",
+                "data": {"a": true},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 1} is invalid",
+                "data": {"a": 1},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 1.0} is invalid",
+                "data": {"a": 1.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 0 does not match other zero-like types",
+        "schema": {"const": 0},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
+                "data": "",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 1 does not match true",
+        "schema": {"const": 1},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "const with -2.0 matches integer and float types",
+        "schema": {"const": -2.0},
+        "tests": [
+            {
+                "description": "integer -2 is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "integer 2 is invalid",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "float -2.0 is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float 2.0 is invalid",
+                "data": 2.0,
+                "valid": false
+            },
+            {
+                "description": "float -2.00001 is invalid",
+                "data": -2.00001,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float and integers are equal up to 64-bit representation limits",
+        "schema": {"const": 9007199254740992},
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 9007199254740992,
+                "valid": true
+            },
+            {
+                "description": "integer minus one is invalid",
+                "data": 9007199254740991,
+                "valid": false
+            },
+            {
+                "description": "float is valid",
+                "data": 9007199254740992.0,
+                "valid": true
+            },
+            {
+                "description": "float minus one is invalid",
+                "data": 9007199254740991.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": { "const": "hello\u0000there" },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/contains.json
+++ b/asdf/_jsonschema/json/tests/draft7/contains.json
@@ -1,0 +1,165 @@
+[
+    {
+        "description": "contains keyword validation",
+        "schema": {
+            "contains": {"minimum": 5}
+        },
+        "tests": [
+            {
+                "description": "array with item matching schema (5) is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with item matching schema (6) is valid",
+                "data": [3, 4, 6],
+                "valid": true
+            },
+            {
+                "description": "array with two items matching schema (5, 6) is valid",
+                "data": [3, 4, 5, 6],
+                "valid": true
+            },
+            {
+                "description": "array without items matching schema is invalid",
+                "data": [2, 3, 4],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "not array is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with const keyword",
+        "schema": {
+            "contains": { "const": 5 }
+        },
+        "tests": [
+            {
+                "description": "array with item 5 is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with two items 5 is valid",
+                "data": [3, 4, 5, 5],
+                "valid": true
+            },
+            {
+                "description": "array without item 5 is invalid",
+                "data": [1, 2, 3, 4],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema true",
+        "schema": {"contains": true},
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema false",
+        "schema": {"contains": false},
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "non-arrays are valid",
+                "data": "contains does not apply to strings",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items + contains",
+        "schema": {
+            "items": { "multipleOf": 2 },
+            "contains": { "multipleOf": 3 }
+        },
+        "tests": [
+            {
+                "description": "matches items, does not match contains",
+                "data": [ 2, 4, 8 ],
+                "valid": false
+            },
+            {
+                "description": "does not match items, matches contains",
+                "data": [ 3, 6, 9 ],
+                "valid": false
+            },
+            {
+                "description": "matches both items and contains",
+                "data": [ 6, 12 ],
+                "valid": true
+            },
+            {
+                "description": "matches neither items nor contains",
+                "data": [ 1, 5 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with false if subschema",
+        "schema": {
+            "contains": {
+                "if": false,
+                "else": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with null instance elements",
+        "schema": {
+            "contains": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null items",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/default.json
+++ b/asdf/_jsonschema/json/tests/draft7/default.json
@@ -1,0 +1,79 @@
+[
+    {
+        "description": "invalid type for default",
+        "schema": {
+            "properties": {
+                "foo": {
+                    "type": "integer",
+                    "default": []
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"foo": 13},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid string value for default",
+        "schema": {
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "minLength": 4,
+                    "default": "bad"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"bar": "good"},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/definitions.json
+++ b/asdf/_jsonschema/json/tests/draft7/definitions.json
@@ -1,0 +1,26 @@
+[
+    {
+        "description": "validate definition against metaschema",
+        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+        "tests": [
+            {
+                "description": "valid definition schema",
+                "data": {
+                    "definitions": {
+                        "foo": {"type": "integer"}
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid definition schema",
+                "data": {
+                    "definitions": {
+                        "foo": {"type": 1}
+                    }
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/dependencies.json
+++ b/asdf/_jsonschema/json/tests/draft7/dependencies.json
@@ -1,0 +1,248 @@
+[
+    {
+        "description": "dependencies",
+        "schema": {
+            "dependencies": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with empty array",
+        "schema": {
+            "dependencies": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies",
+        "schema": {
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies subschema",
+        "schema": {
+            "dependencies": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with boolean subschemas",
+        "schema": {
+            "dependencies": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "dependencies": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\tbar": {
+                    "minProperties": 4
+                },
+                "foo'bar": {"required": ["foo\"bar"]},
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "valid object 1",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "valid object 2",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "valid object 3",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid object 1",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 2",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 3",
+                "data": {
+                    "foo'bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 4",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/enum.json
+++ b/asdf/_jsonschema/json/tests/draft7/enum.json
@@ -1,0 +1,236 @@
+[
+    {
+        "description": "simple enum validation",
+        "schema": {"enum": [1, 2, 3]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": 4,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum validation",
+        "schema": {"enum": [6, "foo", [], true, {"foo": 12}]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": {"foo": false},
+                "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum-with-null validation",
+        "schema": { "enum": [6, null] },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 6,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": "test",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enums in properties",
+        "schema": {
+            "type":"object",
+            "properties": {
+                "foo": {"enum":["foo"]},
+                "bar": {"enum":["bar"]}
+            },
+            "required": ["bar"]
+        },
+        "tests": [
+            {
+                "description": "both properties are valid",
+                "data": {"foo":"foo", "bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "wrong foo value",
+                "data": {"foo":"foot", "bar":"bar"},
+                "valid": false
+            },
+            {
+                "description": "wrong bar value",
+                "data": {"foo":"foo", "bar":"bart"},
+                "valid": false
+            },
+            {
+                "description": "missing optional property is valid",
+                "data": {"bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing required property is invalid",
+                "data": {"foo":"foo"},
+                "valid": false
+            },
+            {
+                "description": "missing all properties is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with escaped characters",
+        "schema": {
+            "enum": ["foo\nbar", "foo\rbar"]
+        },
+        "tests": [
+            {
+                "description": "member 1 is valid",
+                "data": "foo\nbar",
+                "valid": true
+            },
+            {
+                "description": "member 2 is valid",
+                "data": "foo\rbar",
+                "valid": true
+            },
+            {
+                "description": "another string is invalid",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {"enum": [false]},
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {"enum": [true]},
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {"enum": [0]},
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {"enum": [1]},
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": { "enum": [ "hello\u0000there" ] },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/exclusiveMaximum.json
+++ b/asdf/_jsonschema/json/tests/draft7/exclusiveMaximum.json
@@ -1,0 +1,30 @@
+[
+    {
+        "description": "exclusiveMaximum validation",
+        "schema": {
+            "exclusiveMaximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the exclusiveMaximum is valid",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 3.0,
+                "valid": false
+            },
+            {
+                "description": "above the exclusiveMaximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/exclusiveMinimum.json
+++ b/asdf/_jsonschema/json/tests/draft7/exclusiveMinimum.json
@@ -1,0 +1,30 @@
+[
+    {
+        "description": "exclusiveMinimum validation",
+        "schema": {
+            "exclusiveMinimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the exclusiveMinimum is valid",
+                "data": 1.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "below the exclusiveMinimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/format.json
+++ b/asdf/_jsonschema/json/tests/draft7/format.json
@@ -1,0 +1,614 @@
+[
+    {
+        "description": "email format",
+        "schema": { "format": "email" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-email format",
+        "schema": { "format": "idn-email" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "regex format",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv4 format",
+        "schema": { "format": "ipv4" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv6 format",
+        "schema": { "format": "ipv6" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-hostname format",
+        "schema": { "format": "idn-hostname" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "hostname format",
+        "schema": { "format": "hostname" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date format",
+        "schema": { "format": "date" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date-time format",
+        "schema": { "format": "date-time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "time format",
+        "schema": { "format": "time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "json-pointer format",
+        "schema": { "format": "json-pointer" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative-json-pointer format",
+        "schema": { "format": "relative-json-pointer" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri format",
+        "schema": { "format": "iri" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri-reference format",
+        "schema": { "format": "iri-reference" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri format",
+        "schema": { "format": "uri" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-reference format",
+        "schema": { "format": "uri-reference" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-template format",
+        "schema": { "format": "uri-template" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/id.json
+++ b/asdf/_jsonschema/json/tests/draft7/id.json
@@ -1,0 +1,114 @@
+[
+    {
+        "description": "id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an id buried in the enum",
+        "schema": {
+            "definitions": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "$id": "https://localhost:1234/id/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "$id": "https://localhost:1234/id/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/definitions/id_in_enum" },
+                { "$ref": "https://localhost:1234/id/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$id": "https://localhost:1234/id/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to id",
+                "data": "a string to match #/definitions/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing a plain-name $id property",
+        "schema": {
+            "definitions": {
+                "const_not_anchor": {
+                    "const": {
+                        "$id": "#not_a_real_anchor"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_anchor"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/definitions/const_not_anchor"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_anchor",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_anchor does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $id property",
+        "schema": {
+            "definitions": {
+                "const_not_id": {
+                    "const": {
+                        "$id": "not_a_real_id"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_id"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/definitions/const_not_id"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_id",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_id does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/if-then-else.json
+++ b/asdf/_jsonschema/json/tests/draft7/if-then-else.json
@@ -1,0 +1,258 @@
+[
+    {
+        "description": "ignore if without then or else",
+        "schema": {
+            "if": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone if",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone if",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore then without if",
+        "schema": {
+            "then": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone then",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone then",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore else without if",
+        "schema": {
+            "else": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone else",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone else",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and then without else",
+        "schema": {
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid when if test fails",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and else without then",
+        "schema": {
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when if test passes",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validate against correct branch, then vs else",
+        "schema": {
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-interference across combined schemas",
+        "schema": {
+            "allOf": [
+                {
+                    "if": {
+                        "exclusiveMaximum": 0
+                    }
+                },
+                {
+                    "then": {
+                        "minimum": -10
+                    }
+                },
+                {
+                    "else": {
+                        "multipleOf": 2
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid, but would have been invalid through then",
+                "data": -100,
+                "valid": true
+            },
+            {
+                "description": "valid, but would have been invalid through else",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema true",
+        "schema": {
+            "if": true,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema true in if always chooses the then path (valid)",
+                "data": "then",
+                "valid": true
+            },
+            {
+                "description": "boolean schema true in if always chooses the then path (invalid)",
+                "data": "else",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema false",
+        "schema": {
+            "if": false,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema false in if always chooses the else path (invalid)",
+                "data": "then",
+                "valid": false
+            },
+            {
+                "description": "boolean schema false in if always chooses the else path (valid)",
+                "data": "else",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if appears at the end when serialized (keyword processing sequence)",
+        "schema": {
+            "then": { "const": "yes" },
+            "else": { "const": "other" },
+            "if": { "maxLength": 4 }
+        },
+        "tests": [
+            {
+                "description": "yes redirects to then and passes",
+                "data": "yes",
+                "valid": true
+            },
+            {
+                "description": "other redirects to else and passes",
+                "data": "other",
+                "valid": true
+            },
+            {
+                "description": "no redirects to then and fails",
+                "data": "no",
+                "valid": false
+            },
+            {
+                "description": "invalid redirects to else and fails",
+                "data": "invalid",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/infinite-loop-detection.json
+++ b/asdf/_jsonschema/json/tests/draft7/infinite-loop-detection.json
@@ -1,0 +1,36 @@
+[
+    {
+        "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
+        "schema": {
+            "definitions": {
+                "int": { "type": "integer" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "$ref": "#/definitions/int"
+                        }
+                    }
+                },
+                {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/int"
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "passing case",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "failing case",
+                "data": { "foo": "a string" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/items.json
+++ b/asdf/_jsonschema/json/tests/draft7/items.json
@@ -1,0 +1,282 @@
+[
+    {
+        "description": "a schema given for items",
+        "schema": {
+            "items": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of items",
+                "data": [1, "x"],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "length": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "an array of schemas for items",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"type": "string"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "correct types",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "wrong types",
+                "data": [ "foo", 1 ],
+                "valid": false
+            },
+            {
+                "description": "incomplete array of items",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with additional items",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "1": "valid",
+                    "length": 2
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (true)",
+        "schema": {"items": true},
+        "tests": [
+            {
+                "description": "any array is valid",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (false)",
+        "schema": {"items": false},
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": [ 1, "foo", true ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schemas",
+        "schema": {
+            "items": [true, false]
+        },
+        "tests": [
+            {
+                "description": "array with one item is valid",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with two items is invalid",
+                "data": [ 1, "foo" ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "definitions": {
+                "item": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "items": [
+                        { "$ref": "#/definitions/sub-item" },
+                        { "$ref": "#/definitions/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "additionalItems": false,
+            "items": [
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "single-form items with null instance elements",
+        "schema": {
+            "items": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array-form items with null instance elements",
+        "schema": {
+            "items": [
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/maxItems.json
+++ b/asdf/_jsonschema/json/tests/draft7/maxItems.json
@@ -1,0 +1,44 @@
+[
+    {
+        "description": "maxItems validation",
+        "schema": {"maxItems": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "foobar",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {"maxItems": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/maxLength.json
+++ b/asdf/_jsonschema/json/tests/draft7/maxLength.json
@@ -1,0 +1,49 @@
+[
+    {
+        "description": "maxLength validation",
+        "schema": {"maxLength": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {"maxLength": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/maxProperties.json
+++ b/asdf/_jsonschema/json/tests/draft7/maxProperties.json
@@ -1,0 +1,70 @@
+[
+    {
+        "description": "maxProperties validation",
+        "schema": {"maxProperties": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxProperties validation with a decimal",
+        "schema": {"maxProperties": 2.0},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxProperties = 0 means the object is empty",
+        "schema": { "maxProperties": 0 },
+        "tests": [
+            {
+                "description": "no properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "one property is invalid",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/maximum.json
+++ b/asdf/_jsonschema/json/tests/draft7/maximum.json
@@ -1,0 +1,54 @@
+[
+    {
+        "description": "maximum validation",
+        "schema": {"maximum": 3.0},
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maximum validation with unsigned integer",
+        "schema": {"maximum": 300},
+        "tests":  [
+            {
+                "description": "below the maximum is invalid",
+                "data": 299.97,
+                "valid": true
+            },
+            {
+                "description": "boundary point integer is valid",
+                "data": 300,
+                "valid": true
+            },
+            {
+                "description": "boundary point float is valid",
+                "data": 300.00,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 300.5,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/minItems.json
+++ b/asdf/_jsonschema/json/tests/draft7/minItems.json
@@ -1,0 +1,44 @@
+[
+    {
+        "description": "minItems validation",
+        "schema": {"minItems": 1},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {"minItems": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/minLength.json
+++ b/asdf/_jsonschema/json/tests/draft7/minLength.json
@@ -1,0 +1,49 @@
+[
+    {
+        "description": "minLength validation",
+        "schema": {"minLength": 2},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {"minLength": 2.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/minProperties.json
+++ b/asdf/_jsonschema/json/tests/draft7/minProperties.json
@@ -1,0 +1,54 @@
+[
+    {
+        "description": "minProperties validation",
+        "schema": {"minProperties": 1},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {"minProperties": 1.0},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/minimum.json
+++ b/asdf/_jsonschema/json/tests/draft7/minimum.json
@@ -1,0 +1,69 @@
+[
+    {
+        "description": "minimum validation",
+        "schema": {"minimum": 1.1},
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minimum validation with signed integer",
+        "schema": {"minimum": -2},
+        "tests": [
+            {
+                "description": "negative above the minimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the minimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point with float is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float below the minimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the minimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/multipleOf.json
+++ b/asdf/_jsonschema/json/tests/draft7/multipleOf.json
@@ -1,0 +1,71 @@
+[
+    {
+        "description": "by int",
+        "schema": {"multipleOf": 2},
+        "tests": [
+            {
+                "description": "int by int",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "int by int fail",
+                "data": 7,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "by number",
+        "schema": {"multipleOf": 1.5},
+        "tests": [
+            {
+                "description": "zero is multiple of anything",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "4.5 is multiple of 1.5",
+                "data": 4.5,
+                "valid": true
+            },
+            {
+                "description": "35 is not multiple of 1.5",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "by small number",
+        "schema": {"multipleOf": 0.0001},
+        "tests": [
+            {
+                "description": "0.0075 is multiple of 0.0001",
+                "data": 0.0075,
+                "valid": true
+            },
+            {
+                "description": "0.00751 is not multiple of 0.0001",
+                "data": 0.00751,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float division = inf",
+        "schema": {"type": "integer", "multipleOf": 0.123456789},
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/not.json
+++ b/asdf/_jsonschema/json/tests/draft7/not.json
@@ -1,0 +1,117 @@
+[
+    {
+        "description": "not",
+        "schema": {
+            "not": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "allowed",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "disallowed",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not multiple types",
+        "schema": {
+            "not": {"type": ["integer", "boolean"]}
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": true,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not more complex schema",
+        "schema": {
+            "not": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+             }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "other match",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "forbidden property",
+        "schema": {
+            "properties": {
+                "foo": { 
+                    "not": {}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property present",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "property absent",
+                "data": {"bar": 1, "baz": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema true",
+        "schema": {"not": true},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema false",
+        "schema": {"not": false},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/oneOf.json
+++ b/asdf/_jsonschema/json/tests/draft7/oneOf.json
@@ -1,0 +1,274 @@
+[
+    {
+        "description": "oneOf",
+        "schema": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with base schema",
+        "schema": {
+            "type": "string",
+            "oneOf" : [
+                {
+                    "minLength": 2
+                },
+                {
+                    "maxLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one oneOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all true",
+        "schema": {"oneOf": [true, true, true]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, one true",
+        "schema": {"oneOf": [true, false, false]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, more than one true",
+        "schema": {"oneOf": [true, true, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all false",
+        "schema": {"oneOf": [false, false, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf complex types",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+	{
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": true,
+                        "baz": true
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/bignum.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/bignum.json
@@ -1,0 +1,93 @@
+[
+    {
+        "description": "integer",
+        "schema": { "type": "integer" },
+        "tests": [
+            {
+                "description": "a bignum is an integer",
+                "data": 12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is an integer",
+                "data": -12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "number",
+        "schema": { "type": "number" },
+        "tests": [
+            {
+                "description": "a bignum is a number",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is a number",
+                "data": -98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "string",
+        "schema": { "type": "string" },
+        "tests": [
+            {
+                "description": "a bignum is not a string",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum integer comparison",
+        "schema": { "maximum": 18446744073709551615 },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision",
+        "schema": {
+            "exclusiveMaximum": 972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum integer comparison",
+        "schema": { "minimum": -18446744073709551615 },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision on negative numbers",
+        "schema": {
+            "exclusiveMinimum": -972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/content.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/content.json
@@ -1,0 +1,77 @@
+[
+    {
+        "description": "validation of string-encoded content based on media type",
+        "schema": {
+            "contentMediaType": "application/json"
+        },
+        "tests": [
+            {
+                "description": "a valid JSON document",
+                "data": "{\"foo\": \"bar\"}",
+                "valid": true
+            },
+            {
+                "description": "an invalid JSON document",
+                "data": "{:}",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary string-encoding",
+        "schema": {
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64 string",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string (% is not a valid character)",
+                "data": "eyJmb28iOi%iYmFyIn0K",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary-encoded media type documents",
+        "schema": {
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64-encoded JSON document",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "a validly-encoded invalid JSON document",
+                "data": "ezp9Cg==",
+                "valid": false
+            },
+            {
+                "description": "an invalid base64 string that is valid JSON",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/cross-draft.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/cross-draft.json
@@ -1,0 +1,25 @@
+[
+    {
+        "description": "refs to future drafts are processed as future drafts",
+        "schema": {
+            "type": "object",
+            "allOf": [
+                { "properties": { "foo": true } },
+                { "$ref": "http://localhost:1234/draft2019-09/dependentRequired.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "missing bar is invalid",
+                "comment": "if the implementation is not processing the $ref as a 2019-09 schema, this test will fail",
+                "data": {"foo": "any value"},
+                "valid": false
+            },
+            {
+                "description": "present bar is valid",
+                "data": {"foo": "any value", "bar": "also any value"},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/ecmascript-regex.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/ecmascript-regex.json
@@ -1,0 +1,552 @@
+[
+    {
+        "description": "ECMA 262 regex $ does not match trailing newline",
+        "schema": {
+            "type": "string",
+            "pattern": "^abc$"
+        },
+        "tests": [
+            {
+                "description": "matches in Python, but not in ECMA 262",
+                "data": "abc\\n",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "abc",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\t$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\t",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0009",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\W matches everything but ascii letters",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
+                "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but whitespace",
+        "schema": {
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
+                "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with pattern",
+        "schema": { "pattern": "\\p{Letter}cole" },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
+        "schema": { "pattern": "\\wcole" },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with ASCII ranges",
+        "schema": { "pattern": "[a-z]cole" },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in pattern matches [0-9], not unicode digits",
+        "schema": { "pattern": "^\\d+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with non-ASCII digits",
+        "schema": { "pattern": "^\\p{digit}+$" },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with patternProperties",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\p{Letter}cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with ASCII ranges",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in patternProperties matches [0-9], not unicode digits",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with non-ASCII digits",
+        "schema": {
+            "type": "object",
+            "patternProperties": {
+                "^\\p{digit}+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/float-overflow.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/float-overflow.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {"type": "integer", "multipleOf": 0.5},
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/date-time.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/date-time.json
@@ -1,0 +1,133 @@
+[
+    {
+        "description": "validation of date-time strings",
+        "schema": { "format": "date-time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
+                "data": "1990-02-31T15:59:59.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:59-24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid closing Z after time-zone offset",
+                "data": "1963-06-19T08:30:06.28123+01:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "case-insensitive T and Z",
+                "data": "1963-06-19t08:30:06.283185z",
+                "valid": true
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
+                "data": "1963-06-1৪T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
+                "data": "1963-06-11T0৪:00:00Z",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/date.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/date.json
@@ -1,0 +1,223 @@
+[
+    {
+        "description": "validation of date strings",
+        "schema": { "format": "date" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date string",
+                "data": "1963-06-19",
+                "valid": true
+            },
+            {
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
+                "data": "06/19/1963",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350",
+                "valid": false
+            },
+            {
+                "description": "non-padded month dates are not valid",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "non-padded day dates are not valid",
+                "data": "1998-01-1",
+                "valid": false
+            },
+            {
+                "description": "invalid month",
+                "data": "1998-13-01",
+                "valid": false
+            },
+            {
+                "description": "invalid month-day combination",
+                "data": "1998-04-31",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1963-06-1৪",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/email.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/email.json
@@ -1,0 +1,83 @@
+[
+    {
+        "description": "validation of e-mail addresses",
+        "schema": { "format": "email" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/hostname.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/hostname.json
@@ -1,0 +1,98 @@
+[
+    {
+        "description": "validation of host names",
+        "schema": { "format": "hostname" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name",
+                "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid punycoded IDN hostname",
+                "data": "xn--4gbwdl.xn--wgbh1c",
+                "valid": true
+            },
+            {
+                "description": "a host name starting with an illegal character",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": false
+            },
+            {
+                "description": "a host name containing illegal characters",
+                "data": "not_a_valid_host_name",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+                "valid": false
+            },
+            {
+                "description": "starts with hyphen",
+                "data": "-hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with hyphen",
+                "data": "hostname-",
+                "valid": false
+            },
+            {
+                "description": "starts with underscore",
+                "data": "_hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with underscore",
+                "data": "hostname_",
+                "valid": false
+            },
+            {
+                "description": "contains underscore",
+                "data": "host_name",
+                "valid": false
+            },
+            {
+                "description": "maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": true
+            },
+            {
+                "description": "exceeds maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/idn-email.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/idn-email.json
@@ -1,0 +1,58 @@
+[
+    {
+        "description": "validation of an internationalized e-mail addresses",
+        "schema": { "format": "idn-email" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid idn e-mail (example@example.test in Hangul)",
+                "data": "실례@실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "an invalid idn e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/idn-hostname.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/idn-hostname.json
@@ -1,0 +1,304 @@
+[
+    {
+        "description": "validation of internationalized host names",
+        "schema": { "format": "idn-hostname" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name (example.test in Hangul)",
+                "data": "실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "illegal first char U+302E Hangul single dot tone mark",
+                "data": "〮실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "contains illegal char U+302E Hangul single dot tone mark",
+                "data": "실〮례.테스트",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "invalid label, correct Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc3492#section-7.1",
+                "data": "-> $1.00 <--",
+                "valid": false
+            },
+            {
+                "description": "valid Chinese Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4",
+                "data": "xn--ihqwcrb4cv8a8dqg056pqjye",
+                "valid": true
+            },
+            {
+                "description": "invalid Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "xn--X",
+                "valid": false
+            },
+            {
+                "description": "U-label contains \"--\" in the 3rd and 4th position",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "XN--aa---o47jg78q",
+                "valid": false
+            },
+            {
+                "description": "U-label starts with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello",
+                "valid": false
+            },
+            {
+                "description": "U-label ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "hello-",
+                "valid": false
+            },
+            {
+                "description": "U-label starts and ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello-",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Spacing Combining Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0903hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Nonspacing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0300hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with an Enclosing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0488hello",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are PVALID, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u00df\u03c2\u0f0b\u3007",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are PVALID, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u06fd\u06fe",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u0640\u07fa",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6 Note: The two combining marks (U+302E and U+302F) are in the middle and not at the start",
+                "data": "\u3031\u3032\u3033\u3034\u3035\u302e\u302f\u303b",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no preceding 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "a\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing preceding",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no following 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7a",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing following",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with surrounding 'l's",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7l",
+                "valid": true
+            },
+            {
+                "description": "Greek KERAIA not followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375S",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA not followed by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375\u03b2",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERESH not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "A\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05d0\u05f3\u05d1",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "A\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05d0\u05f4\u05d1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no Hiragana, Katakana, or Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "def\u30fbabc",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no other characters",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Hiragana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u3041",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Katakana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u30a1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u4e08",
+                "valid": true
+            },
+            {
+                "description": "Arabic-Indic digits mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0660\u06f0",
+                "valid": false
+            },
+            {
+                "description": "Arabic-Indic digits not mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0628\u0660\u0628",
+                "valid": true
+            },
+            {
+                "description": "Extended Arabic-Indic digits not mixed with Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.9",
+                "data": "\u06f00",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u094d\u200d\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER not preceded by Virama but matches regexp",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
+                "data": "\u0628\u064a\u200c\u0628\u064a",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/ipv4.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/ipv4.json
@@ -1,0 +1,84 @@
+[
+    {
+        "description": "validation of IP addresses",
+        "schema": { "format": "ipv4" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IP address",
+                "data": "192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "an IP address with too many components",
+                "data": "127.0.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "an IP address with out-of-range values",
+                "data": "256.256.256.256",
+                "valid": false
+            },
+            {
+                "description": "an IP address without 4 components",
+                "data": "127.0",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer",
+                "data": "0x7f000001",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
+            },
+            {
+                "description": "invalid leading zeroes, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২7.0.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/ipv6.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/ipv6.json
@@ -1,0 +1,208 @@
+[
+    {
+        "description": "validation of IPv6 addresses",
+        "schema": { "format": "ipv6" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IPv6 address",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "an IPv6 address with out-of-range values",
+                "data": "12345::",
+                "valid": false
+            },
+            {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address with too many components",
+                "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address containing illegal characters",
+                "data": "::laptop",
+                "valid": false
+            },
+            {
+                "description": "no digits is valid",
+                "data": "::",
+                "valid": true
+            },
+            {
+                "description": "leading colons is valid",
+                "data": "::42:ff:1",
+                "valid": true
+            },
+            {
+                "description": "trailing colons is valid",
+                "data": "d6::",
+                "valid": true
+            },
+            {
+                "description": "missing leading octet is invalid",
+                "data": ":2:3:4:5:6:7:8",
+                "valid": false
+            },
+            {
+                "description": "missing trailing octet is invalid",
+                "data": "1:2:3:4:5:6:7:",
+                "valid": false
+            },
+            {
+                "description": "missing leading octet with omitted octets later",
+                "data": ":2:3:4::8",
+                "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
+            },
+            {
+                "description": "two sets of double colons is invalid",
+                "data": "1::d6::42",
+                "valid": false
+            },
+            {
+                "description": "mixed format with the ipv4 section as decimal octets",
+                "data": "1::d6:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with double colons between the sections",
+                "data": "1:2::192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with ipv4 section with octet out of range",
+                "data": "1::2:192.168.256.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with ipv4 section with a hex octet",
+                "data": "1::2:192.168.ff.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with leading double colons (ipv4-mapped ipv6 address)",
+                "data": "::ffff:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "triple colons is invalid",
+                "data": "1:2:3:4:5:::8",
+                "valid": false
+            },
+            {
+                "description": "8 octets",
+                "data": "1:2:3:4:5:6:7:8",
+                "valid": true
+            },
+            {
+                "description": "insufficient octets without double colons",
+                "data": "1:2:3:4:5:6:7",
+                "valid": false
+            },
+            {
+                "description": "no colons is invalid",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 is not ipv6",
+                "data": "127.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 segment must have 4 octets",
+                "data": "1:2:3:4:1.2.3",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1:2:3:4:5:6:7:৪",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
+                "data": "1:2::192.16৪.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/iri-reference.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/iri-reference.json
@@ -1,0 +1,73 @@
+[
+    {
+        "description": "validation of IRI References",
+        "schema": { "format": "iri-reference" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference",
+                "data": "//ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid relative IRI Reference",
+                "data": "/âππ",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI Reference",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "a valid IRI Reference",
+                "data": "âππ",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI fragment",
+                "data": "#ƒrägmênt",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI fragment",
+                "data": "#ƒräg\\mênt",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/iri.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/iri.json
@@ -1,0 +1,83 @@
+[
+    {
+        "description": "validation of IRIs",
+        "schema": { "format": "iri" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag and parentheses",
+                "data": "http://ƒøø.com/blah_(wîkïpédiå)_blah#ßité-1",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with URL-encoded stuff",
+                "data": "http://ƒøø.ßår/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI based on IPv6",
+                "data": "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI based on IPv6",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative IRI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI though valid IRI reference",
+                "data": "âππ",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/json-pointer.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/json-pointer.json
@@ -1,0 +1,198 @@
+[
+    {
+        "description": "validation of JSON-pointers (JSON String Representation)",
+        "schema": { "format": "json-pointer" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid JSON-pointer",
+                "data": "/foo/bar~0/baz~1/%a",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (~ not escaped)",
+                "data": "/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "valid JSON-pointer with empty segment",
+                "data": "/foo//bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer with the last empty segment",
+                "data": "/foo/bar/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #1",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #2",
+                "data": "/foo",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #3",
+                "data": "/foo/0",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #4",
+                "data": "/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #5",
+                "data": "/a~1b",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #6",
+                "data": "/c%d",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #7",
+                "data": "/e^f",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #8",
+                "data": "/g|h",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #9",
+                "data": "/i\\j",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #10",
+                "data": "/k\"l",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #11",
+                "data": "/ ",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #12",
+                "data": "/m~0n",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer used adding to the last array position",
+                "data": "/foo/-",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (- used as object member name)",
+                "data": "/foo/-/bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (multiple escaped characters)",
+                "data": "/~1~0~0~1~1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #1",
+                "data": "/~1.1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #2",
+                "data": "/~0.1",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #1",
+                "data": "#",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #2",
+                "data": "#/",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #3",
+                "data": "#a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #1",
+                "data": "/~0~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #2",
+                "data": "/~0/~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #1",
+                "data": "/~2",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #2",
+                "data": "/~-1",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (multiple characters not escaped)",
+                "data": "/~~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #1",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #2",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #3",
+                "data": "a/a",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/regex.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/regex.json
@@ -1,0 +1,48 @@
+[
+    {
+        "description": "validation of regular expressions",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid regular expression",
+                "data": "([abc])+\\s+$",
+                "valid": true
+            },
+            {
+                "description": "a regular expression with unclosed parens is invalid",
+                "data": "^(abc]",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/relative-json-pointer.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/relative-json-pointer.json
@@ -1,0 +1,98 @@
+[
+    {
+        "description": "validation of Relative JSON Pointers (RJP)",
+        "schema": { "format": "relative-json-pointer" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid upwards RJP",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "a valid downwards RJP",
+                "data": "0/foo/bar",
+                "valid": true
+            },
+            {
+                "description": "a valid up and then down RJP, with array index",
+                "data": "2/0/baz/1/zip",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP taking the member or index name",
+                "data": "0#",
+                "valid": true
+            },
+            {
+                "description": "an invalid RJP that is a valid JSON Pointer",
+                "data": "/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "negative prefix",
+                "data": "-1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "explicit positive prefix",
+                "data": "+1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "## is not a valid json-pointer",
+                "data": "0##",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus json-pointer",
+                "data": "01/a",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus octothorpe",
+                "data": "01#",
+                "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "multi-digit integer prefix",
+                "data": "120/foo/bar",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/time.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/time.json
@@ -1,0 +1,213 @@
+[
+    {
+        "description": "validation of time strings",
+        "schema": { "format": "time" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid time string",
+                "data": "08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with leap second, Zulu",
+                "data": "23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, zero time-offset",
+                "data": "23:59:60+00:00",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong hour)",
+                "data": "22:59:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong minute)",
+                "data": "23:58:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, positive time-offset",
+                "data": "01:29:60+01:30",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large positive time-offset",
+                "data": "23:29:60+23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong hour)",
+                "data": "23:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong minute)",
+                "data": "23:59:60+00:30",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, negative time-offset",
+                "data": "15:59:60-08:00",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large negative time-offset",
+                "data": "00:29:60-23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong hour)",
+                "data": "23:59:60-01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong minute)",
+                "data": "23:59:60-00:30",
+                "valid": false
+            },
+            {
+                "description": "a valid time string with second fraction",
+                "data": "23:20:50.52Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with precise second fraction",
+                "data": "08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with plus offset",
+                "data": "08:30:06+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with minus offset",
+                "data": "08:30:06-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with case-insensitive Z",
+                "data": "08:30:06z",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string with invalid hour",
+                "data": "24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid minute",
+                "data": "00:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid second",
+                "data": "00:00:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset hour",
+                "data": "01:02:03+24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset minute",
+                "data": "01:02:03+00:60",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time with both Z and numoffset",
+                "data": "01:02:03Z+00:30",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset indicator",
+                "data": "08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "01:01:01,1111",
+                "valid": false
+            },
+            {
+                "description": "no time offset",
+                "data": "12:00:00",
+                "valid": false
+            },
+            {
+                "description": "no time offset with second fraction",
+                "data": "12:00:00.52",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "offset not starting with plus or minus",
+                "data": "08:30:06#00:20",
+                "valid": false
+            },
+            {
+                "description": "contains letters",
+                "data": "ab:cd:ef",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/unknown.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/uri-reference.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/uri-reference.json
@@ -1,0 +1,73 @@
+[
+    {
+        "description": "validation of URI References",
+        "schema": { "format": "uri-reference" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URI",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid relative URI Reference",
+                "data": "/abc",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI Reference",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "a valid URI Reference",
+                "data": "abc",
+                "valid": true
+            },
+            {
+                "description": "a valid URI fragment",
+                "data": "#fragment",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI fragment",
+                "data": "#frag\\ment",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/uri-template.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/uri-template.json
@@ -1,0 +1,58 @@
+[
+    {
+        "description": "format: uri-template",
+        "schema": { "format": "uri-template" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term}",
+                "valid": true
+            },
+            {
+                "description": "an invalid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": false
+            },
+            {
+                "description": "a valid uri-template without variables",
+                "data": "http://example.com/dictionary",
+                "valid": true
+            },
+            {
+                "description": "a valid relative uri-template",
+                "data": "dictionary/{term:1}/{term}",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/format/uri.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/format/uri.json
@@ -1,0 +1,138 @@
+[
+    {
+        "description": "validation of URIs",
+        "schema": { "format": "uri" },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag and parentheses",
+                "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with URL-encoded stuff",
+                "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid puny-coded URL ",
+                "data": "http://xn--nw2a.xn--j6w193g/",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid URL based on IPv4",
+                "data": "http://223.255.255.254",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with ftp scheme",
+                "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL for a simple text file",
+                "data": "http://www.ietf.org/rfc/rfc2396.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL ",
+                "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+                "valid": true
+            },
+            {
+                "description": "a valid mailto URI",
+                "data": "mailto:John.Doe@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid newsgroup URI",
+                "data": "news:comp.infosystems.www.servers.unix",
+                "valid": true
+            },
+            {
+                "description": "a valid tel URI",
+                "data": "tel:+1-816-555-1212",
+                "valid": true
+            },
+            {
+                "description": "a valid URN",
+                "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+                "valid": true
+            },
+            {
+                "description": "an invalid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative URI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI though valid URI reference",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces",
+                "data": "http:// shouldfail.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces and missing scheme",
+                "data": ":// should fail",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/optional/non-bmp-regex.json
+++ b/asdf/_jsonschema/json/tests/draft7/optional/non-bmp-regex.json
@@ -1,0 +1,82 @@
+[
+    {
+        "description": "Proper UTF-16 surrogate pair handling: pattern",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": { "pattern": "^🐲*$" },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Proper UTF-16 surrogate pair handling: patternProperties",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐲": "hello" },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐲🐲": "hello" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/pattern.json
+++ b/asdf/_jsonschema/json/tests/draft7/pattern.json
@@ -1,0 +1,59 @@
+[
+    {
+        "description": "pattern validation",
+        "schema": {"pattern": "^a*$"},
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "aaa",
+                "valid": true
+            },
+            {
+                "description": "a non-matching pattern is invalid",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {"pattern": "a+"},
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/patternProperties.json
+++ b/asdf/_jsonschema/json/tests/draft7/patternProperties.json
@@ -1,0 +1,171 @@
+[
+    {
+        "description":
+            "patternProperties validates properties matching a regex",
+        "schema": {
+            "patternProperties": {
+                "f.*o": {"type": "integer"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "multiple valid matches is valid",
+                "data": {"foo": 1, "foooooo" : 2},
+                "valid": true
+            },
+            {
+                "description": "a single invalid match is invalid",
+                "data": {"foo": "bar", "fooooo": 2},
+                "valid": false
+            },
+            {
+                "description": "multiple invalid matches is invalid",
+                "data": {"foo": "bar", "foooooo" : "baz"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple simultaneous patternProperties are validated",
+        "schema": {
+            "patternProperties": {
+                "a*": {"type": "integer"},
+                "aaa*": {"maximum": 20}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"a": 21},
+                "valid": true
+            },
+            {
+                "description": "a simultaneous match is valid",
+                "data": {"aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "multiple matches is valid",
+                "data": {"a": 21, "aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "an invalid due to one is invalid",
+                "data": {"a": "bar"},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to the other is invalid",
+                "data": {"aaaa": 31},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to both is invalid",
+                "data": {"aaa": "foo", "aaaa": 31},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "regexes are not anchored by default and are case sensitive",
+        "schema": {
+            "patternProperties": {
+                "[0-9]{2,}": { "type": "boolean" },
+                "X_": { "type": "string" }
+            }
+        },
+        "tests": [
+            {
+                "description": "non recognized members are ignored",
+                "data": { "answer 1": "42" },
+                "valid": true
+            },
+            {
+                "description": "recognized members are accounted for",
+                "data": { "a31b": null },
+                "valid": false
+            },
+            {
+                "description": "regexes are case sensitive",
+                "data": { "a_x_3": 3 },
+                "valid": true
+            },
+            {
+                "description": "regexes are case sensitive, 2",
+                "data": { "a_X_3": 3 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with boolean schemas",
+        "schema": {
+            "patternProperties": {
+                "f.*": true,
+                "b.*": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property matching schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property matching schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with a property matching both true and false is invalid",
+                "data": {"foobar":1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with null valued instance properties",
+        "schema": {
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/properties.json
+++ b/asdf/_jsonschema/json/tests/draft7/properties.json
@@ -1,0 +1,236 @@
+[
+    {
+        "description": "object properties validation",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties present and valid is valid",
+                "data": {"foo": 1, "bar": "baz"},
+                "valid": true
+            },
+            {
+                "description": "one property invalid is invalid",
+                "data": {"foo": 1, "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "both properties invalid is invalid",
+                "data": {"foo": [], "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "doesn't invalidate other properties",
+                "data": {"quux": []},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description":
+            "properties, patternProperties, additionalProperties interaction",
+        "schema": {
+            "properties": {
+                "foo": {"type": "array", "maxItems": 3},
+                "bar": {"type": "array"}
+            },
+            "patternProperties": {"f.o": {"minItems": 2}},
+            "additionalProperties": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "property validates property",
+                "data": {"foo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "property invalidates property",
+                "data": {"foo": [1, 2, 3, 4]},
+                "valid": false
+            },
+            {
+                "description": "patternProperty invalidates property",
+                "data": {"foo": []},
+                "valid": false
+            },
+            {
+                "description": "patternProperty validates nonproperty",
+                "data": {"fxo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "patternProperty invalidates nonproperty",
+                "data": {"fxo": []},
+                "valid": false
+            },
+            {
+                "description": "additionalProperty ignores property",
+                "data": {"bar": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty validates others",
+                "data": {"quux": 3},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty invalidates others",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with boolean schema",
+        "schema": {
+            "properties": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no property present is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "only 'true' property present is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "only 'false' property present is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "both properties present is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with escaped characters",
+        "schema": {
+            "properties": {
+                "foo\nbar": {"type": "number"},
+                "foo\"bar": {"type": "number"},
+                "foo\\bar": {"type": "number"},
+                "foo\rbar": {"type": "number"},
+                "foo\tbar": {"type": "number"},
+                "foo\fbar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with all numbers is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1",
+                    "foo\\bar": "1",
+                    "foo\rbar": "1",
+                    "foo\tbar": "1",
+                    "foo\fbar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with null valued instance properties",
+        "schema": {
+            "properties": {
+                "foo": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "properties": {
+                "__proto__": {"type": "number"},
+                "toString": {
+                    "properties": { "length": { "type": "string" } }
+                },
+                "constructor": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "__proto__ not valid",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString not valid",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor not valid",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present and valid",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/propertyNames.json
+++ b/asdf/_jsonschema/json/tests/draft7/propertyNames.json
@@ -1,0 +1,107 @@
+[
+    {
+        "description": "propertyNames validation",
+        "schema": {
+            "propertyNames": {"maxLength": 3}
+        },
+        "tests": [
+            {
+                "description": "all property names valid",
+                "data": {
+                    "f": {},
+                    "foo": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "some property names invalid",
+                "data": {
+                    "foo": {},
+                    "foobar": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3, 4],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames validation with pattern",
+        "schema": {
+            "propertyNames": { "pattern": "^a+$" }
+        },
+        "tests": [
+            {
+                "description": "matching property names valid",
+                "data": {
+                    "a": {},
+                    "aa": {},
+                    "aaa": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "non-matching property name is invalid",
+                "data": {
+                    "aaA": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema true",
+        "schema": {"propertyNames": true},
+        "tests": [
+            {
+                "description": "object with any properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema false",
+        "schema": {"propertyNames": false},
+        "tests": [
+            {
+                "description": "object with any properties is invalid",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/ref.json
+++ b/asdf/_jsonschema/json/tests/draft7/ref.json
@@ -1,0 +1,822 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"$ref": "#/items/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "definitions": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
+            },
+            "properties": {
+                "tilde": {"$ref": "#/definitions/tilde~0field"},
+                "slash": {"$ref": "#/definitions/slash~1field"},
+                "percent": {"$ref": "#/definitions/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilde invalid",
+                "data": {"tilde": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilde valid",
+                "data": {"tilde": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "definitions": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/definitions/a"},
+                "c": {"$ref": "#/definitions/b"}
+            },
+            "allOf": [{ "$ref": "#/definitions/c" }]
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref overrides any sibling keywords",
+        "schema": {
+            "definitions": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/definitions/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "ref valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "ref valid, maxItems ignored",
+                "data": { "foo": [ 1, 2, 3] },
+                "valid": true
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref prevents a sibling $id from changing the base uri",
+        "schema": {
+            "$id": "http://localhost:1234/sibling_id/base/",
+            "definitions": {
+                "foo": {
+                    "$id": "http://localhost:1234/sibling_id/foo.json",
+                    "type": "string"
+                },
+                "base_foo": {
+                    "$comment": "this canonical uri is http://localhost:1234/sibling_id/base/foo.json",
+                    "$id": "foo.json",
+                    "type": "number"
+                }
+            },
+            "allOf": [
+                {
+                    "$comment": "$ref resolves to http://localhost:1234/sibling_id/base/foo.json, not http://localhost:1234/sibling_id/foo.json",
+                    "$id": "http://localhost:1234/sibling_id/",
+                    "$ref": "foo.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "$ref resolves to /definitions/base_foo, data does not validate",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "$ref resolves to /definitions/base_foo, data validates",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"minLength": 1},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"minLength": -1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "properties": {
+                "$ref": {"$ref": "#/definitions/is-string"}
+            },
+            "definitions": {
+                "is-string": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema true",
+        "schema": {
+            "allOf": [{ "$ref": "#/definitions/bool" }],
+            "definitions": {
+                "bool": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema false",
+        "schema": {
+            "allOf": [{ "$ref": "#/definitions/bool" }],
+            "definitions": {
+                "bool": false
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "$id": "http://localhost:1234/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {
+                    "type": "array",
+                    "items": {"$ref": "node"}
+                }
+            },
+            "required": ["meta", "nodes"],
+            "definitions": {
+                "node": {
+                    "$id": "http://localhost:1234/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "subtree": {"$ref": "tree"}
+                    },
+                    "required": ["value"]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid tree",
+                "data": { 
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 1.1},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid tree",
+                "data": { 
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": "string is invalid"},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "properties": {
+                "foo\"bar": {"$ref": "#/definitions/foo%22bar"}
+            },
+            "definitions": {
+                "foo\"bar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with numbers is valid",
+                "data": {
+                    "foo\"bar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier",
+        "schema": {
+            "allOf": [{
+                "$ref": "#foo"
+            }],
+            "definitions": {
+                "A": {
+                    "$id": "#foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with base URI change in subschema",
+        "schema": {
+            "$id": "http://localhost:1234/root",
+            "allOf": [{
+                "$ref": "http://localhost:1234/nested.json#foo"
+            }],
+            "definitions": {
+                "A": {
+                    "$id": "nested.json",
+                    "definitions": {
+                        "B": {
+                            "$id": "#foo",
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "definitions": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/definitions/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "do not evaluate the $ref inside the enum, definition exact match",
+                "data": { "type": "string" },
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/definitions/a_string" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "refs with relative uris and defs",
+        "schema": {
+            "$id": "http://example.com/schema-relative-uri-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "schema-relative-uri-defs2.json",
+                    "definitions": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "allOf": [ { "$ref": "#/definitions/inner" } ]
+                }
+            },
+            "allOf": [ { "$ref": "schema-relative-uri-defs2.json" } ]
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative refs with absolute uris and defs",
+        "schema": {
+            "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "http://example.com/schema-refs-absolute-uris-defs2.json",
+                    "definitions": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "allOf": [ { "$ref": "#/definitions/inner" } ]
+                }
+            },
+            "allOf": [ { "$ref": "schema-refs-absolute-uris-defs2.json" } ]
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$id": "http://example.com/a.json",
+            "definitions": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "definitions": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with $ref via the URN",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "minimum": 30,
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
+            }
+        },
+        "tests": [
+            {
+                "description": "valid under the URN IDed schema",
+                "data": {"foo": 37},
+                "valid": true
+            },
+            {
+                "description": "invalid under the URN IDed schema",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with JSON pointer",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with NSS",
+        "schema": {
+            "$comment": "RFC 8141 §2.2",
+            "$id": "urn:example:1/406/47452/2",
+            "properties": {
+                "foo": {"$ref": "#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with r-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.1",
+            "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
+            "properties": {
+                "foo": {"$ref": "#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with q-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.2",
+            "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
+            "properties": {
+                "foo": {"$ref": "#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and JSON pointer ref",
+        "schema": {
+            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/definitions/bar"}
+            },
+            "definitions": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and anchor ref",
+        "schema": {
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
+            },
+            "definitions": {
+                "bar": {
+                    "$id": "#something",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/refRemote.json
+++ b/asdf/_jsonschema/json/tests/draft7/refRemote.json
@@ -1,0 +1,239 @@
+[
+    {
+        "description": "remote ref",
+        "schema": {"$ref": "http://localhost:1234/integer.json"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "fragment within remote ref",
+        "schema": {"$ref": "http://localhost:1234/subSchemas.json#/integer"},
+        "tests": [
+            {
+                "description": "remote fragment valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote fragment invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within remote ref",
+        "schema": {
+            "$ref": "http://localhost:1234/subSchemas.json#/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "ref within ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "ref within ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change",
+        "schema": {
+            "$id": "http://localhost:1234/",
+            "items": {
+                "$id": "baseUriChange/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "base URI change ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "base URI change ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs1.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz"}
+            },
+            "definitions": {
+                "baz": {
+                    "$id": "baseUriChangeFolder/",
+                    "type": "array",
+                    "items": {"$ref": "folderInteger.json"}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz/definitions/bar"}
+            },
+            "definitions": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema/",
+                    "definitions": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "root ref in remote ref",
+        "schema": {
+            "$id": "http://localhost:1234/object",
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "name.json#/definitions/orNull"}
+            }
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": {
+                    "name": null
+                },
+                "valid": true
+            },
+            {
+                "description": "object is invalid",
+                "data": {
+                    "name": {
+                        "name": null
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref with ref to definitions",
+        "schema": {
+            "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
+            "allOf": [
+                { "$ref": "ref-and-definitions.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "invalid",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid",
+                "data": {
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier in remote ref",
+        "schema": {
+            "$ref": "http://localhost:1234/locationIndependentIdentifierPre2019.json#/definitions/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "retrieved nested refs resolve relative to their URI not $id",
+        "schema": {
+            "$id": "http://localhost:1234/some-id",
+            "properties": {
+                "name": {"$ref": "nested/foo-ref-string.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": {
+                    "name": {"foo":  1}
+                },
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/required.json
+++ b/asdf/_jsonschema/json/tests/draft7/required.json
@@ -1,0 +1,151 @@
+[
+    {
+        "description": "required validation",
+        "schema": {
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "required": ["foo"]
+        },
+        "tests": [
+            {
+                "description": "present required property is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "non-present required property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required default validation",
+        "schema": {
+            "properties": {
+                "foo": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required by default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with empty array",
+        "schema": {
+            "properties": {
+                "foo": {}
+            },
+            "required": []
+        },
+        "tests": [
+            {
+                "description": "property not required",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with escaped characters",
+        "schema": {
+            "required": [
+                "foo\nbar",
+                "foo\"bar",
+                "foo\\bar",
+                "foo\rbar",
+                "foo\tbar",
+                "foo\fbar"
+            ]
+        },
+        "tests": [
+            {
+                "description": "object with all properties present is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with some properties missing is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "required properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": { "required": ["__proto__", "toString", "constructor"] },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "__proto__ present",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString present",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor present",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/type.json
+++ b/asdf/_jsonschema/json/tests/draft7/type.json
@@ -1,0 +1,474 @@
+[
+    {
+        "description": "integer type matches integers",
+        "schema": {"type": "integer"},
+        "tests": [
+            {
+                "description": "an integer is an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is an integer",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is not an integer",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an integer",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not an integer, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not an integer",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not an integer",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an integer",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an integer",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "number type matches numbers",
+        "schema": {"type": "number"},
+        "tests": [
+            {
+                "description": "an integer is a number",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is a number (and an integer)",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is a number",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "a string is not a number",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not a number, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not a number",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a number",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a number",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a number",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "string type matches strings",
+        "schema": {"type": "string"},
+        "tests": [
+            {
+                "description": "1 is not a string",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a string",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a string is still a string, even if it looks like a number",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an object is not a string",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a string",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a string",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a string",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "object type matches objects",
+        "schema": {"type": "object"},
+        "tests": [
+            {
+                "description": "an integer is not an object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an object",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an object",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is not an object",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an object",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an object",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "array type matches arrays",
+        "schema": {"type": "array"},
+        "tests": [
+            {
+                "description": "an integer is not an array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an array",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an array",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not an array",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is not an array",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an array",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "boolean type matches booleans",
+        "schema": {"type": "boolean"},
+        "tests": [
+            {
+                "description": "an integer is not a boolean",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a float is not a boolean",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not a boolean",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not a boolean",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a boolean",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is a boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is not a boolean",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "null type matches only the null object",
+        "schema": {"type": "null"},
+        "tests": [
+            {
+                "description": "an integer is not null",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not null",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a string is not null",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not null",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not null",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is not null",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple types can be specified in an array",
+        "schema": {"type": ["integer", "string"]},
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/uniqueItems.json
+++ b/asdf/_jsonschema/json/tests/draft7/uniqueItems.json
@@ -1,0 +1,404 @@
+[
+    {
+        "description": "uniqueItems validation",
+        "schema": {"uniqueItems": true},
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
+                "data": [1, 2, 1],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is invalid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": false
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is invalid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": false
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
+                "data": [["foo"], ["bar"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "[1] and [true] are unique",
+                "data": [[1], [true]],
+                "valid": true
+            },
+            {
+                "description": "[0] and [false] are unique",
+                "data": [[0], [false]],
+                "valid": true
+            },
+            {
+                "description": "nested [1] and [true] are unique",
+                "data": [[[1], "foo"], [[true], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "nested [0] and [false] are unique",
+                "data": [[[0], "foo"], [[false], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1, "{}"],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are invalid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
+                "valid": false
+            },
+            {
+                "description": "{\"a\": false} and {\"a\": 0} are unique",
+                "data": [{"a": false}, {"a": 0}],
+                "valid": true
+            },
+            {
+                "description": "{\"a\": true} and {\"a\": 1} are unique",
+                "data": [{"a": true}, {"a": 1}],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is not valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": false
+            },
+            {
+                "description": "non-unique array extended from [true, false] is not valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": { "uniqueItems": false },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "items": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/draft7/unknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/draft7/unknownKeyword.json
@@ -1,0 +1,56 @@
+[
+    {
+        "description": "$id inside an unknown keyword is not a real identifier",
+        "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
+        "schema": {
+            "definitions": {
+                "id_in_unknown0": {
+                    "not": {
+                        "array_of_schemas": [
+                            {
+                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                    "type": "string"
+                },
+                "id_in_unknown1": {
+                    "not": {
+                        "object_of_schemas": {
+                            "foo": {
+                              "$id": "https://localhost:1234/unknownKeyword/my_identifier.json",
+                              "type": "integer"
+                            }
+                        }
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/definitions/id_in_unknown0" },
+                { "$ref": "#/definitions/id_in_unknown1" },
+                { "$ref": "https://localhost:1234/unknownKeyword/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "type matches second anyOf, which has a real schema in it",
+                "data": "a string",
+                "valid": true
+            },
+            {
+                "description": "type matches non-schema in first anyOf",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "type matches non-schema in third anyOf",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/additionalProperties.json
+++ b/asdf/_jsonschema/json/tests/latest/additionalProperties.json
@@ -1,0 +1,156 @@
+[
+    {
+        "description":
+            "additionalProperties being false does not allow other properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"foo": {}, "bar": {}},
+            "patternProperties": { "^v": {} },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "patternProperties are not additional properties",
+                "data": {"foo":1, "vroom": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "non-ASCII pattern with additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {"^á": {}},
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "matching the pattern is valid",
+                "data": {"ármányos": 2},
+                "valid": true
+            },
+            {
+                "description": "not matching the pattern is invalid",
+                "data": {"élmény": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"foo": {}, "bar": {}},
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties can exist by itself",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties are allowed by default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"foo": {}, "bar": {}}
+        },
+        "tests": [
+            {
+                "description": "additional properties are allowed",
+                "data": {"foo": 1, "bar": 2, "quux": true},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties does not look in applicators",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not examined",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/allOf.json
+++ b/asdf/_jsonschema/json/tests/latest/allOf.json
@@ -1,0 +1,312 @@
+[
+    {
+        "description": "allOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allOf",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "mismatch second",
+                "data": {"foo": "baz"},
+                "valid": false
+            },
+            {
+                "description": "mismatch first",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "baz", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"bar": {"type": "integer"}},
+            "required": ["bar"],
+            "allOf" : [
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                },
+                {
+                    "properties": {
+                        "baz": {"type": "null"}
+                    },
+                    "required": ["baz"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "valid": true
+            },
+            {
+                "description": "mismatch base schema",
+                "data": {"foo": "quux", "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch first allOf",
+                "data": {"bar": 2, "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch second allOf",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "mismatch both",
+                "data": {"bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf simple types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {"maximum": 30},
+                {"minimum": 20}
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": 25,
+                "valid": true
+            },
+            {
+                "description": "mismatch one",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, some false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested allOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf combined with anyOf, oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [ { "multipleOf": 2 } ],
+            "anyOf": [ { "multipleOf": 3 } ],
+            "oneOf": [ { "multipleOf": 5 } ]
+        },
+        "tests": [
+            {
+                "description": "allOf: false, anyOf: false, oneOf: false",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: false, oneOf: true",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: false",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "allOf: false, anyOf: true, oneOf: true",
+                "data": 15,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: false",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: false, oneOf: true",
+                "data": 10,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: false",
+                "data": 6,
+                "valid": false
+            },
+            {
+                "description": "allOf: true, anyOf: true, oneOf: true",
+                "data": 30,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/anchor.json
+++ b/asdf/_jsonschema/json/tests/latest/anchor.json
@@ -1,0 +1,235 @@
+[
+    {
+        "description": "Location-independent identifier",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#foo",
+            "$defs": {
+                "A": {
+                    "$anchor": "foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with absolute URI",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/bar#foo",
+            "$defs": {
+                "A": {
+                    "$id": "http://localhost:1234/draft2020-12/bar",
+                    "$anchor": "foo",
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier with base URI change in subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/root",
+            "$ref": "http://localhost:1234/draft2020-12/nested.json#foo",
+            "$defs": {
+                "A": {
+                    "$id": "nested.json",
+                    "$defs": {
+                        "B": {
+                            "$anchor": "foo",
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$anchor inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $anchor buried in the enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "anchor_in_enum": {
+                    "enum": [
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "null"
+                        }
+                    ]
+                },
+                "real_identifier_in_schema": {
+                    "$anchor": "my_anchor",
+                    "type": "string"
+                },
+                "zzz_anchor_in_const": {
+                    "const": {
+                        "$anchor": "my_anchor",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/anchor_in_enum" },
+                { "$ref": "#my_anchor" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$anchor": "my_anchor",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "in implementations that strip $anchor, this may match either $def",
+                "data": {
+                    "type": "null"
+                },
+                "valid": false
+            },
+            {
+                "description": "match $ref to $anchor",
+                "data": "a string to match #/$defs/anchor_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $anchor",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "same $anchor with different base uri",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/foobar",
+            "$defs": {
+                "A": {
+                    "$id": "child1",
+                    "allOf": [
+                        {
+                            "$id": "child2",
+                            "$anchor": "my_anchor",
+                            "type": "number"
+                        },
+                        {
+                            "$anchor": "my_anchor",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "$ref": "child1#my_anchor"
+        },
+        "tests": [
+            {
+                "description": "$ref resolves to /$defs/A/allOf/1",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "$ref does not resolve to /$defs/A/allOf/0",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $anchor property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "const_not_anchor": {
+                    "const": {
+                        "$anchor": "not_a_real_anchor"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_anchor"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/$defs/const_not_anchor"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_anchor",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_anchor does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "invalid anchors",
+        "comment": "Section 8.2.2",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "MUST start with a letter (and not #)",
+                "data": { "$anchor" : "#foo" },
+                "valid": false
+            },
+            {
+                "description": "JSON pointers are not valid",
+                "data": { "$anchor" : "/a/b" },
+                "valid": false
+            },
+            {
+                "description": "invalid with valid beginning",
+                "data": { "$anchor" : "foo#something" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/anyOf.json
+++ b/asdf/_jsonschema/json/tests/latest/anyOf.json
@@ -1,0 +1,203 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid",
+                "data": 3,
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one anyOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, some true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested anyOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "anyOf": [
+                {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/boolean_schema.json
+++ b/asdf/_jsonschema/json/tests/latest/boolean_schema.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "boolean schema 'true'",
+        "schema": true,
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "boolean true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "boolean false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean schema 'false'",
+        "schema": false,
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "boolean true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "boolean false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/const.json
+++ b/asdf/_jsonschema/json/tests/latest/const.json
@@ -1,0 +1,387 @@
+[
+    {
+        "description": "const validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 2
+        },
+        "tests": [
+            {
+                "description": "same value is valid",
+                "data": 2,
+                "valid": true
+            },
+            {
+                "description": "another value is invalid",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": {"foo": "bar", "baz": "bax"}
+        },
+        "tests": [
+            {
+                "description": "same object is valid",
+                "data": {"foo": "bar", "baz": "bax"},
+                "valid": true
+            },
+            {
+                "description": "same object with different property order is valid",
+                "data": {"baz": "bax", "foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "another object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": [1, 2],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": [{ "foo": "bar" }]
+        },
+        "tests": [
+            {
+                "description": "same array is valid",
+                "data": [{"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "another array item is invalid",
+                "data": [2],
+                "valid": false
+            },
+            {
+                "description": "array with additional items is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with null",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": null
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "not null is invalid",
+                "data": 0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with false does not match 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": false
+        },
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with true does not match 1",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": true
+        },
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [false] does not match [0]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": [false]
+        },
+        "tests": [
+            {
+                "description": "[false] is valid",
+                "data": [false],
+                "valid": true
+            },
+            {
+                "description": "[0] is invalid",
+                "data": [0],
+                "valid": false
+            },
+            {
+                "description": "[0.0] is invalid",
+                "data": [0.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with [true] does not match [1]",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": [true]
+        },
+        "tests": [
+            {
+                "description": "[true] is valid",
+                "data": [true],
+                "valid": true
+            },
+            {
+                "description": "[1] is invalid",
+                "data": [1],
+                "valid": false
+            },
+            {
+                "description": "[1.0] is invalid",
+                "data": [1.0],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": false} does not match {\"a\": 0}",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": {"a": false}
+        },
+        "tests": [
+            {
+                "description": "{\"a\": false} is valid",
+                "data": {"a": false},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 0} is invalid",
+                "data": {"a": 0},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 0.0} is invalid",
+                "data": {"a": 0.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with {\"a\": true} does not match {\"a\": 1}",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": {"a": true}
+        },
+        "tests": [
+            {
+                "description": "{\"a\": true} is valid",
+                "data": {"a": true},
+                "valid": true
+            },
+            {
+                "description": "{\"a\": 1} is invalid",
+                "data": {"a": 1},
+                "valid": false
+            },
+            {
+                "description": "{\"a\": 1.0} is invalid",
+                "data": {"a": 1.0},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 0 does not match other zero-like types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 0
+        },
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
+                "data": "",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with 1 does not match true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 1
+        },
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "const with -2.0 matches integer and float types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": -2.0
+        },
+        "tests": [
+            {
+                "description": "integer -2 is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "integer 2 is invalid",
+                "data": 2,
+                "valid": false
+            },
+            {
+                "description": "float -2.0 is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float 2.0 is invalid",
+                "data": 2.0,
+                "valid": false
+            },
+            {
+                "description": "float -2.00001 is invalid",
+                "data": -2.00001,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float and integers are equal up to 64-bit representation limits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": 9007199254740992
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 9007199254740992,
+                "valid": true
+            },
+            {
+                "description": "integer minus one is invalid",
+                "data": 9007199254740991,
+                "valid": false
+            },
+            {
+                "description": "float is valid",
+                "data": 9007199254740992.0,
+                "valid": true
+            },
+            {
+                "description": "float minus one is invalid",
+                "data": 9007199254740991.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "const": "hello\u0000there"
+        },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/contains.json
+++ b/asdf/_jsonschema/json/tests/latest/contains.json
@@ -1,0 +1,176 @@
+[
+    {
+        "description": "contains keyword validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"minimum": 5}
+        },
+        "tests": [
+            {
+                "description": "array with item matching schema (5) is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with item matching schema (6) is valid",
+                "data": [3, 4, 6],
+                "valid": true
+            },
+            {
+                "description": "array with two items matching schema (5, 6) is valid",
+                "data": [3, 4, 5, 6],
+                "valid": true
+            },
+            {
+                "description": "array without items matching schema is invalid",
+                "data": [2, 3, 4],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "not array is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with const keyword",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": { "const": 5 }
+        },
+        "tests": [
+            {
+                "description": "array with item 5 is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with two items 5 is valid",
+                "data": [3, 4, 5, 5],
+                "valid": true
+            },
+            {
+                "description": "array without item 5 is invalid",
+                "data": [1, 2, 3, 4],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": true
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": false
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "non-arrays are valid",
+                "data": "contains does not apply to strings",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items + contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": { "multipleOf": 2 },
+            "contains": { "multipleOf": 3 }
+        },
+        "tests": [
+            {
+                "description": "matches items, does not match contains",
+                "data": [ 2, 4, 8 ],
+                "valid": false
+            },
+            {
+                "description": "does not match items, matches contains",
+                "data": [ 3, 6, 9 ],
+                "valid": false
+            },
+            {
+                "description": "matches both items and contains",
+                "data": [ 6, 12 ],
+                "valid": true
+            },
+            {
+                "description": "matches neither items nor contains",
+                "data": [ 1, 5 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with false if subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {
+                "if": false,
+                "else": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null items",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/content.json
+++ b/asdf/_jsonschema/json/tests/latest/content.json
@@ -1,0 +1,131 @@
+[
+    {
+        "description": "validation of string-encoded content based on media type",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contentMediaType": "application/json"
+        },
+        "tests": [
+            {
+                "description": "a valid JSON document",
+                "data": "{\"foo\": \"bar\"}",
+                "valid": true
+            },
+            {
+                "description": "an invalid JSON document; validates true",
+                "data": "{:}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary string-encoding",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64 string",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string (% is not a valid character); validates true",
+                "data": "eyJmb28iOi%iYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary-encoded media type documents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64"
+        },
+        "tests": [
+            {
+                "description": "a valid base64-encoded JSON document",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "a validly-encoded invalid JSON document; validates true",
+                "data": "ezp9Cg==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string that is valid JSON; validates true",
+                "data": "{}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "validation of binary-encoded media type documents with schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64",
+            "contentSchema": { "type": "object", "required": ["foo"], "properties": { "foo": { "type": "string" } } }
+        },
+        "tests": [
+            {
+                "description": "a valid base64-encoded JSON document",
+                "data": "eyJmb28iOiAiYmFyIn0K",
+                "valid": true
+            },
+            {
+                "description": "another valid base64-encoded JSON document",
+                "data": "eyJib28iOiAyMCwgImZvbyI6ICJiYXoifQ==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64-encoded JSON document; validates true",
+                "data": "eyJib28iOiAyMH0=",
+                "valid": true
+            },
+            {
+                "description": "an empty object as a base64-encoded JSON document; validates true",
+                "data": "e30=",
+                "valid": true
+            },
+            {
+                "description": "an empty array as a base64-encoded JSON document",
+                "data": "W10=",
+                "valid": true
+            },
+            {
+                "description": "a validly-encoded invalid JSON document; validates true",
+                "data": "ezp9Cg==",
+                "valid": true
+            },
+            {
+                "description": "an invalid base64 string that is valid JSON; validates true",
+                "data": "{}",
+                "valid": true
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/default.json
+++ b/asdf/_jsonschema/json/tests/latest/default.json
@@ -1,0 +1,82 @@
+[
+    {
+        "description": "invalid type for default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "type": "integer",
+                    "default": []
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"foo": 13},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid string value for default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "minLength": 4,
+                    "default": "bad"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"bar": "good"},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "the default keyword does not do anything if the property is missing",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "number",
+                    "maximum": 3,
+                    "default": 5
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "an explicit property value is checked against maximum (passing)",
+                "data": { "alpha": 1 },
+                "valid": true
+            },
+            {
+                "description": "an explicit property value is checked against maximum (failing)",
+                "data": { "alpha": 5 },
+                "valid": false
+            },
+            {
+                "description": "missing properties are not filled in with the default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/defs.json
+++ b/asdf/_jsonschema/json/tests/latest/defs.json
@@ -1,0 +1,21 @@
+[
+    {
+        "description": "validate definition against metaschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "valid definition schema",
+                "data": {"$defs": {"foo": {"type": "integer"}}},
+                "valid": true
+            },
+            {
+                "description": "invalid definition schema",
+                "data": {"$defs": {"foo": {"type": 1}}},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/dependentRequired.json
+++ b/asdf/_jsonschema/json/tests/latest/dependentRequired.json
@@ -1,0 +1,152 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "empty dependents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependents required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentRequired": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "CRLF",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quotes",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "CRLF missing dependent",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quotes missing dependent",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/dependentSchemas.json
+++ b/asdf/_jsonschema/json/tests/latest/dependentSchemas.json
@@ -1,0 +1,132 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentSchemas": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean subschemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentSchemas": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependentSchemas": {
+                "foo\tbar": {"minProperties": 4},
+                "foo'bar": {"required": ["foo\"bar"]}
+            }
+        },
+        "tests": [
+            {
+                "description": "quoted tab",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quote",
+                "data": {
+                    "foo'bar": {"foo\"bar": 1}
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted tab invalid under dependent schema",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quote invalid under dependent schema",
+                "data": {"foo'bar": 1},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/dynamicRef.json
+++ b/asdf/_jsonschema/json/tests/latest/dynamicRef.json
@@ -1,0 +1,635 @@
+[
+    {
+        "description": "A $dynamicRef to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamicRef-dynamicAnchor-same-schema/root",
+            "type": "array",
+            "items": { "$dynamicRef": "#items" },
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef to an $anchor in the same schema resource behaves like a normal $ref to an $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamicRef-anchor-same-schema/root",
+            "type": "array",
+            "items": { "$dynamicRef": "#items" },
+            "$defs": {
+                "foo": {
+                    "$anchor": "items",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $ref to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/ref-dynamicAnchor-same-schema/root",
+            "type": "array",
+            "items": { "$ref": "#items" },
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef resolves to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/typical-dynamic-resolution/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                      "items": {
+                          "$comment": "This is only needed to satisfy the bookending requirement",
+                          "$dynamicAnchor": "items"
+                      }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef with intermediate scopes that don't include a matching $dynamicAnchor does not affect dynamic scope resolution",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-resolution-with-intermediate-scopes/root",
+            "$ref": "intermediate-scope",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "intermediate-scope": {
+                    "$id": "intermediate-scope",
+                    "$ref": "list"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                      "items": {
+                          "$comment": "This is only needed to satisfy the bookending requirement",
+                          "$dynamicAnchor": "items"
+                      }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "An array of strings is valid",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "An array containing non-strings is invalid",
+                "data": ["foo", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "An $anchor with the same name as a $dynamicAnchor is not used for dynamic scope resolution",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-resolution-ignores-anchors/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$anchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                      "items": {
+                          "$comment": "This is only needed to satisfy the bookending requirement",
+                          "$dynamicAnchor": "items"
+                      }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "Any array is valid",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef without a matching $dynamicAnchor in the same schema resource behaves like a normal $ref to $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-resolution-without-bookend/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                        "items": {
+                            "$comment": "This is only needed to give the reference somewhere to resolve to when it behaves like $ref",
+                            "$anchor": "items"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "Any array is valid",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef with a non-matching $dynamicAnchor in the same schema resource behaves like a normal $ref to $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/unmatched-dynamic-anchor/root",
+            "$ref": "list",
+            "$defs": {
+                "foo": {
+                    "$dynamicAnchor": "items",
+                    "type": "string"
+                },
+                "list": {
+                    "$id": "list",
+                    "type": "array",
+                    "items": { "$dynamicRef": "#items" },
+                    "$defs": {
+                        "items": {
+                            "$comment": "This is only needed to give the reference somewhere to resolve to when it behaves like $ref",
+                            "$anchor": "items",
+                            "$dynamicAnchor": "foo"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "Any array is valid",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef that initially resolves to a schema with a matching $dynamicAnchor resolves to the first $dynamicAnchor in the dynamic scope",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/relative-dynamic-reference/root",
+            "$dynamicAnchor": "meta",
+            "type": "object",
+            "properties": {
+                "foo": { "const": "pass" }
+            },
+            "$ref": "extended",
+            "$defs": {
+                "extended": {
+                    "$id": "extended",
+                    "$dynamicAnchor": "meta",
+                    "type": "object",
+                    "properties": {
+                        "bar": { "$ref": "bar" }
+                    }
+                },
+                "bar": {
+                    "$id": "bar",
+                    "type": "object",
+                    "properties": {
+                        "baz": { "$dynamicRef": "extended#meta" }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "The recursive part is valid against the root",
+                "data": {
+                    "foo": "pass",
+                    "bar": {
+                        "baz": { "foo": "pass" }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "The recursive part is not valid against the root",
+                "data": {
+                    "foo": "pass",
+                    "bar": {
+                        "baz": { "foo": "fail" }
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "A $dynamicRef that initially resolves to a schema without a matching $dynamicAnchor behaves like a normal $ref to $anchor",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/relative-dynamic-reference-without-bookend/root",
+            "$dynamicAnchor": "meta",
+            "type": "object",
+            "properties": {
+                "foo": { "const": "pass" }
+            },
+            "$ref": "extended",
+            "$defs": {
+                "extended": {
+                    "$id": "extended",
+                    "$anchor": "meta",
+                    "type": "object",
+                    "properties": {
+                        "bar": { "$ref": "bar" }
+                    }
+                },
+                "bar": {
+                    "$id": "bar",
+                    "type": "object",
+                    "properties": {
+                        "baz": { "$dynamicRef": "extended#meta" }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "The recursive part doesn't need to validate against the root",
+                "data": {
+                    "foo": "pass",
+                    "bar": {
+                        "baz": { "foo": "fail" }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dynamic paths to the $dynamicRef keyword",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-ref-with-multiple-paths/main",
+            "$defs": {
+                "inner": {
+                    "$id": "inner",
+                    "$dynamicAnchor": "foo",
+                    "title": "inner",
+                    "additionalProperties": {
+                        "$dynamicRef": "#foo"
+                    }
+                }
+            },
+            "if": {
+                "propertyNames": {
+                    "pattern": "^[a-m]"
+                }
+            },
+            "then": {
+                "title": "any type of node",
+                "$id": "anyLeafNode",
+                "$dynamicAnchor": "foo",
+                "$ref": "inner"
+            },
+            "else": {
+                "title": "integer node",
+                "$id": "integerNode",
+                "$dynamicAnchor": "foo",
+                "type": [ "object", "integer" ],
+                "$ref": "inner"
+            }
+        },
+        "tests": [
+            {
+                "description": "recurse to anyLeafNode - floats are allowed",
+                "data": { "alpha": 1.1 },
+                "valid": true
+            },
+            {
+                "description": "recurse to integerNode - floats are not allowed",
+                "data": { "november": 1.1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "after leaving a dynamic scope, it is not used by a $dynamicRef",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main",
+            "if": {
+                "$id": "first_scope",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is first_scope#thingy",
+                        "$dynamicAnchor": "thingy",
+                        "type": "number"
+                    }
+                }
+            },
+            "then": {
+                "$id": "second_scope",
+                "$ref": "start",
+                "$defs": {
+                    "thingy": {
+                        "$comment": "this is second_scope#thingy, the final destination of the $dynamicRef",
+                        "$dynamicAnchor": "thingy",
+                        "type": "null"
+                    }
+                }
+            },
+            "$defs": {
+                "start": {
+                    "$comment": "this is the landing spot from $ref",
+                    "$id": "start",
+                    "$dynamicRef": "inner_scope#thingy"
+                },
+                "thingy": {
+                    "$comment": "this is the first stop for the $dynamicRef",
+                    "$id": "inner_scope",
+                    "$dynamicAnchor": "thingy",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "string matches /$defs/thingy, but the $dynamicRef does not stop here",
+                "data": "a string",
+                "valid": false
+            },
+            {
+                "description": "first_scope is not in dynamic scope for the $dynamicRef",
+                "data": 42,
+                "valid": false
+            },
+            {
+                "description": "/then/$defs/thingy is the final stop for the $dynamicRef",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "strict-tree schema, guards against misspelled properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/strict-tree.json",
+            "$dynamicAnchor": "node",
+
+            "$ref": "tree.json",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "instance with misspelled field",
+                "data": {
+                    "children": [{
+                            "daat": 1
+                        }]
+                },
+                "valid": false
+            },
+            {
+                "description": "instance with correct field",
+                "data": {
+                    "children": [{
+                            "data": 1
+                        }]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "tests for implementation dynamic anchor and reference link",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/strict-extendible.json",
+            "$ref": "extendible-dynamic-ref.json",
+            "$defs": {
+                "elements": {
+                    "$dynamicAnchor": "elements",
+                    "properties": {
+                        "a": true
+                    },
+                    "required": ["a"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "incorrect parent schema",
+                "data": {
+                    "a": true
+                },
+                "valid": false
+            },
+            {
+                "description": "incorrect extended schema",
+                "data": {
+                    "elements": [
+                        { "b": 1 }
+                    ]
+                },
+                "valid": false
+            },
+            {
+                "description": "correct extended schema",
+                "data": {
+                    "elements": [
+                        { "a": 1 }
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref and $dynamicAnchor are independent of order - $defs first",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/strict-extendible-allof-defs-first.json",
+            "allOf": [
+                {
+                    "$ref": "extendible-dynamic-ref.json"
+                },
+                {
+                    "$defs": {
+                        "elements": {
+                            "$dynamicAnchor": "elements",
+                            "properties": {
+                                "a": true
+                            },
+                            "required": ["a"],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "incorrect parent schema",
+                "data": {
+                    "a": true
+                },
+                "valid": false
+            },
+            {
+                "description": "incorrect extended schema",
+                "data": {
+                    "elements": [
+                        { "b": 1 }
+                    ]
+                },
+                "valid": false
+            },
+            {
+                "description": "correct extended schema",
+                "data": {
+                    "elements": [
+                        { "a": 1 }
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref and $dynamicAnchor are independent of order - $ref first",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/strict-extendible-allof-ref-first.json",
+            "allOf": [
+                {
+                    "$defs": {
+                        "elements": {
+                            "$dynamicAnchor": "elements",
+                            "properties": {
+                                "a": true
+                            },
+                            "required": ["a"],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                {
+                    "$ref": "extendible-dynamic-ref.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "incorrect parent schema",
+                "data": {
+                    "a": true
+                },
+                "valid": false
+            },
+            {
+                "description": "incorrect extended schema",
+                "data": {
+                    "elements": [
+                        { "b": 1 }
+                    ]
+                },
+                "valid": false
+            },
+            {
+                "description": "correct extended schema",
+                "data": {
+                    "elements": [
+                        { "a": 1 }
+                    ]
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/enum.json
+++ b/asdf/_jsonschema/json/tests/latest/enum.json
@@ -1,0 +1,262 @@
+[
+    {
+        "description": "simple enum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [1, 2, 3]
+        },
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": 4,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [6, "foo", [], true, {"foo": 12}]
+        },
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": {"foo": false},
+                "valid": false
+            },
+            {
+                "description": "valid object matches",
+                "data": {"foo": 12},
+                "valid": true
+            },
+            {
+                "description": "extra properties in object is invalid",
+                "data": {"foo": 12, "boo": 42},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum-with-null validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [6, null]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 6,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": "test",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enums in properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type":"object",
+            "properties": {
+                "foo": {"enum":["foo"]},
+                "bar": {"enum":["bar"]}
+            },
+            "required": ["bar"]
+        },
+        "tests": [
+            {
+                "description": "both properties are valid",
+                "data": {"foo":"foo", "bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "wrong foo value",
+                "data": {"foo":"foot", "bar":"bar"},
+                "valid": false
+            },
+            {
+                "description": "wrong bar value",
+                "data": {"foo":"foo", "bar":"bart"},
+                "valid": false
+            },
+            {
+                "description": "missing optional property is valid",
+                "data": {"bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing required property is invalid",
+                "data": {"foo":"foo"},
+                "valid": false
+            },
+            {
+                "description": "missing all properties is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": ["foo\nbar", "foo\rbar"]
+        },
+        "tests": [
+            {
+                "description": "member 1 is valid",
+                "data": "foo\nbar",
+                "valid": true
+            },
+            {
+                "description": "member 2 is valid",
+                "data": "foo\rbar",
+                "valid": true
+            },
+            {
+                "description": "another string is invalid",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with false does not match 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [false]
+        },
+        "tests": [
+            {
+                "description": "false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "integer zero is invalid",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "float zero is invalid",
+                "data": 0.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with true does not match 1",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [true]
+        },
+        "tests": [
+            {
+                "description": "true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "integer one is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "float one is invalid",
+                "data": 1.0,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with 0 does not match false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [0]
+        },
+        "tests": [
+            {
+                "description": "false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "integer zero is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "float zero is valid",
+                "data": 0.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "enum with 1 does not match true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [1]
+        },
+        "tests": [
+            {
+                "description": "true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "integer one is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "float one is valid",
+                "data": 1.0,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nul characters in strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [ "hello\u0000there" ]
+        },
+        "tests": [
+            {
+                "description": "match string with nul",
+                "data": "hello\u0000there",
+                "valid": true
+            },
+            {
+                "description": "do not match string lacking nul",
+                "data": "hellothere",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/exclusiveMaximum.json
+++ b/asdf/_jsonschema/json/tests/latest/exclusiveMaximum.json
@@ -1,0 +1,31 @@
+[
+    {
+        "description": "exclusiveMaximum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMaximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the exclusiveMaximum is valid",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 3.0,
+                "valid": false
+            },
+            {
+                "description": "above the exclusiveMaximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/exclusiveMinimum.json
+++ b/asdf/_jsonschema/json/tests/latest/exclusiveMinimum.json
@@ -1,0 +1,31 @@
+[
+    {
+        "description": "exclusiveMinimum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMinimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the exclusiveMinimum is valid",
+                "data": 1.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "below the exclusiveMinimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/format.json
+++ b/asdf/_jsonschema/json/tests/latest/format.json
@@ -1,0 +1,743 @@
+[
+    {
+        "description": "email format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-email format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "regex format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv4 format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ipv6 format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv6"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "idn-hostname format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "hostname format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "date-time format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date-time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "time format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "json-pointer format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative-json-pointer format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "relative-json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "iri-reference format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-reference format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uri-template format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-template"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uuid format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uuid"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "duration format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "duration"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/id.json
+++ b/asdf/_jsonschema/json/tests/latest/id.json
@@ -1,0 +1,294 @@
+[
+    {
+        "description": "Invalid use of fragments in location-independent $id",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "Identifier name",
+                "data": {
+                    "$ref": "#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "#foo",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name and no ref",
+                "data": {
+                    "$defs": {
+                        "A": { "$id": "#foo" }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path",
+                "data": {
+                    "$ref": "#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "#/a/b",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/bar#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/bar#foo",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/bar#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/bar#/a/b",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier name with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft2020-12/root",
+                    "$ref": "http://localhost:1234/draft2020-12/nested.json#foo",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#foo",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "Identifier path with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft2020-12/root",
+                    "$ref": "http://localhost:1234/draft2020-12/nested.json#/a/b",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#/a/b",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Valid use of empty fragments in location-independent $id",
+        "comment": "These are allowed but discouraged",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "Identifier name with absolute URI",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/bar",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/bar#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Identifier name with base URI change in subschema",
+                "data": {
+                    "$id": "http://localhost:1234/draft2020-12/root",
+                    "$ref": "http://localhost:1234/draft2020-12/nested.json#/$defs/B",
+                    "$defs": {
+                        "A": {
+                            "$id": "nested.json",
+                            "$defs": {
+                                "B": {
+                                    "$id": "#",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Unnormalized $ids are allowed but discouraged",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "Unnormalized identifier",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/foo/baz",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier and no ref",
+                "data": {
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier with empty fragment",
+                "data": {
+                    "$ref": "http://localhost:1234/draft2020-12/foo/baz",
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "Unnormalized identifier with empty fragment and no ref",
+                "data": {
+                    "$defs": {
+                        "A": {
+                            "$id": "http://localhost:1234/draft2020-12/foo/bar/../baz#",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id inside an enum is not a real identifier",
+        "comment": "the implementation must not be confused by an $id buried in the enum",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "id_in_enum": {
+                    "enum": [
+                        {
+                          "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
+                          "type": "null"
+                        }
+                    ]
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
+                    "type": "string"
+                },
+                "zzz_id_in_const": {
+                    "const": {
+                        "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
+                        "type": "null"
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_enum" },
+                { "$ref": "https://localhost:1234/draft2020-12/id/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "exact match to enum, and type matches",
+                "data": {
+                    "$id": "https://localhost:1234/draft2020-12/id/my_identifier.json",
+                    "type": "null"
+                },
+                "valid": true
+            },
+            {
+                "description": "match $ref to $id",
+                "data": "a string to match #/$defs/id_in_enum",
+                "valid": true
+            },
+            {
+                "description": "no match on enum or $ref to $id",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-schema object containing an $id property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "const_not_id": {
+                    "const": {
+                        "$id": "not_a_real_id"
+                    }
+                }
+            },
+            "if": {
+                "const": "skip not_a_real_id"
+            },
+            "then": true,
+            "else" : {
+                "$ref": "#/$defs/const_not_id"
+            }
+        },
+        "tests": [
+            {
+                "description": "skip traversing definition for a valid result",
+                "data": "skip not_a_real_id",
+                "valid": true
+            },
+            {
+                "description": "const at const_not_id does not match",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/if-then-else.json
+++ b/asdf/_jsonschema/json/tests/latest/if-then-else.json
@@ -1,0 +1,268 @@
+[
+    {
+        "description": "ignore if without then or else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone if",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone if",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore then without if",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "then": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone then",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone then",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore else without if",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "else": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone else",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone else",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and then without else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid when if test fails",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and else without then",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when if test passes",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validate against correct branch, then vs else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-interference across combined schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "if": {
+                        "exclusiveMaximum": 0
+                    }
+                },
+                {
+                    "then": {
+                        "minimum": -10
+                    }
+                },
+                {
+                    "else": {
+                        "multipleOf": 2
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid, but would have been invalid through then",
+                "data": -100,
+                "valid": true
+            },
+            {
+                "description": "valid, but would have been invalid through else",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": true,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema true in if always chooses the then path (valid)",
+                "data": "then",
+                "valid": true
+            },
+            {
+                "description": "boolean schema true in if always chooses the then path (invalid)",
+                "data": "else",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "if with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": false,
+            "then": { "const": "then" },
+            "else": { "const": "else" }
+        },
+        "tests": [
+            {
+                "description": "boolean schema false in if always chooses the else path (invalid)",
+                "data": "then",
+                "valid": false
+            },
+            {
+                "description": "boolean schema false in if always chooses the else path (valid)",
+                "data": "else",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if appears at the end when serialized (keyword processing sequence)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "then": { "const": "yes" },
+            "else": { "const": "other" },
+            "if": { "maxLength": 4 }
+        },
+        "tests": [
+            {
+                "description": "yes redirects to then and passes",
+                "data": "yes",
+                "valid": true
+            },
+            {
+                "description": "other redirects to else and passes",
+                "data": "other",
+                "valid": true
+            },
+            {
+                "description": "no redirects to then and fails",
+                "data": "no",
+                "valid": false
+            },
+            {
+                "description": "invalid redirects to else and fails",
+                "data": "invalid",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/infinite-loop-detection.json
+++ b/asdf/_jsonschema/json/tests/latest/infinite-loop-detection.json
@@ -1,0 +1,37 @@
+[
+    {
+        "description": "evaluating the same schema location against the same data location twice is not a sign of an infinite loop",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "int": { "type": "integer" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "$ref": "#/$defs/int"
+                        }
+                    }
+                },
+                {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/int"
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "passing case",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "failing case",
+                "data": { "foo": "a string" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/items.json
+++ b/asdf/_jsonschema/json/tests/latest/items.json
@@ -1,0 +1,284 @@
+[
+    {
+        "description": "a schema given for items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of items",
+                "data": [1, "x"],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "length": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (true)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": true
+        },
+        "tests": [
+            {
+                "description": "any array is valid",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (false)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": [ 1, "foo", true ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "item": {
+                    "type": "array",
+                    "items": false,
+                    "prefixItems": [
+                        { "$ref": "#/$defs/sub-item" },
+                        { "$ref": "#/$defs/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "items": false,
+            "prefixItems": [
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" },
+                { "$ref": "#/$defs/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "prefixItems with no additional items allowed",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{}, {}, {}],
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (1)",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "fewer number of items present (2)",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "additional items are not permitted",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items does not look in applicators, valid case",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                { "prefixItems": [ { "minimum": 3 } ] }
+            ],
+            "items": { "minimum": 5 }
+        },
+        "tests": [
+            {
+                "description": "prefixItems in allOf does not constrain items, invalid case",
+                "data": [ 3, 5 ],
+                "valid": false
+            },
+            {
+                "description": "prefixItems in allOf does not constrain items, valid case",
+                "data": [ 5, 5 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "prefixItems validation adjusts the starting index for items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [ { "type": "string" } ],
+            "items": { "type": "integer" }
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ "x", 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of second item",
+                "data": [ "x", "y" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/maxContains.json
+++ b/asdf/_jsonschema/json/tests/latest/maxContains.json
@@ -1,0 +1,102 @@
+[
+    {
+        "description": "maxContains without contains is ignored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "one item valid against lone maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "two items still valid against lone maxContains",
+                "data": [ 1, 2 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "all elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            },
+            {
+                "description": "some elements match, valid maxContains",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "some elements match, invalid maxContains",
+                "data": [ 1, 2, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxContains with contains, value with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "maxContains": 1.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, valid maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many elements match, invalid maxContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minContains < maxContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 1,
+            "maxContains": 3
+        },
+        "tests": [
+            {
+                "description": "actual < minContains < maxContains",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "minContains < actual < maxContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            },
+            {
+                "description": "minContains < maxContains < actual",
+                "data": [ 1, 1, 1, 1 ],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/maxItems.json
+++ b/asdf/_jsonschema/json/tests/latest/maxItems.json
@@ -1,0 +1,50 @@
+[
+    {
+        "description": "maxItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxItems": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "foobar",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxItems validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxItems": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/maxLength.json
+++ b/asdf/_jsonschema/json/tests/latest/maxLength.json
@@ -1,0 +1,55 @@
+[
+    {
+        "description": "maxLength validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxLength": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxLength validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxLength": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/maxProperties.json
+++ b/asdf/_jsonschema/json/tests/latest/maxProperties.json
@@ -1,0 +1,79 @@
+[
+    {
+        "description": "maxProperties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxProperties": 2
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxProperties validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxProperties": 2.0
+        },
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maxProperties = 0 means the object is empty",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maxProperties": 0
+        },
+        "tests": [
+            {
+                "description": "no properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "one property is invalid",
+                "data": { "foo": 1 },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/maximum.json
+++ b/asdf/_jsonschema/json/tests/latest/maximum.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "maximum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maximum validation with unsigned integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maximum": 300
+        },
+        "tests":  [
+            {
+                "description": "below the maximum is invalid",
+                "data": 299.97,
+                "valid": true
+            },
+            {
+                "description": "boundary point integer is valid",
+                "data": 300,
+                "valid": true
+            },
+            {
+                "description": "boundary point float is valid",
+                "data": 300.00,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 300.5,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/minContains.json
+++ b/asdf/_jsonschema/json/tests/latest/minContains.json
@@ -1,0 +1,224 @@
+[
+    {
+        "description": "minContains without contains is ignored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minContains": 1
+        },
+        "tests": [
+            {
+                "description": "one item valid against lone minContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "zero items still valid against lone minContains",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=1 with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "no elements match",
+                "data": [ 2 ],
+                "valid": false
+            },
+            {
+                "description": "single element matches, valid minContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "some elements match, valid minContains",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "all elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=2 with contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 2
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "some elements match, invalid minContains",
+                "data": [ 1, 2 ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid minContains (exactly as needed)",
+                "data": [ 1, 1 ],
+                "valid": true
+            },
+            {
+                "description": "all elements match, valid minContains (more than needed)",
+                "data": [ 1, 1, 1 ],
+                "valid": true
+            },
+            {
+                "description": "some elements match, valid minContains",
+                "data": [ 1, 2, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains=2 with contains with a decimal value",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 2.0
+        },
+        "tests": [
+            {
+                "description": "one element matches, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "both elements match, valid minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains = minContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "maxContains": 2,
+            "minContains": 2
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, invalid maxContains",
+                "data": [ 1, 1, 1 ],
+                "valid": false
+            },
+            {
+                "description": "all elements match, valid maxContains and minContains",
+                "data": [ 1, 1 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "maxContains < minContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "maxContains": 1,
+            "minContains": 3
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": false
+            },
+            {
+                "description": "invalid minContains",
+                "data": [ 1 ],
+                "valid": false
+            },
+            {
+                "description": "invalid maxContains",
+                "data": [ 1, 1, 1 ],
+                "valid": false
+            },
+            {
+                "description": "invalid maxContains and minContains",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minContains = 0",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 0
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "minContains = 0 makes contains always pass",
+                "data": [ 2 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minContains = 0 with maxContains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "contains": {"const": 1},
+            "minContains": 0,
+            "maxContains": 1
+        },
+        "tests": [
+            {
+                "description": "empty data",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "not more than maxContains",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "too many",
+                "data": [ 1, 1 ],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/minItems.json
+++ b/asdf/_jsonschema/json/tests/latest/minItems.json
@@ -1,0 +1,50 @@
+[
+    {
+        "description": "minItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minItems": 1
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minItems validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minItems": 1.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/minLength.json
+++ b/asdf/_jsonschema/json/tests/latest/minLength.json
@@ -1,0 +1,55 @@
+[
+    {
+        "description": "minLength validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minLength": 2
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minLength validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minLength": 2.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/minProperties.json
+++ b/asdf/_jsonschema/json/tests/latest/minProperties.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "minProperties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minProperties": 1
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minProperties validation with a decimal",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minProperties": 1.0
+        },
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/minimum.json
+++ b/asdf/_jsonschema/json/tests/latest/minimum.json
@@ -1,0 +1,75 @@
+[
+    {
+        "description": "minimum validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minimum validation with signed integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": -2
+        },
+        "tests": [
+            {
+                "description": "negative above the minimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the minimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "boundary point with float is valid",
+                "data": -2.0,
+                "valid": true
+            },
+            {
+                "description": "float below the minimum is invalid",
+                "data": -2.0001,
+                "valid": false
+            },
+            {
+                "description": "int below the minimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/multipleOf.json
+++ b/asdf/_jsonschema/json/tests/latest/multipleOf.json
@@ -1,0 +1,83 @@
+[
+    {
+        "description": "by int",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "multipleOf": 2
+        },
+        "tests": [
+            {
+                "description": "int by int",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "int by int fail",
+                "data": 7,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "by number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "multipleOf": 1.5
+        },
+        "tests": [
+            {
+                "description": "zero is multiple of anything",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "4.5 is multiple of 1.5",
+                "data": 4.5,
+                "valid": true
+            },
+            {
+                "description": "35 is not multiple of 1.5",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "by small number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "multipleOf": 0.0001
+        },
+        "tests": [
+            {
+                "description": "0.0075 is multiple of 0.0001",
+                "data": 0.0075,
+                "valid": true
+            },
+            {
+                "description": "0.00751 is not multiple of 0.0001",
+                "data": 0.00751,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "float division = inf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer", "multipleOf": 0.123456789
+        },
+        "tests": [
+            {
+                "description": "always invalid, but naive implementations may raise an overflow error",
+                "data": 1e308,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/not.json
+++ b/asdf/_jsonschema/json/tests/latest/not.json
@@ -1,0 +1,127 @@
+[
+    {
+        "description": "not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "allowed",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "disallowed",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not multiple types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": {"type": ["integer", "boolean"]}
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": true,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not more complex schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+             }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "other match",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "forbidden property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": { 
+                    "not": {}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property present",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "property absent",
+                "data": {"bar": 1, "baz": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": true
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "not": false
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/oneOf.json
+++ b/asdf/_jsonschema/json/tests/latest/oneOf.json
@@ -1,0 +1,293 @@
+[
+    {
+        "description": "oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with base schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "oneOf" : [
+                {
+                    "minLength": 2
+                },
+                {
+                    "maxLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one oneOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [true, true, true]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, one true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [true, false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, more than one true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [true, true, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [false, false, false]
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf complex types",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    },
+	{
+        "description": "oneOf with missing optional property",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": true,
+                        "baz": true
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": {"bar": 8},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": {"foo": "foo"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": {"foo": "foo", "bar": 8},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": {"baz": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested oneOf, to check validation semantics",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "anything non-null is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/bignum.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/bignum.json
@@ -1,0 +1,110 @@
+[
+    {
+        "description": "integer",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "a bignum is an integer",
+                "data": 12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is an integer",
+                "data": -12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "number",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number"
+        },
+        "tests": [
+            {
+                "description": "a bignum is a number",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            },
+            {
+                "description": "a negative bignum is a number",
+                "data": -98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "string",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string"
+        },
+        "tests": [
+            {
+                "description": "a bignum is not a string",
+                "data": 98249283749234923498293171823948729348710298301928331,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "maximum integer comparison",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "maximum": 18446744073709551615
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMaximum": 972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for high numbers",
+                "data": 972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "minimum integer comparison",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": -18446744073709551615
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision on negative numbers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "exclusiveMinimum": -972783798187987123879878123.18878137
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/cross-draft.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/cross-draft.json
@@ -1,0 +1,18 @@
+[
+    {
+        "description": "refs to historic drafts are processed as historic drafts",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "$ref": "http://localhost:1234/draft2019-09/ignore-prefixItems.json"
+        },
+        "tests": [
+            {
+                "description": "first item not a string is valid",
+                "comment": "if the implementation is not processing the $ref as a 2019-09 schema, this test will fail",
+                "data": [1, 2, 3],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/dependencies-compatibility.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/dependencies-compatibility.json
@@ -1,0 +1,282 @@
+[
+    {
+        "description": "single dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "empty dependents",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependents required",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "CRLF",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quotes",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "CRLF missing dependent",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quotes missing dependent",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "single schema dependency",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean subschemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "schema dependencies with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "dependencies": {
+                "foo\tbar": {"minProperties": 4},
+                "foo'bar": {"required": ["foo\"bar"]}
+            }
+        },
+        "tests": [
+            {
+                "description": "quoted tab",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "quoted quote",
+                "data": {
+                    "foo'bar": {"foo\"bar": 1}
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted tab invalid under dependent schema",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "quoted quote invalid under dependent schema",
+                "data": {"foo'bar": 1},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/ecmascript-regex.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/ecmascript-regex.json
@@ -1,0 +1,596 @@
+[
+    {
+        "description": "ECMA 262 regex $ does not match trailing newline",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^abc$"
+        },
+        "tests": [
+            {
+                "description": "matches in Python, but not in ECMA 262",
+                "data": "abc\\n",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "abc",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex converts \\t to horizontal tab",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\t$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\t",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0009",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and upper letter",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\cC$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cC",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 regex escapes control codes with \\c and lower letter",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\cc$"
+        },
+        "tests": [
+            {
+                "description": "does not match",
+                "data": "\\cc",
+                "valid": false
+            },
+            {
+                "description": "matches",
+                "data": "\u0003",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\d matches ascii digits only",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\d$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero matches",
+                "data": "0",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO does not match (unlike e.g. Python)",
+                "data": "߀",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) does not match",
+                "data": "\u07c0",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\D matches everything but ascii digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\D$"
+        },
+        "tests": [
+            {
+                "description": "ASCII zero does not match",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "NKO DIGIT ZERO matches (unlike e.g. Python)",
+                "data": "߀",
+                "valid": true
+            },
+            {
+                "description": "NKO DIGIT ZERO (as \\u escape) matches",
+                "data": "\u07c0",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\w matches ascii letters only",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\w$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' matches",
+                "data": "a",
+                "valid": true
+            },
+            {
+                "description": "latin-1 e-acute does not match (unlike e.g. Python)",
+                "data": "é",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\W matches everything but ascii letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\W$"
+        },
+        "tests": [
+            {
+                "description": "ASCII 'a' does not match",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "latin-1 e-acute matches (unlike e.g. Python)",
+                "data": "é",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\s matches whitespace",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\s$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space matches",
+                "data": " ",
+                "valid": true
+            },
+            {
+                "description": "Character tabulation matches",
+                "data": "\t",
+                "valid": true
+            },
+            {
+                "description": "Line tabulation matches",
+                "data": "\u000b",
+                "valid": true
+            },
+            {
+                "description": "Form feed matches",
+                "data": "\u000c",
+                "valid": true
+            },
+            {
+                "description": "latin-1 non-breaking-space matches",
+                "data": "\u00a0",
+                "valid": true
+            },
+            {
+                "description": "zero-width whitespace matches",
+                "data": "\ufeff",
+                "valid": true
+            },
+            {
+                "description": "line feed matches (line terminator)",
+                "data": "\u000a",
+                "valid": true
+            },
+            {
+                "description": "paragraph separator matches (line terminator)",
+                "data": "\u2029",
+                "valid": true
+            },
+            {
+                "description": "EM SPACE matches (Space_Separator)",
+                "data": "\u2003",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace control does not match",
+                "data": "\u0001",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace does not match",
+                "data": "\u2013",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 \\S matches everything but whitespace",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "pattern": "^\\S$"
+        },
+        "tests": [
+            {
+                "description": "ASCII space does not match",
+                "data": " ",
+                "valid": false
+            },
+            {
+                "description": "Character tabulation does not match",
+                "data": "\t",
+                "valid": false
+            },
+            {
+                "description": "Line tabulation does not match",
+                "data": "\u000b",
+                "valid": false
+            },
+            {
+                "description": "Form feed does not match",
+                "data": "\u000c",
+                "valid": false
+            },
+            {
+                "description": "latin-1 non-breaking-space does not match",
+                "data": "\u00a0",
+                "valid": false
+            },
+            {
+                "description": "zero-width whitespace does not match",
+                "data": "\ufeff",
+                "valid": false
+            },
+            {
+                "description": "line feed does not match (line terminator)",
+                "data": "\u000a",
+                "valid": false
+            },
+            {
+                "description": "paragraph separator does not match (line terminator)",
+                "data": "\u2029",
+                "valid": false
+            },
+            {
+                "description": "EM SPACE does not match (Space_Separator)",
+                "data": "\u2003",
+                "valid": false
+            },
+            {
+                "description": "Non-whitespace control matches",
+                "data": "\u0001",
+                "valid": true
+            },
+            {
+                "description": "Non-whitespace matches",
+                "data": "\u2013",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with pattern",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "\\p{Letter}cole"
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patterns matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "\\wcole"
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": "LES HIVERS DE MON ENFANCE ÉTAIENT DES SAISONS LONGUES, LONGUES. NOUS VIVIONS EN TROIS LIEUX: L'ÉCOLE, L'ÉGLISE ET LA PATINOIRE; MAIS LA VRAIE VIE ÉTAIT SUR LA PATINOIRE.",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with ASCII ranges",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "[a-z]cole"
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'école, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": "Les hivers de mon enfance étaient des saisons longues, longues. Nous vivions en trois lieux: l'\u00e9cole, l'église et la patinoire; mais la vraie vie était sur la patinoire.",
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": "Les hivers de mon enfance etaient des saisons longues, longues. Nous vivions en trois lieux: l'ecole, l'eglise et la patinoire; mais la vraie vie etait sur la patinoire.",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in pattern matches [0-9], not unicode digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^\\d+$"
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": { "pattern": "\\a" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "pattern with non-ASCII digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^\\p{digit}+$"
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": "42",
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": "-%#",
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": "৪২",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patterns always use unicode semantics with patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "\\p{Letter}cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "\\w in patternProperties matches [A-Za-z0-9_], not unicode letters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "\\wcole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii character in json string",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            },
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode matching is case-sensitive",
+                "data": { "L'ÉCOLE": "PAS DE VRAIE VIE" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with ASCII ranges",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "[a-z]cole": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "literal unicode character in json string",
+                "data": { "l'école": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "unicode character in hex format in string",
+                "data": { "l'\u00e9cole": "pas de vraie vie" },
+                "valid": false
+            },
+            {
+                "description": "ascii characters match",
+                "data": { "l'ecole": "pas de vraie vie" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "\\d in patternProperties matches [0-9], not unicode digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "^\\d+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with non-ASCII digits",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "^\\p{digit}+$": true
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "ascii digits",
+                "data": { "42": "life, the universe, and everything" },
+                "valid": true
+            },
+            {
+                "description": "ascii non-digits",
+                "data": { "-%#": "spending the year dead for tax reasons" },
+                "valid": false
+            },
+            {
+                "description": "non-ascii digits (BENGALI DIGIT FOUR, BENGALI DIGIT TWO)",
+                "data": { "৪২": "khajit has wares if you have coin" },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/float-overflow.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/float-overflow.json
@@ -1,0 +1,17 @@
+[
+    {
+        "description": "all integers are multiples of 0.5, if overflow is handled",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer",
+            "multipleOf": 0.5
+        },
+        "tests": [
+            {
+                "description": "valid if optional overflow handling is implemented",
+                "data": 1e308,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format-assertion.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format-assertion.json
@@ -1,0 +1,42 @@
+[
+    {
+        "description": "schema that uses custom metaschema with format-assertion: false",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/false",
+            "$schema": "http://localhost:1234/draft2020-12/format-assertion-false.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: false: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: false: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "schema that uses custom metaschema with format-assertion: true",
+        "schema": {
+            "$id": "https://schema/using/format-assertion/true",
+            "$schema": "http://localhost:1234/draft2020-12/format-assertion-true.json",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "format-assertion: true: valid string",
+                "data": "127.0.0.1",
+                "valid": true
+            },
+            {
+                "description": "format-assertion: true: invalid string",
+                "data": "not-an-ipv4",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/date-time.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/date-time.json
@@ -1,0 +1,136 @@
+[
+    {
+        "description": "validation of date-time strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date-time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, UTC",
+                "data": "1998-12-31T23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time with a leap second, with minus offset",
+                "data": "1998-12-31T15:59:60.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "an invalid date-time past leap second, UTC",
+                "data": "1998-12-31T23:59:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong minute, UTC",
+                "data": "1998-12-31T23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time with leap second on a wrong hour, UTC",
+                "data": "1998-12-31T22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid day in date-time string",
+                "data": "1990-02-31T15:59:59.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:59-24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid closing Z after time-zone offset",
+                "data": "1963-06-19T08:30:06.28123+01:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "case-insensitive T and Z",
+                "data": "1963-06-19t08:30:06.283185z",
+                "valid": true
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded month dates",
+                "data": "1963-6-19T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-padded day dates",
+                "data": "1963-06-1T08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in date portion",
+                "data": "1963-06-1৪T00:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in time portion",
+                "data": "1963-06-11T0৪:00:00Z",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/date.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/date.json
@@ -1,0 +1,226 @@
+[
+    {
+        "description": "validation of date strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "date"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid date string",
+                "data": "1963-06-19",
+                "valid": true
+            },
+            {
+                "description": "a valid date string with 31 days in January",
+                "data": "2020-01-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in January",
+                "data": "2020-01-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 28 days in February (normal)",
+                "data": "2021-02-28",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 29 days in February (normal)",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 29 days in February (leap)",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 30 days in February (leap)",
+                "data": "2020-02-30",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in March",
+                "data": "2020-03-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in March",
+                "data": "2020-03-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in April",
+                "data": "2020-04-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in April",
+                "data": "2020-04-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in May",
+                "data": "2020-05-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in May",
+                "data": "2020-05-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in June",
+                "data": "2020-06-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in June",
+                "data": "2020-06-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in July",
+                "data": "2020-07-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in July",
+                "data": "2020-07-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in August",
+                "data": "2020-08-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in August",
+                "data": "2020-08-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in September",
+                "data": "2020-09-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in September",
+                "data": "2020-09-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in October",
+                "data": "2020-10-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in October",
+                "data": "2020-10-32",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 30 days in November",
+                "data": "2020-11-30",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 31 days in November",
+                "data": "2020-11-31",
+                "valid": false
+            },
+            {
+                "description": "a valid date string with 31 days in December",
+                "data": "2020-12-31",
+                "valid": true
+            },
+            {
+                "description": "a invalid date string with 32 days in December",
+                "data": "2020-12-32",
+                "valid": false
+            },
+            {
+                "description": "a invalid date string with invalid month",
+                "data": "2020-13-01",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string",
+                "data": "06/19/1963",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350",
+                "valid": false
+            },
+            {
+                "description": "non-padded month dates are not valid",
+                "data": "1998-1-20",
+                "valid": false
+            },
+            {
+                "description": "non-padded day dates are not valid",
+                "data": "1998-01-1",
+                "valid": false
+            },
+            {
+                "description": "invalid month",
+                "data": "1998-13-01",
+                "valid": false
+            },
+            {
+                "description": "invalid month-day combination",
+                "data": "1998-04-31",
+                "valid": false
+            },
+            {
+                "description": "2021 is not a leap year",
+                "data": "2021-02-29",
+                "valid": false
+            },
+            {
+                "description": "2020 is a leap year",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1963-06-1৪",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/duration.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/duration.json
@@ -1,0 +1,136 @@
+[
+    {
+        "description": "validation of duration strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "duration"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid duration string",
+                "data": "P4DT12H30M5S",
+                "valid": true
+            },
+            {
+                "description": "an invalid duration string",
+                "data": "PT1D",
+                "valid": false
+            },
+            {
+                "description": "no elements present",
+                "data": "P",
+                "valid": false
+            },
+            {
+                "description": "no time elements present",
+                "data": "P1YT",
+                "valid": false
+            },
+            {
+                "description": "no date or time elements present",
+                "data": "PT",
+                "valid": false
+            },
+            {
+                "description": "elements out of order",
+                "data": "P2D1Y",
+                "valid": false
+            },
+            {
+                "description": "missing time separator",
+                "data": "P1D2H",
+                "valid": false
+            },
+            {
+                "description": "time element in the date position",
+                "data": "P2S",
+                "valid": false
+            },
+            {
+                "description": "four years duration",
+                "data": "P4Y",
+                "valid": true
+            },
+            {
+                "description": "zero time, in seconds",
+                "data": "PT0S",
+                "valid": true
+            },
+            {
+                "description": "zero time, in days",
+                "data": "P0D",
+                "valid": true
+            },
+            {
+                "description": "one month duration",
+                "data": "P1M",
+                "valid": true
+            },
+            {
+                "description": "one minute duration",
+                "data": "PT1M",
+                "valid": true
+            },
+            {
+                "description": "one and a half days, in hours",
+                "data": "PT36H",
+                "valid": true
+            },
+            {
+                "description": "one and a half days, in days and hours",
+                "data": "P1DT12H",
+                "valid": true
+            },
+            {
+                "description": "two weeks",
+                "data": "P2W",
+                "valid": true
+            },
+            {
+                "description": "weeks cannot be combined with other units",
+                "data": "P1Y2W",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "P২Y",
+                "valid": false
+            },
+            {
+                "description": "element without unit",
+                "data": "P1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/email.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/email.json
@@ -1,0 +1,121 @@
+[
+    {
+        "description": "validation of e-mail addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "tilde in local part is valid",
+                "data": "te~st@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde before local part is valid",
+                "data": "~test@example.com",
+                "valid": true
+            },
+            {
+                "description": "tilde after local part is valid",
+                "data": "test~@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a space in the local part is valid",
+                "data": "\"joe bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a double dot in the local part is valid",
+                "data": "\"joe..bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a quoted string with a @ in the local part is valid",
+                "data": "\"joe@bloggs\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "an IPv4-address-literal after the @ is valid",
+                "data": "joe.bloggs@[127.0.0.1]",
+                "valid": true
+            },
+            {
+                "description": "an IPv6-address-literal after the @ is valid",
+                "data": "joe.bloggs@[IPv6:::1]",
+                "valid": true
+            },
+            {
+                "description": "dot before local part is not valid",
+                "data": ".test@example.com",
+                "valid": false
+            },
+            {
+                "description": "dot after local part is not valid",
+                "data": "test.@example.com",
+                "valid": false
+            },
+            {
+                "description": "two separated dots inside local part are valid",
+                "data": "te.s.t@example.com",
+                "valid": true
+            },
+            {
+                "description": "two subsequent dots inside local part are not valid",
+                "data": "te..st@example.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid domain",
+                "data": "joe.bloggs@invalid=domain.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid IPv4-address-literal",
+                "data": "joe.bloggs@[127.0.0.300]",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/hostname.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/hostname.json
@@ -1,0 +1,101 @@
+[
+    {
+        "description": "validation of host names",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name",
+                "data": "www.example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid punycoded IDN hostname",
+                "data": "xn--4gbwdl.xn--wgbh1c",
+                "valid": true
+            },
+            {
+                "description": "a host name starting with an illegal character",
+                "data": "-a-host-name-that-starts-with--",
+                "valid": false
+            },
+            {
+                "description": "a host name containing illegal characters",
+                "data": "not_a_valid_host_name",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "a-vvvvvvvvvvvvvvvveeeeeeeeeeeeeeeerrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy-long-host-name-component",
+                "valid": false
+            },
+            {
+                "description": "starts with hyphen",
+                "data": "-hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with hyphen",
+                "data": "hostname-",
+                "valid": false
+            },
+            {
+                "description": "starts with underscore",
+                "data": "_hostname",
+                "valid": false
+            },
+            {
+                "description": "ends with underscore",
+                "data": "hostname_",
+                "valid": false
+            },
+            {
+                "description": "contains underscore",
+                "data": "host_name",
+                "valid": false
+            },
+            {
+                "description": "maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+                "valid": true
+            },
+            {
+                "description": "exceeds maximum label length",
+                "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/idn-email.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/idn-email.json
@@ -1,0 +1,61 @@
+[
+    {
+        "description": "validation of an internationalized e-mail addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-email"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid idn e-mail (example@example.test in Hangul)",
+                "data": "실례@실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "an invalid idn e-mail address",
+                "data": "2962",
+                "valid": false
+            },
+            {
+                "description": "a valid e-mail address",
+                "data": "joe.bloggs@example.com",
+                "valid": true
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": "2962",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/idn-hostname.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/idn-hostname.json
@@ -1,0 +1,307 @@
+[
+    {
+        "description": "validation of internationalized host names",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "idn-hostname"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid host name (example.test in Hangul)",
+                "data": "실례.테스트",
+                "valid": true
+            },
+            {
+                "description": "illegal first char U+302E Hangul single dot tone mark",
+                "data": "〮실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "contains illegal char U+302E Hangul single dot tone mark",
+                "data": "실〮례.테스트",
+                "valid": false
+            },
+            {
+                "description": "a host name with a component too long",
+                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "valid": false
+            },
+            {
+                "description": "invalid label, correct Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc3492#section-7.1",
+                "data": "-> $1.00 <--",
+                "valid": false
+            },
+            {
+                "description": "valid Chinese Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5890#section-2.3.2.1 https://tools.ietf.org/html/rfc5891#section-4.4",
+                "data": "xn--ihqwcrb4cv8a8dqg056pqjye",
+                "valid": true
+            },
+            {
+                "description": "invalid Punycode",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.4 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "xn--X",
+                "valid": false
+            },
+            {
+                "description": "U-label contains \"--\" in the 3rd and 4th position",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1 https://tools.ietf.org/html/rfc5890#section-2.3.2.1",
+                "data": "XN--aa---o47jg78q",
+                "valid": false
+            },
+            {
+                "description": "U-label starts with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello",
+                "valid": false
+            },
+            {
+                "description": "U-label ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "hello-",
+                "valid": false
+            },
+            {
+                "description": "U-label starts and ends with a dash",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.1",
+                "data": "-hello-",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Spacing Combining Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0903hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with a Nonspacing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0300hello",
+                "valid": false
+            },
+            {
+                "description": "Begins with an Enclosing Mark",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.2",
+                "data": "\u0488hello",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are PVALID, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u00df\u03c2\u0f0b\u3007",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are PVALID, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u06fd\u06fe",
+                "valid": true
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, right-to-left chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6",
+                "data": "\u0640\u07fa",
+                "valid": false
+            },
+            {
+                "description": "Exceptions that are DISALLOWED, left-to-right chars",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.2 https://tools.ietf.org/html/rfc5892#section-2.6 Note: The two combining marks (U+302E and U+302F) are in the middle and not at the start",
+                "data": "\u3031\u3032\u3033\u3034\u3035\u302e\u302f\u303b",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no preceding 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "a\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing preceding",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "\u00b7l",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with no following 'l'",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7a",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with nothing following",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7",
+                "valid": false
+            },
+            {
+                "description": "MIDDLE DOT with surrounding 'l's",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.3",
+                "data": "l\u00b7l",
+                "valid": true
+            },
+            {
+                "description": "Greek KERAIA not followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375S",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA not followed by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375",
+                "valid": false
+            },
+            {
+                "description": "Greek KERAIA followed by Greek",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.4",
+                "data": "\u03b1\u0375\u03b2",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERESH not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "A\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05f3\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERESH preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.5",
+                "data": "\u05d0\u05f3\u05d1",
+                "valid": true
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "A\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05f4\u05d1",
+                "valid": false
+            },
+            {
+                "description": "Hebrew GERSHAYIM preceded by Hebrew",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.6",
+                "data": "\u05d0\u05f4\u05d1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no Hiragana, Katakana, or Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "def\u30fbabc",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with no other characters",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb",
+                "valid": false
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Hiragana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u3041",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Katakana",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u30a1",
+                "valid": true
+            },
+            {
+                "description": "KATAKANA MIDDLE DOT with Han",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.7",
+                "data": "\u30fb\u4e08",
+                "valid": true
+            },
+            {
+                "description": "Arabic-Indic digits mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0660\u06f0",
+                "valid": false
+            },
+            {
+                "description": "Arabic-Indic digits not mixed with Extended Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.8",
+                "data": "\u0628\u0660\u0628",
+                "valid": true
+            },
+            {
+                "description": "Extended Arabic-Indic digits not mixed with Arabic-Indic digits",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.9",
+                "data": "\u06f00",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER not preceded by anything",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u200d\u0937",
+                "valid": false
+            },
+            {
+                "description": "ZERO WIDTH JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.2 https://www.unicode.org/review/pr-37.pdf",
+                "data": "\u0915\u094d\u200d\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER preceded by Virama",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937",
+                "valid": true
+            },
+            {
+                "description": "ZERO WIDTH NON-JOINER not preceded by Virama but matches regexp",
+                "comment": "https://tools.ietf.org/html/rfc5891#section-4.2.3.3 https://tools.ietf.org/html/rfc5892#appendix-A.1 https://www.w3.org/TR/alreq/#h_disjoining_enforcement",
+                "data": "\u0628\u064a\u200c\u0628\u064a",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/ipv4.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/ipv4.json
@@ -1,0 +1,87 @@
+[
+    {
+        "description": "validation of IP addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv4"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IP address",
+                "data": "192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "an IP address with too many components",
+                "data": "127.0.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "an IP address with out-of-range values",
+                "data": "256.256.256.256",
+                "valid": false
+            },
+            {
+                "description": "an IP address without 4 components",
+                "data": "127.0",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer",
+                "data": "0x7f000001",
+                "valid": false
+            },
+            {
+                "description": "an IP address as an integer (decimal)",
+                "data": "2130706433",
+                "valid": false
+            },
+            {
+                "description": "invalid leading zeroes, as they are treated as octals",
+                "comment": "see https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/",
+                "data": "087.10.0.1",
+                "valid": false
+            },
+            {
+                "description": "value without leading zero is valid",
+                "data": "87.10.0.1",
+                "valid": true
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২7.0.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/ipv6.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/ipv6.json
@@ -1,0 +1,211 @@
+[
+    {
+        "description": "validation of IPv6 addresses",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "ipv6"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IPv6 address",
+                "data": "::1",
+                "valid": true
+            },
+            {
+                "description": "an IPv6 address with out-of-range values",
+                "data": "12345::",
+                "valid": false
+            },
+            {
+                "description": "trailing 4 hex symbols is valid",
+                "data": "::abef",
+                "valid": true
+            },
+            {
+                "description": "trailing 5 hex symbols is invalid",
+                "data": "::abcef",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address with too many components",
+                "data": "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1",
+                "valid": false
+            },
+            {
+                "description": "an IPv6 address containing illegal characters",
+                "data": "::laptop",
+                "valid": false
+            },
+            {
+                "description": "no digits is valid",
+                "data": "::",
+                "valid": true
+            },
+            {
+                "description": "leading colons is valid",
+                "data": "::42:ff:1",
+                "valid": true
+            },
+            {
+                "description": "trailing colons is valid",
+                "data": "d6::",
+                "valid": true
+            },
+            {
+                "description": "missing leading octet is invalid",
+                "data": ":2:3:4:5:6:7:8",
+                "valid": false
+            },
+            {
+                "description": "missing trailing octet is invalid",
+                "data": "1:2:3:4:5:6:7:",
+                "valid": false
+            },
+            {
+                "description": "missing leading octet with omitted octets later",
+                "data": ":2:3:4::8",
+                "valid": false
+            },
+            {
+                "description": "single set of double colons in the middle is valid",
+                "data": "1:d6::42",
+                "valid": true
+            },
+            {
+                "description": "two sets of double colons is invalid",
+                "data": "1::d6::42",
+                "valid": false
+            },
+            {
+                "description": "mixed format with the ipv4 section as decimal octets",
+                "data": "1::d6:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with double colons between the sections",
+                "data": "1:2::192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "mixed format with ipv4 section with octet out of range",
+                "data": "1::2:192.168.256.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with ipv4 section with a hex octet",
+                "data": "1::2:192.168.ff.1",
+                "valid": false
+            },
+            {
+                "description": "mixed format with leading double colons (ipv4-mapped ipv6 address)",
+                "data": "::ffff:192.168.0.1",
+                "valid": true
+            },
+            {
+                "description": "triple colons is invalid",
+                "data": "1:2:3:4:5:::8",
+                "valid": false
+            },
+            {
+                "description": "8 octets",
+                "data": "1:2:3:4:5:6:7:8",
+                "valid": true
+            },
+            {
+                "description": "insufficient octets without double colons",
+                "data": "1:2:3:4:5:6:7",
+                "valid": false
+            },
+            {
+                "description": "no colons is invalid",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 is not ipv6",
+                "data": "127.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "ipv4 segment must have 4 octets",
+                "data": "1:2:3:4:1.2.3",
+                "valid": false
+            },
+            {
+                "description": "leading whitespace is invalid",
+                "data": "  ::1",
+                "valid": false
+            },
+            {
+                "description": "trailing whitespace is invalid",
+                "data": "::1  ",
+                "valid": false
+            },
+            {
+                "description": "netmask is not a part of ipv6 address",
+                "data": "fe80::/64",
+                "valid": false
+            },
+            {
+                "description": "zone id is not a part of ipv6 address",
+                "data": "fe80::a%eth1",
+                "valid": false
+            },
+            {
+                "description": "a long valid ipv6",
+                "data": "1000:1000:1000:1000:1000:1000:255.255.255.255",
+                "valid": true
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, first",
+                "data": "100:100:100:100:100:100:255.255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "a long invalid ipv6, below length limit, second",
+                "data": "100:100:100:100:100:100:100:255.255.255.255",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4)",
+                "data": "1:2:3:4:5:6:7:৪",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '৪' (a Bengali 4) in the IPv4 portion",
+                "data": "1:2::192.16৪.0.1",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/iri-reference.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/iri-reference.json
@@ -1,0 +1,76 @@
+[
+    {
+        "description": "validation of IRI References",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative IRI Reference",
+                "data": "//ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid relative IRI Reference",
+                "data": "/âππ",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI Reference",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "a valid IRI Reference",
+                "data": "âππ",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI fragment",
+                "data": "#ƒrägmênt",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI fragment",
+                "data": "#ƒräg\\mênt",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/iri.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/iri.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "validation of IRIs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "iri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag",
+                "data": "http://ƒøø.ßår/?∂éœ=πîx#πîüx",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with anchor tag and parentheses",
+                "data": "http://ƒøø.com/blah_(wîkïpédiå)_blah#ßité-1",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with URL-encoded stuff",
+                "data": "http://ƒøø.ßår/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI based on IPv6",
+                "data": "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+                "valid": true
+            },
+            {
+                "description": "an invalid IRI based on IPv6",
+                "data": "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative IRI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI",
+                "data": "\\\\WINDOWS\\filëßåré",
+                "valid": false
+            },
+            {
+                "description": "an invalid IRI though valid IRI reference",
+                "data": "âππ",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/json-pointer.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/json-pointer.json
@@ -1,0 +1,201 @@
+[
+    {
+        "description": "validation of JSON-pointers (JSON String Representation)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid JSON-pointer",
+                "data": "/foo/bar~0/baz~1/%a",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (~ not escaped)",
+                "data": "/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "valid JSON-pointer with empty segment",
+                "data": "/foo//bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer with the last empty segment",
+                "data": "/foo/bar/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #1",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #2",
+                "data": "/foo",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #3",
+                "data": "/foo/0",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #4",
+                "data": "/",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #5",
+                "data": "/a~1b",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #6",
+                "data": "/c%d",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #7",
+                "data": "/e^f",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #8",
+                "data": "/g|h",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #9",
+                "data": "/i\\j",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #10",
+                "data": "/k\"l",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #11",
+                "data": "/ ",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer as stated in RFC 6901 #12",
+                "data": "/m~0n",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer used adding to the last array position",
+                "data": "/foo/-",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (- used as object member name)",
+                "data": "/foo/-/bar",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (multiple escaped characters)",
+                "data": "/~1~0~0~1~1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #1",
+                "data": "/~1.1",
+                "valid": true
+            },
+            {
+                "description": "valid JSON-pointer (escaped with fraction part) #2",
+                "data": "/~0.1",
+                "valid": true
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #1",
+                "data": "#",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #2",
+                "data": "#/",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (URI Fragment Identifier) #3",
+                "data": "#a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #1",
+                "data": "/~0~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (some escaped, but not all) #2",
+                "data": "/~0/~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #1",
+                "data": "/~2",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (wrong escape character) #2",
+                "data": "/~-1",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (multiple characters not escaped)",
+                "data": "/~~",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #1",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #2",
+                "data": "0",
+                "valid": false
+            },
+            {
+                "description": "not a valid JSON-pointer (isn't empty nor starts with /) #3",
+                "data": "a/a",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/regex.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/regex.json
@@ -1,0 +1,51 @@
+[
+    {
+        "description": "validation of regular expressions",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid regular expression",
+                "data": "([abc])+\\s+$",
+                "valid": true
+            },
+            {
+                "description": "a regular expression with unclosed parens is invalid",
+                "data": "^(abc]",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/relative-json-pointer.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/relative-json-pointer.json
@@ -1,0 +1,101 @@
+[
+    {
+        "description": "validation of Relative JSON Pointers (RJP)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "relative-json-pointer"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid upwards RJP",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "a valid downwards RJP",
+                "data": "0/foo/bar",
+                "valid": true
+            },
+            {
+                "description": "a valid up and then down RJP, with array index",
+                "data": "2/0/baz/1/zip",
+                "valid": true
+            },
+            {
+                "description": "a valid RJP taking the member or index name",
+                "data": "0#",
+                "valid": true
+            },
+            {
+                "description": "an invalid RJP that is a valid JSON Pointer",
+                "data": "/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "negative prefix",
+                "data": "-1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "explicit positive prefix",
+                "data": "+1/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "## is not a valid json-pointer",
+                "data": "0##",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus json-pointer",
+                "data": "01/a",
+                "valid": false
+            },
+            {
+                "description": "zero cannot be followed by other digits, plus octothorpe",
+                "data": "01#",
+                "valid": false
+            },
+            {
+                "description": "empty string",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "multi-digit integer prefix",
+                "data": "120/foo/bar",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/time.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/time.json
@@ -1,0 +1,216 @@
+[
+    {
+        "description": "validation of time strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "time"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid time string",
+                "data": "08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with leap second, Zulu",
+                "data": "23:59:60Z",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, Zulu (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, zero time-offset",
+                "data": "23:59:60+00:00",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong hour)",
+                "data": "22:59:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, zero time-offset (wrong minute)",
+                "data": "23:58:60+00:00",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, positive time-offset",
+                "data": "01:29:60+01:30",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large positive time-offset",
+                "data": "23:29:60+23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong hour)",
+                "data": "23:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, positive time-offset (wrong minute)",
+                "data": "23:59:60+00:30",
+                "valid": false
+            },
+            {
+                "description": "valid leap second, negative time-offset",
+                "data": "15:59:60-08:00",
+                "valid": true
+            },
+            {
+                "description": "valid leap second, large negative time-offset",
+                "data": "00:29:60-23:30",
+                "valid": true
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong hour)",
+                "data": "23:59:60-01:00",
+                "valid": false
+            },
+            {
+                "description": "invalid leap second, negative time-offset (wrong minute)",
+                "data": "23:59:60-00:30",
+                "valid": false
+            },
+            {
+                "description": "a valid time string with second fraction",
+                "data": "23:20:50.52Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with precise second fraction",
+                "data": "08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with plus offset",
+                "data": "08:30:06+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with minus offset",
+                "data": "08:30:06-08:00",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with case-insensitive Z",
+                "data": "08:30:06z",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string with invalid hour",
+                "data": "24:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid minute",
+                "data": "00:60:00Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid second",
+                "data": "00:00:61Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong hour)",
+                "data": "22:59:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid leap second (wrong minute)",
+                "data": "23:58:60Z",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset hour",
+                "data": "01:02:03+24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time numoffset minute",
+                "data": "01:02:03+00:60",
+                "valid": false
+            },
+            {
+                "description": "an invalid time string with invalid time with both Z and numoffset",
+                "data": "01:02:03Z+00:30",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset indicator",
+                "data": "08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "01:01:01,1111",
+                "valid": false
+            },
+            {
+                "description": "no time offset",
+                "data": "12:00:00",
+                "valid": false
+            },
+            {
+                "description": "no time offset with second fraction",
+                "data": "12:00:00.52",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII '২' (a Bengali 2)",
+                "data": "1২:00:00Z",
+                "valid": false
+            },
+            {
+                "description": "offset not starting with plus or minus",
+                "data": "08:30:06#00:20",
+                "valid": false
+            },
+            {
+                "description": "contains letters",
+                "data": "ab:cd:ef",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/unknown.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/unknown.json
@@ -1,0 +1,46 @@
+[
+    {
+        "description": "unknown format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "unknown"
+        },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/uri-reference.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/uri-reference.json
@@ -1,0 +1,76 @@
+[
+    {
+        "description": "validation of URI References",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-reference"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URI",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid relative URI Reference",
+                "data": "/abc",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI Reference",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "a valid URI Reference",
+                "data": "abc",
+                "valid": true
+            },
+            {
+                "description": "a valid URI fragment",
+                "data": "#fragment",
+                "valid": true
+            },
+            {
+                "description": "an invalid URI fragment",
+                "data": "#frag\\ment",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/uri-template.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/uri-template.json
@@ -1,0 +1,61 @@
+[
+    {
+        "description": "format: uri-template",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri-template"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term}",
+                "valid": true
+            },
+            {
+                "description": "an invalid uri-template",
+                "data": "http://example.com/dictionary/{term:1}/{term",
+                "valid": false
+            },
+            {
+                "description": "a valid uri-template without variables",
+                "data": "http://example.com/dictionary",
+                "valid": true
+            },
+            {
+                "description": "a valid relative uri-template",
+                "data": "dictionary/{term:1}/{term}",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/uri.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/uri.json
@@ -1,0 +1,141 @@
+[
+    {
+        "description": "validation of URIs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uri"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag",
+                "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag and parentheses",
+                "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with URL-encoded stuff",
+                "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid puny-coded URL ",
+                "data": "http://xn--nw2a.xn--j6w193g/",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid URL based on IPv4",
+                "data": "http://223.255.255.254",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with ftp scheme",
+                "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL for a simple text file",
+                "data": "http://www.ietf.org/rfc/rfc2396.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL ",
+                "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+                "valid": true
+            },
+            {
+                "description": "a valid mailto URI",
+                "data": "mailto:John.Doe@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid newsgroup URI",
+                "data": "news:comp.infosystems.www.servers.unix",
+                "valid": true
+            },
+            {
+                "description": "a valid tel URI",
+                "data": "tel:+1-816-555-1212",
+                "valid": true
+            },
+            {
+                "description": "a valid URN",
+                "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+                "valid": true
+            },
+            {
+                "description": "an invalid protocol-relative URI Reference",
+                "data": "//foo.bar/?baz=qux#quux",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative URI Reference",
+                "data": "/abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI",
+                "data": "\\\\WINDOWS\\fileshare",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI though valid URI reference",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces",
+                "data": "http:// shouldfail.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces and missing scheme",
+                "data": ":// should fail",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with comma in scheme",
+                "data": "bar,baz:foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/format/uuid.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/format/uuid.json
@@ -1,0 +1,116 @@
+[
+    {
+        "description": "uuid format",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "format": "uuid"
+        },
+        "tests": [
+            {
+                "description": "all string formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "all string formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "all upper-case",
+                "data": "2EB8AA08-AA98-11EA-B4AA-73B441D16380",
+                "valid": true
+            },
+            {
+                "description": "all lower-case",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": true
+            },
+            {
+                "description": "mixed case",
+                "data": "2eb8aa08-AA98-11ea-B4Aa-73B441D16380",
+                "valid": true
+            },
+            {
+                "description": "all zeroes is valid",
+                "data": "00000000-0000-0000-0000-000000000000",
+                "valid": true
+            },
+            {
+                "description": "wrong length",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1638",
+                "valid": false
+            },
+            {
+                "description": "missing section",
+                "data": "2eb8aa08-aa98-11ea-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "bad characters (not hex)",
+                "data": "2eb8aa08-aa98-11ea-b4ga-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "no dashes",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too few dashes",
+                "data": "2eb8aa08aa98-11ea-b4aa73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "too many dashes",
+                "data": "2eb8-aa08-aa98-11ea-b4aa73b44-1d16380",
+                "valid": false
+            },
+            {
+                "description": "dashes in the wrong spot",
+                "data": "2eb8aa08aa9811eab4aa73b441d16380----",
+                "valid": false
+            },
+            {
+                "description": "valid version 4",
+                "data": "98d80576-482e-427f-8434-7f86890ab222",
+                "valid": true
+            },
+            {
+                "description": "valid version 5",
+                "data": "99c17cbb-656f-564a-940f-1a4568f03487",
+                "valid": true
+            },
+            {
+                "description": "hypothetical version 6",
+                "data": "99c17cbb-656f-664a-940f-1a4568f03487",
+                "valid": true
+            },
+            {
+                "description": "hypothetical version 15",
+                "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/no-schema.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/no-schema.json
@@ -1,0 +1,26 @@
+[
+    {
+        "description": "validation without $schema",
+        "comment": "minLength is the same across all drafts",
+        "schema": {
+            "minLength": 2
+        },
+        "tests": [
+            {
+                "description": "a 3-character string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a 1-character string is not valid",
+                "data": "a",
+                "valid": false
+            },
+            {
+                "description": "a non-string is valid",
+                "data": 5,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/non-bmp-regex.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/non-bmp-regex.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "Proper UTF-16 surrogate pair handling: pattern",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^🐲*$"
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": "🐲",
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": "🐲🐲",
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": "🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": "🐉🐉",
+                "valid": false
+            },
+            {
+                "description": "doesn't match one ASCII",
+                "data": "D",
+                "valid": false
+            },
+            {
+                "description": "doesn't match two ASCII",
+                "data": "DD",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Proper UTF-16 surrogate pair handling: patternProperties",
+        "comment": "Optional because .Net doesn't correctly handle 32-bit Unicode characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "^🐲*$": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "matches empty",
+                "data": { "": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches single",
+                "data": { "🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "matches two",
+                "data": { "🐲🐲": 1 },
+                "valid": true
+            },
+            {
+                "description": "doesn't match one",
+                "data": { "🐲": "hello" },
+                "valid": false
+            },
+            {
+                "description": "doesn't match two",
+                "data": { "🐲🐲": "hello" },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/optional/refOfUnknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/latest/optional/refOfUnknownKeyword.json
@@ -1,0 +1,46 @@
+[
+    {
+        "description": "reference of a root arbitrary keyword ",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unknown-keyword": {"type": "integer"},
+            "properties": {
+                "bar": {"$ref": "#/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "reference of an arbitrary keyword of a sub-schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"unknown-keyword": {"type": "integer"}},
+                "bar": {"$ref": "#/properties/foo/unknown-keyword"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/pattern.json
+++ b/asdf/_jsonschema/json/tests/latest/pattern.json
@@ -1,0 +1,65 @@
+[
+    {
+        "description": "pattern validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "^a*$"
+        },
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "aaa",
+                "valid": true
+            },
+            {
+                "description": "a non-matching pattern is invalid",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "pattern": "a+"
+        },
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/patternProperties.json
+++ b/asdf/_jsonschema/json/tests/latest/patternProperties.json
@@ -1,0 +1,176 @@
+[
+    {
+        "description":
+            "patternProperties validates properties matching a regex",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "f.*o": {"type": "integer"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "multiple valid matches is valid",
+                "data": {"foo": 1, "foooooo" : 2},
+                "valid": true
+            },
+            {
+                "description": "a single invalid match is invalid",
+                "data": {"foo": "bar", "fooooo": 2},
+                "valid": false
+            },
+            {
+                "description": "multiple invalid matches is invalid",
+                "data": {"foo": "bar", "foooooo" : "baz"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple simultaneous patternProperties are validated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "a*": {"type": "integer"},
+                "aaa*": {"maximum": 20}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"a": 21},
+                "valid": true
+            },
+            {
+                "description": "a simultaneous match is valid",
+                "data": {"aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "multiple matches is valid",
+                "data": {"a": 21, "aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "an invalid due to one is invalid",
+                "data": {"a": "bar"},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to the other is invalid",
+                "data": {"aaaa": 31},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to both is invalid",
+                "data": {"aaa": "foo", "aaaa": 31},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "regexes are not anchored by default and are case sensitive",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "[0-9]{2,}": { "type": "boolean" },
+                "X_": { "type": "string" }
+            }
+        },
+        "tests": [
+            {
+                "description": "non recognized members are ignored",
+                "data": { "answer 1": "42" },
+                "valid": true
+            },
+            {
+                "description": "recognized members are accounted for",
+                "data": { "a31b": null },
+                "valid": false
+            },
+            {
+                "description": "regexes are case sensitive",
+                "data": { "a_x_3": 3 },
+                "valid": true
+            },
+            {
+                "description": "regexes are case sensitive, 2",
+                "data": { "a_X_3": 3 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "f.*": true,
+                "b.*": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property matching schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property matching schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with a property matching both true and false is invalid",
+                "data": {"foobar":1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "patternProperties": {
+                "^.*bar$": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foobar": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/prefixItems.json
+++ b/asdf/_jsonschema/json/tests/latest/prefixItems.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "a schema given for prefixItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                {"type": "integer"},
+                {"type": "string"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "correct types",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "wrong types",
+                "data": [ "foo", 1 ],
+                "valid": false
+            },
+            {
+                "description": "incomplete array of items",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with additional items",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "1": "valid",
+                    "length": 2
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "prefixItems with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [true, false]
+        },
+        "tests": [
+            {
+                "description": "array with one item is valid",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with two items is invalid",
+                "data": [ 1, "foo" ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additional items are allowed by default",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "integer"}]
+        },
+        "tests": [
+            {
+                "description": "only the first item is validated",
+                "data": [1, "foo", false],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "prefixItems with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/properties.json
+++ b/asdf/_jsonschema/json/tests/latest/properties.json
@@ -1,0 +1,242 @@
+[
+    {
+        "description": "object properties validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties present and valid is valid",
+                "data": {"foo": 1, "bar": "baz"},
+                "valid": true
+            },
+            {
+                "description": "one property invalid is invalid",
+                "data": {"foo": 1, "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "both properties invalid is invalid",
+                "data": {"foo": [], "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "doesn't invalidate other properties",
+                "data": {"quux": []},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description":
+            "properties, patternProperties, additionalProperties interaction",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"type": "array", "maxItems": 3},
+                "bar": {"type": "array"}
+            },
+            "patternProperties": {"f.o": {"minItems": 2}},
+            "additionalProperties": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "property validates property",
+                "data": {"foo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "property invalidates property",
+                "data": {"foo": [1, 2, 3, 4]},
+                "valid": false
+            },
+            {
+                "description": "patternProperty invalidates property",
+                "data": {"foo": []},
+                "valid": false
+            },
+            {
+                "description": "patternProperty validates nonproperty",
+                "data": {"fxo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "patternProperty invalidates nonproperty",
+                "data": {"fxo": []},
+                "valid": false
+            },
+            {
+                "description": "additionalProperty ignores property",
+                "data": {"bar": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty validates others",
+                "data": {"quux": 3},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty invalidates others",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with boolean schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no property present is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "only 'true' property present is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "only 'false' property present is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "both properties present is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo\nbar": {"type": "number"},
+                "foo\"bar": {"type": "number"},
+                "foo\\bar": {"type": "number"},
+                "foo\rbar": {"type": "number"},
+                "foo\tbar": {"type": "number"},
+                "foo\fbar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with all numbers is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1",
+                    "foo\\bar": "1",
+                    "foo\rbar": "1",
+                    "foo\tbar": "1",
+                    "foo\fbar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"type": "null"}
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null values",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "__proto__": {"type": "number"},
+                "toString": {
+                    "properties": { "length": { "type": "string" } }
+                },
+                "constructor": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "__proto__ not valid",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString not valid",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor not valid",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present and valid",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/propertyNames.json
+++ b/asdf/_jsonschema/json/tests/latest/propertyNames.json
@@ -1,0 +1,85 @@
+[
+    {
+        "description": "propertyNames validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": {"maxLength": 3}
+        },
+        "tests": [
+            {
+                "description": "all property names valid",
+                "data": {
+                    "f": {},
+                    "foo": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "some property names invalid",
+                "data": {
+                    "foo": {},
+                    "foobar": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3, 4],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": true
+        },
+        "tests": [
+            {
+                "description": "object with any properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "propertyNames": false
+        },
+        "tests": [
+            {
+                "description": "object with any properties is invalid",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/ref.json
+++ b/asdf/_jsonschema/json/tests/latest/ref.json
@@ -1,0 +1,887 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                {"type": "integer"},
+                {"$ref": "#/prefixItems/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
+            },
+            "properties": {
+                "tilde": {"$ref": "#/$defs/tilde~0field"},
+                "slash": {"$ref": "#/$defs/slash~1field"},
+                "percent": {"$ref": "#/$defs/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilde invalid",
+                "data": {"tilde": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilde valid",
+                "data": {"tilde": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/$defs/a"},
+                "c": {"$ref": "#/$defs/b"}
+            },
+            "$ref": "#/$defs/c"
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref applies alongside sibling keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "ref valid, maxItems valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "ref valid, maxItems invalid",
+                "data": { "foo": [1, 2, 3] },
+                "valid": false
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"minLength": 1},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"minLength": -1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "$ref": {"$ref": "#/$defs/is-string"}
+            },
+            "$defs": {
+                "is-string": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": false
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {
+                    "type": "array",
+                    "items": {"$ref": "node"}
+                }
+            },
+            "required": ["meta", "nodes"],
+            "$defs": {
+                "node": {
+                    "$id": "http://localhost:1234/draft2020-12/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "subtree": {"$ref": "tree"}
+                    },
+                    "required": ["value"]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 1.1},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": "string is invalid"},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
+            },
+            "$defs": {
+                "foo\"bar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with numbers is valid",
+                "data": {
+                    "foo\"bar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref creates new scope when adjacent to keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "A": {
+                    "unevaluatedProperties": false
+                }
+            },
+            "properties": {
+                "prop1": {
+                    "type": "string"
+                }
+            },
+            "$ref": "#/$defs/A"
+        },
+        "tests": [
+            {
+                "description": "referenced subschema doesn't see annotations from properties",
+                "data": {
+                    "prop1": "match"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/$defs/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "do not evaluate the $ref inside the enum, definition exact match",
+                "data": { "type": "string" },
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/$defs/a_string" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "refs with relative uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/schema-relative-uri-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "schema-relative-uri-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-relative-uri-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative refs with absolute uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "http://example.com/schema-refs-absolute-uris-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-refs-absolute-uris-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/a.json",
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "$defs": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $ref",
+        "schema": {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "/draft2020-12/ref-and-id1/base.json",
+            "$ref": "int.json",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id1/int.json",
+                    "$id": "int.json",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /ref-and-id1-int.json",
+                    "$id": "/draft2020-12/ref-and-id1-int.json",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $anchor and $ref",
+        "schema": {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "/draft2020-12/ref-and-id2/base.json",
+            "$ref": "#bigint",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "$anchor": "bigint",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
+                    "$id": "/draft2020-12/ref-and-id2/",
+                    "$anchor": "bigint",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with $ref via the URN",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "minimum": 30,
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
+            }
+        },
+        "tests": [
+            {
+                "description": "valid under the URN IDed schema",
+                "data": {"foo": 37},
+                "valid": true
+            },
+            {
+                "description": "invalid under the URN IDed schema",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with JSON pointer",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with NSS",
+        "schema": {
+            "$comment": "RFC 8141 §2.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:1/406/47452/2",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with r-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.1",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with q-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with f-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "is invalid",
+                "data": {"$id": "urn:example:foo-bar-baz-qux#somepart"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and JSON pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and anchor ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
+            },
+            "$defs": {
+                "bar": {
+                    "$anchor": "something",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN ref with nested pointer ref",
+        "schema": {
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+            "$defs": {
+                "foo": {
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$defs": {"bar": {"type": "string"}},
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": "bar",
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": 12,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/refRemote.json
+++ b/asdf/_jsonschema/json/tests/latest/refRemote.json
@@ -1,0 +1,295 @@
+[
+    {
+        "description": "remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/integer.json"
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "fragment within remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/subSchemas-defs.json#/$defs/integer"
+        },
+        "tests": [
+            {
+                "description": "remote fragment valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote fragment invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/subSchemas-defs.json#/$defs/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "ref within ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "ref within ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/",
+            "items": {
+                "$id": "baseUriChange/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "base URI change ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "base URI change ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/scope_change_defs1.json",
+            "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolder/"}},
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolder/",
+                    "type": "array",
+                    "items": {"$ref": "folderInteger.json"}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {"list": {"$ref": "baseUriChangeFolderInSubschema/#/$defs/bar"}},
+            "$defs": {
+                "baz": {
+                    "$id": "baseUriChangeFolderInSubschema/",
+                    "$defs": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "root ref in remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/object",
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "name-defs.json#/$defs/orNull"}
+            }
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": {
+                    "name": null
+                },
+                "valid": true
+            },
+            {
+                "description": "object is invalid",
+                "data": {
+                    "name": {
+                        "name": null
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref with ref to defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/schema-remote-ref-ref-defs1.json",
+            "$ref": "ref-and-defs.json"
+        },
+        "tests": [
+            {
+                "description": "invalid",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid",
+                "data": {
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "Location-independent identifier in remote ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "http://localhost:1234/draft2020-12/locationIndependentIdentifier.json#/$defs/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "retrieved nested refs resolve relative to their URI not $id",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/some-id",
+            "properties": {
+                "name": {"$ref": "nested/foo-ref-string.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": {
+                    "name": {"foo":  1}
+                },
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": {"foo":  "a"}
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different $id",
+        "schema": {"$ref": "http://localhost:1234/different-id-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with different URN $id",
+        "schema": {"$ref": "http://localhost:1234/urn-ref-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "remote HTTP ref with nested absolute ref",
+        "schema": {"$ref": "http://localhost:1234/nested-absolute-ref-to-string.json"},
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/required.json
+++ b/asdf/_jsonschema/json/tests/latest/required.json
@@ -1,0 +1,158 @@
+[
+    {
+        "description": "required validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "required": ["foo"]
+        },
+        "tests": [
+            {
+                "description": "present required property is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "non-present required property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required default validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required by default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with empty array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {}
+            },
+            "required": []
+        },
+        "tests": [
+            {
+                "description": "property not required",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with escaped characters",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "required": [
+                "foo\nbar",
+                "foo\"bar",
+                "foo\\bar",
+                "foo\rbar",
+                "foo\tbar",
+                "foo\fbar"
+            ]
+        },
+        "tests": [
+            {
+                "description": "object with all properties present is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with some properties missing is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "required properties whose names are Javascript object property names",
+        "comment": "Ensure JS implementations don't universally consider e.g. __proto__ to always be present in an object.",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "required": ["__proto__", "toString", "constructor"]
+        },
+        "tests": [
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "none of the properties mentioned",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "__proto__ present",
+                "data": { "__proto__": "foo" },
+                "valid": false
+            },
+            {
+                "description": "toString present",
+                "data": { "toString": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "constructor present",
+                "data": { "constructor": { "length": 37 } },
+                "valid": false
+            },
+            {
+                "description": "all present",
+                "data": { 
+                    "__proto__": 12,
+                    "toString": { "length": "foo" },
+                    "constructor": 37
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/type.json
+++ b/asdf/_jsonschema/json/tests/latest/type.json
@@ -1,0 +1,501 @@
+[
+    {
+        "description": "integer type matches integers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "integer"
+        },
+        "tests": [
+            {
+                "description": "an integer is an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is an integer",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is not an integer",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an integer",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not an integer, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not an integer",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not an integer",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an integer",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an integer",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "number type matches numbers",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number"
+        },
+        "tests": [
+            {
+                "description": "an integer is a number",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float with zero fractional part is a number (and an integer)",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "a float is a number",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "a string is not a number",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not a number, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not a number",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a number",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a number",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a number",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "string type matches strings",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string"
+        },
+        "tests": [
+            {
+                "description": "1 is not a string",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a string",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a string is still a string, even if it looks like a number",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an object is not a string",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a string",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a string",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a string",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "object type matches objects",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object"
+        },
+        "tests": [
+            {
+                "description": "an integer is not an object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an object",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an object",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is not an object",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an object",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an object",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "array type matches arrays",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array"
+        },
+        "tests": [
+            {
+                "description": "an integer is not an array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an array",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an array",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not an array",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is not an array",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an array",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "boolean type matches booleans",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "boolean"
+        },
+        "tests": [
+            {
+                "description": "an integer is not a boolean",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a float is not a boolean",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not a boolean",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not a boolean",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a boolean",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is a boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is not a boolean",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "null type matches only the null object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "null"
+        },
+        "tests": [
+            {
+                "description": "an integer is not null",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not null",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a string is not null",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not null",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not null",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is not null",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple types can be specified in an array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": ["integer", "string"]
+        },
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/unevaluatedItems.json
+++ b/asdf/_jsonschema/json/tests/latest/unevaluatedItems.json
@@ -1,0 +1,675 @@
+[
+    {
+        "description": "unevaluatedItems true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": true
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems as schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": { "type": "string" }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with valid unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with invalid unevaluated items",
+                "data": [42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with uniform items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "items": { "type": "string" },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "unevaluatedItems doesn't apply",
+                "data": ["foo", "bar"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with tuple",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "items": true,
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "unevaluatedItems doesn't apply",
+                "data": ["foo", 42],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested tuple",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "allOf": [
+                {
+                    "prefixItems": [
+                        true,
+                        { "type": "number" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", 42],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", 42, true],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": {"type": "boolean"},
+            "anyOf": [
+                { "items": {"type": "string"} },
+                true
+            ]
+        },
+        "tests": [
+            {
+                "description": "with only (valid) additional items",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "with no additional items",
+                "data": ["yes", "no"],
+                "valid": true
+            },
+            {
+                "description": "with invalid additional item",
+                "data": ["yes", false],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested prefixItems and items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "prefixItems": [
+                        { "type": "string" }
+                    ],
+                    "items": true
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no additional items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with additional items",
+                "data": ["foo", 42, true],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with nested unevaluatedItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "prefixItems": [
+                        { "type": "string" }
+                    ]
+                },
+                { "unevaluatedItems": true }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no additional items",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "with additional items",
+                "data": ["foo", 42, true],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "anyOf": [
+                {
+                    "prefixItems": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                },
+                {
+                    "prefixItems": [
+                        true,
+                        true,
+                        { "const": "baz" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "when one schema matches and has no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "when one schema matches and has unevaluated items",
+                "data": ["foo", "bar", 42],
+                "valid": false
+            },
+            {
+                "description": "when two schemas match and has no unevaluated items",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "when two schemas match and has unevaluated items",
+                "data": ["foo", "bar", "baz", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "oneOf": [
+                {
+                    "prefixItems": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                },
+                {
+                    "prefixItems": [
+                        true,
+                        { "const": "baz" }
+                    ]
+                }
+            ],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "not": {
+                "not": {
+                    "prefixItems": [
+                        true,
+                        { "const": "bar" }
+                    ]
+                }
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with if/then/else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                { "const": "foo" }
+            ],
+            "if": {
+                "prefixItems": [
+                    true,
+                    { "const": "bar" }
+                ]
+            },
+            "then": {
+                "prefixItems": [
+                    true,
+                    true,
+                    { "const": "then" }
+                ]
+            },
+            "else": {
+                "prefixItems": [
+                    true,
+                    true,
+                    true,
+                    { "const": "else" }
+                ]
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "when if matches and it has no unevaluated items",
+                "data": ["foo", "bar", "then"],
+                "valid": true
+            },
+            {
+                "description": "when if matches and it has unevaluated items",
+                "data": ["foo", "bar", "then", "else"],
+                "valid": false
+            },
+            {
+                "description": "when if doesn't match and it has no unevaluated items",
+                "data": ["foo", 42, 42, "else"],
+                "valid": true
+            },
+            {
+                "description": "when if doesn't match and it has unevaluated items",
+                "data": ["foo", 42, 42, "else", 42],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [true],
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bar",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "unevaluatedItems": false,
+            "$defs": {
+              "bar": {
+                  "prefixItems": [
+                      true,
+                      { "type": "string" }
+                  ]
+              }
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated items",
+                "data": ["foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "with unevaluated items",
+                "data": ["foo", "bar", "baz"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems can't see inside cousins",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "prefixItems": [ true ]
+                },
+                { "unevaluatedItems": false }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": [ 1 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "item is evaluated in an uncle schema to unevaluatedItems",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "prefixItems": [
+                        { "type": "string" }
+                    ],
+                    "unevaluatedItems": false
+                  }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "prefixItems": [
+                                true,
+                                { "type": "string" }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "no extra items",
+                "data": {
+                    "foo": [
+                        "test"
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "uncle keyword evaluation is not significant",
+                "data": {
+                    "foo": [
+                        "test",
+                        "test"
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems depends on adjacent contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [true],
+            "contains": {"type": "string"},
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "second item is evaluated by contains",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "contains fails, second item is not evaluated",
+                "data": [ 1, 2 ],
+                "valid": false
+            },
+            {
+                "description": "contains passes, second item is not evaluated",
+                "data": [ 1, 2, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems depends on multiple nested contains",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                { "contains": { "multipleOf": 2 } },
+                { "contains": { "multipleOf": 3 } }
+            ],
+            "unevaluatedItems": { "multipleOf": 5 }
+        },
+        "tests": [
+            {
+                "description": "5 not evaluated, passes unevaluatedItems",
+                "data": [ 2, 3, 4, 5, 6 ],
+                "valid": true
+            },
+            {
+                "description": "7 not evaluated, fails unevaluatedItems",
+                "data": [ 2, 3, 4, 7, 8 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems and contains interact to control item dependency relationship",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "if": {
+                "contains": {"const": "a"}
+            },
+            "then": {
+                "if": {
+                    "contains": {"const": "b"}
+                },
+                "then": {
+                    "if": {
+                        "contains": {"const": "c"}
+                    }
+                }
+            },
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "only a's are valid",
+                "data": [ "a", "a" ],
+                "valid": true
+            },
+            {
+                "description": "a's and b's are valid",
+                "data": [ "a", "b", "a", "b", "a" ],
+                "valid": true
+            },
+            {
+                "description": "a's, b's and c's are valid",
+                "data": [ "c", "a", "c", "c", "b", "a" ],
+                "valid": true
+            },
+            {
+                "description": "only b's are invalid",
+                "data": [ "b", "b" ],
+                "valid": false
+            },
+            {
+                "description": "only c's are invalid",
+                "data": [ "c", "c" ],
+                "valid": false
+            },
+            {
+                "description": "only b's and c's are invalid",
+                "data": [ "c", "b", "c", "b", "c" ],
+                "valid": false
+            },
+            {
+                "description": "only a's and c's are invalid",
+                "data": [ "c", "a", "c", "a", "c" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-array instances are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": false
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedItems with null instance elements",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedItems": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null elements",
+                "data": [ null ],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/unevaluatedProperties.json
+++ b/asdf/_jsonschema/json/tests/latest/unevaluatedProperties.json
@@ -1,0 +1,1423 @@
+[
+    {
+        "description": "unevaluatedProperties true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties schema",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "unevaluatedProperties": {
+                "type": "string",
+                "minLength": 3
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with valid unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with invalid unevaluated properties",
+                "data": {
+                    "foo": "fo"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "patternProperties": {
+                "^foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with adjacent additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "additionalProperties": true,
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": { "type": "string" }
+                    }
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested patternProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+              {
+                  "patternProperties": {
+                      "^bar": { "type": "string" }
+                  }
+              }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested additionalProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "additionalProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no additional properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with additional properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with nested unevaluatedProperties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": {
+                "type": "string",
+                "maxLength": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with anyOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "baz": { "const": "baz" }
+                    },
+                    "required": ["baz"]
+                },
+                {
+                    "properties": {
+                        "quux": { "const": "quux" }
+                    },
+                    "required": ["quux"]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when one matches and has no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when one matches and has unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "not-baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when two match and has no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when two match and has unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz",
+                    "quux": "not-quux"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "baz": { "const": "baz" }
+                    },
+                    "required": ["baz"]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "quux": "quux"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with not",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "not": {
+                "not": {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "then": {
+                "properties": {
+                    "bar": { "type": "string" }
+                },
+                "required": ["bar"]
+            },
+            "else": {
+                "properties": {
+                    "baz": { "type": "string" }
+                },
+                "required": ["baz"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else, then not defined",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "else": {
+                "properties": {
+                    "baz": { "type": "string" }
+                },
+                "required": ["baz"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with if/then/else, else not defined",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "if": {
+                "properties": {
+                    "foo": { "const": "then" }
+                },
+                "required": ["foo"]
+            },
+            "then": {
+                "properties": {
+                    "bar": { "type": "string" }
+                },
+                "required": ["bar"]
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "when if is true and has no unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "when if is true and has unevaluated properties",
+                "data": {
+                    "foo": "then",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has no unevaluated properties",
+                "data": {
+                    "baz": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "when if is false and has unevaluated properties",
+                "data": {
+                    "foo": "else",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with dependentSchemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "dependentSchemas": {
+                "foo": {
+                    "properties": {
+                        "bar": { "const": "bar" }
+                    },
+                    "required": ["bar"]
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with boolean schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [true],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "$ref": "#/$defs/bar",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "unevaluatedProperties": false,
+            "$defs": {
+                "bar": {
+                    "properties": {
+                        "bar": { "type": "string" }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "with no unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            },
+            {
+                "description": "with unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar",
+                    "baz": "baz"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties can't see inside cousins",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                },
+                {
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties can't see inside cousins (reverse order)",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                },
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "always fails",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer false, inner true, properties outside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer false, inner true, properties inside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": true
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer true, inner false, properties outside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "unevaluatedProperties": false
+                }
+            ],
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "nested unevaluatedProperties, outer true, inner false, properties inside",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            ],
+            "unevaluatedProperties": true
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "cousin unevaluatedProperties, true and false, true with properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": true
+                },
+                {
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": false
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "cousin unevaluatedProperties, true and false, false with properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "unevaluatedProperties": true
+                },
+                {
+                    "properties": {
+                        "foo": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "with no nested unevaluated properties",
+                "data": {
+                    "foo": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "with nested unevaluated properties",
+                "data": {
+                    "foo": "foo",
+                    "bar": "bar"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property is evaluated in an uncle schema to unevaluatedProperties",
+        "comment": "see https://stackoverflow.com/questions/66936884/deeply-nested-unevaluatedproperties-and-their-expectations",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "object",
+                    "properties": {
+                        "bar": {
+                            "type": "string"
+                        }
+                    },
+                    "unevaluatedProperties": false
+                  }
+            },
+            "anyOf": [
+                {
+                    "properties": {
+                        "foo": {
+                            "properties": {
+                                "faz": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "no extra properties",
+                "data": {
+                    "foo": {
+                        "bar": "test"
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "uncle keyword evaluation is not significant",
+                "data": {
+                    "foo": {
+                        "bar": "test",
+                        "faz": "test"
+                    }
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "in-place applicator siblings, allOf has unevaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    },
+                    "unevaluatedProperties": false
+                }
+            ],
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": true
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "base case: both properties present",
+                "data": {
+                    "foo": 1,
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, bar is missing",
+                "data": {
+                    "foo": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "in place applicator siblings, foo is missing",
+                "data": {
+                    "bar": 1
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "in-place applicator siblings, anyOf has unevaluated",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "foo": true
+                    }
+                }
+            ],
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": true
+                    },
+                    "unevaluatedProperties": false
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "base case: both properties present",
+                "data": {
+                    "foo": 1,
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, bar is missing",
+                "data": {
+                    "foo": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "in place applicator siblings, foo is missing",
+                "data": {
+                    "bar": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties + single cyclic ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "x": { "$ref": "#" }
+            },
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "Single is valid",
+                "data": { "x": {} },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 1st level is invalid",
+                "data": { "x": {}, "y": {} },
+                "valid": false
+            },
+            {
+                "description": "Nested is valid",
+                "data": { "x": { "x": {} } },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 2nd level is invalid",
+                "data": { "x": { "x": {}, "y": {} } },
+                "valid": false
+            },
+            {
+                "description": "Deep nested is valid",
+                "data": { "x": { "x": { "x": {} } } },
+                "valid": true
+            },
+            {
+                "description": "Unevaluated on 3rd level is invalid",
+                "data": { "x": { "x": { "x": {}, "y": {} } } },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties + ref inside allOf / oneOf",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "one": {
+                    "properties": { "a": true }
+                },
+                "two": {
+                    "required": ["x"],
+                    "properties": { "x": true }
+                }
+            },
+            "allOf": [
+                { "$ref": "#/$defs/one" },
+                { "properties": { "b": true } },
+                {
+                    "oneOf": [
+                        { "$ref": "#/$defs/two" },
+                        {
+                            "required": ["y"],
+                            "properties": { "y": true }
+                        }
+                    ]
+                }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is invalid (no x or y)",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "a and b are invalid (no x or y)",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "x and y are invalid",
+                "data": { "x": 1, "y": 1 },
+                "valid": false
+            },
+            {
+                "description": "a and x are valid",
+                "data": { "a": 1, "x": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and y are valid",
+                "data": { "a": 1, "y": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and x are valid",
+                "data": { "a": 1, "b": 1, "x": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and y are valid",
+                "data": { "a": 1, "b": 1, "y": 1 },
+                "valid": true
+            },
+            {
+                "description": "a and b and x and y are invalid",
+                "data": { "a": 1, "b": 1, "x": 1, "y": 1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dynamic evalation inside nested refs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "one": {
+                    "oneOf": [
+                        { "$ref": "#/$defs/two" },
+                        { "required": ["b"], "properties": { "b": true } },
+                        { "required": ["xx"], "patternProperties": { "x": true } },
+                        { "required": ["all"], "unevaluatedProperties": true }
+                    ]
+                },
+                "two": {
+                    "oneOf": [
+                        { "required": ["c"], "properties": { "c": true } },
+                        { "required": ["d"], "properties": { "d": true } }
+                    ]
+                }
+            },
+            "oneOf": [
+                { "$ref": "#/$defs/one" },
+                { "required": ["a"], "properties": { "a": true } }
+            ],
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "Empty is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "a is valid",
+                "data": { "a": 1 },
+                "valid": true
+            },
+            {
+                "description": "b is valid",
+                "data": { "b": 1 },
+                "valid": true
+            },
+            {
+                "description": "c is valid",
+                "data": { "c": 1 },
+                "valid": true
+            },
+            {
+                "description": "d is valid",
+                "data": { "d": 1 },
+                "valid": true
+            },
+            {
+                "description": "a + b is invalid",
+                "data": { "a": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "a + c is invalid",
+                "data": { "a": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "a + d is invalid",
+                "data": { "a": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "b + c is invalid",
+                "data": { "b": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "b + d is invalid",
+                "data": { "b": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "c + d is invalid",
+                "data": { "c": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx is valid",
+                "data": { "xx": 1 },
+                "valid": true
+            },
+            {
+                "description": "xx + foox is valid",
+                "data": { "xx": 1, "foox": 1 },
+                "valid": true
+            },
+            {
+                "description": "xx + foo is invalid",
+                "data": { "xx": 1, "foo": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + a is invalid",
+                "data": { "xx": 1, "a": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + b is invalid",
+                "data": { "xx": 1, "b": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + c is invalid",
+                "data": { "xx": 1, "c": 1 },
+                "valid": false
+            },
+            {
+                "description": "xx + d is invalid",
+                "data": { "xx": 1, "d": 1 },
+                "valid": false
+            },
+            {
+                "description": "all is valid",
+                "data": { "all": 1 },
+                "valid": true
+            },
+            {
+                "description": "all + foo is valid",
+                "data": { "all": 1, "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "all + a is invalid",
+                "data": { "all": 1, "a": 1 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-object instances are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedProperties": false
+        },
+        "tests": [
+            {
+                "description": "ignores booleans",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "ignores integers",
+                "data": 123,
+                "valid": true
+            },
+            {
+                "description": "ignores floats",
+                "data": 1.0,
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "unevaluatedProperties with null valued instance properties",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "unevaluatedProperties": {
+                "type": "null"
+            }
+        },
+        "tests": [
+            {
+                "description": "allows null valued properties",
+                "data": {"foo": null},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/uniqueItems.json
+++ b/asdf/_jsonschema/json/tests/latest/uniqueItems.json
@@ -1,0 +1,414 @@
+[
+    {
+        "description": "uniqueItems validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two integers is invalid",
+                "data": [1, 2, 1],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of strings is valid",
+                "data": ["foo", "bar", "baz"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of strings is invalid",
+                "data": ["foo", "bar", "foo"],
+                "valid": false
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is invalid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": false
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is invalid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": false
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "non-unique array of more than two arrays is invalid",
+                "data": [["foo"], ["bar"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "[1] and [true] are unique",
+                "data": [[1], [true]],
+                "valid": true
+            },
+            {
+                "description": "[0] and [false] are unique",
+                "data": [[0], [false]],
+                "valid": true
+            },
+            {
+                "description": "nested [1] and [true] are unique",
+                "data": [[[1], "foo"], [[true], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "nested [0] and [false] are unique",
+                "data": [[[0], "foo"], [[false], "foo"]],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1, "{}"],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are invalid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            },
+            {
+                "description": "different objects are unique",
+                "data": [{"a": 1, "b": 2}, {"a": 2, "b": 1}],
+                "valid": true
+            },
+            {
+                "description": "objects are non-unique despite key order",
+                "data": [{"a": 1, "b": 2}, {"b": 2, "a": 1}],
+                "valid": false
+            },
+            {
+                "description": "{\"a\": false} and {\"a\": 0} are unique",
+                "data": [{"a": false}, {"a": 0}],
+                "valid": true
+            },
+            {
+                "description": "{\"a\": true} and {\"a\": 1} are unique",
+                "data": [{"a": true}, {"a": 1}],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is not valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": false
+            },
+            {
+                "description": "non-unique array extended from [true, false] is not valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems with an array of items and additionalItems=false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": true,
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is not valid",
+                "data": [false, false],
+                "valid": false
+            },
+            {
+                "description": "[true, true] from items array is not valid",
+                "data": [true, true],
+                "valid": false
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false validation",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is valid",
+                "data": [1, 1],
+                "valid": true
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": true
+            },
+            {
+                "description": "false is not equal to zero",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "true is not equal to one",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is valid",
+                "data": [["foo"], ["foo"]],
+                "valid": true
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "bar"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [false, true] is valid",
+                "data": [false, true, "foo", "foo"],
+                "valid": true
+            },
+            {
+                "description": "non-unique array extended from [true, false] is valid",
+                "data": [true, false, "foo", "foo"],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "uniqueItems=false with an array of items and additionalItems=false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [{"type": "boolean"}, {"type": "boolean"}],
+            "uniqueItems": false,
+            "items": false
+        },
+        "tests": [
+            {
+                "description": "[false, true] from items array is valid",
+                "data": [false, true],
+                "valid": true
+            },
+            {
+                "description": "[true, false] from items array is valid",
+                "data": [true, false],
+                "valid": true
+            },
+            {
+                "description": "[false, false] from items array is valid",
+                "data": [false, false],
+                "valid": true
+            },
+            {
+                "description": "[true, true] from items array is valid",
+                "data": [true, true],
+                "valid": true
+            },
+            {
+                "description": "extra items are invalid even if unique",
+                "data": [false, true, null],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/unknownKeyword.json
+++ b/asdf/_jsonschema/json/tests/latest/unknownKeyword.json
@@ -1,0 +1,57 @@
+[
+    {
+        "description": "$id inside an unknown keyword is not a real identifier",
+        "comment": "the implementation must not be confused by an $id in locations we do not know how to parse",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "id_in_unknown0": {
+                    "not": {
+                        "array_of_schemas": [
+                            {
+                              "$id": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json",
+                              "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "real_id_in_schema": {
+                    "$id": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json",
+                    "type": "string"
+                },
+                "id_in_unknown1": {
+                    "not": {
+                        "object_of_schemas": {
+                            "foo": {
+                              "$id": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json",
+                              "type": "integer"
+                            }
+                        }
+                    }
+                }
+            },
+            "anyOf": [
+                { "$ref": "#/$defs/id_in_unknown0" },
+                { "$ref": "#/$defs/id_in_unknown1" },
+                { "$ref": "https://localhost:1234/draft2020-12/unknownKeyword/my_identifier.json" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "type matches second anyOf, which has a real schema in it",
+                "data": "a string",
+                "valid": true
+            },
+            {
+                "description": "type matches non-schema in first anyOf",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "type matches non-schema in third anyOf",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tests/latest/vocabulary.json
+++ b/asdf/_jsonschema/json/tests/latest/vocabulary.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "schema that uses custom metaschema with with no validation vocabulary",
+        "schema": {
+            "$id": "https://schema/using/no/validation",
+            "$schema": "http://localhost:1234/draft2020-12/metaschema-no-validation.json",
+            "properties": {
+                "badProperty": false,
+                "numberProperty": {
+                    "minimum": 10
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "applicator vocabulary still works",
+                "data": {
+                    "badProperty": "this property should not exist"
+                },
+                "valid": false
+            },
+            {
+                "description": "no validation: valid number",
+                "data": {
+                    "numberProperty": 20
+                },
+                "valid": true
+            },
+            {
+                "description": "no validation: invalid number, but it still validates",
+                "data": {
+                    "numberProperty": 1
+                },
+                "valid": true
+            }
+        ]
+    }
+]

--- a/asdf/_jsonschema/json/tox.ini
+++ b/asdf/_jsonschema/json/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+minversion = 1.6
+envlist = sanity
+skipsdist = True
+
+[testenv:sanity]
+# used just for validating the structure of the test case files themselves
+deps = jsonschema==4.6.1
+commands = {envpython} bin/jsonschema_suite check

--- a/asdf/_jsonschema/protocols.py
+++ b/asdf/_jsonschema/protocols.py
@@ -1,0 +1,230 @@
+"""
+typing.Protocol classes for asdf._jsonschema interfaces.
+"""
+
+# for reference material on Protocols, see
+#   https://www.python.org/dev/peps/pep-0544/
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, Iterable
+import sys
+
+# doing these imports with `try ... except ImportError` doesn't pass mypy
+# checking because mypy sees `typing._SpecialForm` and
+# `typing_extensions._SpecialForm` as incompatible
+#
+# see:
+# https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-new-additions-to-the-typing-module
+# https://github.com/python/mypy/issues/4427
+if sys.version_info >= (3, 8):
+    from typing import Protocol, runtime_checkable
+else:
+    from typing_extensions import Protocol, runtime_checkable
+
+# in order for Sphinx to resolve references accurately from type annotations,
+# it needs to see names like `asdf._jsonschema.TypeChecker`
+# therefore, only import at type-checking time (to avoid circular references),
+# but use `asdf._jsonschema` for any types which will otherwise not be resolvable
+if TYPE_CHECKING:
+    import asdf._jsonschema
+    import asdf._jsonschema.validators
+
+from asdf._jsonschema.exceptions import ValidationError
+
+# For code authors working on the validator protocol, these are the three
+# use-cases which should be kept in mind:
+#
+# 1. As a protocol class, it can be used in type annotations to describe the
+#    available methods and attributes of a validator
+# 2. It is the source of autodoc for the validator documentation
+# 3. It is runtime_checkable, meaning that it can be used in isinstance()
+#    checks.
+#
+# Since protocols are not base classes, isinstance() checking is limited in
+# its capabilities. See docs on runtime_checkable for detail
+
+
+@runtime_checkable
+class Validator(Protocol):
+    """
+    The protocol to which all validator classes adhere.
+
+    Arguments:
+
+        schema:
+
+            The schema that the validator object will validate with.
+            It is assumed to be valid, and providing
+            an invalid schema can lead to undefined behavior. See
+            `Validator.check_schema` to validate a schema first.
+
+        resolver:
+
+            a resolver that will be used to resolve :kw:`$ref`
+            properties (JSON references). If unprovided, one will be created.
+
+        format_checker:
+
+            if provided, a checker which will be used to assert about
+            :kw:`format` properties present in the schema. If unprovided,
+            *no* format validation is done, and the presence of format
+            within schemas is strictly informational. Certain formats
+            require additional packages to be installed in order to assert
+            against instances. Ensure you've installed `asdf._jsonschema` with
+            its `extra (optional) dependencies <index:extras>` when
+            invoking ``pip``.
+
+    .. deprecated:: v4.12.0
+
+        Subclassing validator classes now explicitly warns this is not part of
+        their public API.
+    """
+
+    #: An object representing the validator's meta schema (the schema that
+    #: describes valid schemas in the given version).
+    META_SCHEMA: ClassVar[Mapping]
+
+    #: A mapping of validation keywords (`str`\s) to functions that
+    #: validate the keyword with that name. For more information see
+    #: `creating-validators`.
+    VALIDATORS: ClassVar[Mapping]
+
+    #: A `asdf._jsonschema.TypeChecker` that will be used when validating
+    #: :kw:`type` keywords in JSON schemas.
+    TYPE_CHECKER: ClassVar[asdf._jsonschema.TypeChecker]
+
+    #: A `asdf._jsonschema.FormatChecker` that will be used when validating
+    #: :kw:`format` keywords in JSON schemas.
+    FORMAT_CHECKER: ClassVar[asdf._jsonschema.FormatChecker]
+
+    #: A function which given a schema returns its ID.
+    ID_OF: Callable[[Any], str | None]
+
+    #: The schema that will be used to validate instances
+    schema: Mapping | bool
+
+    def __init__(
+        self,
+        schema: Mapping | bool,
+        resolver: asdf._jsonschema.validators.RefResolver | None = None,
+        format_checker: asdf._jsonschema.FormatChecker | None = None,
+    ) -> None:
+        ...
+
+    @classmethod
+    def check_schema(cls, schema: Mapping | bool) -> None:
+        """
+        Validate the given schema against the validator's `META_SCHEMA`.
+
+        Raises:
+
+            `asdf._jsonschema.exceptions.SchemaError`:
+
+                if the schema is invalid
+        """
+
+    def is_type(self, instance: Any, type: str) -> bool:
+        """
+        Check if the instance is of the given (JSON Schema) type.
+
+        Arguments:
+
+            instance:
+
+                the value to check
+
+            type:
+
+                the name of a known (JSON Schema) type
+
+        Returns:
+
+            whether the instance is of the given type
+
+        Raises:
+
+            `asdf._jsonschema.exceptions.UnknownType`:
+
+                if ``type`` is not a known type
+        """
+
+    def is_valid(self, instance: Any) -> bool:
+        """
+        Check if the instance is valid under the current `schema`.
+
+        Returns:
+
+            whether the instance is valid or not
+
+        >>> from asdf._jsonschema import Draft202012Validator
+        >>> schema = {"maxItems" : 2}
+        >>> Draft202012Validator(schema).is_valid([2, 3, 4])
+        False
+        """
+
+    def iter_errors(self, instance: Any) -> Iterable[ValidationError]:
+        r"""
+        Lazily yield each of the validation errors in the given instance.
+
+        >>> from asdf._jsonschema import Draft202012Validator
+        >>> schema = {
+        ...     "type" : "array",
+        ...     "items" : {"enum" : [1, 2, 3]},
+        ...     "maxItems" : 2,
+        ... }
+        >>> v = Draft202012Validator(schema)
+        >>> for error in sorted(v.iter_errors([2, 3, 4]), key=str):
+        ...     print(error.message)
+        4 is not one of [1, 2, 3]
+        [2, 3, 4] is too long
+
+        .. deprecated:: v4.0.0
+
+            Calling this function with a second schema argument is deprecated.
+            Use `Validator.evolve` instead.
+        """
+
+    def validate(self, instance: Any) -> None:
+        """
+        Check if the instance is valid under the current `schema`.
+
+        Raises:
+
+            `asdf._jsonschema.exceptions.ValidationError`:
+
+                if the instance is invalid
+
+        >>> from asdf._jsonschema import Draft202012Validator
+        >>> schema = {"maxItems" : 2}
+        >>> Draft202012Validator(schema).validate([2, 3, 4])  # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+            ...
+        ValidationError: [2, 3, 4] is too long
+        """
+
+    def evolve(self, **kwargs) -> "Validator":
+        """
+        Create a new validator like this one, but with given changes.
+
+        Preserves all other attributes, so can be used to e.g. create a
+        validator with a different schema but with the same :kw:`$ref`
+        resolution behavior.
+
+        >>> from asdf._jsonschema import Draft202012Validator
+        >>> validator = Draft202012Validator({})
+        >>> validator.evolve(schema={"type": "number"})
+        Draft202012Validator(schema={'type': 'number'}, format_checker=None)
+
+        The returned object satisfies the validator protocol, but may not
+        be of the same concrete class! In particular this occurs
+        when a :kw:`$ref` occurs to a schema with a different
+        :kw:`$schema` than this one (i.e. for a different draft).
+
+        >>> from asdf._jsonschema import Draft7Validator
+        >>> validator.evolve(
+        ...     schema={"$schema": Draft7Validator.META_SCHEMA["$id"]}
+        ... )
+        Draft7Validator(schema=..., format_checker=None)
+        """

--- a/asdf/_jsonschema/schemas/draft2019-09.json
+++ b/asdf/_jsonschema/schemas/draft2019-09.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/core": true,
+        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-09/vocab/validation": true,
+        "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-09/vocab/format": false,
+        "https://json-schema.org/draft/2019-09/vocab/content": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+        {"$ref": "meta/core"},
+        {"$ref": "meta/applicator"},
+        {"$ref": "meta/validation"},
+        {"$ref": "meta/meta-data"},
+        {"$ref": "meta/format"},
+        {"$ref": "meta/content"}
+    ],
+    "type": ["object", "boolean"],
+    "properties": {
+        "definitions": {
+            "$comment": "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "$comment": "\"dependencies\" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to \"dependentSchemas\" and \"dependentRequired\"",
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$recursiveRef": "#" },
+                    { "$ref": "meta/validation#/$defs/stringArray" }
+                ]
+            }
+        }
+    }
+}

--- a/asdf/_jsonschema/schemas/draft2020-12.json
+++ b/asdf/_jsonschema/schemas/draft2020-12.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+        "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+        "https://json-schema.org/draft/2020-12/vocab/content": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+        {"$ref": "meta/core"},
+        {"$ref": "meta/applicator"},
+        {"$ref": "meta/unevaluated"},
+        {"$ref": "meta/validation"},
+        {"$ref": "meta/meta-data"},
+        {"$ref": "meta/format-annotation"},
+        {"$ref": "meta/content"}
+    ],
+    "type": ["object", "boolean"],
+    "$comment": "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.",
+    "properties": {
+        "definitions": {
+            "$comment": "\"definitions\" has been replaced by \"$defs\".",
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "deprecated": true,
+            "default": {}
+        },
+        "dependencies": {
+            "$comment": "\"dependencies\" has been split and replaced by \"dependentSchemas\" and \"dependentRequired\" in order to serve their differing semantics.",
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$dynamicRef": "#meta" },
+                    { "$ref": "meta/validation#/$defs/stringArray" }
+                ]
+            },
+            "deprecated": true,
+            "default": {}
+        },
+        "$recursiveAnchor": {
+            "$comment": "\"$recursiveAnchor\" has been replaced by \"$dynamicAnchor\".",
+            "$ref": "meta/core#/$defs/anchorString",
+            "deprecated": true
+        },
+        "$recursiveRef": {
+            "$comment": "\"$recursiveRef\" has been replaced by \"$dynamicRef\".",
+            "$ref": "meta/core#/$defs/uriReferenceString",
+            "deprecated": true
+        }
+    }
+}

--- a/asdf/_jsonschema/schemas/draft3.json
+++ b/asdf/_jsonschema/schemas/draft3.json
@@ -1,0 +1,172 @@
+{
+	"$schema" : "http://json-schema.org/draft-03/schema#",
+	"id" : "http://json-schema.org/draft-03/schema#",
+	"type" : "object",
+
+	"properties" : {
+		"type" : {
+			"type" : ["string", "array"],
+			"items" : {
+				"type" : ["string", {"$ref" : "#"}]
+			},
+			"uniqueItems" : true,
+			"default" : "any"
+		},
+
+		"properties" : {
+			"type" : "object",
+			"additionalProperties" : {"$ref" : "#"},
+			"default" : {}
+		},
+
+		"patternProperties" : {
+			"type" : "object",
+			"additionalProperties" : {"$ref" : "#"},
+			"default" : {}
+		},
+
+		"additionalProperties" : {
+			"type" : [{"$ref" : "#"}, "boolean"],
+			"default" : {}
+		},
+
+		"items" : {
+			"type" : [{"$ref" : "#"}, "array"],
+			"items" : {"$ref" : "#"},
+			"default" : {}
+		},
+
+		"additionalItems" : {
+			"type" : [{"$ref" : "#"}, "boolean"],
+			"default" : {}
+		},
+
+		"required" : {
+			"type" : "boolean",
+			"default" : false
+		},
+
+		"dependencies" : {
+			"type" : "object",
+			"additionalProperties" : {
+				"type" : ["string", "array", {"$ref" : "#"}],
+				"items" : {
+					"type" : "string"
+				}
+			},
+			"default" : {}
+		},
+
+		"minimum" : {
+			"type" : "number"
+		},
+
+		"maximum" : {
+			"type" : "number"
+		},
+
+		"exclusiveMinimum" : {
+			"type" : "boolean",
+			"default" : false
+		},
+
+		"exclusiveMaximum" : {
+			"type" : "boolean",
+			"default" : false
+		},
+
+		"minItems" : {
+			"type" : "integer",
+			"minimum" : 0,
+			"default" : 0
+		},
+
+		"maxItems" : {
+			"type" : "integer",
+			"minimum" : 0
+		},
+
+		"uniqueItems" : {
+			"type" : "boolean",
+			"default" : false
+		},
+
+		"pattern" : {
+			"type" : "string",
+			"format" : "regex"
+		},
+
+		"minLength" : {
+			"type" : "integer",
+			"minimum" : 0,
+			"default" : 0
+		},
+
+		"maxLength" : {
+			"type" : "integer"
+		},
+
+		"enum" : {
+			"type" : "array",
+			"minItems" : 1,
+			"uniqueItems" : true
+		},
+
+		"default" : {
+			"type" : "any"
+		},
+
+		"title" : {
+			"type" : "string"
+		},
+
+		"description" : {
+			"type" : "string"
+		},
+
+		"format" : {
+			"type" : "string"
+		},
+
+		"divisibleBy" : {
+			"type" : "number",
+			"minimum" : 0,
+			"exclusiveMinimum" : true,
+			"default" : 1
+		},
+
+		"disallow" : {
+			"type" : ["string", "array"],
+			"items" : {
+				"type" : ["string", {"$ref" : "#"}]
+			},
+			"uniqueItems" : true
+		},
+
+		"extends" : {
+			"type" : [{"$ref" : "#"}, "array"],
+			"items" : {"$ref" : "#"},
+			"default" : {}
+		},
+
+		"id" : {
+			"type" : "string"
+		},
+
+		"$ref" : {
+			"type" : "string"
+		},
+
+		"$schema" : {
+			"type" : "string",
+			"format" : "uri"
+		}
+	},
+
+	"dependencies" : {
+		"exclusiveMinimum" : "minimum",
+		"exclusiveMaximum" : "maximum"
+	},
+
+	"default" : {}
+}

--- a/asdf/_jsonschema/schemas/draft4.json
+++ b/asdf/_jsonschema/schemas/draft4.json
@@ -1,0 +1,149 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "$schema": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}

--- a/asdf/_jsonschema/schemas/draft6.json
+++ b/asdf/_jsonschema/schemas/draft6.json
@@ -1,0 +1,153 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "http://json-schema.org/draft-06/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "examples": {
+            "type": "array",
+            "items": {}
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": {},
+        "enum": {
+            "type": "array"
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": {}
+}

--- a/asdf/_jsonschema/schemas/draft7.json
+++ b/asdf/_jsonschema/schemas/draft7.json
@@ -1,0 +1,166 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": true
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "if": {"$ref": "#"},
+        "then": {"$ref": "#"},
+        "else": {"$ref": "#"},
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": true
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2019-09/applicator
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2019-09/applicator
@@ -1,0 +1,56 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/applicator",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/applicator": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "additionalItems": { "$recursiveRef": "#" },
+        "unevaluatedItems": { "$recursiveRef": "#" },
+        "items": {
+            "anyOf": [
+                { "$recursiveRef": "#" },
+                { "$ref": "#/$defs/schemaArray" }
+            ]
+        },
+        "contains": { "$recursiveRef": "#" },
+        "additionalProperties": { "$recursiveRef": "#" },
+        "unevaluatedProperties": { "$recursiveRef": "#" },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependentSchemas": {
+            "type": "object",
+            "additionalProperties": {
+                "$recursiveRef": "#"
+            }
+        },
+        "propertyNames": { "$recursiveRef": "#" },
+        "if": { "$recursiveRef": "#" },
+        "then": { "$recursiveRef": "#" },
+        "else": { "$recursiveRef": "#" },
+        "allOf": { "$ref": "#/$defs/schemaArray" },
+        "anyOf": { "$ref": "#/$defs/schemaArray" },
+        "oneOf": { "$ref": "#/$defs/schemaArray" },
+        "not": { "$recursiveRef": "#" }
+    },
+    "$defs": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$recursiveRef": "#" }
+        }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2019-09/content
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2019-09/content
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/content",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/content": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Content vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "contentSchema": { "$recursiveRef": "#" }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2019-09/core
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2019-09/core
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/core",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/core": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Core vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference",
+            "$comment": "Non-empty fragments not allowed.",
+            "pattern": "^[^#]*#?$"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$anchor": {
+            "type": "string",
+            "pattern": "^[A-Za-z][-A-Za-z0-9.:_]*$"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$recursiveRef": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$recursiveAnchor": {
+            "type": "boolean",
+            "default": false
+        },
+        "$vocabulary": {
+            "type": "object",
+            "propertyNames": {
+                "type": "string",
+                "format": "uri"
+            },
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "$defs": {
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "default": {}
+        }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2019-09/meta-data
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2019-09/meta-data
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/meta-data",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/meta-data": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Meta-data vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "deprecated": {
+            "type": "boolean",
+            "default": false
+        },
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "writeOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2019-09/validation
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2019-09/validation
@@ -1,0 +1,98 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/validation",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/validation": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Validation vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minContains": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 1
+        },
+        "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/$defs/stringArray" },
+        "dependentRequired": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+            }
+        },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/$defs/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        }
+    },
+    "$defs": {
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 0
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2020-12/applicator
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2020-12/applicator
@@ -1,0 +1,48 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/applicator",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "prefixItems": { "$ref": "#/$defs/schemaArray" },
+        "items": { "$dynamicRef": "#meta" },
+        "contains": { "$dynamicRef": "#meta" },
+        "additionalProperties": { "$dynamicRef": "#meta" },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependentSchemas": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "default": {}
+        },
+        "propertyNames": { "$dynamicRef": "#meta" },
+        "if": { "$dynamicRef": "#meta" },
+        "then": { "$dynamicRef": "#meta" },
+        "else": { "$dynamicRef": "#meta" },
+        "allOf": { "$ref": "#/$defs/schemaArray" },
+        "anyOf": { "$ref": "#/$defs/schemaArray" },
+        "oneOf": { "$ref": "#/$defs/schemaArray" },
+        "not": { "$dynamicRef": "#meta" }
+    },
+    "$defs": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$dynamicRef": "#meta" }
+        }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2020-12/content
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2020-12/content
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/content",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/content": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Content vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "contentEncoding": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentSchema": { "$dynamicRef": "#meta" }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2020-12/core
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2020-12/core
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/core",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Core vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "$ref": "#/$defs/uriReferenceString",
+            "$comment": "Non-empty fragments not allowed.",
+            "pattern": "^[^#]*#?$"
+        },
+        "$schema": { "$ref": "#/$defs/uriString" },
+        "$ref": { "$ref": "#/$defs/uriReferenceString" },
+        "$anchor": { "$ref": "#/$defs/anchorString" },
+        "$dynamicRef": { "$ref": "#/$defs/uriReferenceString" },
+        "$dynamicAnchor": { "$ref": "#/$defs/anchorString" },
+        "$vocabulary": {
+            "type": "object",
+            "propertyNames": { "$ref": "#/$defs/uriString" },
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "$defs": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" }
+        }
+    },
+    "$defs": {
+        "anchorString": {
+            "type": "string",
+            "pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
+        },
+        "uriString": {
+            "type": "string",
+            "format": "uri"
+        },
+        "uriReferenceString": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2020-12/format
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2020-12/format
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/format",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/format": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Format vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "format": { "type": "string" }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2020-12/format-annotation
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2020-12/format-annotation
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/format-annotation",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Format vocabulary meta-schema for annotation results",
+    "type": ["object", "boolean"],
+    "properties": {
+        "format": { "type": "string" }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2020-12/format-assertion
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2020-12/format-assertion
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/format-assertion",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/format-assertion": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Format vocabulary meta-schema for assertion results",
+    "type": ["object", "boolean"],
+    "properties": {
+        "format": { "type": "string" }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2020-12/meta-data
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2020-12/meta-data
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/meta-data",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/meta-data": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Meta-data vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "deprecated": {
+            "type": "boolean",
+            "default": false
+        },
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "writeOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2020-12/unevaluated
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2020-12/unevaluated
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/unevaluated",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Unevaluated applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "unevaluatedItems": { "$dynamicRef": "#meta" },
+        "unevaluatedProperties": { "$dynamicRef": "#meta" }
+    }
+}

--- a/asdf/_jsonschema/schemas/vocabularies/draft2020-12/validation
+++ b/asdf/_jsonschema/schemas/vocabularies/draft2020-12/validation
@@ -1,0 +1,98 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/validation",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/validation": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Validation vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "type": {
+            "anyOf": [
+                { "$ref": "#/$defs/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minContains": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 1
+        },
+        "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/$defs/stringArray" },
+        "dependentRequired": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+            }
+        }
+    },
+    "$defs": {
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 0
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    }
+}

--- a/asdf/_jsonschema/tests/_helpers.py
+++ b/asdf/_jsonschema/tests/_helpers.py
@@ -1,0 +1,25 @@
+from urllib.parse import urljoin
+
+
+def issues_url(organization, repository):
+    return urljoin(
+        "https://github.com/", f"{organization}/{repository}/issues/",
+    )
+
+
+ISSUES_URL = issues_url("asdf-format", "asdf")
+TEST_SUITE_ISSUES_URL = issues_url("json-schema-org", "JSON-Schema-Test-Suite")
+
+
+def bug(issue=None):
+    message = "A known bug."
+    if issue is not None:
+        message += f" See {urljoin(ISSUES_URL, str(issue))}."
+    return message
+
+
+def test_suite_bug(issue):
+    return (
+        "A known test suite bug. "
+        f"See {urljoin(TEST_SUITE_ISSUES_URL, str(issue))}."
+    )

--- a/asdf/_jsonschema/tests/_suite.py
+++ b/asdf/_jsonschema/tests/_suite.py
@@ -1,0 +1,241 @@
+"""
+Python representations of the JSON Schema Test Suite tests.
+"""
+
+from functools import partial
+from pathlib import Path
+import json
+import os
+import re
+import subprocess
+import sys
+import unittest
+
+import attr
+
+from asdf._jsonschema.validators import _VALIDATORS
+import asdf._jsonschema
+
+
+def _find_suite():
+    root = os.environ.get("JSON_SCHEMA_TEST_SUITE")
+    if root is not None:
+        return Path(root)
+
+    root = Path(asdf._jsonschema.__file__).parent / "json"
+    if not root.is_dir():  # pragma: no cover
+        raise ValueError(
+            (
+                "Can't find the JSON-Schema-Test-Suite directory. "
+                "Set the 'JSON_SCHEMA_TEST_SUITE' environment "
+                "variable or run the tests from alongside a checkout "
+                "of the suite."
+            ),
+        )
+    return root
+
+
+@attr.s(hash=True)
+class Suite:
+
+    _root = attr.ib(default=attr.Factory(_find_suite))
+
+    def _remotes(self):
+        jsonschema_suite = self._root.joinpath("bin", "jsonschema_suite")
+        remotes = subprocess.check_output(
+            [sys.executable, str(jsonschema_suite), "remotes"],
+        )
+        return json.loads(remotes.decode("utf-8"))
+
+    def benchmark(self, runner):  # pragma: no cover
+        for name, Validator in _VALIDATORS.items():
+            self.version(name=name).benchmark(
+                runner=runner,
+                Validator=Validator,
+            )
+
+    def version(self, name):
+        return Version(
+            name=name,
+            path=self._root.joinpath("tests", name),
+            remotes=self._remotes(),
+        )
+
+
+@attr.s(hash=True)
+class Version:
+
+    _path = attr.ib()
+    _remotes = attr.ib()
+
+    name = attr.ib()
+
+    def benchmark(self, runner, **kwargs):  # pragma: no cover
+        for suite in self.tests():
+            for test in suite:
+                runner.bench_func(
+                    test.fully_qualified_name,
+                    partial(test.validate_ignoring_errors, **kwargs),
+                )
+
+    def tests(self):
+        return (
+            test
+            for child in self._path.glob("*.json")
+            for test in self._tests_in(
+                subject=child.name[:-5],
+                path=child,
+            )
+        )
+
+    def format_tests(self):
+        path = self._path.joinpath("optional", "format")
+        return (
+            test
+            for child in path.glob("*.json")
+            for test in self._tests_in(
+                subject=child.name[:-5],
+                path=child,
+            )
+        )
+
+    def optional_tests_of(self, name):
+        return self._tests_in(
+            subject=name,
+            path=self._path.joinpath("optional", name + ".json"),
+        )
+
+    def to_unittest_testcase(self, *suites, **kwargs):
+        name = kwargs.pop("name", "Test" + self.name.title().replace("-", ""))
+        methods = {
+            test.method_name: test.to_unittest_method(**kwargs)
+            for suite in suites
+            for tests in suite
+            for test in tests
+        }
+        cls = type(name, (unittest.TestCase,), methods)
+
+        try:
+            cls.__module__ = _someone_save_us_the_module_of_the_caller()
+        except Exception:  # pragma: no cover
+            # We're doing crazy things, so if they go wrong, like a function
+            # behaving differently on some other interpreter, just make them
+            # not happen.
+            pass
+
+        return cls
+
+    def _tests_in(self, subject, path):
+        for each in json.loads(path.read_text(encoding="utf-8")):
+            yield (
+                _Test(
+                    version=self,
+                    subject=subject,
+                    case_description=each["description"],
+                    schema=each["schema"],
+                    remotes=self._remotes,
+                    **test,
+                ) for test in each["tests"]
+            )
+
+
+@attr.s(hash=True, repr=False)
+class _Test:
+
+    version = attr.ib()
+
+    subject = attr.ib()
+    case_description = attr.ib()
+    description = attr.ib()
+
+    data = attr.ib()
+    schema = attr.ib(repr=False)
+
+    valid = attr.ib()
+
+    _remotes = attr.ib()
+
+    comment = attr.ib(default=None)
+
+    def __repr__(self):  # pragma: no cover
+        return "<Test {}>".format(self.fully_qualified_name)
+
+    @property
+    def fully_qualified_name(self):  # pragma: no cover
+        return " > ".join(
+            [
+                self.version.name,
+                self.subject,
+                self.case_description,
+                self.description,
+            ],
+        )
+
+    @property
+    def method_name(self):
+        delimiters = r"[\W\- ]+"
+        return "test_{}_{}_{}".format(
+            re.sub(delimiters, "_", self.subject),
+            re.sub(delimiters, "_", self.case_description),
+            re.sub(delimiters, "_", self.description),
+        )
+
+    def to_unittest_method(self, skip=lambda test: None, **kwargs):
+        if self.valid:
+            def fn(this):
+                self.validate(**kwargs)
+        else:
+            def fn(this):
+                with this.assertRaises(asdf._jsonschema.ValidationError):
+                    self.validate(**kwargs)
+
+        fn.__name__ = self.method_name
+        reason = skip(self)
+        if reason is None or os.environ.get("JSON_SCHEMA_DEBUG", "0") != "0":
+            return fn
+        elif os.environ.get("JSON_SCHEMA_EXPECTED_FAILURES", "0") != "0":
+            return unittest.expectedFailure(fn)
+        else:
+            return unittest.skip(reason)(fn)
+
+    def validate(self, Validator, **kwargs):
+        Validator.check_schema(self.schema)
+        resolver = asdf._jsonschema.RefResolver.from_schema(
+            schema=self.schema,
+            store=self._remotes,
+            id_of=Validator.ID_OF,
+        )
+
+        # XXX: #693 asks to improve the public API for this, since yeah, it's
+        #      bad. Figures that since it's hard for end-users, we experience
+        #      the pain internally here too.
+        def prevent_network_access(uri):
+            raise RuntimeError(f"Tried to access the network: {uri}")
+        resolver.resolve_remote = prevent_network_access
+
+        validator = Validator(schema=self.schema, resolver=resolver, **kwargs)
+        if os.environ.get("JSON_SCHEMA_DEBUG", "0") != "0":
+            breakpoint()
+        validator.validate(instance=self.data)
+
+    def validate_ignoring_errors(self, Validator):  # pragma: no cover
+        try:
+            self.validate(Validator=Validator)
+        except asdf._jsonschema.ValidationError:
+            pass
+
+
+def _someone_save_us_the_module_of_the_caller():
+    """
+    The FQON of the module 2nd stack frames up from here.
+
+    This is intended to allow us to dynamically return test case classes that
+    are indistinguishable from being defined in the module that wants them.
+
+    Otherwise, trial will mis-print the FQON, and copy pasting it won't re-run
+    the class that really is running.
+
+    Save us all, this is all so so so so so terrible.
+    """
+
+    return sys._getframe(2).f_globals["__name__"]

--- a/asdf/_jsonschema/tests/test_deprecations.py
+++ b/asdf/_jsonschema/tests/test_deprecations.py
@@ -1,0 +1,251 @@
+from unittest import TestCase
+import importlib
+import subprocess
+import sys
+
+from asdf._jsonschema import FormatChecker, validators
+
+
+class TestDeprecations(TestCase):
+    def test_validators_ErrorTree(self):
+        """
+        As of v4.0.0, importing ErrorTree from asdf._jsonschema.validators is
+        deprecated in favor of doing so from asdf._jsonschema.exceptions.
+        """
+
+        with self.assertWarns(DeprecationWarning) as w:
+            from asdf._jsonschema.validators import ErrorTree  # noqa
+
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Importing ErrorTree from asdf._jsonschema.validators is deprecated",
+            ),
+        )
+
+    def test_validators_validators(self):
+        """
+        As of v4.0.0, accessing asdf._jsonschema.validators.validators is
+        deprecated.
+        """
+
+        with self.assertWarns(DeprecationWarning) as w:
+            value = validators.validators
+        self.assertEqual(value, validators._VALIDATORS)
+
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Accessing asdf._jsonschema.validators.validators is deprecated",
+            ),
+        )
+
+    def test_validators_meta_schemas(self):
+        """
+        As of v4.0.0, accessing asdf._jsonschema.validators.meta_schemas is
+        deprecated.
+        """
+
+        with self.assertWarns(DeprecationWarning) as w:
+            value = validators.meta_schemas
+        self.assertEqual(value, validators._META_SCHEMAS)
+
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Accessing asdf._jsonschema.validators.meta_schemas is deprecated",
+            ),
+        )
+
+    def test_RefResolver_in_scope(self):
+        """
+        As of v4.0.0, RefResolver.in_scope is deprecated.
+        """
+
+        resolver = validators.RefResolver.from_schema({})
+        with self.assertWarns(DeprecationWarning) as w:
+            with resolver.in_scope("foo"):
+                pass
+
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "asdf._jsonschema.RefResolver.in_scope is deprecated ",
+            ),
+        )
+
+    def test_Validator_is_valid_two_arguments(self):
+        """
+        As of v4.0.0, calling is_valid with two arguments (to provide a
+        different schema) is deprecated.
+        """
+
+        validator = validators.Draft7Validator({})
+        with self.assertWarns(DeprecationWarning) as w:
+            result = validator.is_valid("foo", {"type": "number"})
+
+        self.assertFalse(result)
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Passing a schema to Validator.is_valid is deprecated ",
+            ),
+        )
+
+    def test_Validator_iter_errors_two_arguments(self):
+        """
+        As of v4.0.0, calling iter_errors with two arguments (to provide a
+        different schema) is deprecated.
+        """
+
+        validator = validators.Draft7Validator({})
+        with self.assertWarns(DeprecationWarning) as w:
+            error, = validator.iter_errors("foo", {"type": "number"})
+
+        self.assertEqual(error.validator, "type")
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Passing a schema to Validator.iter_errors is deprecated ",
+            ),
+        )
+
+    def test_Validator_subclassing(self):
+        """
+        As of v4.12.0, subclassing a validator class produces an explicit
+        deprecation warning.
+
+        This was never intended to be public API (and some comments over the
+        years in issues said so, but obviously that's not a great way to make
+        sure it's followed).
+
+        A future version will explicitly raise an error.
+        """
+
+        with self.assertWarns(DeprecationWarning) as w:
+            class Subclass(validators.Draft202012Validator):
+                pass
+
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith("Subclassing validator classes is "),
+        )
+
+        with self.assertWarns(DeprecationWarning) as w:
+            class AnotherSubclass(validators.create(meta_schema={})):
+                pass
+
+    def test_FormatChecker_cls_checks(self):
+        """
+        As of v4.14.0, FormatChecker.cls_checks is deprecated without
+        replacement.
+        """
+
+        self.addCleanup(FormatChecker.checkers.pop, "boom", None)
+
+        with self.assertWarns(DeprecationWarning) as w:
+            FormatChecker.cls_checks("boom")
+
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith("FormatChecker.cls_checks "),
+        )
+
+    def test_draftN_format_checker(self):
+        """
+        As of v4.16.0, accessing asdf._jsonschema.draftn_format_checker is deprecated
+        in favor of Validator.FORMAT_CHECKER.
+        """
+
+        with self.assertWarns(DeprecationWarning) as w:
+            from asdf._jsonschema import draft202012_format_checker  # noqa
+
+        self.assertIs(
+            draft202012_format_checker,
+            validators.Draft202012Validator.FORMAT_CHECKER,
+        )
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Accessing asdf._jsonschema.draft202012_format_checker is ",
+            ),
+            msg=w.warning,
+        )
+
+        with self.assertWarns(DeprecationWarning) as w:
+            from asdf._jsonschema import draft201909_format_checker  # noqa
+
+        self.assertIs(
+            draft201909_format_checker,
+            validators.Draft201909Validator.FORMAT_CHECKER,
+        )
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Accessing asdf._jsonschema.draft201909_format_checker is ",
+            ),
+            msg=w.warning,
+        )
+
+        with self.assertWarns(DeprecationWarning) as w:
+            from asdf._jsonschema import draft7_format_checker  # noqa
+
+        self.assertIs(
+            draft7_format_checker,
+            validators.Draft7Validator.FORMAT_CHECKER,
+        )
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Accessing asdf._jsonschema.draft7_format_checker is ",
+            ),
+            msg=w.warning,
+        )
+
+        with self.assertWarns(DeprecationWarning) as w:
+            from asdf._jsonschema import draft6_format_checker  # noqa
+
+        self.assertIs(
+            draft6_format_checker,
+            validators.Draft6Validator.FORMAT_CHECKER,
+        )
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Accessing asdf._jsonschema.draft6_format_checker is ",
+            ),
+            msg=w.warning,
+        )
+
+        with self.assertWarns(DeprecationWarning) as w:
+            from asdf._jsonschema import draft4_format_checker  # noqa
+
+        self.assertIs(
+            draft4_format_checker,
+            validators.Draft4Validator.FORMAT_CHECKER,
+        )
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Accessing asdf._jsonschema.draft4_format_checker is ",
+            ),
+            msg=w.warning,
+        )
+
+        with self.assertWarns(DeprecationWarning) as w:
+            from asdf._jsonschema import draft3_format_checker  # noqa
+
+        self.assertIs(
+            draft3_format_checker,
+            validators.Draft3Validator.FORMAT_CHECKER,
+        )
+        self.assertEqual(w.filename, __file__)
+        self.assertTrue(
+            str(w.warning).startswith(
+                "Accessing asdf._jsonschema.draft3_format_checker is ",
+            ),
+            msg=w.warning,
+        )
+
+        with self.assertRaises(ImportError):
+            from asdf._jsonschema import draft1234_format_checker  # noqa

--- a/asdf/_jsonschema/tests/test_exceptions.py
+++ b/asdf/_jsonschema/tests/test_exceptions.py
@@ -1,0 +1,601 @@
+from unittest import TestCase
+import textwrap
+
+from asdf._jsonschema import exceptions
+from asdf._jsonschema.validators import _LATEST_VERSION
+
+
+class TestBestMatch(TestCase):
+    def best_match_of(self, instance, schema):
+        errors = list(_LATEST_VERSION(schema).iter_errors(instance))
+        best = exceptions.best_match(iter(errors))
+        reversed_best = exceptions.best_match(reversed(errors))
+        self.assertEqual(
+            best._contents(),
+            reversed_best._contents(),
+            f"No consistent best match!\nGot: {best}\n\nThen: {reversed_best}",
+        )
+        return best
+
+    def test_shallower_errors_are_better_matches(self):
+        schema = {
+            "properties": {
+                "foo": {
+                    "minProperties": 2,
+                    "properties": {"bar": {"type": "object"}},
+                },
+            },
+        }
+        best = self.best_match_of(instance={"foo": {"bar": []}}, schema=schema)
+        self.assertEqual(best.validator, "minProperties")
+
+    def test_oneOf_and_anyOf_are_weak_matches(self):
+        """
+        A property you *must* match is probably better than one you have to
+        match a part of.
+        """
+
+        schema = {
+            "minProperties": 2,
+            "anyOf": [{"type": "string"}, {"type": "number"}],
+            "oneOf": [{"type": "string"}, {"type": "number"}],
+        }
+        best = self.best_match_of(instance={}, schema=schema)
+        self.assertEqual(best.validator, "minProperties")
+
+    def test_if_the_most_relevant_error_is_anyOf_it_is_traversed(self):
+        """
+        If the most relevant error is an anyOf, then we traverse its context
+        and select the otherwise *least* relevant error, since in this case
+        that means the most specific, deep, error inside the instance.
+
+        I.e. since only one of the schemas must match, we look for the most
+        relevant one.
+        """
+
+        schema = {
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"properties": {"bar": {"type": "array"}}},
+                    ],
+                },
+            },
+        }
+        best = self.best_match_of(instance={"foo": {"bar": 12}}, schema=schema)
+        self.assertEqual(best.validator_value, "array")
+
+    def test_no_anyOf_traversal_for_equally_relevant_errors(self):
+        """
+        We don't traverse into an anyOf (as above) if all of its context errors
+        seem to be equally "wrong" against the instance.
+        """
+
+        schema = {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"},
+                {"type": "object"},
+            ],
+        }
+        best = self.best_match_of(instance=[], schema=schema)
+        self.assertEqual(best.validator, "anyOf")
+
+    def test_anyOf_traversal_for_single_equally_relevant_error(self):
+        """
+        We *do* traverse anyOf with a single nested error, even though it is
+        vacuously equally relevant to itself.
+        """
+
+        schema = {
+            "anyOf": [
+                {"type": "string"},
+            ],
+        }
+        best = self.best_match_of(instance=[], schema=schema)
+        self.assertEqual(best.validator, "type")
+
+    def test_if_the_most_relevant_error_is_oneOf_it_is_traversed(self):
+        """
+        If the most relevant error is an oneOf, then we traverse its context
+        and select the otherwise *least* relevant error, since in this case
+        that means the most specific, deep, error inside the instance.
+
+        I.e. since only one of the schemas must match, we look for the most
+        relevant one.
+        """
+
+        schema = {
+            "properties": {
+                "foo": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"properties": {"bar": {"type": "array"}}},
+                    ],
+                },
+            },
+        }
+        best = self.best_match_of(instance={"foo": {"bar": 12}}, schema=schema)
+        self.assertEqual(best.validator_value, "array")
+
+    def test_no_oneOf_traversal_for_equally_relevant_errors(self):
+        """
+        We don't traverse into an oneOf (as above) if all of its context errors
+        seem to be equally "wrong" against the instance.
+        """
+
+        schema = {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "integer"},
+                {"type": "object"},
+            ],
+        }
+        best = self.best_match_of(instance=[], schema=schema)
+        self.assertEqual(best.validator, "oneOf")
+
+    def test_oneOf_traversal_for_single_equally_relevant_error(self):
+        """
+        We *do* traverse oneOf with a single nested error, even though it is
+        vacuously equally relevant to itself.
+        """
+
+        schema = {
+            "oneOf": [
+                {"type": "string"},
+            ],
+        }
+        best = self.best_match_of(instance=[], schema=schema)
+        self.assertEqual(best.validator, "type")
+
+    def test_if_the_most_relevant_error_is_allOf_it_is_traversed(self):
+        """
+        Now, if the error is allOf, we traverse but select the *most* relevant
+        error from the context, because all schemas here must match anyways.
+        """
+
+        schema = {
+            "properties": {
+                "foo": {
+                    "allOf": [
+                        {"type": "string"},
+                        {"properties": {"bar": {"type": "array"}}},
+                    ],
+                },
+            },
+        }
+        best = self.best_match_of(instance={"foo": {"bar": 12}}, schema=schema)
+        self.assertEqual(best.validator_value, "string")
+
+    def test_nested_context_for_oneOf(self):
+        """
+        We traverse into nested contexts (a oneOf containing an error in a
+        nested oneOf here).
+        """
+
+        schema = {
+            "properties": {
+                "foo": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {
+                            "oneOf": [
+                                {"type": "string"},
+                                {
+                                    "properties": {
+                                        "bar": {"type": "array"},
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        }
+        best = self.best_match_of(instance={"foo": {"bar": 12}}, schema=schema)
+        self.assertEqual(best.validator_value, "array")
+
+    def test_it_prioritizes_matching_types(self):
+        schema = {
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {"type": "array", "minItems": 2},
+                        {"type": "string", "minLength": 10},
+                    ],
+                },
+            },
+        }
+        best = self.best_match_of(instance={"foo": "bar"}, schema=schema)
+        self.assertEqual(best.validator, "minLength")
+
+        reordered = {
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {"type": "string", "minLength": 10},
+                        {"type": "array", "minItems": 2},
+                    ],
+                },
+            },
+        }
+        best = self.best_match_of(instance={"foo": "bar"}, schema=reordered)
+        self.assertEqual(best.validator, "minLength")
+
+    def test_it_prioritizes_matching_union_types(self):
+        schema = {
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {"type": ["array", "object"], "minItems": 2},
+                        {"type": ["integer", "string"], "minLength": 10},
+                    ],
+                },
+            },
+        }
+        best = self.best_match_of(instance={"foo": "bar"}, schema=schema)
+        self.assertEqual(best.validator, "minLength")
+
+        reordered = {
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {"type": "string", "minLength": 10},
+                        {"type": "array", "minItems": 2},
+                    ],
+                },
+            },
+        }
+        best = self.best_match_of(instance={"foo": "bar"}, schema=reordered)
+        self.assertEqual(best.validator, "minLength")
+
+    def test_boolean_schemas(self):
+        schema = {"properties": {"foo": False}}
+        best = self.best_match_of(instance={"foo": "bar"}, schema=schema)
+        self.assertIsNone(best.validator)
+
+    def test_one_error(self):
+        validator = _LATEST_VERSION({"minProperties": 2})
+        error, = validator.iter_errors({})
+        self.assertEqual(
+            exceptions.best_match(validator.iter_errors({})).validator,
+            "minProperties",
+        )
+
+    def test_no_errors(self):
+        validator = _LATEST_VERSION({})
+        self.assertIsNone(exceptions.best_match(validator.iter_errors({})))
+
+
+class TestByRelevance(TestCase):
+    def test_short_paths_are_better_matches(self):
+        shallow = exceptions.ValidationError("Oh no!", path=["baz"])
+        deep = exceptions.ValidationError("Oh yes!", path=["foo", "bar"])
+        match = max([shallow, deep], key=exceptions.relevance)
+        self.assertIs(match, shallow)
+
+        match = max([deep, shallow], key=exceptions.relevance)
+        self.assertIs(match, shallow)
+
+    def test_global_errors_are_even_better_matches(self):
+        shallow = exceptions.ValidationError("Oh no!", path=[])
+        deep = exceptions.ValidationError("Oh yes!", path=["foo"])
+
+        errors = sorted([shallow, deep], key=exceptions.relevance)
+        self.assertEqual(
+            [list(error.path) for error in errors],
+            [["foo"], []],
+        )
+
+        errors = sorted([deep, shallow], key=exceptions.relevance)
+        self.assertEqual(
+            [list(error.path) for error in errors],
+            [["foo"], []],
+        )
+
+    def test_weak_keywords_are_lower_priority(self):
+        weak = exceptions.ValidationError("Oh no!", path=[], validator="a")
+        normal = exceptions.ValidationError("Oh yes!", path=[], validator="b")
+
+        best_match = exceptions.by_relevance(weak="a")
+
+        match = max([weak, normal], key=best_match)
+        self.assertIs(match, normal)
+
+        match = max([normal, weak], key=best_match)
+        self.assertIs(match, normal)
+
+    def test_strong_keywords_are_higher_priority(self):
+        weak = exceptions.ValidationError("Oh no!", path=[], validator="a")
+        normal = exceptions.ValidationError("Oh yes!", path=[], validator="b")
+        strong = exceptions.ValidationError("Oh fine!", path=[], validator="c")
+
+        best_match = exceptions.by_relevance(weak="a", strong="c")
+
+        match = max([weak, normal, strong], key=best_match)
+        self.assertIs(match, strong)
+
+        match = max([strong, normal, weak], key=best_match)
+        self.assertIs(match, strong)
+
+
+class TestErrorTree(TestCase):
+    def test_it_knows_how_many_total_errors_it_contains(self):
+        # FIXME: #442
+        errors = [
+            exceptions.ValidationError("Something", validator=i)
+            for i in range(8)
+        ]
+        tree = exceptions.ErrorTree(errors)
+        self.assertEqual(tree.total_errors, 8)
+
+    def test_it_contains_an_item_if_the_item_had_an_error(self):
+        errors = [exceptions.ValidationError("a message", path=["bar"])]
+        tree = exceptions.ErrorTree(errors)
+        self.assertIn("bar", tree)
+
+    def test_it_does_not_contain_an_item_if_the_item_had_no_error(self):
+        errors = [exceptions.ValidationError("a message", path=["bar"])]
+        tree = exceptions.ErrorTree(errors)
+        self.assertNotIn("foo", tree)
+
+    def test_keywords_that_failed_appear_in_errors_dict(self):
+        error = exceptions.ValidationError("a message", validator="foo")
+        tree = exceptions.ErrorTree([error])
+        self.assertEqual(tree.errors, {"foo": error})
+
+    def test_it_creates_a_child_tree_for_each_nested_path(self):
+        errors = [
+            exceptions.ValidationError("a bar message", path=["bar"]),
+            exceptions.ValidationError("a bar -> 0 message", path=["bar", 0]),
+        ]
+        tree = exceptions.ErrorTree(errors)
+        self.assertIn(0, tree["bar"])
+        self.assertNotIn(1, tree["bar"])
+
+    def test_children_have_their_errors_dicts_built(self):
+        e1, e2 = (
+            exceptions.ValidationError("1", validator="foo", path=["bar", 0]),
+            exceptions.ValidationError("2", validator="quux", path=["bar", 0]),
+        )
+        tree = exceptions.ErrorTree([e1, e2])
+        self.assertEqual(tree["bar"][0].errors, {"foo": e1, "quux": e2})
+
+    def test_multiple_errors_with_instance(self):
+        e1, e2 = (
+            exceptions.ValidationError(
+                "1",
+                validator="foo",
+                path=["bar", "bar2"],
+                instance="i1"),
+            exceptions.ValidationError(
+                "2",
+                validator="quux",
+                path=["foobar", 2],
+                instance="i2"),
+        )
+        exceptions.ErrorTree([e1, e2])
+
+    def test_it_does_not_contain_subtrees_that_are_not_in_the_instance(self):
+        error = exceptions.ValidationError("123", validator="foo", instance=[])
+        tree = exceptions.ErrorTree([error])
+
+        with self.assertRaises(IndexError):
+            tree[0]
+
+    def test_if_its_in_the_tree_anyhow_it_does_not_raise_an_error(self):
+        """
+        If a keyword refers to a path that isn't in the instance, the
+        tree still properly returns a subtree for that path.
+        """
+
+        error = exceptions.ValidationError(
+            "a message", validator="foo", instance={}, path=["foo"],
+        )
+        tree = exceptions.ErrorTree([error])
+        self.assertIsInstance(tree["foo"], exceptions.ErrorTree)
+
+    def test_repr_single(self):
+        error = exceptions.ValidationError(
+            "1",
+            validator="foo",
+            path=["bar", "bar2"],
+            instance="i1",
+        )
+        tree = exceptions.ErrorTree([error])
+        self.assertEqual(repr(tree), "<ErrorTree (1 total error)>")
+
+    def test_repr_multiple(self):
+        e1, e2 = (
+            exceptions.ValidationError(
+                "1",
+                validator="foo",
+                path=["bar", "bar2"],
+                instance="i1"),
+            exceptions.ValidationError(
+                "2",
+                validator="quux",
+                path=["foobar", 2],
+                instance="i2"),
+        )
+        tree = exceptions.ErrorTree([e1, e2])
+        self.assertEqual(repr(tree), "<ErrorTree (2 total errors)>")
+
+    def test_repr_empty(self):
+        tree = exceptions.ErrorTree([])
+        self.assertEqual(repr(tree), "<ErrorTree (0 total errors)>")
+
+
+class TestErrorInitReprStr(TestCase):
+    def make_error(self, **kwargs):
+        defaults = dict(
+            message="hello",
+            validator="type",
+            validator_value="string",
+            instance=5,
+            schema={"type": "string"},
+        )
+        defaults.update(kwargs)
+        return exceptions.ValidationError(**defaults)
+
+    def assertShows(self, expected, **kwargs):
+        expected = textwrap.dedent(expected).rstrip("\n")
+
+        error = self.make_error(**kwargs)
+        message_line, _, rest = str(error).partition("\n")
+        self.assertEqual(message_line, error.message)
+        self.assertEqual(rest, expected)
+
+    def test_it_calls_super_and_sets_args(self):
+        error = self.make_error()
+        self.assertGreater(len(error.args), 1)
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(exceptions.ValidationError(message="Hello!")),
+            "<ValidationError: 'Hello!'>",
+        )
+
+    def test_unset_error(self):
+        error = exceptions.ValidationError("message")
+        self.assertEqual(str(error), "message")
+
+        kwargs = {
+            "validator": "type",
+            "validator_value": "string",
+            "instance": 5,
+            "schema": {"type": "string"},
+        }
+        # Just the message should show if any of the attributes are unset
+        for attr in kwargs:
+            k = dict(kwargs)
+            del k[attr]
+            error = exceptions.ValidationError("message", **k)
+            self.assertEqual(str(error), "message")
+
+    def test_empty_paths(self):
+        self.assertShows(
+            """
+            Failed validating 'type' in schema:
+                {'type': 'string'}
+
+            On instance:
+                5
+            """,
+            path=[],
+            schema_path=[],
+        )
+
+    def test_one_item_paths(self):
+        self.assertShows(
+            """
+            Failed validating 'type' in schema:
+                {'type': 'string'}
+
+            On instance[0]:
+                5
+            """,
+            path=[0],
+            schema_path=["items"],
+        )
+
+    def test_multiple_item_paths(self):
+        self.assertShows(
+            """
+            Failed validating 'type' in schema['items'][0]:
+                {'type': 'string'}
+
+            On instance[0]['a']:
+                5
+            """,
+            path=[0, "a"],
+            schema_path=["items", 0, 1],
+        )
+
+    def test_uses_pprint(self):
+        self.assertShows(
+            """
+            Failed validating 'maxLength' in schema:
+                {0: 0,
+                 1: 1,
+                 2: 2,
+                 3: 3,
+                 4: 4,
+                 5: 5,
+                 6: 6,
+                 7: 7,
+                 8: 8,
+                 9: 9,
+                 10: 10,
+                 11: 11,
+                 12: 12,
+                 13: 13,
+                 14: 14,
+                 15: 15,
+                 16: 16,
+                 17: 17,
+                 18: 18,
+                 19: 19}
+
+            On instance:
+                [0,
+                 1,
+                 2,
+                 3,
+                 4,
+                 5,
+                 6,
+                 7,
+                 8,
+                 9,
+                 10,
+                 11,
+                 12,
+                 13,
+                 14,
+                 15,
+                 16,
+                 17,
+                 18,
+                 19,
+                 20,
+                 21,
+                 22,
+                 23,
+                 24]
+            """,
+            instance=list(range(25)),
+            schema=dict(zip(range(20), range(20))),
+            validator="maxLength",
+        )
+
+    def test_str_works_with_instances_having_overriden_eq_operator(self):
+        """
+        Check for #164 which rendered exceptions unusable when a
+        `ValidationError` involved instances with an `__eq__` method
+        that returned truthy values.
+        """
+
+        class DontEQMeBro:
+            def __eq__(this, other):  # pragma: no cover
+                self.fail("Don't!")
+
+            def __ne__(this, other):  # pragma: no cover
+                self.fail("Don't!")
+
+        instance = DontEQMeBro()
+        error = exceptions.ValidationError(
+            "a message",
+            validator="foo",
+            instance=instance,
+            validator_value="some",
+            schema="schema",
+        )
+        self.assertIn(repr(instance), str(error))
+
+
+class TestHashable(TestCase):
+    def test_hashable(self):
+        set([exceptions.ValidationError("")])
+        set([exceptions.SchemaError("")])

--- a/asdf/_jsonschema/tests/test_format.py
+++ b/asdf/_jsonschema/tests/test_format.py
@@ -1,0 +1,108 @@
+"""
+Tests for the parts of asdf._jsonschema related to the :kw:`format` keyword.
+"""
+
+from unittest import TestCase
+
+from asdf._jsonschema import FormatChecker, FormatError, ValidationError
+from asdf._jsonschema.validators import Draft4Validator
+
+BOOM = ValueError("Boom!")
+BANG = ZeroDivisionError("Bang!")
+
+
+def boom(thing):
+    if thing == "bang":
+        raise BANG
+    raise BOOM
+
+
+class TestFormatChecker(TestCase):
+    def test_it_can_validate_no_formats(self):
+        checker = FormatChecker(formats=())
+        self.assertFalse(checker.checkers)
+
+    def test_it_raises_a_key_error_for_unknown_formats(self):
+        with self.assertRaises(KeyError):
+            FormatChecker(formats=["o noes"])
+
+    def test_it_can_register_cls_checkers(self):
+        original = dict(FormatChecker.checkers)
+        self.addCleanup(FormatChecker.checkers.pop, "boom")
+        with self.assertWarns(DeprecationWarning):
+            FormatChecker.cls_checks("boom")(boom)
+        self.assertEqual(
+            FormatChecker.checkers,
+            dict(original, boom=(boom, ())),
+        )
+
+    def test_it_can_register_checkers(self):
+        checker = FormatChecker()
+        checker.checks("boom")(boom)
+        self.assertEqual(
+            checker.checkers,
+            dict(FormatChecker.checkers, boom=(boom, ())),
+        )
+
+    def test_it_catches_registered_errors(self):
+        checker = FormatChecker()
+        checker.checks("boom", raises=type(BOOM))(boom)
+
+        with self.assertRaises(FormatError) as cm:
+            checker.check(instance=12, format="boom")
+
+        self.assertIs(cm.exception.cause, BOOM)
+        self.assertIs(cm.exception.__cause__, BOOM)
+
+        # Unregistered errors should not be caught
+        with self.assertRaises(type(BANG)):
+            checker.check(instance="bang", format="boom")
+
+    def test_format_error_causes_become_validation_error_causes(self):
+        checker = FormatChecker()
+        checker.checks("boom", raises=ValueError)(boom)
+        validator = Draft4Validator({"format": "boom"}, format_checker=checker)
+
+        with self.assertRaises(ValidationError) as cm:
+            validator.validate("BOOM")
+
+        self.assertIs(cm.exception.cause, BOOM)
+        self.assertIs(cm.exception.__cause__, BOOM)
+
+    def test_format_checkers_come_with_defaults(self):
+        # This is bad :/ but relied upon.
+        # The docs for quite awhile recommended people do things like
+        # validate(..., format_checker=FormatChecker())
+        # We should change that, but we can't without deprecation...
+        checker = FormatChecker()
+        with self.assertRaises(FormatError):
+            checker.check(instance="not-an-ipv4", format="ipv4")
+
+    def test_repr(self):
+        checker = FormatChecker(formats=())
+        checker.checks("foo")(lambda thing: True)  # pragma: no cover
+        checker.checks("bar")(lambda thing: True)  # pragma: no cover
+        checker.checks("baz")(lambda thing: True)  # pragma: no cover
+        self.assertEqual(
+            repr(checker),
+            "<FormatChecker checkers=['bar', 'baz', 'foo']>",
+        )
+
+    def test_duration_format(self):
+        try:
+            from asdf._jsonschema._format import is_duration  # noqa: F401
+        except ImportError:  # pragma: no cover
+            pass
+        else:
+            checker = FormatChecker()
+            self.assertTrue(checker.conforms(1, "duration"))
+            self.assertTrue(checker.conforms("P4Y", "duration"))
+            self.assertFalse(checker.conforms("test", "duration"))
+
+    def test_uuid_format(self):
+        checker = FormatChecker()
+        self.assertTrue(checker.conforms(1, "uuid"))
+        self.assertTrue(
+            checker.conforms("6e6659ec-4503-4428-9f03-2e2ea4d6c278", "uuid"),
+        )
+        self.assertFalse(checker.conforms("test", "uuid"))

--- a/asdf/_jsonschema/tests/test_jsonschema_test_suite.py
+++ b/asdf/_jsonschema/tests/test_jsonschema_test_suite.py
@@ -1,0 +1,546 @@
+"""
+Test runner for the JSON Schema official test suite
+
+Tests comprehensive correctness of each draft's validator.
+
+See https://github.com/json-schema-org/JSON-Schema-Test-Suite for details.
+"""
+
+import sys
+
+from asdf._jsonschema.tests._helpers import bug
+from asdf._jsonschema.tests._suite import Suite
+import asdf._jsonschema
+
+SUITE = Suite()
+DRAFT3 = SUITE.version(name="draft3")
+DRAFT4 = SUITE.version(name="draft4")
+DRAFT6 = SUITE.version(name="draft6")
+DRAFT7 = SUITE.version(name="draft7")
+DRAFT201909 = SUITE.version(name="draft2019-09")
+DRAFT202012 = SUITE.version(name="draft2020-12")
+
+
+def skip(message, **kwargs):
+    def skipper(test):
+        if all(value == getattr(test, attr) for attr, value in kwargs.items()):
+            return message
+    return skipper
+
+
+def missing_format(Validator):
+    def missing_format(test):  # pragma: no cover
+        schema = test.schema
+        if (
+            schema is True
+            or schema is False
+            or "format" not in schema
+            or schema["format"] in Validator.FORMAT_CHECKER.checkers
+            or test.valid
+        ):
+            return
+
+        return "Format checker {0!r} not found.".format(schema["format"])
+    return missing_format
+
+
+def complex_email_validation(test):
+    if test.subject != "email":
+        return
+
+    message = "Complex email validation is (intentionally) unsupported."
+    return skip(
+        message=message,
+        description="an invalid domain",
+    )(test) or skip(
+        message=message,
+        description="an invalid IPv4-address-literal",
+    )(test) or skip(
+        message=message,
+        description="dot after local part is not valid",
+    )(test) or skip(
+        message=message,
+        description="dot before local part is not valid",
+    )(test) or skip(
+        message=message,
+        description="two subsequent dots inside local part are not valid",
+    )(test)
+
+
+is_narrow_build = sys.maxunicode == 2 ** 16 - 1
+if is_narrow_build:  # pragma: no cover
+    message = "Not running surrogate Unicode case, this Python is narrow."
+
+    def narrow_unicode_build(test):  # pragma: no cover
+        return skip(
+            message=message,
+            description=(
+                "one supplementary Unicode code point is not long enough"
+            ),
+        )(test) or skip(
+            message=message,
+            description="two supplementary Unicode code points is long enough",
+        )(test)
+else:
+    def narrow_unicode_build(test):  # pragma: no cover
+        return
+
+
+if sys.version_info < (3, 9):  # pragma: no cover
+    message = "Rejecting leading zeros is 3.9+"
+    allowed_leading_zeros = skip(
+        message=message,
+        subject="ipv4",
+        description="invalid leading zeroes, as they are treated as octals",
+    )
+else:
+    def allowed_leading_zeros(test):  # pragma: no cover
+        return
+
+
+def leap_second(test):
+    message = "Leap seconds are unsupported."
+    return skip(
+        message=message,
+        subject="time",
+        description="a valid time string with leap second",
+    )(test) or skip(
+        message=message,
+        subject="time",
+        description="a valid time string with leap second, Zulu",
+    )(test) or skip(
+        message=message,
+        subject="time",
+        description="a valid time string with leap second with offset",
+    )(test) or skip(
+        message=message,
+        subject="time",
+        description="valid leap second, positive time-offset",
+    )(test) or skip(
+        message=message,
+        subject="time",
+        description="valid leap second, negative time-offset",
+    )(test) or skip(
+        message=message,
+        subject="time",
+        description="valid leap second, large positive time-offset",
+    )(test) or skip(
+        message=message,
+        subject="time",
+        description="valid leap second, large negative time-offset",
+    )(test) or skip(
+        message=message,
+        subject="time",
+        description="valid leap second, zero time-offset",
+    )(test) or skip(
+        message=message,
+        subject="date-time",
+        description="a valid date-time with a leap second, UTC",
+    )(test) or skip(
+        message=message,
+        subject="date-time",
+        description="a valid date-time with a leap second, with minus offset",
+    )(test)
+
+
+TestDraft3 = DRAFT3.to_unittest_testcase(
+    DRAFT3.tests(),
+    DRAFT3.format_tests(),
+    DRAFT3.optional_tests_of(name="bignum"),
+    DRAFT3.optional_tests_of(name="non-bmp-regex"),
+    DRAFT3.optional_tests_of(name="zeroTerminatedFloats"),
+    Validator=asdf._jsonschema.Draft3Validator,
+    format_checker=asdf._jsonschema.Draft3Validator.FORMAT_CHECKER,
+    skip=lambda test: (
+        narrow_unicode_build(test)
+        or missing_format(asdf._jsonschema.Draft3Validator)(test)
+        or complex_email_validation(test)
+        or skip(
+            message=bug(),
+            subject="ref",
+            valid=False,
+            case_description=(
+                "$ref prevents a sibling id from changing the base uri"
+            ),
+        )(test)
+    ),
+)
+
+
+TestDraft4 = DRAFT4.to_unittest_testcase(
+    DRAFT4.tests(),
+    DRAFT4.format_tests(),
+    DRAFT4.optional_tests_of(name="bignum"),
+    DRAFT4.optional_tests_of(name="float-overflow"),
+    DRAFT4.optional_tests_of(name="non-bmp-regex"),
+    DRAFT4.optional_tests_of(name="zeroTerminatedFloats"),
+    Validator=asdf._jsonschema.Draft4Validator,
+    format_checker=asdf._jsonschema.Draft4Validator.FORMAT_CHECKER,
+    skip=lambda test: (
+        narrow_unicode_build(test)
+        or allowed_leading_zeros(test)
+        or leap_second(test)
+        or missing_format(asdf._jsonschema.Draft4Validator)(test)
+        or complex_email_validation(test)
+        or skip(
+            message=bug(),
+            subject="ref",
+            case_description="Recursive references between schemas",
+        )(test)
+        or skip(
+            message=bug(),
+            subject="ref",
+            case_description=(
+                "Location-independent identifier with "
+                "base URI change in subschema"
+            ),
+        )(test)
+        or skip(
+            message=bug(),
+            subject="ref",
+            case_description=(
+                "$ref prevents a sibling id from changing the base uri"
+            ),
+        )(test)
+        or skip(
+            message=bug(),
+            subject="id",
+            description="match $ref to id",
+        )(test)
+        or skip(
+            message=bug(),
+            subject="id",
+            description="no match on enum or $ref to id",
+        )(test)
+        or skip(
+            message=bug(),
+            subject="refRemote",
+            case_description="base URI change - change folder in subschema",
+        )(test)
+        or skip(
+            message=bug(),
+            subject="ref",
+            case_description=(
+                "id must be resolved against nearest parent, "
+                "not just immediate parent"
+            ),
+        )(test)
+    ),
+)
+
+
+TestDraft6 = DRAFT6.to_unittest_testcase(
+    DRAFT6.tests(),
+    DRAFT6.format_tests(),
+    DRAFT6.optional_tests_of(name="bignum"),
+    DRAFT6.optional_tests_of(name="float-overflow"),
+    DRAFT6.optional_tests_of(name="non-bmp-regex"),
+    Validator=asdf._jsonschema.Draft6Validator,
+    format_checker=asdf._jsonschema.Draft6Validator.FORMAT_CHECKER,
+    skip=lambda test: (
+        narrow_unicode_build(test)
+        or allowed_leading_zeros(test)
+        or leap_second(test)
+        or missing_format(asdf._jsonschema.Draft6Validator)(test)
+        or complex_email_validation(test)
+        or skip(
+            message=bug(),
+            subject="refRemote",
+            case_description="base URI change - change folder in subschema",
+        )(test)
+    ),
+)
+
+
+TestDraft7 = DRAFT7.to_unittest_testcase(
+    DRAFT7.tests(),
+    DRAFT7.format_tests(),
+    DRAFT7.optional_tests_of(name="bignum"),
+    DRAFT7.optional_tests_of(name="cross-draft"),
+    DRAFT7.optional_tests_of(name="float-overflow"),
+    DRAFT7.optional_tests_of(name="non-bmp-regex"),
+    Validator=asdf._jsonschema.Draft7Validator,
+    format_checker=asdf._jsonschema.Draft7Validator.FORMAT_CHECKER,
+    skip=lambda test: (
+        narrow_unicode_build(test)
+        or allowed_leading_zeros(test)
+        or leap_second(test)
+        or missing_format(asdf._jsonschema.Draft7Validator)(test)
+        or complex_email_validation(test)
+        or skip(
+            message=bug(),
+            subject="refRemote",
+            case_description="base URI change - change folder in subschema",
+        )(test)
+        or skip(
+            message=bug(),
+            subject="ref",
+            case_description=(
+                "$id must be resolved against nearest parent, "
+                "not just immediate parent"
+            ),
+        )(test)
+    ),
+)
+
+
+TestDraft201909 = DRAFT201909.to_unittest_testcase(
+    DRAFT201909.tests(),
+    DRAFT201909.optional_tests_of(name="bignum"),
+    DRAFT201909.optional_tests_of(name="cross-draft"),
+    DRAFT201909.optional_tests_of(name="float-overflow"),
+    DRAFT201909.optional_tests_of(name="non-bmp-regex"),
+    DRAFT201909.optional_tests_of(name="refOfUnknownKeyword"),
+    Validator=asdf._jsonschema.Draft201909Validator,
+    skip=lambda test: (
+        skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            case_description=(
+                "$recursiveRef with no $recursiveAnchor in "
+                "the initial target schema resource"
+            ),
+            description=(
+                "leaf node does not match: recursion uses the inner schema"
+            ),
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            description="leaf node matches: recursion uses the inner schema",
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            case_description=(
+                "dynamic $recursiveRef destination (not predictable "
+                "at schema compile time)"
+            ),
+            description="integer node",
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            case_description=(
+                "multiple dynamic paths to the $recursiveRef keyword"
+            ),
+            description="recurse to integerNode - floats are not allowed",
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            description="integer does not match as a property value",
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            description=(
+                "leaf node does not match: "
+                "recursion only uses inner schema"
+            ),
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            description=(
+                "leaf node matches: "
+                "recursion only uses inner schema"
+            ),
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            description=(
+                "two levels, integer does not match as a property value"
+            ),
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            description="recursive mismatch",
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="recursiveRef",
+            description="two levels, no match",
+        )(test)
+        or skip(
+            message="recursiveRef support isn't working yet.",
+            subject="id",
+            case_description=(
+                "Invalid use of fragments in location-independent $id"
+            ),
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="defs",
+            description="invalid definition schema",
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="anchor",
+            case_description="same $anchor with different base uri",
+        )(test)
+        or skip(
+            message="Vocabulary support is still in-progress.",
+            subject="vocabulary",
+            description=(
+                "no validation: invalid number, but it still validates"
+            ),
+        )(test)
+        or skip(
+            message=bug(),
+            subject="ref",
+            case_description=(
+                "$id must be resolved against nearest parent, "
+                "not just immediate parent"
+            ),
+        )(test)
+        or skip(
+            message=bug(),
+            subject="refRemote",
+            case_description="remote HTTP ref with nested absolute ref",
+        )(test)
+    ),
+)
+
+
+TestDraft201909Format = DRAFT201909.to_unittest_testcase(
+    DRAFT201909.format_tests(),
+    name="TestDraft201909Format",
+    Validator=asdf._jsonschema.Draft201909Validator,
+    format_checker=asdf._jsonschema.Draft201909Validator.FORMAT_CHECKER,
+    skip=lambda test: (
+        complex_email_validation(test)
+        or allowed_leading_zeros(test)
+        or leap_second(test)
+        or missing_format(asdf._jsonschema.Draft201909Validator)(test)
+        or complex_email_validation(test)
+    ),
+)
+
+
+TestDraft202012 = DRAFT202012.to_unittest_testcase(
+    DRAFT202012.tests(),
+    DRAFT202012.optional_tests_of(name="bignum"),
+    DRAFT202012.optional_tests_of(name="cross-draft"),
+    DRAFT202012.optional_tests_of(name="float-overflow"),
+    DRAFT202012.optional_tests_of(name="non-bmp-regex"),
+    DRAFT202012.optional_tests_of(name="refOfUnknownKeyword"),
+    Validator=asdf._jsonschema.Draft202012Validator,
+    skip=lambda test: (
+        narrow_unicode_build(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="dynamicRef",
+            description="The recursive part is not valid against the root",
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="dynamicRef",
+            description="incorrect extended schema",
+            case_description=(
+                "$ref and $dynamicAnchor are independent of order - "
+                "$defs first"
+            ),
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="dynamicRef",
+            description="correct extended schema",
+            case_description=(
+                "$ref and $dynamicAnchor are independent of order - "
+                "$defs first"
+            ),
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="dynamicRef",
+            description="correct extended schema",
+            case_description=(
+                "$ref and $dynamicAnchor are independent of order - $ref first"
+            ),
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="dynamicRef",
+            description="incorrect extended schema",
+            case_description=(
+                "$ref and $dynamicAnchor are independent of order - $ref first"
+            ),
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="dynamicRef",
+            description=(
+                "/then/$defs/thingy is the final stop for the $dynamicRef"
+            ),
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="dynamicRef",
+            description=(
+                "string matches /$defs/thingy, but the $dynamicRef "
+                "does not stop here"
+            ),
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="dynamicRef",
+            description=(
+                "string matches /$defs/thingy, but the $dynamicRef "
+                "does not stop here"
+            ),
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="dynamicRef",
+            description="recurse to integerNode - floats are not allowed",
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="defs",
+            description="invalid definition schema",
+        )(test)
+        or skip(
+            message="dynamicRef support isn't fully working yet.",
+            subject="anchor",
+            case_description="same $anchor with different base uri",
+        )(test)
+        or skip(
+            message="Vocabulary support is still in-progress.",
+            subject="vocabulary",
+            description=(
+                "no validation: invalid number, but it still validates"
+            ),
+        )(test)
+        or skip(
+            message=bug(),
+            subject="ref",
+            case_description=(
+                "$id must be resolved against nearest parent, "
+                "not just immediate parent"
+            ),
+        )(test)
+        or skip(
+            message=bug(),
+            subject="refRemote",
+            case_description="remote HTTP ref with nested absolute ref",
+        )(test)
+    ),
+)
+
+
+TestDraft202012Format = DRAFT202012.to_unittest_testcase(
+    DRAFT202012.format_tests(),
+    name="TestDraft202012Format",
+    Validator=asdf._jsonschema.Draft202012Validator,
+    format_checker=asdf._jsonschema.Draft202012Validator.FORMAT_CHECKER,
+    skip=lambda test: (
+        complex_email_validation(test)
+        or allowed_leading_zeros(test)
+        or leap_second(test)
+        or missing_format(asdf._jsonschema.Draft202012Validator)(test)
+        or complex_email_validation(test)
+    ),
+)

--- a/asdf/_jsonschema/tests/test_types.py
+++ b/asdf/_jsonschema/tests/test_types.py
@@ -1,0 +1,221 @@
+"""
+Tests for the `TypeChecker`-based type interface.
+
+The actual correctness of the type checking is handled in
+`test_jsonschema_test_suite`; these tests check that TypeChecker
+functions correctly at a more granular level.
+"""
+from collections import namedtuple
+from unittest import TestCase
+
+from asdf._jsonschema import ValidationError, _validators
+from asdf._jsonschema._types import TypeChecker
+from asdf._jsonschema.exceptions import UndefinedTypeCheck, UnknownType
+from asdf._jsonschema.validators import Draft202012Validator, extend
+
+
+def equals_2(checker, instance):
+    return instance == 2
+
+
+def is_namedtuple(instance):
+    return isinstance(instance, tuple) and getattr(instance, "_fields", None)
+
+
+def is_object_or_named_tuple(checker, instance):
+    if Draft202012Validator.TYPE_CHECKER.is_type(instance, "object"):
+        return True
+    return is_namedtuple(instance)
+
+
+class TestTypeChecker(TestCase):
+    def test_is_type(self):
+        checker = TypeChecker({"two": equals_2})
+        self.assertEqual(
+            (
+                checker.is_type(instance=2, type="two"),
+                checker.is_type(instance="bar", type="two"),
+            ),
+            (True, False),
+        )
+
+    def test_is_unknown_type(self):
+        with self.assertRaises(UndefinedTypeCheck) as e:
+            TypeChecker().is_type(4, "foobar")
+        self.assertIn(
+            "'foobar' is unknown to this type checker",
+            str(e.exception),
+        )
+        self.assertTrue(
+            e.exception.__suppress_context__,
+            msg="Expected the internal KeyError to be hidden.",
+        )
+
+    def test_checks_can_be_added_at_init(self):
+        checker = TypeChecker({"two": equals_2})
+        self.assertEqual(checker, TypeChecker().redefine("two", equals_2))
+
+    def test_redefine_existing_type(self):
+        self.assertEqual(
+            TypeChecker().redefine("two", object()).redefine("two", equals_2),
+            TypeChecker().redefine("two", equals_2),
+        )
+
+    def test_remove(self):
+        self.assertEqual(
+            TypeChecker({"two": equals_2}).remove("two"),
+            TypeChecker(),
+        )
+
+    def test_remove_unknown_type(self):
+        with self.assertRaises(UndefinedTypeCheck) as context:
+            TypeChecker().remove("foobar")
+        self.assertIn("foobar", str(context.exception))
+
+    def test_redefine_many(self):
+        self.assertEqual(
+            TypeChecker().redefine_many({"foo": int, "bar": str}),
+            TypeChecker().redefine("foo", int).redefine("bar", str),
+        )
+
+    def test_remove_multiple(self):
+        self.assertEqual(
+            TypeChecker({"foo": int, "bar": str}).remove("foo", "bar"),
+            TypeChecker(),
+        )
+
+    def test_type_check_can_raise_key_error(self):
+        """
+        Make sure no one writes:
+
+            try:
+                self._type_checkers[type](...)
+            except KeyError:
+
+        ignoring the fact that the function itself can raise that.
+        """
+
+        error = KeyError("Stuff")
+
+        def raises_keyerror(checker, instance):
+            raise error
+
+        with self.assertRaises(KeyError) as context:
+            TypeChecker({"foo": raises_keyerror}).is_type(4, "foo")
+
+        self.assertIs(context.exception, error)
+
+    def test_repr(self):
+        checker = TypeChecker({"foo": is_namedtuple, "bar": is_namedtuple})
+        self.assertEqual(repr(checker), "<TypeChecker types={'bar', 'foo'}>")
+
+
+class TestCustomTypes(TestCase):
+    def test_simple_type_can_be_extended(self):
+        def int_or_str_int(checker, instance):
+            if not isinstance(instance, (int, str)):
+                return False
+            try:
+                int(instance)
+            except ValueError:
+                return False
+            return True
+
+        CustomValidator = extend(
+            Draft202012Validator,
+            type_checker=Draft202012Validator.TYPE_CHECKER.redefine(
+                "integer", int_or_str_int,
+            ),
+        )
+        validator = CustomValidator({"type": "integer"})
+
+        validator.validate(4)
+        validator.validate("4")
+
+        with self.assertRaises(ValidationError):
+            validator.validate(4.4)
+
+        with self.assertRaises(ValidationError):
+            validator.validate("foo")
+
+    def test_object_can_be_extended(self):
+        schema = {"type": "object"}
+
+        Point = namedtuple("Point", ["x", "y"])
+
+        type_checker = Draft202012Validator.TYPE_CHECKER.redefine(
+            "object", is_object_or_named_tuple,
+        )
+
+        CustomValidator = extend(
+            Draft202012Validator,
+            type_checker=type_checker,
+        )
+        validator = CustomValidator(schema)
+
+        validator.validate(Point(x=4, y=5))
+
+    def test_object_extensions_require_custom_validators(self):
+        schema = {"type": "object", "required": ["x"]}
+
+        type_checker = Draft202012Validator.TYPE_CHECKER.redefine(
+            "object", is_object_or_named_tuple,
+        )
+
+        CustomValidator = extend(
+            Draft202012Validator,
+            type_checker=type_checker,
+        )
+        validator = CustomValidator(schema)
+
+        Point = namedtuple("Point", ["x", "y"])
+        # Cannot handle required
+        with self.assertRaises(ValidationError):
+            validator.validate(Point(x=4, y=5))
+
+    def test_object_extensions_can_handle_custom_validators(self):
+        schema = {
+            "type": "object",
+            "required": ["x"],
+            "properties": {"x": {"type": "integer"}},
+        }
+
+        type_checker = Draft202012Validator.TYPE_CHECKER.redefine(
+            "object", is_object_or_named_tuple,
+        )
+
+        def coerce_named_tuple(fn):
+            def coerced(validator, value, instance, schema):
+                if is_namedtuple(instance):
+                    instance = instance._asdict()
+                return fn(validator, value, instance, schema)
+            return coerced
+
+        required = coerce_named_tuple(_validators.required)
+        properties = coerce_named_tuple(_validators.properties)
+
+        CustomValidator = extend(
+            Draft202012Validator,
+            type_checker=type_checker,
+            validators={"required": required, "properties": properties},
+        )
+
+        validator = CustomValidator(schema)
+
+        Point = namedtuple("Point", ["x", "y"])
+        # Can now process required and properties
+        validator.validate(Point(x=4, y=5))
+
+        with self.assertRaises(ValidationError):
+            validator.validate(Point(x="not an integer", y=5))
+
+        # As well as still handle objects.
+        validator.validate({"x": 4, "y": 5})
+
+        with self.assertRaises(ValidationError):
+            validator.validate({"x": "not an integer", "y": 5})
+
+    def test_unknown_type(self):
+        with self.assertRaises(UnknownType) as e:
+            Draft202012Validator({}).is_type(12, "some unknown type")
+        self.assertIn("'some unknown type'", str(e.exception))

--- a/asdf/_jsonschema/tests/test_utils.py
+++ b/asdf/_jsonschema/tests/test_utils.py
@@ -1,0 +1,124 @@
+from unittest import TestCase
+
+from asdf._jsonschema._utils import equal
+
+
+class TestEqual(TestCase):
+    def test_none(self):
+        self.assertTrue(equal(None, None))
+
+
+class TestDictEqual(TestCase):
+    def test_equal_dictionaries(self):
+        dict_1 = {"a": "b", "c": "d"}
+        dict_2 = {"c": "d", "a": "b"}
+        self.assertTrue(equal(dict_1, dict_2))
+
+    def test_missing_key(self):
+        dict_1 = {"a": "b", "c": "d"}
+        dict_2 = {"c": "d", "x": "b"}
+        self.assertFalse(equal(dict_1, dict_2))
+
+    def test_additional_key(self):
+        dict_1 = {"a": "b", "c": "d"}
+        dict_2 = {"c": "d", "a": "b", "x": "x"}
+        self.assertFalse(equal(dict_1, dict_2))
+
+    def test_missing_value(self):
+        dict_1 = {"a": "b", "c": "d"}
+        dict_2 = {"c": "d", "a": "x"}
+        self.assertFalse(equal(dict_1, dict_2))
+
+    def test_empty_dictionaries(self):
+        dict_1 = {}
+        dict_2 = {}
+        self.assertTrue(equal(dict_1, dict_2))
+
+    def test_one_none(self):
+        dict_1 = None
+        dict_2 = {"a": "b", "c": "d"}
+        self.assertFalse(equal(dict_1, dict_2))
+
+    def test_same_item(self):
+        dict_1 = {"a": "b", "c": "d"}
+        self.assertTrue(equal(dict_1, dict_1))
+
+    def test_nested_equal(self):
+        dict_1 = {"a": {"a": "b", "c": "d"}, "c": "d"}
+        dict_2 = {"c": "d", "a": {"a": "b", "c": "d"}}
+        self.assertTrue(equal(dict_1, dict_2))
+
+    def test_nested_dict_unequal(self):
+        dict_1 = {"a": {"a": "b", "c": "d"}, "c": "d"}
+        dict_2 = {"c": "d", "a": {"a": "b", "c": "x"}}
+        self.assertFalse(equal(dict_1, dict_2))
+
+    def test_mixed_nested_equal(self):
+        dict_1 = {"a": ["a", "b", "c", "d"], "c": "d"}
+        dict_2 = {"c": "d", "a": ["a", "b", "c", "d"]}
+        self.assertTrue(equal(dict_1, dict_2))
+
+    def test_nested_list_unequal(self):
+        dict_1 = {"a": ["a", "b", "c", "d"], "c": "d"}
+        dict_2 = {"c": "d", "a": ["b", "c", "d", "a"]}
+        self.assertFalse(equal(dict_1, dict_2))
+
+
+class TestListEqual(TestCase):
+    def test_equal_lists(self):
+        list_1 = ["a", "b", "c"]
+        list_2 = ["a", "b", "c"]
+        self.assertTrue(equal(list_1, list_2))
+
+    def test_unsorted_lists(self):
+        list_1 = ["a", "b", "c"]
+        list_2 = ["b", "b", "a"]
+        self.assertFalse(equal(list_1, list_2))
+
+    def test_first_list_larger(self):
+        list_1 = ["a", "b", "c"]
+        list_2 = ["a", "b"]
+        self.assertFalse(equal(list_1, list_2))
+
+    def test_second_list_larger(self):
+        list_1 = ["a", "b"]
+        list_2 = ["a", "b", "c"]
+        self.assertFalse(equal(list_1, list_2))
+
+    def test_list_with_none_unequal(self):
+        list_1 = ["a", "b", None]
+        list_2 = ["a", "b", "c"]
+        self.assertFalse(equal(list_1, list_2))
+
+        list_1 = ["a", "b", None]
+        list_2 = [None, "b", "c"]
+        self.assertFalse(equal(list_1, list_2))
+
+    def test_list_with_none_equal(self):
+        list_1 = ["a", None, "c"]
+        list_2 = ["a", None, "c"]
+        self.assertTrue(equal(list_1, list_2))
+
+    def test_empty_list(self):
+        list_1 = []
+        list_2 = []
+        self.assertTrue(equal(list_1, list_2))
+
+    def test_one_none(self):
+        list_1 = None
+        list_2 = []
+        self.assertFalse(equal(list_1, list_2))
+
+    def test_same_list(self):
+        list_1 = ["a", "b", "c"]
+        self.assertTrue(equal(list_1, list_1))
+
+    def test_equal_nested_lists(self):
+        list_1 = ["a", ["b", "c"], "d"]
+        list_2 = ["a", ["b", "c"], "d"]
+        self.assertTrue(equal(list_1, list_2))
+
+    def test_unequal_nested_lists(self):
+        list_1 = ["a", ["b", "c"], "d"]
+        list_2 = ["a", [], "c"]
+        self.assertFalse(equal(list_1, list_2))

--- a/asdf/_jsonschema/tests/test_validators.py
+++ b/asdf/_jsonschema/tests/test_validators.py
@@ -1,0 +1,2316 @@
+from __future__ import annotations
+
+from collections import deque, namedtuple
+from contextlib import contextmanager
+from decimal import Decimal
+from io import BytesIO
+from unittest import TestCase, mock
+from urllib.request import pathname2url
+import json
+import os
+import sys
+import tempfile
+import unittest
+import warnings
+
+import attr
+
+from asdf._jsonschema import (
+    FormatChecker,
+    TypeChecker,
+    exceptions,
+    protocols,
+    validators,
+)
+from asdf._jsonschema.tests._helpers import bug
+
+
+def fail(validator, errors, instance, schema):
+    for each in errors:
+        each.setdefault("message", "You told me to fail!")
+        yield exceptions.ValidationError(**each)
+
+
+class TestCreateAndExtend(TestCase):
+    def setUp(self):
+        self.addCleanup(
+            self.assertEqual,
+            validators._META_SCHEMAS,
+            dict(validators._META_SCHEMAS),
+        )
+
+        self.meta_schema = {"$id": "some://meta/schema"}
+        self.validators = {"fail": fail}
+        self.type_checker = TypeChecker()
+        self.Validator = validators.create(
+            meta_schema=self.meta_schema,
+            validators=self.validators,
+            type_checker=self.type_checker,
+        )
+
+    def test_attrs(self):
+        self.assertEqual(
+            (
+                self.Validator.VALIDATORS,
+                self.Validator.META_SCHEMA,
+                self.Validator.TYPE_CHECKER,
+            ), (
+                self.validators,
+                self.meta_schema,
+                self.type_checker,
+            ),
+        )
+
+    def test_init(self):
+        schema = {"fail": []}
+        self.assertEqual(self.Validator(schema).schema, schema)
+
+    def test_iter_errors_successful(self):
+        schema = {"fail": []}
+        validator = self.Validator(schema)
+
+        errors = list(validator.iter_errors("hello"))
+        self.assertEqual(errors, [])
+
+    def test_iter_errors_one_error(self):
+        schema = {"fail": [{"message": "Whoops!"}]}
+        validator = self.Validator(schema)
+
+        expected_error = exceptions.ValidationError(
+            "Whoops!",
+            instance="goodbye",
+            schema=schema,
+            validator="fail",
+            validator_value=[{"message": "Whoops!"}],
+            schema_path=deque(["fail"]),
+        )
+
+        errors = list(validator.iter_errors("goodbye"))
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]._contents(), expected_error._contents())
+
+    def test_iter_errors_multiple_errors(self):
+        schema = {
+            "fail": [
+                {"message": "First"},
+                {"message": "Second!", "validator": "asdf"},
+                {"message": "Third"},
+            ],
+        }
+        validator = self.Validator(schema)
+
+        errors = list(validator.iter_errors("goodbye"))
+        self.assertEqual(len(errors), 3)
+
+    def test_if_a_version_is_provided_it_is_registered(self):
+        Validator = validators.create(
+            meta_schema={"$id": "something"},
+            version="my version",
+        )
+        self.addCleanup(validators._META_SCHEMAS.pop, "something")
+        self.assertEqual(Validator.__name__, "MyVersionValidator")
+        self.assertEqual(Validator.__qualname__, "MyVersionValidator")
+
+    def test_repr(self):
+        Validator = validators.create(
+            meta_schema={"$id": "something"},
+            version="my version",
+        )
+        self.addCleanup(validators._META_SCHEMAS.pop, "something")
+        self.assertEqual(
+            repr(Validator({})),
+            "MyVersionValidator(schema={}, format_checker=None)",
+        )
+
+    def test_long_repr(self):
+        Validator = validators.create(
+            meta_schema={"$id": "something"},
+            version="my version",
+        )
+        self.addCleanup(validators._META_SCHEMAS.pop, "something")
+        self.assertEqual(
+            repr(Validator({"a": list(range(1000))})), (
+                "MyVersionValidator(schema={'a': [0, 1, 2, 3, 4, 5, ...]}, "
+                "format_checker=None)"
+            ),
+        )
+
+    def test_repr_no_version(self):
+        Validator = validators.create(meta_schema={})
+        self.assertEqual(
+            repr(Validator({})),
+            "Validator(schema={}, format_checker=None)",
+        )
+
+    def test_dashes_are_stripped_from_validator_names(self):
+        Validator = validators.create(
+            meta_schema={"$id": "something"},
+            version="foo-bar",
+        )
+        self.addCleanup(validators._META_SCHEMAS.pop, "something")
+        self.assertEqual(Validator.__qualname__, "FooBarValidator")
+
+    def test_if_a_version_is_not_provided_it_is_not_registered(self):
+        original = dict(validators._META_SCHEMAS)
+        validators.create(meta_schema={"id": "id"})
+        self.assertEqual(validators._META_SCHEMAS, original)
+
+    def test_validates_registers_meta_schema_id(self):
+        meta_schema_key = "meta schema id"
+        my_meta_schema = {"id": meta_schema_key}
+
+        validators.create(
+            meta_schema=my_meta_schema,
+            version="my version",
+            id_of=lambda s: s.get("id", ""),
+        )
+        self.addCleanup(validators._META_SCHEMAS.pop, meta_schema_key)
+
+        self.assertIn(meta_schema_key, validators._META_SCHEMAS)
+
+    def test_validates_registers_meta_schema_draft6_id(self):
+        meta_schema_key = "meta schema $id"
+        my_meta_schema = {"$id": meta_schema_key}
+
+        validators.create(
+            meta_schema=my_meta_schema,
+            version="my version",
+        )
+        self.addCleanup(validators._META_SCHEMAS.pop, meta_schema_key)
+
+        self.assertIn(meta_schema_key, validators._META_SCHEMAS)
+
+    def test_create_default_types(self):
+        Validator = validators.create(meta_schema={}, validators=())
+        self.assertTrue(
+            all(
+                Validator({}).is_type(instance=instance, type=type)
+                for type, instance in [
+                    ("array", []),
+                    ("boolean", True),
+                    ("integer", 12),
+                    ("null", None),
+                    ("number", 12.0),
+                    ("object", {}),
+                    ("string", "foo"),
+                ]
+            ),
+        )
+
+    def test_check_schema_with_different_metaschema(self):
+        """
+        One can create a validator class whose metaschema uses a different
+        dialect than itself.
+        """
+
+        NoEmptySchemasValidator = validators.create(
+            meta_schema={
+                "$schema": validators.Draft202012Validator.META_SCHEMA["$id"],
+                "not": {"const": {}},
+            },
+        )
+        NoEmptySchemasValidator.check_schema({"foo": "bar"})
+
+        with self.assertRaises(exceptions.SchemaError):
+            NoEmptySchemasValidator.check_schema({})
+
+        NoEmptySchemasValidator({"foo": "bar"}).validate("foo")
+
+    def test_check_schema_with_different_metaschema_defaults_to_self(self):
+        """
+        A validator whose metaschema doesn't declare $schema defaults to its
+        own validation behavior, not the latest "normal" specification.
+        """
+
+        NoEmptySchemasValidator = validators.create(
+            meta_schema={"fail": [{"message": "Meta schema whoops!"}]},
+            validators={"fail": fail},
+        )
+        with self.assertRaises(exceptions.SchemaError):
+            NoEmptySchemasValidator.check_schema({})
+
+    def test_extend(self):
+        original = dict(self.Validator.VALIDATORS)
+        new = object()
+
+        Extended = validators.extend(
+            self.Validator,
+            validators={"new": new},
+        )
+        self.assertEqual(
+            (
+                Extended.VALIDATORS,
+                Extended.META_SCHEMA,
+                Extended.TYPE_CHECKER,
+                self.Validator.VALIDATORS,
+            ), (
+                dict(original, new=new),
+                self.Validator.META_SCHEMA,
+                self.Validator.TYPE_CHECKER,
+                original,
+            ),
+        )
+
+    def test_extend_idof(self):
+        """
+        Extending a validator preserves its notion of schema IDs.
+        """
+        def id_of(schema):
+            return schema.get("__test__", self.Validator.ID_OF(schema))
+        correct_id = "the://correct/id/"
+        meta_schema = {
+            "$id": "the://wrong/id/",
+            "__test__": correct_id,
+        }
+        Original = validators.create(
+            meta_schema=meta_schema,
+            validators=self.validators,
+            type_checker=self.type_checker,
+            id_of=id_of,
+        )
+        self.assertEqual(Original.ID_OF(Original.META_SCHEMA), correct_id)
+
+        Derived = validators.extend(Original)
+        self.assertEqual(Derived.ID_OF(Derived.META_SCHEMA), correct_id)
+
+
+class TestValidationErrorMessages(TestCase):
+    def message_for(self, instance, schema, *args, **kwargs):
+        cls = kwargs.pop("cls", validators._LATEST_VERSION)
+        cls.check_schema(schema)
+        validator = cls(schema, *args, **kwargs)
+        errors = list(validator.iter_errors(instance))
+        self.assertTrue(errors, msg=f"No errors were raised for {instance!r}")
+        self.assertEqual(
+            len(errors),
+            1,
+            msg=f"Expected exactly one error, found {errors!r}",
+        )
+        return errors[0].message
+
+    def test_single_type_failure(self):
+        message = self.message_for(instance=1, schema={"type": "string"})
+        self.assertEqual(message, "1 is not of type 'string'")
+
+    def test_single_type_list_failure(self):
+        message = self.message_for(instance=1, schema={"type": ["string"]})
+        self.assertEqual(message, "1 is not of type 'string'")
+
+    def test_multiple_type_failure(self):
+        types = "string", "object"
+        message = self.message_for(instance=1, schema={"type": list(types)})
+        self.assertEqual(message, "1 is not of type 'string', 'object'")
+
+    def test_object_with_named_type_failure(self):
+        schema = {"type": [{"name": "Foo", "minimum": 3}]}
+        message = self.message_for(
+            instance=1,
+            schema=schema,
+            cls=validators.Draft3Validator,
+        )
+        self.assertEqual(message, "1 is not of type 'Foo'")
+
+    def test_minimum(self):
+        message = self.message_for(instance=1, schema={"minimum": 2})
+        self.assertEqual(message, "1 is less than the minimum of 2")
+
+    def test_maximum(self):
+        message = self.message_for(instance=1, schema={"maximum": 0})
+        self.assertEqual(message, "1 is greater than the maximum of 0")
+
+    def test_dependencies_single_element(self):
+        depend, on = "bar", "foo"
+        schema = {"dependencies": {depend: on}}
+        message = self.message_for(
+            instance={"bar": 2},
+            schema=schema,
+            cls=validators.Draft3Validator,
+        )
+        self.assertEqual(message, "'foo' is a dependency of 'bar'")
+
+    def test_object_without_title_type_failure_draft3(self):
+        type = {"type": [{"minimum": 3}]}
+        message = self.message_for(
+            instance=1,
+            schema={"type": [type]},
+            cls=validators.Draft3Validator,
+        )
+        self.assertEqual(
+            message,
+            "1 is not of type {'type': [{'minimum': 3}]}",
+        )
+
+    def test_dependencies_list_draft3(self):
+        depend, on = "bar", "foo"
+        schema = {"dependencies": {depend: [on]}}
+        message = self.message_for(
+            instance={"bar": 2},
+            schema=schema,
+            cls=validators.Draft3Validator,
+        )
+        self.assertEqual(message, "'foo' is a dependency of 'bar'")
+
+    def test_dependencies_list_draft7(self):
+        depend, on = "bar", "foo"
+        schema = {"dependencies": {depend: [on]}}
+        message = self.message_for(
+            instance={"bar": 2},
+            schema=schema,
+            cls=validators.Draft7Validator,
+        )
+        self.assertEqual(message, "'foo' is a dependency of 'bar'")
+
+    def test_additionalItems_single_failure(self):
+        message = self.message_for(
+            instance=[2],
+            schema={"items": [], "additionalItems": False},
+            cls=validators.Draft3Validator,
+        )
+        self.assertIn("(2 was unexpected)", message)
+
+    def test_additionalItems_multiple_failures(self):
+        message = self.message_for(
+            instance=[1, 2, 3],
+            schema={"items": [], "additionalItems": False},
+            cls=validators.Draft3Validator,
+        )
+        self.assertIn("(1, 2, 3 were unexpected)", message)
+
+    def test_additionalProperties_single_failure(self):
+        additional = "foo"
+        schema = {"additionalProperties": False}
+        message = self.message_for(instance={additional: 2}, schema=schema)
+        self.assertIn("('foo' was unexpected)", message)
+
+    def test_additionalProperties_multiple_failures(self):
+        schema = {"additionalProperties": False}
+        message = self.message_for(
+            instance=dict.fromkeys(["foo", "bar"]),
+            schema=schema,
+        )
+
+        self.assertIn(repr("foo"), message)
+        self.assertIn(repr("bar"), message)
+        self.assertIn("were unexpected)", message)
+
+    def test_const(self):
+        schema = {"const": 12}
+        message = self.message_for(
+            instance={"foo": "bar"},
+            schema=schema,
+        )
+        self.assertIn("12 was expected", message)
+
+    def test_contains_draft_6(self):
+        schema = {"contains": {"const": 12}}
+        message = self.message_for(
+            instance=[2, {}, []],
+            schema=schema,
+            cls=validators.Draft6Validator,
+        )
+        self.assertEqual(
+            message,
+            "None of [2, {}, []] are valid under the given schema",
+        )
+
+    def test_invalid_format_default_message(self):
+        checker = FormatChecker(formats=())
+        checker.checks("thing")(lambda value: False)
+
+        schema = {"format": "thing"}
+        message = self.message_for(
+            instance="bla",
+            schema=schema,
+            format_checker=checker,
+        )
+
+        self.assertIn(repr("bla"), message)
+        self.assertIn(repr("thing"), message)
+        self.assertIn("is not a", message)
+
+    def test_additionalProperties_false_patternProperties(self):
+        schema = {"type": "object",
+                  "additionalProperties": False,
+                  "patternProperties": {
+                      "^abc$": {"type": "string"},
+                      "^def$": {"type": "string"},
+                  }}
+        message = self.message_for(
+            instance={"zebra": 123},
+            schema=schema,
+            cls=validators.Draft4Validator,
+        )
+        self.assertEqual(
+            message,
+            "{} does not match any of the regexes: {}, {}".format(
+                repr("zebra"), repr("^abc$"), repr("^def$"),
+            ),
+        )
+        message = self.message_for(
+            instance={"zebra": 123, "fish": 456},
+            schema=schema,
+            cls=validators.Draft4Validator,
+        )
+        self.assertEqual(
+            message,
+            "{}, {} do not match any of the regexes: {}, {}".format(
+                repr("fish"), repr("zebra"), repr("^abc$"), repr("^def$"),
+            ),
+        )
+
+    def test_False_schema(self):
+        message = self.message_for(
+            instance="something",
+            schema=False,
+        )
+        self.assertEqual(message, "False schema does not allow 'something'")
+
+    def test_multipleOf(self):
+        message = self.message_for(
+            instance=3,
+            schema={"multipleOf": 2},
+        )
+        self.assertEqual(message, "3 is not a multiple of 2")
+
+    def test_minItems(self):
+        message = self.message_for(instance=[], schema={"minItems": 2})
+        self.assertEqual(message, "[] is too short")
+
+    def test_maxItems(self):
+        message = self.message_for(instance=[1, 2, 3], schema={"maxItems": 2})
+        self.assertEqual(message, "[1, 2, 3] is too long")
+
+    def test_prefixItems_with_items(self):
+        message = self.message_for(
+            instance=[1, 2, "foo", 5],
+            schema={"items": False, "prefixItems": [{}, {}]},
+        )
+        self.assertEqual(message, "Expected at most 2 items, but found 4")
+
+    def test_minLength(self):
+        message = self.message_for(
+            instance="",
+            schema={"minLength": 2},
+        )
+        self.assertEqual(message, "'' is too short")
+
+    def test_maxLength(self):
+        message = self.message_for(
+            instance="abc",
+            schema={"maxLength": 2},
+        )
+        self.assertEqual(message, "'abc' is too long")
+
+    def test_pattern(self):
+        message = self.message_for(
+            instance="bbb",
+            schema={"pattern": "^a*$"},
+        )
+        self.assertEqual(message, "'bbb' does not match '^a*$'")
+
+    def test_does_not_contain(self):
+        message = self.message_for(
+            instance=[],
+            schema={"contains": {"type": "string"}},
+        )
+        self.assertEqual(
+            message,
+            "[] does not contain items matching the given schema",
+        )
+
+    def test_contains_too_few(self):
+        message = self.message_for(
+            instance=["foo", 1],
+            schema={"contains": {"type": "string"}, "minContains": 2},
+        )
+        self.assertEqual(
+            message,
+            "Too few items match the given schema "
+            "(expected at least 2 but only 1 matched)",
+        )
+
+    def test_contains_too_few_both_constrained(self):
+        message = self.message_for(
+            instance=["foo", 1],
+            schema={
+                "contains": {"type": "string"},
+                "minContains": 2,
+                "maxContains": 4,
+            },
+        )
+        self.assertEqual(
+            message,
+            "Too few items match the given schema (expected at least 2 but "
+            "only 1 matched)",
+        )
+
+    def test_contains_too_many(self):
+        message = self.message_for(
+            instance=["foo", "bar", "baz"],
+            schema={"contains": {"type": "string"}, "maxContains": 2},
+        )
+        self.assertEqual(
+            message,
+            "Too many items match the given schema (expected at most 2)",
+        )
+
+    def test_contains_too_many_both_constrained(self):
+        message = self.message_for(
+            instance=["foo"] * 5,
+            schema={
+                "contains": {"type": "string"},
+                "minContains": 2,
+                "maxContains": 4,
+            },
+        )
+        self.assertEqual(
+            message,
+            "Too many items match the given schema (expected at most 4)",
+        )
+
+    def test_exclusiveMinimum(self):
+        message = self.message_for(
+            instance=3,
+            schema={"exclusiveMinimum": 5},
+        )
+        self.assertEqual(
+            message,
+            "3 is less than or equal to the minimum of 5",
+        )
+
+    def test_exclusiveMaximum(self):
+        message = self.message_for(instance=3, schema={"exclusiveMaximum": 2})
+        self.assertEqual(
+            message,
+            "3 is greater than or equal to the maximum of 2",
+        )
+
+    def test_required(self):
+        message = self.message_for(instance={}, schema={"required": ["foo"]})
+        self.assertEqual(message, "'foo' is a required property")
+
+    def test_dependentRequired(self):
+        message = self.message_for(
+            instance={"foo": {}},
+            schema={"dependentRequired": {"foo": ["bar"]}},
+        )
+        self.assertEqual(message, "'bar' is a dependency of 'foo'")
+
+    def test_minProperties(self):
+        message = self.message_for(instance={}, schema={"minProperties": 2})
+        self.assertEqual(message, "{} does not have enough properties")
+
+    def test_maxProperties(self):
+        message = self.message_for(
+            instance={"a": {}, "b": {}, "c": {}},
+            schema={"maxProperties": 2},
+        )
+        self.assertEqual(
+            message,
+            "{'a': {}, 'b': {}, 'c': {}} has too many properties",
+        )
+
+    def test_oneOf_matches_none(self):
+        message = self.message_for(instance={}, schema={"oneOf": [False]})
+        self.assertEqual(
+            message,
+            "{} is not valid under any of the given schemas",
+        )
+
+    def test_oneOf_matches_too_many(self):
+        message = self.message_for(instance={}, schema={"oneOf": [True, True]})
+        self.assertEqual(message, "{} is valid under each of True, True")
+
+    def test_unevaluated_items(self):
+        schema = {"type": "array", "unevaluatedItems": False}
+        message = self.message_for(instance=["foo", "bar"], schema=schema)
+        self.assertIn(
+            message,
+            "Unevaluated items are not allowed ('bar', 'foo' were unexpected)",
+        )
+
+    def test_unevaluated_items_on_invalid_type(self):
+        schema = {"type": "array", "unevaluatedItems": False}
+        message = self.message_for(instance="foo", schema=schema)
+        self.assertEqual(message, "'foo' is not of type 'array'")
+
+    def test_unevaluated_properties_invalid_against_subschema(self):
+        schema = {
+            "properties": {"foo": {"type": "string"}},
+            "unevaluatedProperties": {"const": 12},
+        }
+        message = self.message_for(
+            instance={
+                "foo": "foo",
+                "bar": "bar",
+                "baz": 12,
+            },
+            schema=schema,
+        )
+        self.assertEqual(
+            message,
+            "Unevaluated properties are not valid under the given schema "
+            "('bar' was unevaluated and invalid)",
+        )
+
+    def test_unevaluated_properties_disallowed(self):
+        schema = {"type": "object", "unevaluatedProperties": False}
+        message = self.message_for(
+            instance={
+                "foo": "foo",
+                "bar": "bar",
+            },
+            schema=schema,
+        )
+        self.assertEqual(
+            message,
+            "Unevaluated properties are not allowed "
+            "('bar', 'foo' were unexpected)",
+        )
+
+    def test_unevaluated_properties_on_invalid_type(self):
+        schema = {"type": "object", "unevaluatedProperties": False}
+        message = self.message_for(instance="foo", schema=schema)
+        self.assertEqual(message, "'foo' is not of type 'object'")
+
+
+class TestValidationErrorDetails(TestCase):
+    # TODO: These really need unit tests for each individual keyword, rather
+    #       than just these higher level tests.
+    def test_anyOf(self):
+        instance = 5
+        schema = {
+            "anyOf": [
+                {"minimum": 20},
+                {"type": "string"},
+            ],
+        }
+
+        validator = validators.Draft4Validator(schema)
+        errors = list(validator.iter_errors(instance))
+        self.assertEqual(len(errors), 1)
+        e = errors[0]
+
+        self.assertEqual(e.validator, "anyOf")
+        self.assertEqual(e.validator_value, schema["anyOf"])
+        self.assertEqual(e.instance, instance)
+        self.assertEqual(e.schema, schema)
+        self.assertIsNone(e.parent)
+
+        self.assertEqual(e.path, deque([]))
+        self.assertEqual(e.relative_path, deque([]))
+        self.assertEqual(e.absolute_path, deque([]))
+        self.assertEqual(e.json_path, "$")
+
+        self.assertEqual(e.schema_path, deque(["anyOf"]))
+        self.assertEqual(e.relative_schema_path, deque(["anyOf"]))
+        self.assertEqual(e.absolute_schema_path, deque(["anyOf"]))
+
+        self.assertEqual(len(e.context), 2)
+
+        e1, e2 = sorted_errors(e.context)
+
+        self.assertEqual(e1.validator, "minimum")
+        self.assertEqual(e1.validator_value, schema["anyOf"][0]["minimum"])
+        self.assertEqual(e1.instance, instance)
+        self.assertEqual(e1.schema, schema["anyOf"][0])
+        self.assertIs(e1.parent, e)
+
+        self.assertEqual(e1.path, deque([]))
+        self.assertEqual(e1.absolute_path, deque([]))
+        self.assertEqual(e1.relative_path, deque([]))
+        self.assertEqual(e1.json_path, "$")
+
+        self.assertEqual(e1.schema_path, deque([0, "minimum"]))
+        self.assertEqual(e1.relative_schema_path, deque([0, "minimum"]))
+        self.assertEqual(
+            e1.absolute_schema_path, deque(["anyOf", 0, "minimum"]),
+        )
+
+        self.assertFalse(e1.context)
+
+        self.assertEqual(e2.validator, "type")
+        self.assertEqual(e2.validator_value, schema["anyOf"][1]["type"])
+        self.assertEqual(e2.instance, instance)
+        self.assertEqual(e2.schema, schema["anyOf"][1])
+        self.assertIs(e2.parent, e)
+
+        self.assertEqual(e2.path, deque([]))
+        self.assertEqual(e2.relative_path, deque([]))
+        self.assertEqual(e2.absolute_path, deque([]))
+        self.assertEqual(e2.json_path, "$")
+
+        self.assertEqual(e2.schema_path, deque([1, "type"]))
+        self.assertEqual(e2.relative_schema_path, deque([1, "type"]))
+        self.assertEqual(e2.absolute_schema_path, deque(["anyOf", 1, "type"]))
+
+        self.assertEqual(len(e2.context), 0)
+
+    def test_type(self):
+        instance = {"foo": 1}
+        schema = {
+            "type": [
+                {"type": "integer"},
+                {
+                    "type": "object",
+                    "properties": {"foo": {"enum": [2]}},
+                },
+            ],
+        }
+
+        validator = validators.Draft3Validator(schema)
+        errors = list(validator.iter_errors(instance))
+        self.assertEqual(len(errors), 1)
+        e = errors[0]
+
+        self.assertEqual(e.validator, "type")
+        self.assertEqual(e.validator_value, schema["type"])
+        self.assertEqual(e.instance, instance)
+        self.assertEqual(e.schema, schema)
+        self.assertIsNone(e.parent)
+
+        self.assertEqual(e.path, deque([]))
+        self.assertEqual(e.relative_path, deque([]))
+        self.assertEqual(e.absolute_path, deque([]))
+        self.assertEqual(e.json_path, "$")
+
+        self.assertEqual(e.schema_path, deque(["type"]))
+        self.assertEqual(e.relative_schema_path, deque(["type"]))
+        self.assertEqual(e.absolute_schema_path, deque(["type"]))
+
+        self.assertEqual(len(e.context), 2)
+
+        e1, e2 = sorted_errors(e.context)
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e1.validator_value, schema["type"][0]["type"])
+        self.assertEqual(e1.instance, instance)
+        self.assertEqual(e1.schema, schema["type"][0])
+        self.assertIs(e1.parent, e)
+
+        self.assertEqual(e1.path, deque([]))
+        self.assertEqual(e1.relative_path, deque([]))
+        self.assertEqual(e1.absolute_path, deque([]))
+        self.assertEqual(e1.json_path, "$")
+
+        self.assertEqual(e1.schema_path, deque([0, "type"]))
+        self.assertEqual(e1.relative_schema_path, deque([0, "type"]))
+        self.assertEqual(e1.absolute_schema_path, deque(["type", 0, "type"]))
+
+        self.assertFalse(e1.context)
+
+        self.assertEqual(e2.validator, "enum")
+        self.assertEqual(e2.validator_value, [2])
+        self.assertEqual(e2.instance, 1)
+        self.assertEqual(e2.schema, {"enum": [2]})
+        self.assertIs(e2.parent, e)
+
+        self.assertEqual(e2.path, deque(["foo"]))
+        self.assertEqual(e2.relative_path, deque(["foo"]))
+        self.assertEqual(e2.absolute_path, deque(["foo"]))
+        self.assertEqual(e2.json_path, "$.foo")
+
+        self.assertEqual(
+            e2.schema_path, deque([1, "properties", "foo", "enum"]),
+        )
+        self.assertEqual(
+            e2.relative_schema_path, deque([1, "properties", "foo", "enum"]),
+        )
+        self.assertEqual(
+            e2.absolute_schema_path,
+            deque(["type", 1, "properties", "foo", "enum"]),
+        )
+
+        self.assertFalse(e2.context)
+
+    def test_single_nesting(self):
+        instance = {"foo": 2, "bar": [1], "baz": 15, "quux": "spam"}
+        schema = {
+            "properties": {
+                "foo": {"type": "string"},
+                "bar": {"minItems": 2},
+                "baz": {"maximum": 10, "enum": [2, 4, 6, 8]},
+            },
+        }
+
+        validator = validators.Draft3Validator(schema)
+        errors = validator.iter_errors(instance)
+        e1, e2, e3, e4 = sorted_errors(errors)
+
+        self.assertEqual(e1.path, deque(["bar"]))
+        self.assertEqual(e2.path, deque(["baz"]))
+        self.assertEqual(e3.path, deque(["baz"]))
+        self.assertEqual(e4.path, deque(["foo"]))
+
+        self.assertEqual(e1.relative_path, deque(["bar"]))
+        self.assertEqual(e2.relative_path, deque(["baz"]))
+        self.assertEqual(e3.relative_path, deque(["baz"]))
+        self.assertEqual(e4.relative_path, deque(["foo"]))
+
+        self.assertEqual(e1.absolute_path, deque(["bar"]))
+        self.assertEqual(e2.absolute_path, deque(["baz"]))
+        self.assertEqual(e3.absolute_path, deque(["baz"]))
+        self.assertEqual(e4.absolute_path, deque(["foo"]))
+
+        self.assertEqual(e1.json_path, "$.bar")
+        self.assertEqual(e2.json_path, "$.baz")
+        self.assertEqual(e3.json_path, "$.baz")
+        self.assertEqual(e4.json_path, "$.foo")
+
+        self.assertEqual(e1.validator, "minItems")
+        self.assertEqual(e2.validator, "enum")
+        self.assertEqual(e3.validator, "maximum")
+        self.assertEqual(e4.validator, "type")
+
+    def test_multiple_nesting(self):
+        instance = [1, {"foo": 2, "bar": {"baz": [1]}}, "quux"]
+        schema = {
+            "type": "string",
+            "items": {
+                "type": ["string", "object"],
+                "properties": {
+                    "foo": {"enum": [1, 3]},
+                    "bar": {
+                        "type": "array",
+                        "properties": {
+                            "bar": {"required": True},
+                            "baz": {"minItems": 2},
+                        },
+                    },
+                },
+            },
+        }
+
+        validator = validators.Draft3Validator(schema)
+        errors = validator.iter_errors(instance)
+        e1, e2, e3, e4, e5, e6 = sorted_errors(errors)
+
+        self.assertEqual(e1.path, deque([]))
+        self.assertEqual(e2.path, deque([0]))
+        self.assertEqual(e3.path, deque([1, "bar"]))
+        self.assertEqual(e4.path, deque([1, "bar", "bar"]))
+        self.assertEqual(e5.path, deque([1, "bar", "baz"]))
+        self.assertEqual(e6.path, deque([1, "foo"]))
+
+        self.assertEqual(e1.json_path, "$")
+        self.assertEqual(e2.json_path, "$[0]")
+        self.assertEqual(e3.json_path, "$[1].bar")
+        self.assertEqual(e4.json_path, "$[1].bar.bar")
+        self.assertEqual(e5.json_path, "$[1].bar.baz")
+        self.assertEqual(e6.json_path, "$[1].foo")
+
+        self.assertEqual(e1.schema_path, deque(["type"]))
+        self.assertEqual(e2.schema_path, deque(["items", "type"]))
+        self.assertEqual(
+            list(e3.schema_path), ["items", "properties", "bar", "type"],
+        )
+        self.assertEqual(
+            list(e4.schema_path),
+            ["items", "properties", "bar", "properties", "bar", "required"],
+        )
+        self.assertEqual(
+            list(e5.schema_path),
+            ["items", "properties", "bar", "properties", "baz", "minItems"],
+        )
+        self.assertEqual(
+            list(e6.schema_path), ["items", "properties", "foo", "enum"],
+        )
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e2.validator, "type")
+        self.assertEqual(e3.validator, "type")
+        self.assertEqual(e4.validator, "required")
+        self.assertEqual(e5.validator, "minItems")
+        self.assertEqual(e6.validator, "enum")
+
+    def test_recursive(self):
+        schema = {
+            "definitions": {
+                "node": {
+                    "anyOf": [{
+                        "type": "object",
+                        "required": ["name", "children"],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                            },
+                            "children": {
+                                "type": "object",
+                                "patternProperties": {
+                                    "^.*$": {
+                                        "$ref": "#/definitions/node",
+                                    },
+                                },
+                            },
+                        },
+                    }],
+                },
+            },
+            "type": "object",
+            "required": ["root"],
+            "properties": {"root": {"$ref": "#/definitions/node"}},
+        }
+
+        instance = {
+            "root": {
+                "name": "root",
+                "children": {
+                    "a": {
+                        "name": "a",
+                        "children": {
+                            "ab": {
+                                "name": "ab",
+                                # missing "children"
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        validator = validators.Draft4Validator(schema)
+
+        e, = validator.iter_errors(instance)
+        self.assertEqual(e.absolute_path, deque(["root"]))
+        self.assertEqual(
+            e.absolute_schema_path, deque(["properties", "root", "anyOf"]),
+        )
+        self.assertEqual(e.json_path, "$.root")
+
+        e1, = e.context
+        self.assertEqual(e1.absolute_path, deque(["root", "children", "a"]))
+        self.assertEqual(
+            e1.absolute_schema_path, deque(
+                [
+                    "properties",
+                    "root",
+                    "anyOf",
+                    0,
+                    "properties",
+                    "children",
+                    "patternProperties",
+                    "^.*$",
+                    "anyOf",
+                ],
+            ),
+        )
+        self.assertEqual(e1.json_path, "$.root.children.a")
+
+        e2, = e1.context
+        self.assertEqual(
+            e2.absolute_path, deque(
+                ["root", "children", "a", "children", "ab"],
+            ),
+        )
+        self.assertEqual(
+            e2.absolute_schema_path, deque(
+                [
+                    "properties",
+                    "root",
+                    "anyOf",
+                    0,
+                    "properties",
+                    "children",
+                    "patternProperties",
+                    "^.*$",
+                    "anyOf",
+                    0,
+                    "properties",
+                    "children",
+                    "patternProperties",
+                    "^.*$",
+                    "anyOf",
+                ],
+            ),
+        )
+        self.assertEqual(e2.json_path, "$.root.children.a.children.ab")
+
+    def test_additionalProperties(self):
+        instance = {"bar": "bar", "foo": 2}
+        schema = {"additionalProperties": {"type": "integer", "minimum": 5}}
+
+        validator = validators.Draft3Validator(schema)
+        errors = validator.iter_errors(instance)
+        e1, e2 = sorted_errors(errors)
+
+        self.assertEqual(e1.path, deque(["bar"]))
+        self.assertEqual(e2.path, deque(["foo"]))
+
+        self.assertEqual(e1.json_path, "$.bar")
+        self.assertEqual(e2.json_path, "$.foo")
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e2.validator, "minimum")
+
+    def test_patternProperties(self):
+        instance = {"bar": 1, "foo": 2}
+        schema = {
+            "patternProperties": {
+                "bar": {"type": "string"},
+                "foo": {"minimum": 5},
+            },
+        }
+
+        validator = validators.Draft3Validator(schema)
+        errors = validator.iter_errors(instance)
+        e1, e2 = sorted_errors(errors)
+
+        self.assertEqual(e1.path, deque(["bar"]))
+        self.assertEqual(e2.path, deque(["foo"]))
+
+        self.assertEqual(e1.json_path, "$.bar")
+        self.assertEqual(e2.json_path, "$.foo")
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e2.validator, "minimum")
+
+    def test_additionalItems(self):
+        instance = ["foo", 1]
+        schema = {
+            "items": [],
+            "additionalItems": {"type": "integer", "minimum": 5},
+        }
+
+        validator = validators.Draft3Validator(schema)
+        errors = validator.iter_errors(instance)
+        e1, e2 = sorted_errors(errors)
+
+        self.assertEqual(e1.path, deque([0]))
+        self.assertEqual(e2.path, deque([1]))
+
+        self.assertEqual(e1.json_path, "$[0]")
+        self.assertEqual(e2.json_path, "$[1]")
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e2.validator, "minimum")
+
+    def test_additionalItems_with_items(self):
+        instance = ["foo", "bar", 1]
+        schema = {
+            "items": [{}],
+            "additionalItems": {"type": "integer", "minimum": 5},
+        }
+
+        validator = validators.Draft3Validator(schema)
+        errors = validator.iter_errors(instance)
+        e1, e2 = sorted_errors(errors)
+
+        self.assertEqual(e1.path, deque([1]))
+        self.assertEqual(e2.path, deque([2]))
+
+        self.assertEqual(e1.json_path, "$[1]")
+        self.assertEqual(e2.json_path, "$[2]")
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e2.validator, "minimum")
+
+    def test_propertyNames(self):
+        instance = {"foo": 12}
+        schema = {"propertyNames": {"not": {"const": "foo"}}}
+
+        validator = validators.Draft7Validator(schema)
+        error, = validator.iter_errors(instance)
+
+        self.assertEqual(error.validator, "not")
+        self.assertEqual(
+            error.message,
+            "'foo' should not be valid under {'const': 'foo'}",
+        )
+        self.assertEqual(error.path, deque([]))
+        self.assertEqual(error.json_path, "$")
+        self.assertEqual(error.schema_path, deque(["propertyNames", "not"]))
+
+    def test_if_then(self):
+        schema = {
+            "if": {"const": 12},
+            "then": {"const": 13},
+        }
+
+        validator = validators.Draft7Validator(schema)
+        error, = validator.iter_errors(12)
+
+        self.assertEqual(error.validator, "const")
+        self.assertEqual(error.message, "13 was expected")
+        self.assertEqual(error.path, deque([]))
+        self.assertEqual(error.json_path, "$")
+        self.assertEqual(error.schema_path, deque(["then", "const"]))
+
+    def test_if_else(self):
+        schema = {
+            "if": {"const": 12},
+            "else": {"const": 13},
+        }
+
+        validator = validators.Draft7Validator(schema)
+        error, = validator.iter_errors(15)
+
+        self.assertEqual(error.validator, "const")
+        self.assertEqual(error.message, "13 was expected")
+        self.assertEqual(error.path, deque([]))
+        self.assertEqual(error.json_path, "$")
+        self.assertEqual(error.schema_path, deque(["else", "const"]))
+
+    def test_boolean_schema_False(self):
+        validator = validators.Draft7Validator(False)
+        error, = validator.iter_errors(12)
+
+        self.assertEqual(
+            (
+                error.message,
+                error.validator,
+                error.validator_value,
+                error.instance,
+                error.schema,
+                error.schema_path,
+                error.json_path,
+            ),
+            (
+                "False schema does not allow 12",
+                None,
+                None,
+                12,
+                False,
+                deque([]),
+                "$",
+            ),
+        )
+
+    def test_ref(self):
+        ref, schema = "someRef", {"additionalProperties": {"type": "integer"}}
+        validator = validators.Draft7Validator(
+            {"$ref": ref},
+            resolver=validators.RefResolver("", {}, store={ref: schema}),
+        )
+        error, = validator.iter_errors({"foo": "notAnInteger"})
+
+        self.assertEqual(
+            (
+                error.message,
+                error.validator,
+                error.validator_value,
+                error.instance,
+                error.absolute_path,
+                error.schema,
+                error.schema_path,
+                error.json_path,
+            ),
+            (
+                "'notAnInteger' is not of type 'integer'",
+                "type",
+                "integer",
+                "notAnInteger",
+                deque(["foo"]),
+                {"type": "integer"},
+                deque(["additionalProperties", "type"]),
+                "$.foo",
+            ),
+        )
+
+    def test_prefixItems(self):
+        schema = {"prefixItems": [{"type": "string"}, {}, {}, {"maximum": 3}]}
+        validator = validators.Draft202012Validator(schema)
+        type_error, min_error = validator.iter_errors([1, 2, "foo", 5])
+        self.assertEqual(
+            (
+                type_error.message,
+                type_error.validator,
+                type_error.validator_value,
+                type_error.instance,
+                type_error.absolute_path,
+                type_error.schema,
+                type_error.schema_path,
+                type_error.json_path,
+            ),
+            (
+                "1 is not of type 'string'",
+                "type",
+                "string",
+                1,
+                deque([0]),
+                {"type": "string"},
+                deque(["prefixItems", 0, "type"]),
+                "$[0]",
+            ),
+        )
+        self.assertEqual(
+            (
+                min_error.message,
+                min_error.validator,
+                min_error.validator_value,
+                min_error.instance,
+                min_error.absolute_path,
+                min_error.schema,
+                min_error.schema_path,
+                min_error.json_path,
+            ),
+            (
+                "5 is greater than the maximum of 3",
+                "maximum",
+                3,
+                5,
+                deque([3]),
+                {"maximum": 3},
+                deque(["prefixItems", 3, "maximum"]),
+                "$[3]",
+            ),
+        )
+
+    def test_prefixItems_with_items(self):
+        schema = {
+            "items": {"type": "string"},
+            "prefixItems": [{}],
+        }
+        validator = validators.Draft202012Validator(schema)
+        e1, e2 = validator.iter_errors(["foo", 2, "bar", 4, "baz"])
+        self.assertEqual(
+            (
+                e1.message,
+                e1.validator,
+                e1.validator_value,
+                e1.instance,
+                e1.absolute_path,
+                e1.schema,
+                e1.schema_path,
+                e1.json_path,
+            ),
+            (
+                "2 is not of type 'string'",
+                "type",
+                "string",
+                2,
+                deque([1]),
+                {"type": "string"},
+                deque(["items", "type"]),
+                "$[1]",
+            ),
+        )
+        self.assertEqual(
+            (
+                e2.message,
+                e2.validator,
+                e2.validator_value,
+                e2.instance,
+                e2.absolute_path,
+                e2.schema,
+                e2.schema_path,
+                e2.json_path,
+            ),
+            (
+                "4 is not of type 'string'",
+                "type",
+                "string",
+                4,
+                deque([3]),
+                {"type": "string"},
+                deque(["items", "type"]),
+                "$[3]",
+            ),
+        )
+
+    def test_contains_too_many(self):
+        """
+        `contains` + `maxContains` produces only one error, even if there are
+        many more incorrectly matching elements.
+        """
+        schema = {"contains": {"type": "string"}, "maxContains": 2}
+        validator = validators.Draft202012Validator(schema)
+        error, = validator.iter_errors(["foo", 2, "bar", 4, "baz", "quux"])
+        self.assertEqual(
+            (
+                error.message,
+                error.validator,
+                error.validator_value,
+                error.instance,
+                error.absolute_path,
+                error.schema,
+                error.schema_path,
+                error.json_path,
+            ),
+            (
+                "Too many items match the given schema (expected at most 2)",
+                "maxContains",
+                2,
+                ["foo", 2, "bar", 4, "baz", "quux"],
+                deque([]),
+                {"contains": {"type": "string"}, "maxContains": 2},
+                deque(["contains"]),
+                "$",
+            ),
+        )
+
+    def test_contains_too_few(self):
+        schema = {"contains": {"type": "string"}, "minContains": 2}
+        validator = validators.Draft202012Validator(schema)
+        error, = validator.iter_errors(["foo", 2, 4])
+        self.assertEqual(
+            (
+                error.message,
+                error.validator,
+                error.validator_value,
+                error.instance,
+                error.absolute_path,
+                error.schema,
+                error.schema_path,
+                error.json_path,
+            ),
+            (
+                (
+                    "Too few items match the given schema "
+                    "(expected at least 2 but only 1 matched)"
+                ),
+                "minContains",
+                2,
+                ["foo", 2, 4],
+                deque([]),
+                {"contains": {"type": "string"}, "minContains": 2},
+                deque(["contains"]),
+                "$",
+            ),
+        )
+
+    def test_contains_none(self):
+        schema = {"contains": {"type": "string"}, "minContains": 2}
+        validator = validators.Draft202012Validator(schema)
+        error, = validator.iter_errors([2, 4])
+        self.assertEqual(
+            (
+                error.message,
+                error.validator,
+                error.validator_value,
+                error.instance,
+                error.absolute_path,
+                error.schema,
+                error.schema_path,
+                error.json_path,
+            ),
+            (
+                "[2, 4] does not contain items matching the given schema",
+                "contains",
+                {"type": "string"},
+                [2, 4],
+                deque([]),
+                {"contains": {"type": "string"}, "minContains": 2},
+                deque(["contains"]),
+                "$",
+            ),
+        )
+
+    def test_ref_sibling(self):
+        schema = {
+            "$defs": {"foo": {"required": ["bar"]}},
+            "properties": {
+                "aprop": {
+                    "$ref": "#/$defs/foo",
+                    "required": ["baz"],
+                },
+            },
+        }
+
+        validator = validators.Draft202012Validator(schema)
+        e1, e2 = validator.iter_errors({"aprop": {}})
+        self.assertEqual(
+            (
+                e1.message,
+                e1.validator,
+                e1.validator_value,
+                e1.instance,
+                e1.absolute_path,
+                e1.schema,
+                e1.schema_path,
+                e1.relative_schema_path,
+                e1.json_path,
+            ),
+            (
+                "'bar' is a required property",
+                "required",
+                ["bar"],
+                {},
+                deque(["aprop"]),
+                {"required": ["bar"]},
+                deque(["properties", "aprop", "required"]),
+                deque(["properties", "aprop", "required"]),
+                "$.aprop",
+            ),
+        )
+        self.assertEqual(
+            (
+                e2.message,
+                e2.validator,
+                e2.validator_value,
+                e2.instance,
+                e2.absolute_path,
+                e2.schema,
+                e2.schema_path,
+                e2.relative_schema_path,
+                e2.json_path,
+            ),
+            (
+                "'baz' is a required property",
+                "required",
+                ["baz"],
+                {},
+                deque(["aprop"]),
+                {"$ref": "#/$defs/foo", "required": ["baz"]},
+                deque(["properties", "aprop", "required"]),
+                deque(["properties", "aprop", "required"]),
+                "$.aprop",
+            ),
+        )
+
+
+class MetaSchemaTestsMixin:
+    # TODO: These all belong upstream
+    def test_invalid_properties(self):
+        with self.assertRaises(exceptions.SchemaError):
+            self.Validator.check_schema({"properties": 12})
+
+    def test_minItems_invalid_string(self):
+        with self.assertRaises(exceptions.SchemaError):
+            # needs to be an integer
+            self.Validator.check_schema({"minItems": "1"})
+
+    def test_enum_allows_empty_arrays(self):
+        """
+        Technically, all the spec says is they SHOULD have elements, not MUST.
+
+        (As of Draft 6. Previous drafts do say MUST).
+
+        See #529.
+        """
+        if self.Validator in {
+            validators.Draft3Validator,
+            validators.Draft4Validator,
+        }:
+            with self.assertRaises(exceptions.SchemaError):
+                self.Validator.check_schema({"enum": []})
+        else:
+            self.Validator.check_schema({"enum": []})
+
+    def test_enum_allows_non_unique_items(self):
+        """
+        Technically, all the spec says is they SHOULD be unique, not MUST.
+
+        (As of Draft 6. Previous drafts do say MUST).
+
+        See #529.
+        """
+        if self.Validator in {
+            validators.Draft3Validator,
+            validators.Draft4Validator,
+        }:
+            with self.assertRaises(exceptions.SchemaError):
+                self.Validator.check_schema({"enum": [12, 12]})
+        else:
+            self.Validator.check_schema({"enum": [12, 12]})
+
+    def test_schema_with_invalid_regex(self):
+        with self.assertRaises(exceptions.SchemaError):
+            self.Validator.check_schema({"pattern": "*notaregex"})
+
+    def test_schema_with_invalid_regex_with_disabled_format_validation(self):
+        self.Validator.check_schema(
+            {"pattern": "*notaregex"},
+            format_checker=None,
+        )
+
+
+class ValidatorTestMixin(MetaSchemaTestsMixin, object):
+    def test_it_implements_the_validator_protocol(self):
+        self.assertIsInstance(self.Validator({}), protocols.Validator)
+
+    def test_valid_instances_are_valid(self):
+        schema, instance = self.valid
+        self.assertTrue(self.Validator(schema).is_valid(instance))
+
+    def test_invalid_instances_are_not_valid(self):
+        schema, instance = self.invalid
+        self.assertFalse(self.Validator(schema).is_valid(instance))
+
+    def test_non_existent_properties_are_ignored(self):
+        self.Validator({object(): object()}).validate(instance=object())
+
+    def test_it_creates_a_ref_resolver_if_not_provided(self):
+        self.assertIsInstance(
+            self.Validator({}).resolver,
+            validators.RefResolver,
+        )
+
+    def test_it_delegates_to_a_ref_resolver(self):
+        ref, schema = "someCoolRef", {"type": "integer"}
+        resolver = validators.RefResolver("", {}, store={ref: schema})
+        validator = self.Validator({"$ref": ref}, resolver=resolver)
+
+        with self.assertRaises(exceptions.ValidationError):
+            validator.validate(None)
+
+    def test_evolve(self):
+        ref, schema = "someCoolRef", {"type": "integer"}
+        resolver = validators.RefResolver("", {}, store={ref: schema})
+
+        validator = self.Validator(schema, resolver=resolver)
+        new = validator.evolve(schema={"type": "string"})
+
+        expected = self.Validator({"type": "string"}, resolver=resolver)
+
+        self.assertEqual(new, expected)
+        self.assertNotEqual(new, validator)
+
+    def test_evolve_with_subclass(self):
+        """
+        Subclassing validators isn't supported public API, but some users have
+        done it, because we don't actually error entirely when it's done :/
+
+        We need to deprecate doing so first to help as many of these users
+        ensure they can move to supported APIs, but this test ensures that in
+        the interim, we haven't broken those users.
+        """
+
+        with self.assertWarns(DeprecationWarning):
+            @attr.s
+            class OhNo(self.Validator):
+                foo = attr.ib(factory=lambda: [1, 2, 3])
+                _bar = attr.ib(default=37)
+
+        validator = OhNo({}, bar=12)
+        self.assertEqual(validator.foo, [1, 2, 3])
+
+        new = validator.evolve(schema={"type": "integer"})
+        self.assertEqual(new.foo, [1, 2, 3])
+        self.assertEqual(new._bar, 12)
+
+    def test_it_delegates_to_a_legacy_ref_resolver(self):
+        """
+        Legacy RefResolvers support only the context manager form of
+        resolution.
+        """
+
+        class LegacyRefResolver:
+            @contextmanager
+            def resolving(this, ref):
+                self.assertEqual(ref, "the ref")
+                yield {"type": "integer"}
+
+        resolver = LegacyRefResolver()
+        schema = {"$ref": "the ref"}
+
+        with self.assertRaises(exceptions.ValidationError):
+            self.Validator(schema, resolver=resolver).validate(None)
+
+    def test_is_type_is_true_for_valid_type(self):
+        self.assertTrue(self.Validator({}).is_type("foo", "string"))
+
+    def test_is_type_is_false_for_invalid_type(self):
+        self.assertFalse(self.Validator({}).is_type("foo", "array"))
+
+    def test_is_type_evades_bool_inheriting_from_int(self):
+        self.assertFalse(self.Validator({}).is_type(True, "integer"))
+        self.assertFalse(self.Validator({}).is_type(True, "number"))
+
+    def test_it_can_validate_with_decimals(self):
+        schema = {"items": {"type": "number"}}
+        Validator = validators.extend(
+            self.Validator,
+            type_checker=self.Validator.TYPE_CHECKER.redefine(
+                "number",
+                lambda checker, thing: isinstance(
+                    thing, (int, float, Decimal),
+                ) and not isinstance(thing, bool),
+            ),
+        )
+
+        validator = Validator(schema)
+        validator.validate([1, 1.1, Decimal(1) / Decimal(8)])
+
+        invalid = ["foo", {}, [], True, None]
+        self.assertEqual(
+            [error.instance for error in validator.iter_errors(invalid)],
+            invalid,
+        )
+
+    def test_it_returns_true_for_formats_it_does_not_know_about(self):
+        validator = self.Validator(
+            {"format": "carrot"}, format_checker=FormatChecker(),
+        )
+        validator.validate("bugs")
+
+    def test_it_does_not_validate_formats_by_default(self):
+        validator = self.Validator({})
+        self.assertIsNone(validator.format_checker)
+
+    def test_it_validates_formats_if_a_checker_is_provided(self):
+        checker = FormatChecker()
+        bad = ValueError("Bad!")
+
+        @checker.checks("foo", raises=ValueError)
+        def check(value):
+            if value == "good":
+                return True
+            elif value == "bad":
+                raise bad
+            else:  # pragma: no cover
+                self.fail("What is {}? [Baby Don't Hurt Me]".format(value))
+
+        validator = self.Validator(
+            {"format": "foo"}, format_checker=checker,
+        )
+
+        validator.validate("good")
+        with self.assertRaises(exceptions.ValidationError) as cm:
+            validator.validate("bad")
+
+        # Make sure original cause is attached
+        self.assertIs(cm.exception.cause, bad)
+
+    def test_non_string_custom_type(self):
+        non_string_type = object()
+        schema = {"type": [non_string_type]}
+        Crazy = validators.extend(
+            self.Validator,
+            type_checker=self.Validator.TYPE_CHECKER.redefine(
+                non_string_type,
+                lambda checker, thing: isinstance(thing, int),
+            ),
+        )
+        Crazy(schema).validate(15)
+
+    def test_it_properly_formats_tuples_in_errors(self):
+        """
+        A tuple instance properly formats validation errors for uniqueItems.
+
+        See #224
+        """
+        TupleValidator = validators.extend(
+            self.Validator,
+            type_checker=self.Validator.TYPE_CHECKER.redefine(
+                "array",
+                lambda checker, thing: isinstance(thing, tuple),
+            ),
+        )
+        with self.assertRaises(exceptions.ValidationError) as e:
+            TupleValidator({"uniqueItems": True}).validate((1, 1))
+        self.assertIn("(1, 1) has non-unique elements", str(e.exception))
+
+    def test_check_redefined_sequence(self):
+        """
+        Allow array to validate against another defined sequence type
+        """
+        schema = {"type": "array", "uniqueItems": True}
+        MyMapping = namedtuple("MyMapping", "a, b")
+        Validator = validators.extend(
+            self.Validator,
+            type_checker=self.Validator.TYPE_CHECKER.redefine_many(
+                {
+                    "array": lambda checker, thing: isinstance(
+                        thing, (list, deque),
+                    ),
+                    "object": lambda checker, thing: isinstance(
+                        thing, (dict, MyMapping),
+                    ),
+                },
+            ),
+        )
+        validator = Validator(schema)
+
+        valid_instances = [
+            deque(["a", None, "1", "", True]),
+            deque([[False], [0]]),
+            [deque([False]), deque([0])],
+            [[deque([False])], [deque([0])]],
+            [[[[[deque([False])]]]], [[[[deque([0])]]]]],
+            [deque([deque([False])]), deque([deque([0])])],
+            [MyMapping("a", 0), MyMapping("a", False)],
+            [
+                MyMapping("a", [deque([0])]),
+                MyMapping("a", [deque([False])]),
+            ],
+            [
+                MyMapping("a", [MyMapping("a", deque([0]))]),
+                MyMapping("a", [MyMapping("a", deque([False]))]),
+            ],
+            [deque(deque(deque([False]))), deque(deque(deque([0])))],
+        ]
+
+        for instance in valid_instances:
+            validator.validate(instance)
+
+        invalid_instances = [
+            deque(["a", "b", "a"]),
+            deque([[False], [False]]),
+            [deque([False]), deque([False])],
+            [[deque([False])], [deque([False])]],
+            [[[[[deque([False])]]]], [[[[deque([False])]]]]],
+            [deque([deque([False])]), deque([deque([False])])],
+            [MyMapping("a", False), MyMapping("a", False)],
+            [
+                MyMapping("a", [deque([False])]),
+                MyMapping("a", [deque([False])]),
+            ],
+            [
+                MyMapping("a", [MyMapping("a", deque([False]))]),
+                MyMapping("a", [MyMapping("a", deque([False]))]),
+            ],
+            [deque(deque(deque([False]))), deque(deque(deque([False])))],
+        ]
+
+        for instance in invalid_instances:
+            with self.assertRaises(exceptions.ValidationError):
+                validator.validate(instance)
+
+
+class AntiDraft6LeakMixin:
+    """
+    Make sure functionality from draft 6 doesn't leak backwards in time.
+    """
+
+    def test_True_is_not_a_schema(self):
+        with self.assertRaises(exceptions.SchemaError) as e:
+            self.Validator.check_schema(True)
+        self.assertIn("True is not of type", str(e.exception))
+
+    def test_False_is_not_a_schema(self):
+        with self.assertRaises(exceptions.SchemaError) as e:
+            self.Validator.check_schema(False)
+        self.assertIn("False is not of type", str(e.exception))
+
+    @unittest.skip(bug(523))
+    def test_True_is_not_a_schema_even_if_you_forget_to_check(self):
+        resolver = validators.RefResolver("", {})
+        with self.assertRaises(Exception) as e:
+            self.Validator(True, resolver=resolver).validate(12)
+        self.assertNotIsInstance(e.exception, exceptions.ValidationError)
+
+    @unittest.skip(bug(523))
+    def test_False_is_not_a_schema_even_if_you_forget_to_check(self):
+        resolver = validators.RefResolver("", {})
+        with self.assertRaises(Exception) as e:
+            self.Validator(False, resolver=resolver).validate(12)
+        self.assertNotIsInstance(e.exception, exceptions.ValidationError)
+
+
+class TestDraft3Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
+    Validator = validators.Draft3Validator
+    valid: tuple[dict, dict] = ({}, {})
+    invalid = {"type": "integer"}, "foo"
+
+    def test_any_type_is_valid_for_type_any(self):
+        validator = self.Validator({"type": "any"})
+        validator.validate(object())
+
+    def test_any_type_is_redefinable(self):
+        """
+        Sigh, because why not.
+        """
+        Crazy = validators.extend(
+            self.Validator,
+            type_checker=self.Validator.TYPE_CHECKER.redefine(
+                "any", lambda checker, thing: isinstance(thing, int),
+            ),
+        )
+        validator = Crazy({"type": "any"})
+        validator.validate(12)
+        with self.assertRaises(exceptions.ValidationError):
+            validator.validate("foo")
+
+    def test_is_type_is_true_for_any_type(self):
+        self.assertTrue(self.Validator({"type": "any"}).is_valid(object()))
+
+    def test_is_type_does_not_evade_bool_if_it_is_being_tested(self):
+        self.assertTrue(self.Validator({}).is_type(True, "boolean"))
+        self.assertTrue(self.Validator({"type": "any"}).is_valid(True))
+
+
+class TestDraft4Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
+    Validator = validators.Draft4Validator
+    valid: tuple[dict, dict] = ({}, {})
+    invalid = {"type": "integer"}, "foo"
+
+
+class TestDraft6Validator(ValidatorTestMixin, TestCase):
+    Validator = validators.Draft6Validator
+    valid: tuple[dict, dict] = ({}, {})
+    invalid = {"type": "integer"}, "foo"
+
+
+class TestDraft7Validator(ValidatorTestMixin, TestCase):
+    Validator = validators.Draft7Validator
+    valid: tuple[dict, dict] = ({}, {})
+    invalid = {"type": "integer"}, "foo"
+
+
+class TestDraft201909Validator(ValidatorTestMixin, TestCase):
+    Validator = validators.Draft201909Validator
+    valid: tuple[dict, dict] = ({}, {})
+    invalid = {"type": "integer"}, "foo"
+
+
+class TestDraft202012Validator(ValidatorTestMixin, TestCase):
+    Validator = validators.Draft202012Validator
+    valid: tuple[dict, dict] = ({}, {})
+    invalid = {"type": "integer"}, "foo"
+
+
+class TestLatestValidator(TestCase):
+    """
+    These really apply to multiple versions but are easiest to test on one.
+    """
+
+    def test_ref_resolvers_may_have_boolean_schemas_stored(self):
+        ref = "someCoolRef"
+        schema = {"$ref": ref}
+        resolver = validators.RefResolver("", {}, store={ref: False})
+        validator = validators._LATEST_VERSION(schema, resolver=resolver)
+
+        with self.assertRaises(exceptions.ValidationError):
+            validator.validate(None)
+
+
+class TestValidatorFor(TestCase):
+    def test_draft_3(self):
+        schema = {"$schema": "http://json-schema.org/draft-03/schema"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft3Validator,
+        )
+
+        schema = {"$schema": "http://json-schema.org/draft-03/schema#"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft3Validator,
+        )
+
+    def test_draft_4(self):
+        schema = {"$schema": "http://json-schema.org/draft-04/schema"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft4Validator,
+        )
+
+        schema = {"$schema": "http://json-schema.org/draft-04/schema#"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft4Validator,
+        )
+
+    def test_draft_6(self):
+        schema = {"$schema": "http://json-schema.org/draft-06/schema"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft6Validator,
+        )
+
+        schema = {"$schema": "http://json-schema.org/draft-06/schema#"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft6Validator,
+        )
+
+    def test_draft_7(self):
+        schema = {"$schema": "http://json-schema.org/draft-07/schema"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft7Validator,
+        )
+
+        schema = {"$schema": "http://json-schema.org/draft-07/schema#"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft7Validator,
+        )
+
+    def test_draft_201909(self):
+        schema = {"$schema": "https://json-schema.org/draft/2019-09/schema"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft201909Validator,
+        )
+
+        schema = {"$schema": "https://json-schema.org/draft/2019-09/schema#"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft201909Validator,
+        )
+
+    def test_draft_202012(self):
+        schema = {"$schema": "https://json-schema.org/draft/2020-12/schema"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft202012Validator,
+        )
+
+        schema = {"$schema": "https://json-schema.org/draft/2020-12/schema#"}
+        self.assertIs(
+            validators.validator_for(schema),
+            validators.Draft202012Validator,
+        )
+
+    def test_True(self):
+        self.assertIs(
+            validators.validator_for(True),
+            validators._LATEST_VERSION,
+        )
+
+    def test_False(self):
+        self.assertIs(
+            validators.validator_for(False),
+            validators._LATEST_VERSION,
+        )
+
+    def test_custom_validator(self):
+        Validator = validators.create(
+            meta_schema={"id": "meta schema id"},
+            version="12",
+            id_of=lambda s: s.get("id", ""),
+        )
+        schema = {"$schema": "meta schema id"}
+        self.assertIs(
+            validators.validator_for(schema),
+            Validator,
+        )
+
+    def test_custom_validator_draft6(self):
+        Validator = validators.create(
+            meta_schema={"$id": "meta schema $id"},
+            version="13",
+        )
+        schema = {"$schema": "meta schema $id"}
+        self.assertIs(
+            validators.validator_for(schema),
+            Validator,
+        )
+
+    def test_validator_for_jsonschema_default(self):
+        self.assertIs(validators.validator_for({}), validators._LATEST_VERSION)
+
+    def test_validator_for_custom_default(self):
+        self.assertIs(validators.validator_for({}, default=None), None)
+
+    def test_warns_if_meta_schema_specified_was_not_found(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            validators.validator_for(schema={"$schema": "unknownSchema"})
+
+        self.assertEqual(cm.filename, __file__)
+        self.assertEqual(
+            str(cm.warning),
+            "The metaschema specified by $schema was not found. "
+            "Using the latest draft to validate, but this will raise "
+            "an error in the future.",
+        )
+
+    def test_does_not_warn_if_meta_schema_is_unspecified(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            validators.validator_for(schema={}, default={})
+        self.assertFalse(w)
+
+    def test_validator_for_custom_default_with_schema(self):
+        schema, default = {"$schema": "mailto:foo@example.com"}, object()
+        self.assertIs(validators.validator_for(schema, default), default)
+
+
+class TestValidate(TestCase):
+    def assertUses(self, schema, Validator):
+        result = []
+        with mock.patch.object(Validator, "check_schema", result.append):
+            validators.validate({}, schema)
+        self.assertEqual(result, [schema])
+
+    def test_draft3_validator_is_chosen(self):
+        self.assertUses(
+            schema={"$schema": "http://json-schema.org/draft-03/schema#"},
+            Validator=validators.Draft3Validator,
+        )
+        # Make sure it works without the empty fragment
+        self.assertUses(
+            schema={"$schema": "http://json-schema.org/draft-03/schema"},
+            Validator=validators.Draft3Validator,
+        )
+
+    def test_draft4_validator_is_chosen(self):
+        self.assertUses(
+            schema={"$schema": "http://json-schema.org/draft-04/schema#"},
+            Validator=validators.Draft4Validator,
+        )
+        # Make sure it works without the empty fragment
+        self.assertUses(
+            schema={"$schema": "http://json-schema.org/draft-04/schema"},
+            Validator=validators.Draft4Validator,
+        )
+
+    def test_draft6_validator_is_chosen(self):
+        self.assertUses(
+            schema={"$schema": "http://json-schema.org/draft-06/schema#"},
+            Validator=validators.Draft6Validator,
+        )
+        # Make sure it works without the empty fragment
+        self.assertUses(
+            schema={"$schema": "http://json-schema.org/draft-06/schema"},
+            Validator=validators.Draft6Validator,
+        )
+
+    def test_draft7_validator_is_chosen(self):
+        self.assertUses(
+            schema={"$schema": "http://json-schema.org/draft-07/schema#"},
+            Validator=validators.Draft7Validator,
+        )
+        # Make sure it works without the empty fragment
+        self.assertUses(
+            schema={"$schema": "http://json-schema.org/draft-07/schema"},
+            Validator=validators.Draft7Validator,
+        )
+
+    def test_draft202012_validator_is_chosen(self):
+        self.assertUses(
+            schema={
+                "$schema": "https://json-schema.org/draft/2020-12/schema#",
+            },
+            Validator=validators.Draft202012Validator,
+        )
+        # Make sure it works without the empty fragment
+        self.assertUses(
+            schema={
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+            },
+            Validator=validators.Draft202012Validator,
+        )
+
+    def test_draft202012_validator_is_the_default(self):
+        self.assertUses(schema={}, Validator=validators.Draft202012Validator)
+
+    def test_validation_error_message(self):
+        with self.assertRaises(exceptions.ValidationError) as e:
+            validators.validate(12, {"type": "string"})
+        self.assertRegex(
+            str(e.exception),
+            "(?s)Failed validating '.*' in schema.*On instance",
+        )
+
+    def test_schema_error_message(self):
+        with self.assertRaises(exceptions.SchemaError) as e:
+            validators.validate(12, {"type": 12})
+        self.assertRegex(
+            str(e.exception),
+            "(?s)Failed validating '.*' in metaschema.*On schema",
+        )
+
+    def test_it_uses_best_match(self):
+        schema = {
+            "oneOf": [
+                {"type": "number", "minimum": 20},
+                {"type": "array"},
+            ],
+        }
+        with self.assertRaises(exceptions.ValidationError) as e:
+            validators.validate(12, schema)
+        self.assertIn("12 is less than the minimum of 20", str(e.exception))
+
+
+class TestRefResolver(TestCase):
+
+    base_uri = ""
+    stored_uri = "foo://stored"
+    stored_schema = {"stored": "schema"}
+
+    def setUp(self):
+        self.referrer = {}
+        self.store = {self.stored_uri: self.stored_schema}
+        self.resolver = validators.RefResolver(
+            self.base_uri, self.referrer, self.store,
+        )
+
+    def test_it_does_not_retrieve_schema_urls_from_the_network(self):
+        ref = validators.Draft3Validator.META_SCHEMA["id"]
+        with mock.patch.object(self.resolver, "resolve_remote") as patched:
+            with self.resolver.resolving(ref) as resolved:
+                pass
+        self.assertEqual(resolved, validators.Draft3Validator.META_SCHEMA)
+        self.assertFalse(patched.called)
+
+    def test_it_resolves_local_refs(self):
+        ref = "#/properties/foo"
+        self.referrer["properties"] = {"foo": object()}
+        with self.resolver.resolving(ref) as resolved:
+            self.assertEqual(resolved, self.referrer["properties"]["foo"])
+
+    def test_it_resolves_local_refs_with_id(self):
+        schema = {"id": "http://bar/schema#", "a": {"foo": "bar"}}
+        resolver = validators.RefResolver.from_schema(
+            schema,
+            id_of=lambda schema: schema.get("id", ""),
+        )
+        with resolver.resolving("#/a") as resolved:
+            self.assertEqual(resolved, schema["a"])
+        with resolver.resolving("http://bar/schema#/a") as resolved:
+            self.assertEqual(resolved, schema["a"])
+
+    def test_it_retrieves_stored_refs(self):
+        with self.resolver.resolving(self.stored_uri) as resolved:
+            self.assertIs(resolved, self.stored_schema)
+
+        self.resolver.store["cached_ref"] = {"foo": 12}
+        with self.resolver.resolving("cached_ref#/foo") as resolved:
+            self.assertEqual(resolved, 12)
+
+    def test_it_retrieves_unstored_refs_via_requests(self):
+        ref = "http://bar#baz"
+        schema = {"baz": 12}
+
+        if "requests" in sys.modules:
+            self.addCleanup(
+                sys.modules.__setitem__, "requests", sys.modules["requests"],
+            )
+        sys.modules["requests"] = ReallyFakeRequests({"http://bar": schema})
+
+        with self.resolver.resolving(ref) as resolved:
+            self.assertEqual(resolved, 12)
+
+    def test_it_retrieves_unstored_refs_via_urlopen(self):
+        ref = "http://bar#baz"
+        schema = {"baz": 12}
+
+        if "requests" in sys.modules:
+            self.addCleanup(
+                sys.modules.__setitem__, "requests", sys.modules["requests"],
+            )
+        sys.modules["requests"] = None
+
+        @contextmanager
+        def fake_urlopen(url):
+            self.assertEqual(url, "http://bar")
+            yield BytesIO(json.dumps(schema).encode("utf8"))
+
+        self.addCleanup(setattr, validators, "urlopen", validators.urlopen)
+        validators.urlopen = fake_urlopen
+
+        with self.resolver.resolving(ref) as resolved:
+            pass
+        self.assertEqual(resolved, 12)
+
+    def test_it_retrieves_local_refs_via_urlopen(self):
+        with tempfile.NamedTemporaryFile(delete=False, mode="wt") as tempf:
+            self.addCleanup(os.remove, tempf.name)
+            json.dump({"foo": "bar"}, tempf)
+
+        ref = "file://{}#foo".format(pathname2url(tempf.name))
+        with self.resolver.resolving(ref) as resolved:
+            self.assertEqual(resolved, "bar")
+
+    def test_it_can_construct_a_base_uri_from_a_schema(self):
+        schema = {"id": "foo"}
+        resolver = validators.RefResolver.from_schema(
+            schema,
+            id_of=lambda schema: schema.get("id", ""),
+        )
+        self.assertEqual(resolver.base_uri, "foo")
+        self.assertEqual(resolver.resolution_scope, "foo")
+        with resolver.resolving("") as resolved:
+            self.assertEqual(resolved, schema)
+        with resolver.resolving("#") as resolved:
+            self.assertEqual(resolved, schema)
+        with resolver.resolving("foo") as resolved:
+            self.assertEqual(resolved, schema)
+        with resolver.resolving("foo#") as resolved:
+            self.assertEqual(resolved, schema)
+
+    def test_it_can_construct_a_base_uri_from_a_schema_without_id(self):
+        schema = {}
+        resolver = validators.RefResolver.from_schema(schema)
+        self.assertEqual(resolver.base_uri, "")
+        self.assertEqual(resolver.resolution_scope, "")
+        with resolver.resolving("") as resolved:
+            self.assertEqual(resolved, schema)
+        with resolver.resolving("#") as resolved:
+            self.assertEqual(resolved, schema)
+
+    def test_custom_uri_scheme_handlers(self):
+        def handler(url):
+            self.assertEqual(url, ref)
+            return schema
+
+        schema = {"foo": "bar"}
+        ref = "foo://bar"
+        resolver = validators.RefResolver("", {}, handlers={"foo": handler})
+        with resolver.resolving(ref) as resolved:
+            self.assertEqual(resolved, schema)
+
+    def test_cache_remote_on(self):
+        response = [object()]
+
+        def handler(url):
+            try:
+                return response.pop()
+            except IndexError:  # pragma: no cover
+                self.fail("Response must not have been cached!")
+
+        ref = "foo://bar"
+        resolver = validators.RefResolver(
+            "", {}, cache_remote=True, handlers={"foo": handler},
+        )
+        with resolver.resolving(ref):
+            pass
+        with resolver.resolving(ref):
+            pass
+
+    def test_cache_remote_off(self):
+        response = [object()]
+
+        def handler(url):
+            try:
+                return response.pop()
+            except IndexError:  # pragma: no cover
+                self.fail("Handler called twice!")
+
+        ref = "foo://bar"
+        resolver = validators.RefResolver(
+            "", {}, cache_remote=False, handlers={"foo": handler},
+        )
+        with resolver.resolving(ref):
+            pass
+
+    def test_if_you_give_it_junk_you_get_a_resolution_error(self):
+        error = ValueError("Oh no! What's this?")
+
+        def handler(url):
+            raise error
+
+        ref = "foo://bar"
+        resolver = validators.RefResolver("", {}, handlers={"foo": handler})
+        with self.assertRaises(exceptions.RefResolutionError) as err:
+            with resolver.resolving(ref):
+                self.fail("Shouldn't get this far!")  # pragma: no cover
+        self.assertEqual(err.exception, exceptions.RefResolutionError(error))
+
+    def test_helpful_error_message_on_failed_pop_scope(self):
+        resolver = validators.RefResolver("", {})
+        resolver.pop_scope()
+        with self.assertRaises(exceptions.RefResolutionError) as exc:
+            resolver.pop_scope()
+        self.assertIn("Failed to pop the scope", str(exc.exception))
+
+
+def sorted_errors(errors):
+    def key(error):
+        return (
+            [str(e) for e in error.path],
+            [str(e) for e in error.schema_path],
+        )
+    return sorted(errors, key=key)
+
+
+@attr.s
+class ReallyFakeRequests:
+
+    _responses = attr.ib()
+
+    def get(self, url):
+        response = self._responses.get(url)
+        if url is None:  # pragma: no cover
+            raise ValueError("Unknown URL: " + repr(url))
+        return _ReallyFakeJSONResponse(json.dumps(response))
+
+
+@attr.s
+class _ReallyFakeJSONResponse:
+
+    _response = attr.ib()
+
+    def json(self):
+        return json.loads(self._response)

--- a/asdf/_jsonschema/validators.py
+++ b/asdf/_jsonschema/validators.py
@@ -16,7 +16,6 @@ import reprlib
 import typing
 import warnings
 
-from pyrsistent import m
 import attr
 
 from asdf._jsonschema import (
@@ -724,12 +723,14 @@ class RefResolver:
         self,
         base_uri,
         referrer,
-        store=m(),
+        store=None,
         cache_remote=True,
         handlers=(),
         urljoin_cache=None,
         remote_cache=None,
     ):
+        store = store or {}
+
         if urljoin_cache is None:
             urljoin_cache = lru_cache(1024)(urljoin)
         if remote_cache is None:

--- a/asdf/_jsonschema/validators.py
+++ b/asdf/_jsonschema/validators.py
@@ -1,0 +1,1162 @@
+"""
+Creation and extension of validators, with implementations for existing drafts.
+"""
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping, Sequence
+from functools import lru_cache
+from operator import methodcaller
+from urllib.parse import unquote, urldefrag, urljoin, urlsplit
+from urllib.request import urlopen
+from warnings import warn
+import contextlib
+import json
+import reprlib
+import typing
+import warnings
+
+from pyrsistent import m
+import attr
+
+from asdf._jsonschema import (
+    _format,
+    _legacy_validators,
+    _types,
+    _utils,
+    _validators,
+    exceptions,
+)
+
+_UNSET = _utils.Unset()
+
+_VALIDATORS: dict[str, typing.Any] = {}
+_META_SCHEMAS = _utils.URIDict()
+_VOCABULARIES: list[tuple[str, typing.Any]] = []
+
+
+def __getattr__(name):
+    if name == "ErrorTree":
+        warnings.warn(
+            "Importing ErrorTree from asdf._jsonschema.validators is deprecated. "
+            "Instead import it from asdf._jsonschema.exceptions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from asdf._jsonschema.exceptions import ErrorTree
+        return ErrorTree
+    elif name == "validators":
+        warnings.warn(
+            "Accessing asdf._jsonschema.validators.validators is deprecated. "
+            "Use asdf._jsonschema.validators.validator_for with a given schema.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _VALIDATORS
+    elif name == "meta_schemas":
+        warnings.warn(
+            "Accessing asdf._jsonschema.validators.meta_schemas is deprecated. "
+            "Use asdf._jsonschema.validators.validator_for with a given schema.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _META_SCHEMAS
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
+
+def validates(version):
+    """
+    Register the decorated validator for a ``version`` of the specification.
+
+    Registered validators and their meta schemas will be considered when
+    parsing :kw:`$schema` keywords' URIs.
+
+    Arguments:
+
+        version (str):
+
+            An identifier to use as the version's name
+
+    Returns:
+
+        collections.abc.Callable:
+
+            a class decorator to decorate the validator with the version
+    """
+
+    def _validates(cls):
+        _VALIDATORS[version] = cls
+        meta_schema_id = cls.ID_OF(cls.META_SCHEMA)
+        _META_SCHEMAS[meta_schema_id] = cls
+        return cls
+    return _validates
+
+
+def _id_of(schema):
+    """
+    Return the ID of a schema for recent JSON Schema drafts.
+    """
+    if schema is True or schema is False:
+        return ""
+    return schema.get("$id", "")
+
+
+def _store_schema_list():
+    if not _VOCABULARIES:
+        package = _utils.resources.files(__package__)
+        for version in package.joinpath("schemas", "vocabularies").iterdir():
+            for path in version.iterdir():
+                vocabulary = json.loads(path.read_text())
+                _VOCABULARIES.append((vocabulary["$id"], vocabulary))
+    return [
+        (id, validator.META_SCHEMA) for id, validator in _META_SCHEMAS.items()
+    ] + _VOCABULARIES
+
+
+def create(
+    meta_schema,
+    validators=(),
+    version=None,
+    type_checker=_types.draft202012_type_checker,
+    format_checker=_format.draft202012_format_checker,
+    id_of=_id_of,
+    applicable_validators=methodcaller("items"),
+):
+    """
+    Create a new validator class.
+
+    Arguments:
+
+        meta_schema (collections.abc.Mapping):
+
+            the meta schema for the new validator class
+
+        validators (collections.abc.Mapping):
+
+            a mapping from names to callables, where each callable will
+            validate the schema property with the given name.
+
+            Each callable should take 4 arguments:
+
+                1. a validator instance,
+                2. the value of the property being validated within the
+                   instance
+                3. the instance
+                4. the schema
+
+        version (str):
+
+            an identifier for the version that this validator class will
+            validate. If provided, the returned validator class will
+            have its ``__name__`` set to include the version, and also
+            will have `asdf._jsonschema.validators.validates` automatically
+            called for the given version.
+
+        type_checker (asdf._jsonschema.TypeChecker):
+
+            a type checker, used when applying the :kw:`type` keyword.
+
+            If unprovided, a `asdf._jsonschema.TypeChecker` will be created
+            with a set of default types typical of JSON Schema drafts.
+
+        format_checker (asdf._jsonschema.FormatChecker):
+
+            a format checker, used when applying the :kw:`format` keyword.
+
+            If unprovided, a `asdf._jsonschema.FormatChecker` will be created
+            with a set of default formats typical of JSON Schema drafts.
+
+        id_of (collections.abc.Callable):
+
+            A function that given a schema, returns its ID.
+
+        applicable_validators (collections.abc.Callable):
+
+            A function that given a schema, returns the list of
+            applicable validators (validation keywords and callables)
+            which will be used to validate the instance.
+
+    Returns:
+
+        a new `asdf._jsonschema.protocols.Validator` class
+    """
+    # preemptively don't shadow the `Validator.format_checker` local
+    format_checker_arg = format_checker
+
+    @attr.s
+    class Validator:
+
+        VALIDATORS = dict(validators)
+        META_SCHEMA = dict(meta_schema)
+        TYPE_CHECKER = type_checker
+        FORMAT_CHECKER = format_checker_arg
+        ID_OF = staticmethod(id_of)
+
+        schema = attr.ib(repr=reprlib.repr)
+        resolver = attr.ib(default=None, repr=False)
+        format_checker = attr.ib(default=None)
+
+        def __init_subclass__(cls):
+            warnings.warn(
+                (
+                    "Subclassing validator classes is not intended to "
+                    "be part of their public API. A future version "
+                    "will make doing so an error, as the behavior of "
+                    "subclasses isn't guaranteed to stay the same "
+                    "between releases of asdf._jsonschema. Instead, prefer "
+                    "composition of validators, wrapping them in an object "
+                    "owned entirely by the downstream library."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        def __attrs_post_init__(self):
+            if self.resolver is None:
+                self.resolver = RefResolver.from_schema(
+                    self.schema,
+                    id_of=id_of,
+                )
+
+        @classmethod
+        def check_schema(cls, schema, format_checker=_UNSET):
+            Validator = validator_for(cls.META_SCHEMA, default=cls)
+            if format_checker is _UNSET:
+                format_checker = Validator.FORMAT_CHECKER
+            validator = Validator(
+                schema=cls.META_SCHEMA,
+                format_checker=format_checker,
+            )
+            for error in validator.iter_errors(schema):
+                raise exceptions.SchemaError.create_from(error)
+
+        def evolve(self, **changes):
+            # Essentially reproduces attr.evolve, but may involve instantiating
+            # a different class than this one.
+            cls = self.__class__
+
+            schema = changes.setdefault("schema", self.schema)
+            NewValidator = validator_for(schema, default=cls)
+
+            for field in attr.fields(cls):
+                if not field.init:
+                    continue
+                attr_name = field.name  # To deal with private attributes.
+                init_name = attr_name if attr_name[0] != "_" else attr_name[1:]
+                if init_name not in changes:
+                    changes[init_name] = getattr(self, attr_name)
+
+            return NewValidator(**changes)
+
+        def iter_errors(self, instance, _schema=None):
+            if _schema is not None:
+                warnings.warn(
+                    (
+                        "Passing a schema to Validator.iter_errors "
+                        "is deprecated and will be removed in a future "
+                        "release. Call validator.evolve(schema=new_schema)."
+                        "iter_errors(...) instead."
+                    ),
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            else:
+                _schema = self.schema
+
+            if _schema is True:
+                return
+            elif _schema is False:
+                yield exceptions.ValidationError(
+                    f"False schema does not allow {instance!r}",
+                    validator=None,
+                    validator_value=None,
+                    instance=instance,
+                    schema=_schema,
+                )
+                return
+
+            scope = id_of(_schema)
+            if scope:
+                self.resolver.push_scope(scope)
+            try:
+                for k, v in applicable_validators(_schema):
+                    validator = self.VALIDATORS.get(k)
+                    if validator is None:
+                        continue
+
+                    errors = validator(self, v, instance, _schema) or ()
+                    for error in errors:
+                        # set details if not already set by the called fn
+                        error._set(
+                            validator=k,
+                            validator_value=v,
+                            instance=instance,
+                            schema=_schema,
+                            type_checker=self.TYPE_CHECKER,
+                        )
+                        if k not in {"if", "$ref"}:
+                            error.schema_path.appendleft(k)
+                        yield error
+            finally:
+                if scope:
+                    self.resolver.pop_scope()
+
+        def descend(self, instance, schema, path=None, schema_path=None):
+            for error in self.evolve(schema=schema).iter_errors(instance):
+                if path is not None:
+                    error.path.appendleft(path)
+                if schema_path is not None:
+                    error.schema_path.appendleft(schema_path)
+                yield error
+
+        def validate(self, *args, **kwargs):
+            for error in self.iter_errors(*args, **kwargs):
+                raise error
+
+        def is_type(self, instance, type):
+            try:
+                return self.TYPE_CHECKER.is_type(instance, type)
+            except exceptions.UndefinedTypeCheck:
+                raise exceptions.UnknownType(type, instance, self.schema)
+
+        def is_valid(self, instance, _schema=None):
+            if _schema is not None:
+                warnings.warn(
+                    (
+                        "Passing a schema to Validator.is_valid is deprecated "
+                        "and will be removed in a future release. Call "
+                        "validator.evolve(schema=new_schema).is_valid(...) "
+                        "instead."
+                    ),
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                self = self.evolve(schema=_schema)
+
+            error = next(self.iter_errors(instance), None)
+            return error is None
+
+    if version is not None:
+        safe = version.title().replace(" ", "").replace("-", "")
+        Validator.__name__ = Validator.__qualname__ = f"{safe}Validator"
+        Validator = validates(version)(Validator)
+
+    return Validator
+
+
+def extend(
+    validator,
+    validators=(),
+    version=None,
+    type_checker=None,
+    format_checker=None,
+):
+    """
+    Create a new validator class by extending an existing one.
+
+    Arguments:
+
+        validator (asdf._jsonschema.protocols.Validator):
+
+            an existing validator class
+
+        validators (collections.abc.Mapping):
+
+            a mapping of new validator callables to extend with, whose
+            structure is as in `create`.
+
+            .. note::
+
+                Any validator callables with the same name as an
+                existing one will (silently) replace the old validator
+                callable entirely, effectively overriding any validation
+                done in the "parent" validator class.
+
+                If you wish to instead extend the behavior of a parent's
+                validator callable, delegate and call it directly in
+                the new validator function by retrieving it using
+                ``OldValidator.VALIDATORS["validation_keyword_name"]``.
+
+        version (str):
+
+            a version for the new validator class
+
+        type_checker (asdf._jsonschema.TypeChecker):
+
+            a type checker, used when applying the :kw:`type` keyword.
+
+            If unprovided, the type checker of the extended
+            `asdf._jsonschema.protocols.Validator` will be carried along.
+
+        format_checker (asdf._jsonschema.FormatChecker):
+
+            a format checker, used when applying the :kw:`format` keyword.
+
+            If unprovided, the format checker of the extended
+            `asdf._jsonschema.protocols.Validator` will be carried along.
+
+    Returns:
+
+        a new `asdf._jsonschema.protocols.Validator` class extending the one
+        provided
+
+    .. note:: Meta Schemas
+
+        The new validator class will have its parent's meta schema.
+
+        If you wish to change or extend the meta schema in the new
+        validator class, modify ``META_SCHEMA`` directly on the returned
+        class. Note that no implicit copying is done, so a copy should
+        likely be made before modifying it, in order to not affect the
+        old validator.
+    """
+
+    all_validators = dict(validator.VALIDATORS)
+    all_validators.update(validators)
+
+    if type_checker is None:
+        type_checker = validator.TYPE_CHECKER
+    if format_checker is None:
+        format_checker = validator.FORMAT_CHECKER
+    return create(
+        meta_schema=validator.META_SCHEMA,
+        validators=all_validators,
+        version=version,
+        type_checker=type_checker,
+        format_checker=format_checker,
+        id_of=validator.ID_OF,
+    )
+
+
+Draft3Validator = create(
+    meta_schema=_utils.load_schema("draft3"),
+    validators={
+        "$ref": _validators.ref,
+        "additionalItems": _validators.additionalItems,
+        "additionalProperties": _validators.additionalProperties,
+        "dependencies": _legacy_validators.dependencies_draft3,
+        "disallow": _legacy_validators.disallow_draft3,
+        "divisibleBy": _validators.multipleOf,
+        "enum": _validators.enum,
+        "extends": _legacy_validators.extends_draft3,
+        "format": _validators.format,
+        "items": _legacy_validators.items_draft3_draft4,
+        "maxItems": _validators.maxItems,
+        "maxLength": _validators.maxLength,
+        "maximum": _legacy_validators.maximum_draft3_draft4,
+        "minItems": _validators.minItems,
+        "minLength": _validators.minLength,
+        "minimum": _legacy_validators.minimum_draft3_draft4,
+        "pattern": _validators.pattern,
+        "patternProperties": _validators.patternProperties,
+        "properties": _legacy_validators.properties_draft3,
+        "type": _legacy_validators.type_draft3,
+        "uniqueItems": _validators.uniqueItems,
+    },
+    type_checker=_types.draft3_type_checker,
+    format_checker=_format.draft3_format_checker,
+    version="draft3",
+    id_of=_legacy_validators.id_of_ignore_ref(property="id"),
+    applicable_validators=_legacy_validators.ignore_ref_siblings,
+)
+
+Draft4Validator = create(
+    meta_schema=_utils.load_schema("draft4"),
+    validators={
+        "$ref": _validators.ref,
+        "additionalItems": _validators.additionalItems,
+        "additionalProperties": _validators.additionalProperties,
+        "allOf": _validators.allOf,
+        "anyOf": _validators.anyOf,
+        "dependencies": _legacy_validators.dependencies_draft4_draft6_draft7,
+        "enum": _validators.enum,
+        "format": _validators.format,
+        "items": _legacy_validators.items_draft3_draft4,
+        "maxItems": _validators.maxItems,
+        "maxLength": _validators.maxLength,
+        "maxProperties": _validators.maxProperties,
+        "maximum": _legacy_validators.maximum_draft3_draft4,
+        "minItems": _validators.minItems,
+        "minLength": _validators.minLength,
+        "minProperties": _validators.minProperties,
+        "minimum": _legacy_validators.minimum_draft3_draft4,
+        "multipleOf": _validators.multipleOf,
+        "not": _validators.not_,
+        "oneOf": _validators.oneOf,
+        "pattern": _validators.pattern,
+        "patternProperties": _validators.patternProperties,
+        "properties": _validators.properties,
+        "required": _validators.required,
+        "type": _validators.type,
+        "uniqueItems": _validators.uniqueItems,
+    },
+    type_checker=_types.draft4_type_checker,
+    format_checker=_format.draft4_format_checker,
+    version="draft4",
+    id_of=_legacy_validators.id_of_ignore_ref(property="id"),
+    applicable_validators=_legacy_validators.ignore_ref_siblings,
+)
+
+Draft6Validator = create(
+    meta_schema=_utils.load_schema("draft6"),
+    validators={
+        "$ref": _validators.ref,
+        "additionalItems": _validators.additionalItems,
+        "additionalProperties": _validators.additionalProperties,
+        "allOf": _validators.allOf,
+        "anyOf": _validators.anyOf,
+        "const": _validators.const,
+        "contains": _legacy_validators.contains_draft6_draft7,
+        "dependencies": _legacy_validators.dependencies_draft4_draft6_draft7,
+        "enum": _validators.enum,
+        "exclusiveMaximum": _validators.exclusiveMaximum,
+        "exclusiveMinimum": _validators.exclusiveMinimum,
+        "format": _validators.format,
+        "items": _legacy_validators.items_draft6_draft7_draft201909,
+        "maxItems": _validators.maxItems,
+        "maxLength": _validators.maxLength,
+        "maxProperties": _validators.maxProperties,
+        "maximum": _validators.maximum,
+        "minItems": _validators.minItems,
+        "minLength": _validators.minLength,
+        "minProperties": _validators.minProperties,
+        "minimum": _validators.minimum,
+        "multipleOf": _validators.multipleOf,
+        "not": _validators.not_,
+        "oneOf": _validators.oneOf,
+        "pattern": _validators.pattern,
+        "patternProperties": _validators.patternProperties,
+        "properties": _validators.properties,
+        "propertyNames": _validators.propertyNames,
+        "required": _validators.required,
+        "type": _validators.type,
+        "uniqueItems": _validators.uniqueItems,
+    },
+    type_checker=_types.draft6_type_checker,
+    format_checker=_format.draft6_format_checker,
+    version="draft6",
+    id_of=_legacy_validators.id_of_ignore_ref(),
+    applicable_validators=_legacy_validators.ignore_ref_siblings,
+)
+
+Draft7Validator = create(
+    meta_schema=_utils.load_schema("draft7"),
+    validators={
+        "$ref": _validators.ref,
+        "additionalItems": _validators.additionalItems,
+        "additionalProperties": _validators.additionalProperties,
+        "allOf": _validators.allOf,
+        "anyOf": _validators.anyOf,
+        "const": _validators.const,
+        "contains": _legacy_validators.contains_draft6_draft7,
+        "dependencies": _legacy_validators.dependencies_draft4_draft6_draft7,
+        "enum": _validators.enum,
+        "exclusiveMaximum": _validators.exclusiveMaximum,
+        "exclusiveMinimum": _validators.exclusiveMinimum,
+        "format": _validators.format,
+        "if": _validators.if_,
+        "items": _legacy_validators.items_draft6_draft7_draft201909,
+        "maxItems": _validators.maxItems,
+        "maxLength": _validators.maxLength,
+        "maxProperties": _validators.maxProperties,
+        "maximum": _validators.maximum,
+        "minItems": _validators.minItems,
+        "minLength": _validators.minLength,
+        "minProperties": _validators.minProperties,
+        "minimum": _validators.minimum,
+        "multipleOf": _validators.multipleOf,
+        "not": _validators.not_,
+        "oneOf": _validators.oneOf,
+        "pattern": _validators.pattern,
+        "patternProperties": _validators.patternProperties,
+        "properties": _validators.properties,
+        "propertyNames": _validators.propertyNames,
+        "required": _validators.required,
+        "type": _validators.type,
+        "uniqueItems": _validators.uniqueItems,
+    },
+    type_checker=_types.draft7_type_checker,
+    format_checker=_format.draft7_format_checker,
+    version="draft7",
+    id_of=_legacy_validators.id_of_ignore_ref(),
+    applicable_validators=_legacy_validators.ignore_ref_siblings,
+)
+
+Draft201909Validator = create(
+    meta_schema=_utils.load_schema("draft2019-09"),
+    validators={
+        "$recursiveRef": _legacy_validators.recursiveRef,
+        "$ref": _validators.ref,
+        "additionalItems": _validators.additionalItems,
+        "additionalProperties": _validators.additionalProperties,
+        "allOf": _validators.allOf,
+        "anyOf": _validators.anyOf,
+        "const": _validators.const,
+        "contains": _validators.contains,
+        "dependentRequired": _validators.dependentRequired,
+        "dependentSchemas": _validators.dependentSchemas,
+        "enum": _validators.enum,
+        "exclusiveMaximum": _validators.exclusiveMaximum,
+        "exclusiveMinimum": _validators.exclusiveMinimum,
+        "format": _validators.format,
+        "if": _validators.if_,
+        "items": _legacy_validators.items_draft6_draft7_draft201909,
+        "maxItems": _validators.maxItems,
+        "maxLength": _validators.maxLength,
+        "maxProperties": _validators.maxProperties,
+        "maximum": _validators.maximum,
+        "minItems": _validators.minItems,
+        "minLength": _validators.minLength,
+        "minProperties": _validators.minProperties,
+        "minimum": _validators.minimum,
+        "multipleOf": _validators.multipleOf,
+        "not": _validators.not_,
+        "oneOf": _validators.oneOf,
+        "pattern": _validators.pattern,
+        "patternProperties": _validators.patternProperties,
+        "properties": _validators.properties,
+        "propertyNames": _validators.propertyNames,
+        "required": _validators.required,
+        "type": _validators.type,
+        "unevaluatedItems": _legacy_validators.unevaluatedItems_draft2019,
+        "unevaluatedProperties": _validators.unevaluatedProperties,
+        "uniqueItems": _validators.uniqueItems,
+    },
+    type_checker=_types.draft201909_type_checker,
+    format_checker=_format.draft201909_format_checker,
+    version="draft2019-09",
+)
+
+Draft202012Validator = create(
+    meta_schema=_utils.load_schema("draft2020-12"),
+    validators={
+        "$dynamicRef": _validators.dynamicRef,
+        "$ref": _validators.ref,
+        "additionalItems": _validators.additionalItems,
+        "additionalProperties": _validators.additionalProperties,
+        "allOf": _validators.allOf,
+        "anyOf": _validators.anyOf,
+        "const": _validators.const,
+        "contains": _validators.contains,
+        "dependentRequired": _validators.dependentRequired,
+        "dependentSchemas": _validators.dependentSchemas,
+        "enum": _validators.enum,
+        "exclusiveMaximum": _validators.exclusiveMaximum,
+        "exclusiveMinimum": _validators.exclusiveMinimum,
+        "format": _validators.format,
+        "if": _validators.if_,
+        "items": _validators.items,
+        "maxItems": _validators.maxItems,
+        "maxLength": _validators.maxLength,
+        "maxProperties": _validators.maxProperties,
+        "maximum": _validators.maximum,
+        "minItems": _validators.minItems,
+        "minLength": _validators.minLength,
+        "minProperties": _validators.minProperties,
+        "minimum": _validators.minimum,
+        "multipleOf": _validators.multipleOf,
+        "not": _validators.not_,
+        "oneOf": _validators.oneOf,
+        "pattern": _validators.pattern,
+        "patternProperties": _validators.patternProperties,
+        "prefixItems": _validators.prefixItems,
+        "properties": _validators.properties,
+        "propertyNames": _validators.propertyNames,
+        "required": _validators.required,
+        "type": _validators.type,
+        "unevaluatedItems": _validators.unevaluatedItems,
+        "unevaluatedProperties": _validators.unevaluatedProperties,
+        "uniqueItems": _validators.uniqueItems,
+    },
+    type_checker=_types.draft202012_type_checker,
+    format_checker=_format.draft202012_format_checker,
+    version="draft2020-12",
+)
+
+_LATEST_VERSION = Draft202012Validator
+
+
+class RefResolver:
+    """
+    Resolve JSON References.
+
+    Arguments:
+
+        base_uri (str):
+
+            The URI of the referring document
+
+        referrer:
+
+            The actual referring document
+
+        store (dict):
+
+            A mapping from URIs to documents to cache
+
+        cache_remote (bool):
+
+            Whether remote refs should be cached after first resolution
+
+        handlers (dict):
+
+            A mapping from URI schemes to functions that should be used
+            to retrieve them
+
+        urljoin_cache (:func:`functools.lru_cache`):
+
+            A cache that will be used for caching the results of joining
+            the resolution scope to subscopes.
+
+        remote_cache (:func:`functools.lru_cache`):
+
+            A cache that will be used for caching the results of
+            resolved remote URLs.
+
+    Attributes:
+
+        cache_remote (bool):
+
+            Whether remote refs should be cached after first resolution
+    """
+
+    def __init__(
+        self,
+        base_uri,
+        referrer,
+        store=m(),
+        cache_remote=True,
+        handlers=(),
+        urljoin_cache=None,
+        remote_cache=None,
+    ):
+        if urljoin_cache is None:
+            urljoin_cache = lru_cache(1024)(urljoin)
+        if remote_cache is None:
+            remote_cache = lru_cache(1024)(self.resolve_from_url)
+
+        self.referrer = referrer
+        self.cache_remote = cache_remote
+        self.handlers = dict(handlers)
+
+        self._scopes_stack = [base_uri]
+
+        self.store = _utils.URIDict(_store_schema_list())
+        self.store.update(store)
+        self.store.update(
+            (schema["$id"], schema)
+            for schema in store.values()
+            if isinstance(schema, Mapping) and "$id" in schema
+        )
+        self.store[base_uri] = referrer
+
+        self._urljoin_cache = urljoin_cache
+        self._remote_cache = remote_cache
+
+    @classmethod
+    def from_schema(cls, schema, id_of=_id_of, *args, **kwargs):
+        """
+        Construct a resolver from a JSON schema object.
+
+        Arguments:
+
+            schema:
+
+                the referring schema
+
+        Returns:
+
+            `RefResolver`
+        """
+
+        return cls(base_uri=id_of(schema), referrer=schema, *args, **kwargs)  # noqa: B026, E501
+
+    def push_scope(self, scope):
+        """
+        Enter a given sub-scope.
+
+        Treats further dereferences as being performed underneath the
+        given scope.
+        """
+        self._scopes_stack.append(
+            self._urljoin_cache(self.resolution_scope, scope),
+        )
+
+    def pop_scope(self):
+        """
+        Exit the most recent entered scope.
+
+        Treats further dereferences as being performed underneath the
+        original scope.
+
+        Don't call this method more times than `push_scope` has been
+        called.
+        """
+        try:
+            self._scopes_stack.pop()
+        except IndexError:
+            raise exceptions.RefResolutionError(
+                "Failed to pop the scope from an empty stack. "
+                "`pop_scope()` should only be called once for every "
+                "`push_scope()`",
+            )
+
+    @property
+    def resolution_scope(self):
+        """
+        Retrieve the current resolution scope.
+        """
+        return self._scopes_stack[-1]
+
+    @property
+    def base_uri(self):
+        """
+        Retrieve the current base URI, not including any fragment.
+        """
+        uri, _ = urldefrag(self.resolution_scope)
+        return uri
+
+    @contextlib.contextmanager
+    def in_scope(self, scope):
+        """
+        Temporarily enter the given scope for the duration of the context.
+
+        .. deprecated:: v4.0.0
+        """
+        warnings.warn(
+            "asdf._jsonschema.RefResolver.in_scope is deprecated and will be "
+            "removed in a future release.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        self.push_scope(scope)
+        try:
+            yield
+        finally:
+            self.pop_scope()
+
+    @contextlib.contextmanager
+    def resolving(self, ref):
+        """
+        Resolve the given ``ref`` and enter its resolution scope.
+
+        Exits the scope on exit of this context manager.
+
+        Arguments:
+
+            ref (str):
+
+                The reference to resolve
+        """
+
+        url, resolved = self.resolve(ref)
+        self.push_scope(url)
+        try:
+            yield resolved
+        finally:
+            self.pop_scope()
+
+    def _find_in_referrer(self, key):
+        return self._get_subschemas_cache()[key]
+
+    @lru_cache()  # noqa: B019
+    def _get_subschemas_cache(self):
+        cache = {key: [] for key in _SUBSCHEMAS_KEYWORDS}
+        for keyword, subschema in _search_schema(
+            self.referrer, _match_subschema_keywords,
+        ):
+            cache[keyword].append(subschema)
+        return cache
+
+    @lru_cache()  # noqa: B019
+    def _find_in_subschemas(self, url):
+        subschemas = self._get_subschemas_cache()["$id"]
+        if not subschemas:
+            return None
+        uri, fragment = urldefrag(url)
+        for subschema in subschemas:
+            target_uri = self._urljoin_cache(
+                self.resolution_scope, subschema["$id"],
+            )
+            if target_uri.rstrip("/") == uri.rstrip("/"):
+                if fragment:
+                    subschema = self.resolve_fragment(subschema, fragment)
+                self.store[url] = subschema
+                return url, subschema
+        return None
+
+    def resolve(self, ref):
+        """
+        Resolve the given reference.
+        """
+        url = self._urljoin_cache(self.resolution_scope, ref).rstrip("/")
+
+        match = self._find_in_subschemas(url)
+        if match is not None:
+            return match
+
+        return url, self._remote_cache(url)
+
+    def resolve_from_url(self, url):
+        """
+        Resolve the given URL.
+        """
+        url, fragment = urldefrag(url)
+        if not url:
+            url = self.base_uri
+
+        try:
+            document = self.store[url]
+        except KeyError:
+            try:
+                document = self.resolve_remote(url)
+            except Exception as exc:
+                raise exceptions.RefResolutionError(exc)
+
+        return self.resolve_fragment(document, fragment)
+
+    def resolve_fragment(self, document, fragment):
+        """
+        Resolve a ``fragment`` within the referenced ``document``.
+
+        Arguments:
+
+            document:
+
+                The referent document
+
+            fragment (str):
+
+                a URI fragment to resolve within it
+        """
+
+        fragment = fragment.lstrip("/")
+
+        if not fragment:
+            return document
+
+        if document is self.referrer:
+            find = self._find_in_referrer
+        else:
+
+            def find(key):
+                yield from _search_schema(document, _match_keyword(key))
+
+        for keyword in ["$anchor", "$dynamicAnchor"]:
+            for subschema in find(keyword):
+                if fragment == subschema[keyword]:
+                    return subschema
+        for keyword in ["id", "$id"]:
+            for subschema in find(keyword):
+                if "#" + fragment == subschema[keyword]:
+                    return subschema
+
+        # Resolve via path
+        parts = unquote(fragment).split("/") if fragment else []
+        for part in parts:
+            part = part.replace("~1", "/").replace("~0", "~")
+
+            if isinstance(document, Sequence):
+                # Array indexes should be turned into integers
+                try:
+                    part = int(part)
+                except ValueError:
+                    pass
+            try:
+                document = document[part]
+            except (TypeError, LookupError):
+                raise exceptions.RefResolutionError(
+                    f"Unresolvable JSON pointer: {fragment!r}",
+                )
+
+        return document
+
+    def resolve_remote(self, uri):
+        """
+        Resolve a remote ``uri``.
+
+        If called directly, does not check the store first, but after
+        retrieving the document at the specified URI it will be saved in
+        the store if :attr:`cache_remote` is True.
+
+        .. note::
+
+            If the requests_ library is present, ``asdf._jsonschema`` will use it to
+            request the remote ``uri``, so that the correct encoding is
+            detected and used.
+
+            If it isn't, or if the scheme of the ``uri`` is not ``http`` or
+            ``https``, UTF-8 is assumed.
+
+        Arguments:
+
+            uri (str):
+
+                The URI to resolve
+
+        Returns:
+
+            The retrieved document
+
+        .. _requests: https://pypi.org/project/requests/
+        """
+        try:
+            import requests
+        except ImportError:
+            requests = None
+
+        scheme = urlsplit(uri).scheme
+
+        if scheme in self.handlers:
+            result = self.handlers[scheme](uri)
+        elif scheme in ["http", "https"] and requests:
+            # Requests has support for detecting the correct encoding of
+            # json over http
+            result = requests.get(uri).json()
+        else:
+            # Otherwise, pass off to urllib and assume utf-8
+            with urlopen(uri) as url:
+                result = json.loads(url.read().decode("utf-8"))
+
+        if self.cache_remote:
+            self.store[uri] = result
+        return result
+
+
+_SUBSCHEMAS_KEYWORDS = ("$id", "id", "$anchor", "$dynamicAnchor")
+
+
+def _match_keyword(keyword):
+
+    def matcher(value):
+        if keyword in value:
+            yield value
+
+    return matcher
+
+
+def _match_subschema_keywords(value):
+    for keyword in _SUBSCHEMAS_KEYWORDS:
+        if keyword in value:
+            yield keyword, value
+
+
+def _search_schema(schema, matcher):
+    """Breadth-first search routine."""
+    values = deque([schema])
+    while values:
+        value = values.pop()
+        if not isinstance(value, dict):
+            continue
+        yield from matcher(value)
+        values.extendleft(value.values())
+
+
+def validate(instance, schema, cls=None, *args, **kwargs):
+    """
+    Validate an instance under the given schema.
+
+        >>> from asdf._jsonschema.validators import validate
+        >>> validate([2, 3, 4], {"maxItems": 2})  # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+            ...
+        ValidationError: [2, 3, 4] is too long
+
+    :func:`~asdf._jsonschema.validators.validate` will first verify that the
+    provided schema is itself valid, since not doing so can lead to less
+    obvious error messages and fail in less obvious or consistent ways.
+
+    If you know you have a valid schema already, especially
+    if you intend to validate multiple instances with
+    the same schema, you likely would prefer using the
+    `asdf._jsonschema.protocols.Validator.validate` method directly on a
+    specific validator (e.g. ``Draft20212Validator.validate``).
+
+
+    Arguments:
+
+        instance:
+
+            The instance to validate
+
+        schema:
+
+            The schema to validate with
+
+        cls (asdf._jsonschema.protocols.Validator):
+
+            The class that will be used to validate the instance.
+
+    If the ``cls`` argument is not provided, two things will happen
+    in accordance with the specification. First, if the schema has a
+    :kw:`$schema` keyword containing a known meta-schema [#]_ then the
+    proper validator will be used. The specification recommends that
+    all schemas contain :kw:`$schema` properties for this reason. If no
+    :kw:`$schema` property is found, the default validator class is the
+    latest released draft.
+
+    Any other provided positional and keyword arguments will be passed
+    on when instantiating the ``cls``.
+
+    Raises:
+
+        `asdf._jsonschema.exceptions.ValidationError`:
+
+            if the instance is invalid
+
+        `asdf._jsonschema.exceptions.SchemaError`:
+
+            if the schema itself is invalid
+
+    .. rubric:: Footnotes
+    .. [#] known by a validator registered with
+        `asdf._jsonschema.validators.validates`
+    """
+    if cls is None:
+        cls = validator_for(schema)
+
+    cls.check_schema(schema)
+    validator = cls(schema, *args, **kwargs)
+    error = exceptions.best_match(validator.iter_errors(instance))
+    if error is not None:
+        raise error
+
+
+def validator_for(schema, default=_UNSET):
+    """
+    Retrieve the validator class appropriate for validating the given schema.
+
+    Uses the :kw:`$schema` keyword that should be present in the given
+    schema to look up the appropriate validator class.
+
+    Arguments:
+
+        schema (collections.abc.Mapping or bool):
+
+            the schema to look at
+
+        default:
+
+            the default to return if the appropriate validator class
+            cannot be determined.
+
+            If unprovided, the default is to return the latest supported
+            draft.
+    """
+
+    DefaultValidator = _LATEST_VERSION if default is _UNSET else default
+
+    if schema is True or schema is False or "$schema" not in schema:
+        return DefaultValidator
+    if schema["$schema"] not in _META_SCHEMAS:
+        if default is _UNSET:
+            warn(
+                (
+                    "The metaschema specified by $schema was not found. "
+                    "Using the latest draft to validate, but this will raise "
+                    "an error in the future."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+    return _META_SCHEMAS.get(schema["$schema"], DefaultValidator)

--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -3,7 +3,6 @@ import os
 import re
 import sys
 
-import jsonschema
 import numpy as np
 import pytest
 import yaml
@@ -14,6 +13,7 @@ import asdf
 from asdf import util
 from asdf._tests import _helpers as helpers
 from asdf._tests.objects import CustomTestType
+from asdf.exceptions import ValidationError
 from asdf.tags.core import ndarray
 
 from . import data as test_data
@@ -536,7 +536,7 @@ def test_invalid_mask_datatype(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r".* is not valid under any of the given schemas"), asdf.open(
+    with pytest.raises(ValidationError, match=r".* is not valid under any of the given schemas"), asdf.open(
         buff,
     ):
         pass
@@ -550,7 +550,7 @@ def test_ndim_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r"Wrong number of dimensions:.*"), asdf.open(
+    with pytest.raises(ValidationError, match=r"Wrong number of dimensions:.*"), asdf.open(
         buff,
         extensions=CustomExtension(),
     ):
@@ -604,7 +604,7 @@ def test_ndim_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r"Wrong number of dimensions:.*"), asdf.open(
+    with pytest.raises(ValidationError, match=r"Wrong number of dimensions:.*"), asdf.open(
         buff,
         extensions=CustomExtension(),
     ):
@@ -631,7 +631,7 @@ def test_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r"Can not safely cast from .* to .*"), asdf.open(
+    with pytest.raises(ValidationError, match=r"Can not safely cast from .* to .*"), asdf.open(
         buff,
         extensions=CustomExtension(),
     ):
@@ -656,7 +656,7 @@ def test_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r"Expected datatype .*, got .*"), asdf.open(
+    with pytest.raises(ValidationError, match=r"Expected datatype .*, got .*"), asdf.open(
         buff,
         extensions=CustomExtension(),
     ):
@@ -674,7 +674,7 @@ def test_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r"Expected scalar datatype .*, got .*"), asdf.open(
+    with pytest.raises(ValidationError, match=r"Expected scalar datatype .*, got .*"), asdf.open(
         buff,
         extensions=CustomExtension(),
     ):
@@ -709,7 +709,7 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r"Can not safely cast to expected datatype.*"), asdf.open(
+    with pytest.raises(ValidationError, match=r"Can not safely cast to expected datatype.*"), asdf.open(
         buff,
         extensions=CustomExtension(),
     ):
@@ -729,7 +729,7 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r"Mismatch in number of columns:.*"), asdf.open(
+    with pytest.raises(ValidationError, match=r"Mismatch in number of columns:.*"), asdf.open(
         buff,
         extensions=CustomExtension(),
     ):
@@ -742,7 +742,7 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r"Expected structured datatype.*"), asdf.open(
+    with pytest.raises(ValidationError, match=r"Expected structured datatype.*"), asdf.open(
         buff,
         extensions=CustomExtension(),
     ):
@@ -760,7 +760,7 @@ def test_structured_datatype_validation(tmpdir):
     """
     buff = helpers.yaml_to_asdf(content)
 
-    with pytest.raises(jsonschema.ValidationError, match=r"Expected datatype .*, got .*"), asdf.open(
+    with pytest.raises(ValidationError, match=r"Expected datatype .*, got .*"), asdf.open(
         buff,
         extensions=CustomExtension(),
     ):

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -8,14 +8,13 @@ import sys
 import numpy as np
 import pytest
 from astropy.modeling import models
-from jsonschema.exceptions import ValidationError
 from numpy.testing import assert_array_equal
 
 import asdf
 import asdf.extension._legacy as _legacy_extension
 from asdf import _resolver as resolver
 from asdf import config_context, get_config, treeutil, versioning
-from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
+from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning, ValidationError
 from asdf.extension import ExtensionProxy
 
 from ._helpers import assert_no_warnings, assert_roundtrip_tree, assert_tree_match, yaml_to_asdf

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -3,10 +3,9 @@ import fractions
 import warnings
 
 import pytest
-from jsonschema import ValidationError
 
 import asdf
-from asdf.exceptions import AsdfWarning
+from asdf.exceptions import AsdfWarning, ValidationError
 from asdf.extension import Converter, Extension
 from asdf.tags.core import HistoryEntry
 from asdf.testing import helpers

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 import numpy as np
 import pytest
-from jsonschema import ValidationError
 from numpy.testing import assert_array_equal
 
 import asdf
@@ -13,7 +12,7 @@ from asdf import _types as types
 from asdf import config_context, constants, get_config, schema, tagged, util, yamlutil
 from asdf._tests import _helpers as helpers
 from asdf._tests.objects import CustomExtension
-from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning
+from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning, ValidationError
 from asdf.extension import _legacy as _legacy_extension
 
 with pytest.warns(AsdfDeprecationWarning, match=".*subclasses the deprecated CustomType.*"):

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -6,7 +6,6 @@ import pathlib
 import time
 import warnings
 
-from jsonschema import ValidationError
 from packaging.version import Version
 
 from . import _display as display
@@ -15,7 +14,13 @@ from . import _version as version
 from . import block, constants, generic_io, reference, schema, treeutil, util, versioning, yamlutil
 from ._helpers import validate_version
 from .config import config_context, get_config
-from .exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning, DelimiterNotFoundError
+from .exceptions import (
+    AsdfConversionWarning,
+    AsdfDeprecationWarning,
+    AsdfWarning,
+    DelimiterNotFoundError,
+    ValidationError,
+)
 from .extension import Extension, ExtensionProxy, SerializationContext, _legacy, get_cached_extension_manager
 from .search import AsdfSearchResult
 from .tags.core import AsdfObject, ExtensionMetadata, HistoryEntry, Software

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -1,4 +1,4 @@
-from jsonschema import ValidationError
+from asdf._jsonschema import ValidationError
 
 __all__ = [
     "AsdfConversionWarning",

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -181,7 +181,7 @@ class JsonschemaResourceMapping(Mapping):
 
     def __getitem__(self, uri):
         filename = _JSONSCHEMA_URI_TO_FILENAME[uri]
-        return pkgutil.get_data("jsonschema", f"schemas/{filename}")
+        return pkgutil.get_data("asdf._jsonschema", f"schemas/{filename}")
 
     def __len__(self):
         return len(_JSONSCHEMA_URI_TO_FILENAME)

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -10,8 +10,9 @@ from operator import methodcaller
 
 import numpy as np
 import yaml
-from jsonschema import validators as mvalidators
-from jsonschema.exceptions import RefResolutionError, ValidationError
+
+from asdf._jsonschema import validators as mvalidators
+from asdf._jsonschema.exceptions import RefResolutionError, ValidationError
 
 from . import constants, generic_io, reference, tagged, treeutil, util, versioning, yamlutil
 from .config import get_config

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -194,6 +194,8 @@ class _ValidationContext:
     when exiting the outermost context.
     """
 
+    __slots__ = ["_depth", "_seen"]
+
     def __init__(self):
         self._depth = 0
         self._seen = set()

--- a/asdf/tagged.py
+++ b/asdf/tagged.py
@@ -15,7 +15,7 @@ schema, which only understands basic Python data types, not the
 However, basic Python data types do not preserve the tag information
 from the YAML file that we need later to convert elements to custom
 data types.  Therefore, the approach here is to wrap those basic types
-inside of `Tagged` objects long enough to run through the jsonschema
+inside of `Tagged` objects long enough to run through the asdf._jsonschema
 validator, and then convert to custom data types and throwing away the
 tag annotations in the process.
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -2,10 +2,10 @@ import mmap
 import sys
 
 import numpy as np
-from jsonschema import ValidationError
 from numpy import ma
 
 from asdf import _types, util
+from asdf._jsonschema import ValidationError
 
 _datatype_names = {
     "int8": "i1",

--- a/conftest.py
+++ b/conftest.py
@@ -16,3 +16,12 @@ def _temp_cwd(tmpdir_factory):
         yield
     finally:
         os.chdir(original_cwd)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--jsonschema",
+        action="store_true",
+        default=False,
+        help="Run jsonschema test suite tests",
+    )

--- a/docs/asdf/developer_api.rst
+++ b/docs/asdf/developer_api.rst
@@ -10,7 +10,6 @@ to create their own custom ASDF types and extensions.
 .. automodapi:: asdf.tagged
 
 .. automodapi:: asdf.exceptions
-    :skip: ValidationError
 
 .. automodapi:: asdf.extension
 

--- a/docs/asdf/developer_api.rst
+++ b/docs/asdf/developer_api.rst
@@ -10,6 +10,7 @@ to create their own custom ASDF types and extensions.
 .. automodapi:: asdf.tagged
 
 .. automodapi:: asdf.exceptions
+    :allowed-package-names: jsonschema, asdf
 
 .. automodapi:: asdf.extension
 

--- a/docs/asdf/whats_new.rst
+++ b/docs/asdf/whats_new.rst
@@ -1,0 +1,32 @@
+.. currentmodule:: asdf
+
+.. _whats_new:
+
+**********
+What's new
+**********
+
+jsonschema
+----------
+
+Asdf 3.0.0 includes internally a version of jsonschema 4.17.3. This inclusion
+was done to deal with incompatible changes in jsonschema 4.18.
+
+Many libraries that use asdf import jsonschema to allow catching of ``ValidationError``
+instances that might be raised during schema validation. Prior to asdf 2.15 this
+error type was not part of the public asdf API. For 2.15 and later users are
+expected to import ``ValidationError`` from `asdf.exceptions` (instead of jsonschema
+directly).
+
+To further ease the transition, asdf will, when possible, use exceptions imported
+from any installed version of jsonschema. This means that when the asdf internal
+jsonschema raises a ``ValidationError`` on a system where jsonschema was separately
+installed, the internal jsonschema will attempt to use ``ValidationError`` from the
+installed version. This should allow code that catches exceptions imported from
+jsonschema to continue to work with no changes. However, asdf cannot guarantee
+compatibility with future installed jsonschema versions and users are encouraged
+to update their code to import ``ValidationError`` from `asdf.exceptions`.
+
+Finally, asdf is temporarily keeping jsonschema as a dependency as many libraries
+expected this to be installed by asdf. We expect to drop this requirement soon and
+this change might occur in a minor or even patch version.

--- a/docs/asdf/whats_new.rst
+++ b/docs/asdf/whats_new.rst
@@ -3,7 +3,7 @@
 .. _whats_new:
 
 **********
-What's new
+What's New
 **********
 
 jsonschema

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,8 @@ Format (ASDF) files.
 
    ASDF 2.15 introduced a number of deprecation warnings in preparation
    for changes planned for ASDF 3.0. Please see the :ref:`deprecations`
-   page for more information.
+   page for more information. Also see :ref:`whats_new` for a description
+   of other major changes.
 
 Getting Started
 ===============
@@ -90,6 +91,7 @@ Resources
   asdf/contributing
   asdf/CODE_OF_CONDUCT
   asdf/release_and_support
+  asdf/whats_new
   asdf/deprecations
   asdf/changes
   asdf/citation

--- a/licenses/JSONSCHEMA_LICENSE
+++ b/licenses/JSONSCHEMA_LICENSE
@@ -1,0 +1,1 @@
+../asdf/_jsonschema/COPYING

--- a/licenses/JSON_LICENSE
+++ b/licenses/JSON_LICENSE
@@ -1,0 +1,1 @@
+../asdf/_jsonschema/json/LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,15 @@ dependencies = [
   "asdf-unit-schemas>=0.1",
   "importlib-metadata>=4.11.4",
   "jmespath>=0.6.2",
-  "jsonschema<4.18,>=4.0.1", # jsonschema 4.18 contains incompatible changes: https://github.com/asdf-format/asdf/issues/1485
   "numpy>=1.22",
   "packaging>=19",
   "pyyaml>=5.4.1",
   "semantic_version>=2.8",
+  # for vendorized jsonschema
+  "attrs>=20.1.0",
+  # end of vendorized jsonschema deps
+  # include jsonschema for all the downstream packages expecting us to provide this
+  "jsonschema>=4.8",
 ]
 [project.optional-dependencies]
 all = [
@@ -71,6 +75,7 @@ requires = [
 
 [tool.setuptools.packages.find]
 include = ['asdf*', 'pytest_asdf*']
+exclude = ['asdf/_jsonschema/json/*']
 
 [tool.setuptools.package-data]
 'asdf.commands.tests.data' = ["*"]
@@ -90,6 +95,7 @@ force-exclude = '''
     | \.pytest_cache
     | \.tox
     | asdf/extern
+    | asdf/_jsonschema
     | build
     | dist
   )/
@@ -127,6 +133,7 @@ omit = [
     'asdf/version.*',
     'asdf/compat*',
     'asdf/extern*',
+    'asdf/_jsonschema/**',
     # And again for running against installed version
     '*/asdf/_astropy_init*',
     '*/asdf/conftest*',
@@ -141,6 +148,7 @@ omit = [
     '*/asdf/version.*',
     '*/asdf/compat*',
     '*/asdf/extern*',
+    '*/asdf/_jsonschema/**',
 ]
 
 [tool.coverage.report]
@@ -174,7 +182,7 @@ extend-ignore = [
     "S310", # URL open for permitted schemes
     "RUF012",  # mutable-class-default (typing related)
 ]
-extend-exclude = ["asdf/extern/*", "docs/*"]
+extend-exclude = ["asdf/extern/*", "asdf/_jsonschema/*", "docs/*"]
 
 [tool.ruff.per-file-ignores]
 "test_*.py" = ["S101"]
@@ -182,10 +190,10 @@ extend-exclude = ["asdf/extern/*", "docs/*"]
 "compatibility_tests/common.py" = ["S101"]
 
 [tool.flynt]
-exclude = ["asdf/extern/*"]
+exclude = ["asdf/extern/*", "asdf/_jsonschema/*"]
 
 [tool.codespell]
-skip="*.pdf,*.asdf,.tox,asdf/extern,build,./tags,.git,docs/_build"
+skip="*.pdf,*.asdf,.tox,asdf/extern,asdf/_jsonschema,build,./tags,.git,docs/_build"
 ignore-words-list="""
 fo,afile,
 """

--- a/tox.ini
+++ b/tox.ini
@@ -32,12 +32,15 @@ commands =
     pytest \
     compatibility: compatibility_tests/ \
     --remote-data \
+    --durations=10 \
+    jsonschema: --jsonschema \
     coverage: --open-files \
     parallel: --numprocesses auto \
 # the OpenAstronomy workflow appends `--cov-report` in `{posargs}`, which `coverage` doesn't recognize
     !coverage: {posargs}
     coverage:
     coverage: coverage xml -o {tox_root}/coverage.xml
+    coverage: coverage report
 
 [testenv:asdf-standard]
 change_dir = {env_tmp_dir}


### PR DESCRIPTION
This is a follow up to #1586 that is largely the same except for preserving all drafts (4 and others) as removing all but draft 4 resulted in no significant gains.

This PR 'vendorizes' jsonschema 4.17.3 and removes much of it's unused features including:
 - cli
 - removes automatic http/s url fetching
 - change pyrsistent pmap usage to dictionaries (performance seems comparable and allows removal of the pyrsistent dependency)
 - removed the deprecated `jsonschema.__version__` (which relied on reading the package metadata)

The tests and test suite from jsonschema are preserved mostly intact (tests related to removed features above were removed). As there are many drafts and many tests (especially when the test suite is used), this PR adds a pytest option `jsonschema` which when provided will run the jsonschema related tests (these are off by default). This PR also adds checks to the github ci to trigger these tests when a `jsonschema` label is added to a PR (like with this PR).

This PR keeps jsonschema as a dependency (but remove the upper pin) and conditionally use the pypi provided jsonschema only for exception classes to allow downstream code to continue catching jsonschema.exceptions.ValidationError until we can add equivalent exceptions in asdf and transition downstream code to catch the asdf provided exceptions.

I have mixed thoughts about these changes but overall think they are an improvement over keeping the upper pin for jsonschema.

Some pros are:

- we no longer have to work around jsonschema API changes (and our previous [modifications](https://github.com/asdf-format/asdf/blob/8ef92d367d052111bf7c246e27b48231cd293fae/asdf/schema.py#L311-L312) can be revisited by reaching into the vendorized version to avoid needing to patch classes we were no longer allowed to subclass)
- we remove a dependency that is undergoing rather major change in a minor version (and with the modifications in this PR also remove the indirect dependency onpyrsistent). Note that jsonschema 4.18 introduced [several new dependencies](https://github.com/python-jsonschema/jsonschema/blob/f79bad5fcd1baf5ac2fcd979dbd31616f913febd/pyproject.toml#L37C4-L39) (jsonschema-specifications, referencing, rpds-py), all less than a year old, not yet at version 1.0 (except for jsonschema-specifications which doesn't follow semantic versioning) and introduces rust as a dependency (via rpds-py)
- we can remove the upper pin on jsonschema

Some cons are:

- we inherit all of the known and unknown bugs in 4.17.3 and it is now our problem to fix
- we are now responsible for maintaining the vendorized code to maintain compatibility with new python and dependency versions
- we no longer benefit from an actively maintained project

Related to the last con, I am hopeful that 4.18 (or perhaps a later version) will be more performant and hopefully compatible with asdf in the future. So hopefully this vendorization is a temporary change.

Related to the last pro, the removal of the upper pin, jsonschema is a popular library (3 million downloads yesterday). Keeping the upper pin risks compatibility issues with asdf and other libraries (which can likely upgrade to 4.18 because they don't rely on complex schemas like asdf) so this seems like a major pro.

The asdf-standard CI failure should be fixed by:
https://github.com/asdf-format/asdf-standard/pull/391

Specifically, jsonschema 4.18 does not currently support custom metaschemas (used extensively in asdf). The asdf-standard test suite uses jsonschema directly to test schemas. These tests are not correctly finding errors with 4.18 as the schemas are being checked against the draft 4 meta schema and not the defined custom schema.