### PR TITLE
define python envs in github ci

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,17 @@
 [tox]
-env_list = py{39,310}{,-compatibility,-coverage}{,-parallel}
+env_list =
+    compatibility
+    coverage
+    py{39,310,311}{,-compatibility,-coverage,-jsonschema}{,-parallel}
+    asdf{-standard,-transform-schemas,-unit-schemas,-wcs-schemas,-coordinates-schemas,-astropy}
+    gwcs
+    jwst
+    stdatamodels
+    stpipe
+    roman_datamodels
+    weldx
+    sunpy
+    dkist
 
 [testenv]
 set_env =


### PR DESCRIPTION
Updates tox.ini to define used environments as tox 4.9 does not allow 'on-the-fly' environment creation unless the environment is prefixed with `pyXX`.