### PR TITLE
add devdeps parameterization to tox.ini environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 env_list =
     compatibility
     coverage
-    devdep{,-parallel}
-    py{39,310,311,312}{,-compatibility,-coverage,-jsonschema}{,-parallel}
+    py{39,310,311,312}{,-compatibility,-coverage,-jsonschema}{,-devdeps}{,-parallel}
     asdf{-standard,-transform-schemas,-unit-schemas,-wcs-schemas,-coordinates-schemas,-astropy}
     gwcs
     jwst


### PR DESCRIPTION
These improvements to `tox.ini` were originally included in #1651 I split them off into this separate PR so that the changes can make it into main and that test PR can be closed.

devdeps failures are unrelated and addressed in: #1665