### PR TITLE
index converters by type when no converter is found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@
   extension was created from a manifest registered with a uri that
   does not match the id in the manifest [#1785]
 
+- Allow converters to provide types as strings that can
+  resolve to public classes (even if the class is implemented
+  in a private module). [#1654]
+
 
 3.2.0 (2024-04-05)
 ------------------

--- a/asdf/extension/_manager.py
+++ b/asdf/extension/_manager.py
@@ -8,11 +8,26 @@ from ._extension import ExtensionProxy
 
 
 def _resolve_type(path):
+    """
+    Convert a class path (like the string "asdf.AsdfFile") to a
+    class (``asdf.AsdfFile``) only if the module implementing the
+    class has already been imported.
+
+    Parameters
+    ----------
+
+    path : str
+        Path/name of class (for example, "asdf.AsdfFile")
+
+    Returns
+    -------
+
+    typ : class or None
+        The class (if it's already been imported) or None
+    """
     if "." not in path:
-        # this path does not appear to include a module
-        if path in globals():
-            return globals()[path]
-        elif path in sys.modules:
+        # check if this path is a module
+        if path in sys.modules:
             return sys.modules[path]
         return None
     # this type is part of a module

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -26,12 +26,12 @@ characters up to a ``/``, or ``**``, which matches any sequence of characters.
 The `~asdf.util.uri_match` method can be used to test URI patterns.
 
 `Converter.types` - a list of Python types or fully-qualified Python type names handled
-by the converter.  Note that a string name must reflect the actual location of the
-class's implementation and not just a module where it is imported for convenience.
-For example, if class ``Foo`` is implemented in ``example_package.foo.Foo`` but
-imported as ``example_package.Foo`` for convenience, it is the former name that
-must be used.  The `~asdf.util.get_class_name` method will return the name that
-`asdf` expects.
+by the converter. For strings, the private or public path can be used. For example,
+if class ``Foo`` is implemented in ``example_package.foo.Foo`` but imported
+as ``example_package.Foo`` for convenience either ``example_package.foo.Foo``
+or ``example_package.Foo`` can be used. As most libraries do not consider moving
+where a class is implemented it is preferred to use the "public" location
+where the class is imported (in this example ``example_package.Foo``).
 
 The string type name is recommended over a type object for performance reasons,
 see :ref:`extending_converters_performance`.


### PR DESCRIPTION
This changes how converters with class paths/names as types are handled by asdf.

Prior to PR, when converting a class instance (foo) of class (Foo) the class path of the instance was inspected with ``get_class_name`` and the ``_converters_by_type`` index was searched using the class name. This index contained both classes and class paths (as converters could use both/either) with classes being preferred. This creates issues when a module has a different class path from the typical 'public' path for the class as the module might move the private implementation without changing the 'public' path with the expectation that this will not break downstream code. For converters that use class paths these types of moves will break the converter.

This PR changes the handling of class paths used for converters so that the 'public' path can be used. If a converter is not found for a class in ``_converters_by_type`` (which now only contains classes as keys) then ``_converters_by_class_path`` is indexed by checking what classes referred to by the paths are already imported (to avoid importing every class supported by every extension). If the class is imported it is added to ``_converters_by_type`` and removed from ``_converters_by_class_path``.

Closes #1653

The changes in this PR will be helpful for maintaining `asdf_astropy` and other asdf extensions that provide converters for types implemented in a different library. To illustrate this, the following branch was created on a fork of `asdf_astropy` that uses the public class paths and when run with this PR passes all unit tests:
https://github.com/astropy/asdf-astropy/compare/main...braingram:class_path?expand=1