### PR TITLE
Add support for python 3.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ The ASDF Standard is at v1.6.0
   ``asdf.tags.core.Stream``, update block storage support for
   Converter and update internal block API [#1537]
 - Remove deprecated resolve_local_refs argument to load_schema [#1623]
+- Add support for python 3.12 [#1641]
 
 2.15.1 (2023-08-07)
 -------------------

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -1336,8 +1336,8 @@ class AsdfFile:
         elif software is not None:
             software = Software(software)
 
-        time_ = datetime.datetime.utcfromtimestamp(
-            int(os.environ.get("SOURCE_DATE_EPOCH", time.time())),
+        time_ = datetime.datetime.fromtimestamp(
+            int(os.environ.get("SOURCE_DATE_EPOCH", time.time())), datetime.timezone.utc
         )
 
         entry = HistoryEntry(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
 ]
 dynamic = [
   'version',


### PR DESCRIPTION
Testing (by cleaning up out test dependencies that don't yet support python 3.12) revealed only 1 required change to allow asdf to support python 3.12, removal of one use of `utcfromtimestamp`:
https://github.com/asdf-format/asdf/blob/cee306e74217b275a69ee4d7c96b18d1bc55bdd8/asdf/asdf.py#L1339-L1341

The tests can be found here: https://github.com/asdf-format/asdf/pull/1633

This change was broken out into this PR to make backporting easier. Python 3.12 will be released 2023-10-02 and we may want to consider releasing a 2.15.2 that includes the change in this PR even if we release 3.0 before that time (so users that can't yet update to 3.0 have an option to run 3.12).

Updating the CI to test python 3.12 would ideally be included in this PR but given the lack of released 3.12 support for some test dependencies (astropy) and the changes required to work around these limitations (see https://github.com/asdf-format/asdf/pull/1633) I propose that we separate this change from the dependency cleanup and rely on the tests in #1633 to show expected python 3.12 compatibility once all the dependencies are updated.