### PR TITLE
use np.memmap instead of np.core.memmap

### DIFF
--- a/asdf/_tests/test_generic_io.py
+++ b/asdf/_tests/test_generic_io.py
@@ -112,7 +112,7 @@ def test_path(tree, tmp_path):
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(ff._blocks.blocks) == 2
-        assert isinstance(ff._blocks.blocks[0].cached_data, np.core.memmap)
+        assert isinstance(ff._blocks.blocks[0].cached_data, np.memmap)
 
 
 def test_open2(tree, tmp_path):
@@ -135,7 +135,7 @@ def test_open2(tree, tmp_path):
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(ff._blocks.blocks) == 2
-        assert isinstance(ff._blocks.blocks[0].cached_data, np.core.memmap)
+        assert isinstance(ff._blocks.blocks[0].cached_data, np.memmap)
 
 
 @pytest.mark.parametrize("mode", ["r", "w", "rw"])
@@ -172,7 +172,7 @@ def test_io_open(tree, tmp_path):
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(ff._blocks.blocks) == 2
-        assert isinstance(ff._blocks.blocks[0].cached_data, np.core.memmap)
+        assert isinstance(ff._blocks.blocks[0].cached_data, np.memmap)
         ff.tree["science_data"][0] = 42
 
 
@@ -208,7 +208,7 @@ def test_bytes_io(tree):
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(ff._blocks.blocks) == 2
-        assert not isinstance(ff._blocks.blocks[0].cached_data, np.core.memmap)
+        assert not isinstance(ff._blocks.blocks[0].cached_data, np.memmap)
         ff.tree["science_data"][0] = 42
 
 
@@ -224,7 +224,7 @@ def test_streams(tree):
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(ff._blocks.blocks) == 2
-        assert not isinstance(ff._blocks.blocks[0].cached_data, np.core.memmap)
+        assert not isinstance(ff._blocks.blocks[0].cached_data, np.memmap)
         ff.tree["science_data"][0] = 42
 
 
@@ -252,7 +252,7 @@ def test_urlopen(tree, httpserver):
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(ff._blocks.blocks) == 2
-        assert not isinstance(ff._blocks.blocks[0].cached_data, np.core.memmap)
+        assert not isinstance(ff._blocks.blocks[0].cached_data, np.memmap)
 
 
 @pytest.mark.remote_data()

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -637,7 +637,7 @@ class GenericFile(metaclass=util.InheritDocstrings):
 
     def memmap_array(self, offset, size):
         """
-        Memmap a chunk of the file into a `np.core.memmap` object.
+        Memmap a chunk of the file into a `np.memmap` object.
 
         Parameters
         ----------
@@ -649,7 +649,7 @@ class GenericFile(metaclass=util.InheritDocstrings):
 
         Returns
         -------
-        array : np.core.memmap
+        array : np.memmap
         """
         msg = f"memmapping is not implemented for {self.__class__.__name__}"
         raise NotImplementedError(msg)
@@ -680,7 +680,7 @@ class GenericFile(metaclass=util.InheritDocstrings):
 
         Returns
         -------
-        array : np.core.memmap
+        array : np.memmap
         """
         buff = self.read(size)
         return np.frombuffer(buff, np.uint8, size, 0)


### PR DESCRIPTION
`np.core` is deprecated in numpy 2.0 and causing failures in the devdeps tests:
https://github.com/asdf-format/asdf/actions/runs/6619133498/job/17979194872?pr=1664#step:10:607
This PR replaces all references to `np.core.memmap` with `np.memmap` to fix these errors.