### PR TITLE
remove deprecated AsdfFile.open, asdf.open, write_to, update kwargs, 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,8 @@ The ASDF Standard is at v1.6.0
 - Remove deprecated tests.helpers [#1597]
 - Remove deprecated load_custom_schema [#1596]
 - Remove deprecated TagDefinition.schema_uri [#1595]
-- Removed deprecated AsdfFile.open [#1592]
+- Removed deprecated AsdfFile.open and deprecated asdf.open
+  AsdfFile.write_to and AsdfFile.update kwargs [#1592]
 
 2.15.1 (2023-08-07)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ The ASDF Standard is at v1.6.0
 - Remove deprecated tests.helpers [#1597]
 - Remove deprecated load_custom_schema [#1596]
 - Remove deprecated TagDefinition.schema_uri [#1595]
+- Removed deprecated AsdfFile.open [#1592]
 
 2.15.1 (2023-08-07)
 -------------------

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -50,17 +50,6 @@ def test_no_warning_nan_array(tmp_path):
         assert_roundtrip_tree(tree, tmp_path)
 
 
-def test_warning_deprecated_open(tmp_path):
-    tmpfile = str(tmp_path / "foo.asdf")
-
-    tree = {"foo": 42, "bar": "hello"}
-    with asdf.AsdfFile(tree) as af:
-        af.write_to(tmpfile)
-
-    with pytest.warns(AsdfDeprecationWarning), asdf.AsdfFile.open(tmpfile) as af:
-        assert_tree_match(tree, af.tree)
-
-
 @pytest.mark.skipif(
     not sys.platform.startswith("win") and getpass.getuser() == "root",
     reason="Cannot make file read-only if user is root",

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -344,38 +344,6 @@ def test_extension_version_check(installed, extension, warns):
         af._check_extensions(tree)
 
 
-@pytest.mark.filterwarnings(AsdfDeprecationWarning)
-def test_auto_inline(tmp_path):
-    outfile = str(tmp_path / "test.asdf")
-    tree = {"small_array": np.arange(6), "large_array": np.arange(100)}
-
-    # Use the same object for each write in order to make sure that there
-    # aren't unanticipated side effects
-    with asdf.AsdfFile(tree) as af:
-        # By default blocks are written internal.
-        af.write_to(outfile)
-        assert len(list(af._blocks.inline_blocks)) == 0
-        assert len(list(af._blocks.internal_blocks)) == 2
-
-        af.write_to(outfile, auto_inline=10)
-        assert len(list(af._blocks.inline_blocks)) == 1
-        assert len(list(af._blocks.internal_blocks)) == 1
-
-        # The previous write modified the small array block's storage
-        # to inline, and a subsequent write should maintain that setting.
-        af.write_to(outfile)
-        assert len(list(af._blocks.inline_blocks)) == 1
-        assert len(list(af._blocks.internal_blocks)) == 1
-
-        af.write_to(outfile, auto_inline=7)
-        assert len(list(af._blocks.inline_blocks)) == 1
-        assert len(list(af._blocks.internal_blocks)) == 1
-
-        af.write_to(outfile, auto_inline=5)
-        assert len(list(af._blocks.inline_blocks)) == 0
-        assert len(list(af._blocks.internal_blocks)) == 2
-
-
 @pytest.mark.parametrize(
     ("array_inline_threshold", "inline_blocks", "internal_blocks"),
     [

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -488,45 +488,30 @@ custom: !<tag:nowhere.org:custom/default-1.0.0>
         assert ff.tree["custom"]["j"]["l"] == 362
 
     buff.seek(0)
-    with pytest.warns(AsdfDeprecationWarning, match=r"do_not_fill_defaults"), asdf.open(
-        buff,
-        extensions=[DefaultTypeExtension()],
-        do_not_fill_defaults=True,
-    ) as ff:
-        assert "a" not in ff.tree["custom"]
-        assert "c" not in ff.tree["custom"]["b"]
-        assert "e" not in ff.tree["custom"]["d"]
-        assert "f" not in ff.tree["custom"]["d"]
-        assert "h" not in ff.tree["custom"]["g"]
-        assert "i" not in ff.tree["custom"]["g"]
-        assert "k" not in ff.tree["custom"]["j"]
-        assert ff.tree["custom"]["j"]["l"] == 362
-        ff.fill_defaults()
-        assert "a" in ff.tree["custom"]
-        assert ff.tree["custom"]["a"] == 42
-        assert "c" in ff.tree["custom"]["b"]
-        assert ff.tree["custom"]["b"]["c"] == 82
-        assert ff.tree["custom"]["b"]["c"] == 82
-        assert ff.tree["custom"]["d"]["e"] == 122
-        assert ff.tree["custom"]["d"]["f"] == 162
-        assert "h" not in ff.tree["custom"]["g"]
-        assert "i" not in ff.tree["custom"]["g"]
-        assert "k" not in ff.tree["custom"]["j"]
-        assert ff.tree["custom"]["j"]["l"] == 362
-        ff.remove_defaults()
-        assert "a" not in ff.tree["custom"]
-        assert "c" not in ff.tree["custom"]["b"]
-        assert "e" not in ff.tree["custom"]["d"]
-        assert "f" not in ff.tree["custom"]["d"]
-        assert "h" not in ff.tree["custom"]["g"]
-        assert "i" not in ff.tree["custom"]["g"]
-        assert "k" not in ff.tree["custom"]["j"]
-        assert ff.tree["custom"]["j"]["l"] == 362
-
-    buff.seek(0)
     with config_context() as config:
         config.legacy_fill_schema_defaults = False
         with asdf.open(buff, extensions=[DefaultTypeExtension()]) as ff:
+            assert "a" not in ff.tree["custom"]
+            assert "c" not in ff.tree["custom"]["b"]
+            assert "e" not in ff.tree["custom"]["d"]
+            assert "f" not in ff.tree["custom"]["d"]
+            assert "h" not in ff.tree["custom"]["g"]
+            assert "i" not in ff.tree["custom"]["g"]
+            assert "k" not in ff.tree["custom"]["j"]
+            assert ff.tree["custom"]["j"]["l"] == 362
+            ff.fill_defaults()
+            assert "a" in ff.tree["custom"]
+            assert ff.tree["custom"]["a"] == 42
+            assert "c" in ff.tree["custom"]["b"]
+            assert ff.tree["custom"]["b"]["c"] == 82
+            assert ff.tree["custom"]["b"]["c"] == 82
+            assert ff.tree["custom"]["d"]["e"] == 122
+            assert ff.tree["custom"]["d"]["f"] == 162
+            assert "h" not in ff.tree["custom"]["g"]
+            assert "i" not in ff.tree["custom"]["g"]
+            assert "k" not in ff.tree["custom"]["j"]
+            assert ff.tree["custom"]["j"]["l"] == 362
+            ff.remove_defaults()
             assert "a" not in ff.tree["custom"]
             assert "c" not in ff.tree["custom"]["b"]
             assert "e" not in ff.tree["custom"]["d"]

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1004,7 +1004,15 @@ class AsdfFile:
         if len(self._tree):
             self._run_hook("post_write")
 
-    def update(self, **kwargs):
+    def update(
+        self,
+        all_array_storage=NotSet,
+        all_array_compression=NotSet,
+        compression_kwargs=NotSet,
+        pad_blocks=False,
+        include_block_index=True,
+        version=None,
+    ):
         """
         Update the file on disk in place.
 
@@ -1037,6 +1045,10 @@ class AsdfFile:
             - ``input``: Use the same compression as in the file read.
               If there is no prior file, acts as None
 
+        compression_kwargs : dict, optional
+            If provided, set this as the compression keyword arguments
+            for all binary blocks in the file.
+
         pad_blocks : float or bool, optional
             Add extra space between blocks to allow for updating of
             the file.  If `False` (default), add no padding (always
@@ -1054,17 +1066,13 @@ class AsdfFile:
             writing.
         """
 
-        pad_blocks = kwargs.pop("pad_blocks", False)
-        include_block_index = kwargs.pop("include_block_index", True)
-        version = kwargs.pop("version", None)
-
         with config_context() as config:
-            if "all_array_storage" in kwargs:
-                config.all_array_storage = kwargs.pop("all_array_storage")
-            if "all_array_compression" in kwargs:
-                config.all_array_compression = kwargs.pop("all_array_compression")
-            if "compression_kwargs" in kwargs:
-                config.all_array_compression_kwargs = kwargs.pop("compression_kwargs")
+            if all_array_storage is not NotSet:
+                config.all_array_storage = all_array_storage
+            if all_array_compression is not NotSet:
+                config.all_array_compression = all_array_compression
+            if compression_kwargs is not NotSet:
+                config.all_array_compression_kwargs = compression_kwargs
 
             fd = self._fd
 
@@ -1147,7 +1155,12 @@ class AsdfFile:
     def write_to(
         self,
         fd,
-        **kwargs,
+        all_array_storage=NotSet,
+        all_array_compression=NotSet,
+        compression_kwargs=NotSet,
+        pad_blocks=False,
+        include_block_index=True,
+        version=None,
     ):
         """
         Write the ASDF file to the given file-like object.
@@ -1191,6 +1204,10 @@ class AsdfFile:
             - ``input``: Use the same compression as in the file read.
               If there is no prior file, acts as None.
 
+        compression_kwargs : dict, optional
+            If provided, set this as the compression keyword arguments
+            for all binary blocks in the file.
+
         pad_blocks : float or bool, optional
             Add extra space between blocks to allow for updating of
             the file.  If `False` (default), add no padding (always
@@ -1208,12 +1225,12 @@ class AsdfFile:
             writing.
         """
         with config_context() as config:
-            if "all_array_storage" in kwargs:
-                config.all_array_storage = kwargs["all_array_storage"]
-            if "all_array_compression" in kwargs:
-                config.all_array_compression = kwargs["all_array_compression"]
-            if "compression_kwargs" in kwargs:
-                config.all_array_compression_kwargs = kwargs["compression_kwargs"]
+            if all_array_storage is not NotSet:
+                config.all_array_storage = all_array_storage
+            if all_array_compression is not NotSet:
+                config.all_array_compression = all_array_compression
+            if compression_kwargs is not NotSet:
+                config.all_array_compression_kwargs = compression_kwargs
 
             used_blocks = self._blocks._find_used_blocks(self.tree, self, remove=False)
 
@@ -1258,24 +1275,33 @@ class AsdfFile:
                     blk = naf._blocks.find_or_create_block(key)
                     blk._used = True
                     blk._data_callback = b._data_callback
-            naf._write_to(fd, **kwargs)
+            naf._write_to(
+                fd,
+                all_array_storage=all_array_storage,
+                all_array_compression=all_array_compression,
+                compression_kwargs=compression_kwargs,
+                pad_blocks=pad_blocks,
+                include_block_index=include_block_index,
+                version=version,
+            )
 
     def _write_to(
         self,
         fd,
-        **kwargs,
+        all_array_storage=NotSet,
+        all_array_compression=NotSet,
+        compression_kwargs=NotSet,
+        pad_blocks=False,
+        include_block_index=True,
+        version=None,
     ):
-        pad_blocks = kwargs.pop("pad_blocks", False)
-        include_block_index = kwargs.pop("include_block_index", True)
-        version = kwargs.pop("version", None)
-
         with config_context() as config:
-            if "all_array_storage" in kwargs:
-                config.all_array_storage = kwargs.pop("all_array_storage")
-            if "all_array_compression" in kwargs:
-                config.all_array_compression = kwargs.pop("all_array_compression")
-            if "compression_kwargs" in kwargs:
-                config.all_array_compression_kwargs = kwargs.pop("compression_kwargs")
+            if all_array_storage is not NotSet:
+                config.all_array_storage = all_array_storage
+            if all_array_compression is not NotSet:
+                config.all_array_compression = all_array_compression
+            if compression_kwargs is not NotSet:
+                config.all_array_compression_kwargs = compression_kwargs
 
             if version is not None:
                 self.version = version

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -930,55 +930,6 @@ class AsdfFile:
                 generic_file.close()
             raise
 
-    @classmethod
-    def open(
-        cls,
-        fd,
-        uri=None,
-        mode="r",
-        validate_checksums=False,
-        extensions=None,
-        ignore_version_mismatch=True,
-        ignore_unrecognized_tag=False,
-        _force_raw_types=False,
-        copy_arrays=False,
-        lazy_load=True,
-        custom_schema=None,
-        strict_extension_check=False,
-        ignore_missing_extensions=False,
-        **kwargs,
-    ):
-        """
-        Open an existing ASDF file.
-
-        .. deprecated:: 2.2
-            Use `asdf.open` instead.
-        """
-
-        warnings.warn(
-            "The method AsdfFile.open has been deprecated and will be removed "
-            "in asdf-3.0. Use the top-level asdf.open function instead.",
-            AsdfDeprecationWarning,
-        )
-
-        return open_asdf(
-            fd,
-            uri=uri,
-            mode=mode,
-            validate_checksums=validate_checksums,
-            extensions=extensions,
-            ignore_version_mismatch=ignore_version_mismatch,
-            ignore_unrecognized_tag=ignore_unrecognized_tag,
-            _force_raw_types=_force_raw_types,
-            copy_arrays=copy_arrays,
-            lazy_load=lazy_load,
-            custom_schema=custom_schema,
-            strict_extension_check=strict_extension_check,
-            ignore_missing_extensions=ignore_missing_extensions,
-            _compat=True,
-            **kwargs,
-        )
-
     def _write_tree(self, tree, fd, pad_blocks):
         fd.write(constants.ASDF_MAGIC)
         fd.write(b" ")

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -905,7 +905,6 @@ class AsdfFile:
         _force_raw_types=False,
         strict_extension_check=False,
         ignore_missing_extensions=False,
-        **kwargs,
     ):
         """Attempt to open file-like object as an AsdfFile"""
         close_on_fail = isinstance(fd, (str, pathlib.Path))
@@ -920,7 +919,6 @@ class AsdfFile:
                 _force_raw_types=_force_raw_types,
                 strict_extension_check=strict_extension_check,
                 ignore_missing_extensions=ignore_missing_extensions,
-                **kwargs,
             )
         except Exception:
             if close_on_fail:
@@ -1640,7 +1638,7 @@ def open_asdf(
     custom_schema=None,
     strict_extension_check=False,
     ignore_missing_extensions=False,
-    **kwargs,
+    _get_yaml_content=False,
 ):
     """
     Open an existing ASDF file.
@@ -1741,8 +1739,8 @@ def open_asdf(
         mode=mode,
         validate_checksums=validate_checksums,
         extensions=extensions,
+        _get_yaml_content=_get_yaml_content,
         _force_raw_types=_force_raw_types,
         strict_extension_check=strict_extension_check,
         ignore_missing_extensions=ignore_missing_extensions,
-        **kwargs,
     )


### PR DESCRIPTION
With the removal of the deprecated kwargs the `**kwargs` were also expanded and documented to make it more explicit what arguments are supported.

devdeps will fail due to pyyaml and cython3 incompatibility: https://github.com/yaml/pyyaml/issues/601

stdatamodels downstream failure addressed in: https://github.com/asdf-format/asdf/pull/1594