### PR TITLE
build with python 3.11 (not 3.12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
     needs: [core, asdf-schemas]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
+      python-version: "3.11"
       upload_to_pypi: false
       upload_to_anaconda: false
       test_extras: tests


### PR DESCRIPTION
The OpenAstronomy build workflow uses python version `3.x`. This is now defaulting to `3.12`. As `aiohttp` does not yet have a stable python 3.12 version (and this is a test dependency installed as part of the build testing run) this is causing build to fail:
https://github.com/asdf-format/asdf/actions/runs/6657397904/job/18092159951?pr=1668

This PR forces the build version to 3.11.