### PR TITLE
convert numpy scalars to python types before yaml encoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ The ASDF Standard is at v1.6.0
 - Fix issue opening files that don't support ``fileno`` [#1557]
 - Allow Converters to defer conversion to other Converters
   by returning ``None`` in ``Converter.select_tag`` [#1561]
+- Convert numpy scalars to python types during yaml encoding
+  to handle NEP51 changes for numpy 2.0 [#1605]
 
 2.15.0 (2023-03-28)
 -------------------

--- a/asdf/_tests/test_yaml.py
+++ b/asdf/_tests/test_yaml.py
@@ -287,4 +287,10 @@ def test_numpy_scalar(numpy_value, expected_value):
     yamlutil.dump_tree(tree, buffer, ctx)
     buffer.seek(0)
 
-    assert yamlutil.load_tree(buffer)["value"] == expected_value
+    loaded_value = yamlutil.load_tree(buffer)["value"]
+    if isinstance(numpy_value, np.floating):
+        abs_diff = abs(expected_value - loaded_value)
+        eps = np.finfo(numpy_value.dtype).eps
+        assert abs_diff < eps, abs_diff
+    else:
+        assert loaded_value == expected_value

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -117,11 +117,12 @@ AsdfDumper.add_representer(OrderedDict, represent_ordereddict)
 # ----------------------------------------------------------------------
 # Handle numpy scalars
 
+
 for scalar_type in util.iter_subclasses(np.floating):
-    AsdfDumper.add_representer(scalar_type, AsdfDumper.represent_float)
+    AsdfDumper.add_representer(scalar_type, lambda dumper, data: dumper.represent_float(float(data)))
 
 for scalar_type in util.iter_subclasses(np.integer):
-    AsdfDumper.add_representer(scalar_type, AsdfDumper.represent_int)
+    AsdfDumper.add_representer(scalar_type, lambda dumper, data: dumper.represent_int(int(data)))
 
 
 def represent_numpy_str(dumper, data):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,9 @@ git+https://github.com/asdf-format/asdf-unit-schemas.git
 git+https://github.com/asdf-format/asdf-wcs-schemas
 git+https://github.com/astropy/astropy
 git+https://github.com/spacetelescope/gwcs
-git+https://github.com/yaml/pyyaml.git
+#git+https://github.com/yaml/pyyaml.git
 # jsonschema 4.18 contains incompatible changes: https://github.com/asdf-format/asdf/issues/1485
 #git+https://github.com/python-jsonschema/jsonschema
 
 numpy>=0.0.dev0
+scipy>=0.0.dev0


### PR DESCRIPTION
[nep51](https://numpy.org/neps/nep-0051-scalar-representation.html) changes numpy scalars modifying the repr.

this change conflicts with represent_float/int (from pyyaml, which uses repr). With numpy 2.0 (which implements nep51) scalars are being encoded as, for example, 'np.float64(3.14)' instead of '3.14'. To work around this change, convert the values to builtin python types before passing them to pyyaml for encoding.

This PR also disables pyyaml devdeps testing as it is incompatible with cython 3.0 and it's failure to install stops devdeps testing.