### PR TITLE
fix Converter type indexing for Converters not supported by Extension

### DIFF
--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -1,5 +1,6 @@
 import pytest
 from packaging.specifiers import SpecifierSet
+from yaml.representer import RepresenterError
 
 from asdf import AsdfFile, config_context
 from asdf._tests._helpers import assert_extension_correctness
@@ -501,19 +502,6 @@ def test_converter():
 
     assert issubclass(ConverterNoSubclass, Converter)
 
-    class ConverterWithSubclass(Converter):
-        tags = []
-        types = []
-
-        def to_yaml_tree(self, *args):
-            pass
-
-        def from_yaml_tree(self, *args):
-            pass
-
-    # Confirm the behavior of the default select_tag implementation
-    assert ConverterWithSubclass().select_tag(object(), ["tag1", "tag2"], object()) == "tag1"
-
 
 def test_converter_proxy():
     # Test the minimum set of converter methods:
@@ -633,7 +621,7 @@ def test_converter_subclass_with_no_supported_tags():
     tree = {"obj": Foo()}
     with config_context() as cfg:
         cfg.add_extension(FooExtension())
-        with pytest.raises(RuntimeError, match=r"Converter.select_tag was called with no supported tags.*"):
+        with pytest.raises(RepresenterError, match=r"cannot represent an object"):
             roundtrip_object(tree)
 
 

--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -1,6 +1,5 @@
 import pytest
 from packaging.specifiers import SpecifierSet
-from yaml.representer import RepresenterError
 
 from asdf import AsdfFile, config_context
 from asdf._tests._helpers import assert_extension_correctness
@@ -610,8 +609,7 @@ def test_converter_proxy():
 def test_converter_subclass_with_no_supported_tags():
     """
     Adding a Converter to an Extension that doesn't list support for the tags
-    associated with the Converter should not index the types listed for the
-    Converter.
+    associated with the Converter should result in a failure to convert.
     """
 
     class Foo:
@@ -635,7 +633,7 @@ def test_converter_subclass_with_no_supported_tags():
     tree = {"obj": Foo()}
     with config_context() as cfg:
         cfg.add_extension(FooExtension())
-        with pytest.raises(RepresenterError, match=r"cannot represent an object"):
+        with pytest.raises(RuntimeError, match=r"Converter.select_tag was called with no supported tags.*"):
             roundtrip_object(tree)
 
 

--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -914,11 +914,19 @@ def test_converter_loop():
 
 
 @pytest.mark.parametrize("is_subclass", [True, False])
-def test_warning_or_error_for_default_select_tag(is_subclass):
+@pytest.mark.parametrize("indirect", [True, False])
+def test_warning_or_error_for_default_select_tag(is_subclass, indirect):
     class Foo:
         pass
 
     ParentClass = Converter if is_subclass else object
+
+    if indirect:
+
+        class IntermediateClass(ParentClass):
+            pass
+
+        ParentClass = IntermediateClass
 
     class FooConverter(ParentClass):
         tags = ["asdf://somewhere.org/tags/foo-*"]

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -3,7 +3,9 @@ Support for Converter, the new API for serializing custom
 types.  Will eventually replace the `asdf.types` module.
 """
 import abc
+import warnings
 
+from asdf.exceptions import AsdfWarning
 from asdf.util import get_class_name, uri_match
 
 
@@ -166,6 +168,23 @@ class ConverterProxy(Converter):
             else:
                 msg = "Converter property 'tags' must contain str values"
                 raise TypeError(msg)
+
+        if len(relevant_tags) > 1 and not hasattr(delegate, "select_tag"):
+            if isinstance(delegate, Converter):
+                # prior to asdf 3.0 Converter provided a default select_tag
+                # to provide backwards compatibility allow Converter subclasses
+                # to be registered with >1 tag but produce a warning
+                msg = (
+                    "Converter handles multiple tags for this extension, "
+                    "but does not implement a select_tag method. "
+                    "This previously worked because Converter subclasses inherited "
+                    "the now removed select_tag. This will be an error in a future "
+                    "version of asdf"
+                )
+                warnings.warn(msg, AsdfWarning)
+            else:
+                msg = "Converter handles multiple tags for this extension, but does not implement a select_tag method."
+                raise RuntimeError(msg)
 
         self._tags = sorted(relevant_tags)
 

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -14,7 +14,23 @@ class Converter(abc.ABC):
 
     Implementing classes must provide the `tags` and `types`
     properties and `to_yaml_tree` and `from_yaml_tree` methods.
-    The `select_tag` method is optional.
+    The ``select_tag`` method is optional.
+
+    If implemented, ``select_tag`` should accept 3 parameters
+
+        obj : object
+            Instance of the custom type being converted.  Guaranteed
+            to be an instance of one of the types listed in the
+            `types` property.
+        tags : list of str
+            List of active tags to choose from.  Guaranteed to match
+            one of the tag patterns listed in the 'tags' property.
+        ctx : asdf.asdf.SerializationContext
+            Context of the current serialization request.
+
+    and return a str, the selected tag (should be one of tags) or
+    `None` which will trigger the result of ``to_yaml_tree`` to be
+    used to look up the next converter for this object.
     """
 
     @classmethod
@@ -54,41 +70,6 @@ class Converter(abc.ABC):
         iterable of str or type
             If str, the fully qualified class name of the type.
         """
-
-    def select_tag(self, obj, tags, ctx):
-        """
-        Select the tag to use when converting an object to YAML.
-        Typically only one tag will be active in a given context, but
-        converters that map one type to many tags must provide logic
-        to choose the appropriate tag.
-
-        Parameters
-        ----------
-        obj : object
-            Instance of the custom type being converted.  Guaranteed
-            to be an instance of one of the types listed in the
-            `types` property.
-        tags : list of str
-            List of active tags to choose from.  Guaranteed to match
-            one of the tag patterns listed in the 'tags' property.
-        ctx : asdf.extension.SerializationContext
-            Context of the current serialization request.
-
-        Returns
-        -------
-        str or None
-            The selected tag.  Should be one of the tags passed
-            to this method in the `tags` parameter.  If `None`
-            the result of ``to_yaml_tree`` will be used to look
-            up the next converter for this object.
-        """
-        if not len(tags):
-            msg = (
-                "Converter.select_tag was called with no supported tags. "
-                f"The Converter tags {self.tags} might not be supported by the Extension."
-            )
-            raise RuntimeError(msg)
-        return tags[0]
 
     @abc.abstractmethod
     def to_yaml_tree(self, obj, tag, ctx):
@@ -185,10 +166,6 @@ class ConverterProxy(Converter):
             else:
                 msg = "Converter property 'tags' must contain str values"
                 raise TypeError(msg)
-
-        if len(relevant_tags) > 1 and not hasattr(delegate, "select_tag"):
-            msg = "Converter handles multiple tags for this extension, but does not implement a select_tag method."
-            raise RuntimeError(msg)
 
         self._tags = sorted(relevant_tags)
 

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -170,7 +170,9 @@ class ConverterProxy(Converter):
                 raise TypeError(msg)
 
         if len(relevant_tags) > 1 and not hasattr(delegate, "select_tag"):
-            if isinstance(delegate, Converter):
+            # we cannot use isinstance here because Converter supports
+            # virtual subclasses
+            if Converter in delegate.__class__.__bases__:
                 # prior to asdf 3.0 Converter provided a default select_tag
                 # to provide backwards compatibility allow Converter subclasses
                 # to be registered with >1 tag but produce a warning

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -172,7 +172,7 @@ class ConverterProxy(Converter):
         if len(relevant_tags) > 1 and not hasattr(delegate, "select_tag"):
             # we cannot use isinstance here because Converter supports
             # virtual subclasses
-            if Converter in delegate.__class__.__bases__:
+            if Converter in delegate.__class__.__mro__:
                 # prior to asdf 3.0 Converter provided a default select_tag
                 # to provide backwards compatibility allow Converter subclasses
                 # to be registered with >1 tag but produce a warning

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -3,7 +3,6 @@ Support for Converter, the new API for serializing custom
 types.  Will eventually replace the `asdf.types` module.
 """
 import abc
-import inspect
 
 from asdf.util import get_class_name, uri_match
 
@@ -83,6 +82,12 @@ class Converter(abc.ABC):
             the result of ``to_yaml_tree`` will be used to look
             up the next converter for this object.
         """
+        if not len(tags):
+            msg = (
+                "Converter.select_tag was called with no supported tags. "
+                f"The Converter tags {self.tags} might not be supported by the Extension."
+            )
+            raise RuntimeError(msg)
         return tags[0]
 
     @abc.abstractmethod
@@ -189,25 +194,9 @@ class ConverterProxy(Converter):
 
         self._types = []
 
-        if not len(self._tags):
-            # this converter supports no tags supported by the extension
-            # before indexing it's types we need to check select_tag
-
-            # check if it implements select_tag (and not just because it
-            # subclasses Converter)
-            if not hasattr(delegate, "select_tag"):
-                return
-
-            # find which class implements select_tag
-            for class_ in inspect.getmro(delegate.__class__):
-                if "select_tag" in class_.__dict__:
-                    if class_ is not Converter:
-                        # a non-Converter class implements select_tag so consider the types for this Converter
-                        break
-                    else:
-                        # this converter implements select_tag only because it inherits from Converter
-                        # don't index it's types
-                        return
+        if not len(self._tags) and not hasattr(delegate, "select_tag"):
+            # this converter supports no tags so don't inspect the types
+            return
 
         for typ in delegate.types:
             if isinstance(typ, (str, type)):

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -51,7 +51,7 @@ situation.
 Additionally, the Converter interface includes a method that must be implemented
 when some logic is required to select the tag to assign to a ``to_yaml_tree`` result:
 
-`Converter.select_tag` - a method that accepts a complex Python object and a list
+``Converter.select_tag`` - an optional method that accepts a complex Python object and a list
 candidate tags and returns the tag that should be used to serialize the object.
 
 A simple example
@@ -357,7 +357,7 @@ storing data in ASDF blocks.
 
 For applications that require more flexibility,
 Converters can control block storage through use of the `asdf.extension.SerializationContext`
-provided as an argument to `Converter.to_yaml_tree` `Converter.from_yaml_tree` and `Converter.select_tag`.
+provided as an argument to `Converter.to_yaml_tree` `Converter.from_yaml_tree` and ``Converter.select_tag``.
 
 It is helpful to first review some details of how asdf
 :ref:`stores block <asdf-standard:block>`. Blocks are stored sequentially within a

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -51,7 +51,7 @@ situation.
 Additionally, the Converter interface includes a method that must be implemented
 when some logic is required to select the tag to assign to a ``to_yaml_tree`` result:
 
-``Converter.select_tag`` - an optional method that accepts a complex Python object and a list
+`Converter.select_tag<Converter>` - an optional method that accepts a complex Python object and a list
 candidate tags and returns the tag that should be used to serialize the object.
 
 A simple example
@@ -137,7 +137,7 @@ Multiple tags
 
 Now say we want to map our one Rectangle class to one of two tags, either
 rectangle-1.0.0 or square-1.0.0.  We'll need to add square-1.0.0 to
-the converter's list of tags and implement a ``select_tag`` method:
+the converter's list of tags and implement a `select_tag<Converter>` method:
 
 .. code-block:: python
 
@@ -179,7 +179,7 @@ the converter's list of tags and implement a ``select_tag`` method:
 Deferring to another converter
 ==============================
 
-Converters only support the exact types listed in ``Converter.types``. When a
+Converters only support the exact types listed in `Converter.types`. When a
 supported type is subclassed the extension will need to be updated to support
 the new subclass. There are a few options for supporting subclasses.
 
@@ -188,7 +188,7 @@ Converter, tag and schema should be defined.
 
 If the subclass can be treated the same as the superclass (specifically if
 subclass instances can be serialized as the superclass) then the subclass
-can be added to the existing ``Converter.types``. Note that adding the
+can be added to the existing `Converter.types`. Note that adding the
 subclass to the supported types (without making other changes to the Converter)
 will result in subclass instances using the same tag as the superclass. This
 means that any instances created during deserialization will always
@@ -197,8 +197,8 @@ be of the superclass (subclass instances will never be read from an ASDF file).
 Another option (useful when modifying the existing Converter is not
 convenient) is to define a Converter that does not tag the subclass instance
 being serialized and instead defers to the existing Converter. Deferral
-is triggered by returning ``None`` from ``Converter.select_tag`` and
-implementing ``Converter.to_yaml_tree`` to convert the subclass instance
+is triggered by returning ``None`` from `Converter.select_tag<Converter>` and
+implementing `Converter.to_yaml_tree` to convert the subclass instance
 into an instance of the (supported) superclass.
 
 For example, using the example ``Rectangle`` class above, let's say we
@@ -414,14 +414,14 @@ A simple example of a Converter using block storage to store the ``payload`` for
 
 .. asdf:: block_converter_example.asdf
 
-During read, ``Converter.from_yaml_tree`` will be called. Within this method
+During read, `Converter.from_yaml_tree` will be called. Within this method
 the Converter can prepare to access a block by calling
 ``SerializationContext.get_block_data_callback``. This will return a function
 that when called will return the contents of the block (to support lazy
 loading without keeping a reference to the ``SerializationContext`` (which is meant
 to be a short lived and lightweight object).
 
-During write, ``Converter.to_yaml_tree`` will be called. The Converter can
+During write, `Converter.to_yaml_tree` will be called. The Converter can
 use ``SerializationContext.find_available_block_index`` to find the location of an
 available block for writing. The data to be written to the block can be provided
 as an ``ndarray`` or a callable function that will return a ``ndarray`` (note that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,12 @@ remote_data_strict = true
 filterwarnings = [
     'error',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
+    # gwcs 0.18.3 contains a bug, new asdf versions will correctly raise
+    # a warning for this bug. We're ignoring the warning to allow the extension
+    # to be loaded and used. This warning filter (and similar ones in tox.ini)
+    # can be removed when the bug is fixed in gwcs/asdf-wcs-schemas.
+    # See: https://github.com/spacetelescope/gwcs/pull/469
+    'ignore:asdf.extensions plugin from package gwcs==0.18.3:asdf.exceptions.AsdfWarning',
 ]
 # Configuration for pytest-doctestplus
 text_file_format = 'rst'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ docs = [
 tests = [
   "astropy>=5.0.4",
   "fsspec[http]>=2022.8.2",
-  "gwcs>=0.18.3",
+  "asdf-astropy>=0.4.0",
   "lz4>=0.10",
   "psutil",
   "pytest>=6",
@@ -114,12 +114,6 @@ remote_data_strict = true
 filterwarnings = [
     'error',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
-    # gwcs 0.18.3 contains a bug, new asdf versions will correctly raise
-    # a warning for this bug. We're ignoring the warning to allow the extension
-    # to be loaded and used. This warning filter (and similar ones in tox.ini)
-    # can be removed when the bug is fixed in gwcs/asdf-wcs-schemas.
-    # See: https://github.com/spacetelescope/gwcs/pull/469
-    'ignore:asdf.extensions plugin from package gwcs==0.18.3:asdf.exceptions.AsdfWarning',
 ]
 # Configuration for pytest-doctestplus
 text_file_format = 'rst'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-unit-schemas.git
 git+https://github.com/asdf-format/asdf-wcs-schemas
 git+https://github.com/astropy/astropy
-git+https://github.com/spacetelescope/gwcs
 #git+https://github.com/yaml/pyyaml.git
 # jsonschema 4.18 contains incompatible changes: https://github.com/asdf-format/asdf/issues/1485
 #git+https://github.com/python-jsonschema/jsonschema

--- a/tox.ini
+++ b/tox.ini
@@ -243,7 +243,8 @@ commands_pre =
     pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
-    pytest roman_datamodels/tests
+    pytest roman_datamodels/tests \
+        -W "ignore:asdf.extensions plugin from package gwcs==0.18.3:asdf.exceptions.AsdfWarning"
 
 [testenv:weldx]
 change_dir = {env_tmp_dir}
@@ -288,4 +289,5 @@ commands_pre =
     pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
-    pytest dkist
+    pytest dkist \
+        -W "ignore:asdf.extensions plugin from package gwcs==0.18.3:asdf.exceptions.AsdfWarning"


### PR DESCRIPTION
tldr; #1561 introduced a subtle change to which Converters are ignored. stdatamodels includes an erroneous converter that is now not ignored. This PR fixes the asdf side of the issue (and drops the unused `gwcs` test dependency).

Prior to #1561 the types supported by a converter that doesn't support any tags that are supported by the extension were ignored. The modifications in that PR checked if the converter implemented 'select_tag' and if not ignored the types. However if the converter implemented 'select_tag' the converter types were indexed (as the converter could return None from 'select_tag' and defer to a new converter).

If a converter inherits from Converter it gains the select_tag method from the parent Converter class
(which provides documentation of the method but doesn't implement functionality that is otherwise covered by ConverterProxy). This creates an issue when indexing the converter tags/types if a converter is included in an extension that doesn't list support for the tags supported by the converter.

The changes included here removes the default 'select_tag' provided by Converter and adds a warning for any Converter subclasses that support more than 1 relevant tag in an extension and don't implement `select_tag`. This is a warning to provide backwards compatibility with extensions that relied on this bug.

As gwcs implements a few converters that subclass from Converter and support more than one tag, with the changes in this PR the gwcs extension will raise a warning (this is addressed in asdf-wcs-schemas PR: https://github.com/asdf-format/asdf-wcs-schemas/pull/46 and gwcs PR: https://github.com/spacetelescope/gwcs/pull/469 which splits the multiple tag versions across multiple extensions).

As gwcs is unused in the asdf tests, this PR removes gwcs as a test dependency and adds `asdf-astropy` (which was previously installed because of the `gwcs` dependency) for a few tests that rely on astropy objects.