### PR TITLE
switch to simple changelog check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,8 +17,10 @@ jobs:
     name: Confirm changelog entry
     runs-on: ubuntu-latest
     steps:
-    - name: Check change log entry
-      uses: scientific-python/action-check-changelogfile@6087eddce1d684b0132be651a4dad97699513113  # 0.2
-      env:
-        CHANGELOG_FILENAME: CHANGES.rst
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Grep for PR number in CHANGES.rst
+        run: grep -P '\[[^\]]*#${{github.event.number}}[,\]]' CHANGES.rst
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-entry-needed') }}


### PR DESCRIPTION
The scientific-python changelog checker by default also checks milestones. Since https://github.com/asdf-format/asdf/pull/1610 removed the requirement that PRs have milestones this can result in PRs incorrectly failing the changelog check because they don't have a milestone.

The workflow is based largely off of one used for jwst: https://github.com/spacetelescope/jwst/blob/master/.github/workflows/changelog.yml and what was [used previously in asdf](https://github.com/asdf-format/asdf/blob/9e746c899482523b668b8737cd744c4c8fb0c45e/.github/workflows/changelog.yml).