### PR TITLE
TEST: Py312

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ docs = [
   'tomli; python_version < "3.11"',
 ]
 tests = [
-  "fsspec[http]>=2022.8.2",
+  #"fsspec[http]>=2022.8.2",
   "lz4>=0.10",
   "psutil",
   "pytest>=6",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ scipy>=0.0.dev0
 
 # attempt to get fsspec working with python 3.12
 aiohttp==3.9.0b0
+fsspec[http]>=2022.8.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,6 @@ numpy>=0.0.dev0
 # that uses it during these tests will use the development version
 # which is more likely to work with the above development version of numpy
 scipy>=0.0.dev0
+
+# attempt to get fsspec working with python 3.12
+aiohttp==3.9.0b0

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 env_list =
     compatibility
     coverage
-    devdep{,-parallel}
-    py{39,310,311,312}{,-compatibility,-coverage,-jsonschema}{,-parallel}
+    py{39,310,311,312}{,-compatibility,-coverage,-jsonschema}{,-devdeps}{,-parallel}
     asdf{-standard,-transform-schemas,-unit-schemas,-wcs-schemas,-coordinates-schemas,-astropy}
     gwcs
     jwst


### PR DESCRIPTION
Removes fsspec from our test dependencies to allow the python 3.12 tests to run.

Based off changes in: https://github.com/asdf-format/asdf/pull/1633