### PR TITLE
Clean up test dependencies, add python 3.12 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         - linux: py39-devdeps-parallel
         - linux: py310-devdeps-parallel
         - linux: py311-devdeps-parallel
+        - linux: py312-devdeps-parallel
+          python-version: '3.12-dev'
 
   oldest:
     needs: [core, asdf-schemas]

--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -254,23 +254,20 @@ def test_array_inline_threshold_recursive(tmpdir):
         def array(self):
             return np.array(self._array)
 
-
     class NDArrayContainerConverter:
         tags = ["http://somewhere.org/tags/foo-1.0.0"]
         types = [NDArrayContainer]
 
         def to_yaml_tree(self, obj, tag, ctx):
-            return {'array': obj.array}
+            return {"array": obj.array}
 
         def from_yaml_tree(self, node, tag, ctx):
-            return NDArrayContainer(node['array'])
-
+            return NDArrayContainer(node["array"])
 
     class NDArrayContainerExtension:
         tags = NDArrayContainerConverter.tags
         converters = [NDArrayContainerConverter()]
         extension_uri = "http://somewhere.org/extensions/foo-1.0.0"
-
 
     container = NDArrayContainer([[1, 2], [3, 4]])
     tree = {"test": container}

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -7,7 +7,6 @@ import sys
 
 import numpy as np
 import pytest
-from astropy.modeling import models
 from numpy.testing import assert_array_equal
 
 import asdf
@@ -115,23 +114,6 @@ def test_atomic_write(tmp_path, small_tree):
 
     with asdf.open(tmpfile, mode="r") as ff:
         ff.write_to(tmpfile)
-
-
-def test_overwrite(tmp_path):
-    """
-    This is intended to reproduce the following issue:
-    https://github.com/asdf-format/asdf/issues/100
-    """
-    tmpfile = str(tmp_path / "test.asdf")
-    aff = models.AffineTransformation2D(matrix=[[1, 2], [3, 4]])
-    f = asdf.AsdfFile()
-    f.tree["model"] = aff
-    f.write_to(tmpfile)
-    model = f.tree["model"]
-
-    ff = asdf.AsdfFile()
-    ff.tree["model"] = model
-    ff.write_to(tmpfile)
 
 
 def test_default_version():

--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -1,6 +1,5 @@
 import os
 
-import fsspec
 import pytest
 
 from asdf import config_context
@@ -361,6 +360,8 @@ def test_fsspec(tmp_path):
     Issue #1146 reported errors when opening a fsspec 'file'
     This is a regression test for the fix in PR #1226
     """
+    fsspec = pytest.importorskip("fsspec")
+
     tree = {"a": 1}
     af = AsdfFile(tree)
     fn = tmp_path / "test.asdf"
@@ -378,6 +379,8 @@ def test_fsspec_http(httpserver):
     filesystem)
     This is a regression test for the fix in PR #1228
     """
+    fsspec = pytest.importorskip("fsspec")
+
     tree = {"a": 1}
     af = AsdfFile(tree)
     path = os.path.join(httpserver.tmpdir, "test")

--- a/asdf/_tests/test_file_format.py
+++ b/asdf/_tests/test_file_format.py
@@ -59,7 +59,6 @@ baz: 42
         assert len(ff.tree) == 2
 
 
-@pytest.mark.filterwarnings("ignore::astropy.io.fits.verify.VerifyWarning")
 def test_no_asdf_header(tmp_path):
     content = b"What? This ain't no ASDF file"
 
@@ -98,7 +97,6 @@ def test_empty_file():
         assert len(ff._blocks.blocks) == 0
 
 
-@pytest.mark.filterwarnings("ignore::astropy.io.fits.verify.VerifyWarning")
 @pytest.mark.filterwarnings("ignore::asdf.exceptions.AsdfDeprecationWarning")
 def test_not_asdf_file():
     buff = io.BytesIO(b"SIMPLE")

--- a/asdf/_tests/test_generic_io.py
+++ b/asdf/_tests/test_generic_io.py
@@ -5,7 +5,6 @@ import stat
 import sys
 import urllib.request as urllib_request
 
-import fsspec
 import numpy as np
 import pytest
 
@@ -786,6 +785,8 @@ def test_fsspec(tmp_path):
     Issue #1146 reported errors when opening a fsspec 'file'
     This is a regression test for the fix in PR #1226
     """
+    fsspec = pytest.importorskip("fsspec")
+
     ref = b"01234567890"
     fn = tmp_path / "test"
 
@@ -809,6 +810,8 @@ def test_fsspec_http(httpserver):
     filesystem)
     This is a regression test for the fix in PR #1228
     """
+    fsspec = pytest.importorskip("fsspec")
+
     ref = b"01234567890"
     path = os.path.join(httpserver.tmpdir, "test")
 

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -68,7 +68,8 @@ def test_tagging_scalars():
         def __init__(self, value):
             self.value = value
 
-    scalar_tag = 'http://somewhere.org/tags/scalar-1.0.0'
+    scalar_tag = "http://somewhere.org/tags/scalar-1.0.0"
+
     class ScalarConverter:
         tags = [scalar_tag]
         types = [Scalar]
@@ -82,7 +83,7 @@ def test_tagging_scalars():
     class ScalarExtension:
         tags = [scalar_tag]
         converters = [ScalarConverter()]
-        extension_uri = 'http://somewhere.org/extensions/scalar-1.0.0'
+        extension_uri = "http://somewhere.org/extensions/scalar-1.0.0"
 
     yaml = f"""
 tagged: !<{scalar_tag}>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,7 @@ docs = [
   'tomli; python_version < "3.11"',
 ]
 tests = [
-  "fsspec[http]>=2022.8.2",
-  "asdf-astropy>=0.4.0",
+  #"fsspec[http]>=2022.8.2",
   "lz4>=0.10",
   "psutil",
   "pytest>=6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ tests = [
   "psutil",
   "pytest>=6",
   "pytest-doctestplus",
-  "pytest-openfiles",
   "pytest-remotedata",
 ]
 [project.urls]
@@ -107,15 +106,13 @@ minversion = 4.6
 norecursedirs = ['build', 'docs/_build', 'docs/sphinxext']
 doctest_plus = 'enabled'
 remote_data_strict = true
-# The asdf.asdftypes module emits a warning on import,
-# which pytest trips over during collection:
 filterwarnings = [
     'error',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
 ]
 # Configuration for pytest-doctestplus
 text_file_format = 'rst'
-addopts = '--color=yes --doctest-rst'
+addopts = '--color=yes --doctest-rst -rsx'
 
 [tool.coverage.run]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ docs = [
   'tomli; python_version < "3.11"',
 ]
 tests = [
-  "astropy>=5.0.4",
   "fsspec[http]>=2022.8.2",
   "asdf-astropy>=0.4.0",
   "lz4>=0.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ docs = [
   'tomli; python_version < "3.11"',
 ]
 tests = [
-  #"fsspec[http]>=2022.8.2",
+  "fsspec[http]>=2022.8.2",
   "lz4>=0.10",
   "psutil",
   "pytest>=6",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ git+https://github.com/asdf-format/asdf-standard
 git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-unit-schemas.git
 git+https://github.com/asdf-format/asdf-wcs-schemas
-#git+https://github.com/yaml/pyyaml.git
+git+https://github.com/yaml/pyyaml.git
 
 numpy>=0.0.dev0
 # although we don't use scipy, we include it here so that any dependency

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,12 @@
-git+https://github.com/astropy/asdf-astropy
 git+https://github.com/asdf-format/asdf-coordinates-schemas
 git+https://github.com/asdf-format/asdf-standard
 git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-unit-schemas.git
 git+https://github.com/asdf-format/asdf-wcs-schemas
-git+https://github.com/astropy/astropy
 #git+https://github.com/yaml/pyyaml.git
 
 numpy>=0.0.dev0
+# although we don't use scipy, we include it here so that any dependency
+# that uses it during these tests will use the development version
+# which is more likely to work with the above development version of numpy
 scipy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,6 @@ commands =
     --remote-data \
     --durations=10 \
     jsonschema: --jsonschema \
-    coverage: --open-files \
     parallel: --numprocesses auto \
 # the OpenAstronomy workflow appends `--cov-report` in `{posargs}`, which `coverage` doesn't recognize
     !coverage: {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 env_list =
     compatibility
     coverage
-    py{39,310,311}{,-compatibility,-coverage,-jsonschema}{,-parallel}
+    devdep{,-parallel}
+    py{39,310,311,312}{,-compatibility,-coverage,-jsonschema}{,-parallel}
     asdf{-standard,-transform-schemas,-unit-schemas,-wcs-schemas,-coordinates-schemas,-astropy}
     gwcs
     jwst


### PR DESCRIPTION
~After https://github.com/asdf-format/asdf/pull/1594 is sorted (which at the moment removes the gwcs test dependency) this PR can be finished and brought out of draft.~

~EDIT: based off changes in https://github.com/asdf-format/asdf/pull/1650 which fixes 1 test for python 3.12.~

The changes in this PR clean up the `test` dependencies. Some likely targets are:
- gwcs: looks to be entirely unused
- asdf-astropy: used for a handful of outdated tests and for some tests of 'nested' objects which could be handled by custom objects
- astropy: mostly incorrect usage now that serialization has moved to asdf-astropy

This also adds 3.12 testing which will currently fail because of aiohttp (required by fsspec). See https://github.com/asdf-format/asdf/pull/1651 for results with fsspec removed as a test dependency.

This also re-adds pyyaml to devdeps testing as the cython issues appear to be addressed:
Fixes: https://github.com/asdf-format/asdf/issues/1607