### PR TITLE
remove deprecated  load_schema argument, resolve_local_refs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ The ASDF Standard is at v1.6.0
   to ``asdf.config.AsdfConfig``, move ``asdf.Stream`` to
   ``asdf.tags.core.Stream``, update block storage support for
   Converter and update internal block API [#1537]
+- Remove deprecated resolve_local_refs argument to load_schema [#1623]
 
 2.15.1 (2023-08-07)
 -------------------

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -1020,13 +1020,6 @@ def test_custom_validation_with_external_ref_bad(tmp_path):
         pass
 
 
-def test_load_schema_resolve_local_refs_deprecated():
-    custom_schema_path = helpers.get_test_data_path("custom_schema_definitions.yaml")
-
-    with pytest.deprecated_call():
-        schema.load_schema(custom_schema_path, resolve_local_refs=True)
-
-
 def test_nonexistent_tag(tmp_path):
     """
     This tests the case where a node is tagged with a type that apparently

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -145,7 +145,7 @@ class AsdfFile:
         self._extension_list_ = None
 
         if custom_schema is not None:
-            self._custom_schema = schema._load_schema_cached(custom_schema, self._resolver, True, False)
+            self._custom_schema = schema._load_schema_cached(custom_schema, self._resolver, True)
         else:
             self._custom_schema = None
 


### PR DESCRIPTION
This PR removes the deprecated `resolve_local_refs` argument to `asdf.schema.load_schema`.