### PR TITLE
require and add min version to sphinx theme for rtd

### DIFF
--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -6,3 +6,4 @@ dependencies:
   - python=3.11
   - pip
   - graphviz
+  - sphinx_rtd_theme>1.2.0


### PR DESCRIPTION
readthedocs is choosing to use an ancient version of the sphinx theme (0.4.3 from 2019). This PR modifies the rtd environment file to require a newer version of the theme.