### PR TITLE
switch IOBase to FileIO in test

### DIFF
--- a/asdf/_tests/test_generic_io.py
+++ b/asdf/_tests/test_generic_io.py
@@ -394,7 +394,7 @@ def test_invalid_obj(tmp_path):
 
 
 def test_nonseekable_file(tmp_path):
-    base = io.IOBase
+    base = io.FileIO
 
     class FileWrapper(base):
         def tell(self):


### PR DESCRIPTION
Testing with python 3.12 in https://github.com/asdf-format/asdf/pull/1633 revealed an issue with one test that is using `IOBase`. See comment: https://github.com/asdf-format/asdf/pull/1633#discussion_r1328802508

It appears that in python 3.12 `IOBase.__init__` no longer accepts accepts the same arguments. This appears to be an undocumented change (I can't seen to find any documentation) and I don't recall this occurring in rc1. The use of `IOBase` in the test can be replaced with `FileIO` (which fits the usage better).

This change is split from #1633 to make it easier to backport to 2.15.x