### PR TITLE
[benchmarks] add commit URL for showing commits when clicked

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -6,8 +6,8 @@
     "branches": [
         "main"
     ],
+    "show_commit_url": "http://github.com/asdf-format/asdf/commit/",
     "environment_type": "virtualenv",
-
     "install_command": [
         "pip install ."
     ],


### PR DESCRIPTION
Currently, the benchmarks at https://spacetelescope.github.io/bench/asdf/ do not show a commit when clicked; this configuration change should fix that.