### PR TITLE
Introduce `tree_type` argument to `asdf.open` to allow reading files as tagged (instead of custom) objects.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ The ASDF Standard is at v1.6.0
 - Deprecate ``asdf.asdf`` and ``AsdfFile.resolve_and_inline`` [#1690]
 
 - Deprecate ``_force_raw_types`` argument to ``asdf.open`` and replace
-  with ``as_tagged`` (also deprecate ``force_raw_types`` argument
+  with ``tree_type`` (also deprecate ``force_raw_types`` argument
   to ``yamlutil.tagged_tree_to_custom_tree`` with no replacement) [#1677]
 
 3.0.1 (2023-10-30)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ The ASDF Standard is at v1.6.0
 
 - Deprecate ``asdf.asdf`` and ``AsdfFile.resolve_and_inline`` [#1690]
 
+- Deprecate ``_force_raw_types`` argument to ``asdf.open`` and replace
+  with ``as_tagged`` (also deprecate ``force_raw_types`` argument
+  to ``yamlutil.tagged_tree_to_custom_tree`` with no replacement) [#1677]
+
 3.0.1 (2023-10-30)
 ------------------
 

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -763,7 +763,7 @@ class AsdfFile:
         validate_checksums=False,
         extensions=None,
         _get_yaml_content=False,
-        _force_raw_types=False,
+        _force_raw_types=NotSet,
         strict_extension_check=False,
         ignore_missing_extensions=False,
     ):
@@ -851,9 +851,16 @@ class AsdfFile:
                     self.close()
                     raise
 
-            tree = yamlutil.tagged_tree_to_custom_tree(tree, self, _force_raw_types)
+            if _force_raw_types is not NotSet:
+                warnings.warn(
+                    "_force_raw_types is deprecated and will be replaced by as_tagged", AsdfDeprecationWarning
+                )
+                as_tagged = _force_raw_types
 
-            if not (ignore_missing_extensions or _force_raw_types):
+            if not as_tagged:
+                tree = yamlutil.tagged_tree_to_custom_tree(tree, self)
+
+            if not (ignore_missing_extensions or as_tagged):
                 self._check_extensions(tree, strict=strict_extension_check)
 
             self._tree = tree
@@ -870,7 +877,7 @@ class AsdfFile:
         validate_checksums=False,
         extensions=None,
         _get_yaml_content=False,
-        _force_raw_types=False,
+        _force_raw_types=NotSet,
         strict_extension_check=False,
         ignore_missing_extensions=False,
     ):
@@ -883,6 +890,7 @@ class AsdfFile:
                 generic_file,
                 validate_checksums=validate_checksums,
                 extensions=extensions,
+                as_tagged=as_tagged,
                 _get_yaml_content=_get_yaml_content,
                 _force_raw_types=_force_raw_types,
                 strict_extension_check=strict_extension_check,
@@ -1487,7 +1495,8 @@ def open_asdf(
     extensions=None,
     ignore_version_mismatch=True,
     ignore_unrecognized_tag=False,
-    _force_raw_types=False,
+    as_tagged=False,
+    _force_raw_types=NotSet,
     copy_arrays=False,
     lazy_load=True,
     custom_schema=None,
@@ -1560,6 +1569,10 @@ def open_asdf(
         contains metadata about extensions that are not available. Defaults
         to `False`.
 
+    as_tagged : bool, optional
+        When `True` do not convert the ASDF tree to custom types and instead
+        returned `asdf.tagged` objects.
+
     Returns
     -------
     asdffile : AsdfFile
@@ -1594,6 +1607,7 @@ def open_asdf(
         mode=mode,
         validate_checksums=validate_checksums,
         extensions=extensions,
+        as_tagged=as_tagged,
         _get_yaml_content=_get_yaml_content,
         _force_raw_types=_force_raw_types,
         strict_extension_check=strict_extension_check,

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1581,8 +1581,9 @@ def open_asdf(
     tree_type : str, optional
         Controls the tree type for the returned AsdfFile instance. Supported
         values are:
-            "custom" (default), for a tree with custom objects
-            "tagged", for a tree with `asdf.tagged` objects
+
+            - "custom" (default) for a tree with custom objects
+            - "tagged" for a tree with `asdf.tagged` objects
 
     Returns
     -------

--- a/asdf/_tests/_helpers.py
+++ b/asdf/_tests/_helpers.py
@@ -25,7 +25,7 @@ import yaml
 import asdf
 from asdf import generic_io, versioning
 from asdf._asdf import AsdfFile, _get_asdf_library_info
-from asdf.constants import YAML_TAG_PREFIX
+from asdf.constants import YAML_END_MARKER_REGEX, YAML_TAG_PREFIX
 from asdf.exceptions import AsdfConversionWarning
 from asdf.tags.core import AsdfObject
 from asdf.versioning import (
@@ -219,13 +219,13 @@ def _assert_roundtrip_tree(
             asdf_check_func(ff)
 
     buff.seek(0)
-    ff = AsdfFile(extensions=extensions, **init_options)
-    content = AsdfFile._open_impl(ff, buff, mode="r", _get_yaml_content=True)
+    gf = generic_io.get_file(buff)
+    content = gf.reader_until(YAML_END_MARKER_REGEX, 7, "End of YAML marker", include=True).read()
     buff.close()
     # We *never* want to get any raw python objects out
     assert b"!!python" not in content
     assert b"!core/asdf" in content
-    assert content.startswith(b"%YAML 1.1")
+    assert b"%YAML 1.1" in content
     if raw_yaml_check_func:
         raw_yaml_check_func(content)
 

--- a/asdf/_tests/tags/core/tests/test_integer.py
+++ b/asdf/_tests/tags/core/tests/test_integer.py
@@ -46,7 +46,7 @@ def test_integer_storage(tmpdir, inline):
     with asdf.AsdfFile(tree) as af:
         af.write_to(tmpfile)
 
-    with asdf.open(tmpfile, _force_raw_types=True) as rf:
+    with asdf.open(tmpfile, as_tagged=True) as rf:
         if inline:
             assert "source" not in rf.tree["integer"]["words"]
             assert "data" in rf.tree["integer"]["words"]

--- a/asdf/_tests/tags/core/tests/test_integer.py
+++ b/asdf/_tests/tags/core/tests/test_integer.py
@@ -46,7 +46,7 @@ def test_integer_storage(tmpdir, inline):
     with asdf.AsdfFile(tree) as af:
         af.write_to(tmpfile)
 
-    with asdf.open(tmpfile, as_tagged=True) as rf:
+    with asdf.open(tmpfile, tree_type="tagged") as rf:
         if inline:
             assert "source" not in rf.tree["integer"]["words"]
             assert "data" in rf.tree["integer"]["words"]

--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -1,7 +1,9 @@
 import os
 
+import numpy as np
 import pytest
 
+import asdf
 from asdf import config_context
 from asdf._asdf import AsdfFile, open_asdf
 from asdf._entry_points import get_extensions
@@ -390,3 +392,15 @@ def test_fsspec_http(httpserver):
     with fsspec.open(fn) as f:
         af = open_asdf(f)
         assert_tree_match(tree, af.tree)
+
+
+@pytest.mark.parametrize("as_tagged", [True, False])
+def test_asdf_open_as_tagged(tmp_path, as_tagged):
+    fn = tmp_path / "test.asdf"
+    asdf.AsdfFile({"a": np.zeros(3)}).write_to(fn)
+
+    with asdf.open(fn, as_tagged=as_tagged) as af:
+        if as_tagged:
+            assert isinstance(af["a"], asdf.tagged.TaggedDict)
+        else:
+            assert isinstance(af["a"], asdf.tags.core.ndarray.NDArrayType)

--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -394,13 +394,18 @@ def test_fsspec_http(httpserver):
         assert_tree_match(tree, af.tree)
 
 
-@pytest.mark.parametrize("as_tagged", [True, False])
-def test_asdf_open_as_tagged(tmp_path, as_tagged):
+@pytest.mark.parametrize("tree_type", [None, "custom", "tagged", "unknown"])
+def test_asdf_open_tree_type(tmp_path, tree_type):
     fn = tmp_path / "test.asdf"
     asdf.AsdfFile({"a": np.zeros(3)}).write_to(fn)
 
-    with asdf.open(fn, as_tagged=as_tagged) as af:
-        if as_tagged:
+    if tree_type == "unknown":
+        with pytest.raises(ValueError, match=f"Unsupported tree type {tree_type}"), asdf.open(fn, tree_type=tree_type):
+            pass
+        return
+
+    with asdf.open(fn, tree_type=tree_type) as af:
+        if tree_type == "tagged":
             assert isinstance(af["a"], asdf.tagged.TaggedDict)
         else:
             assert isinstance(af["a"], asdf.tags.core.ndarray.NDArrayType)

--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -394,7 +394,7 @@ def test_fsspec_http(httpserver):
         assert_tree_match(tree, af.tree)
 
 
-@pytest.mark.parametrize("tree_type", [None, "custom", "tagged", "unknown"])
+@pytest.mark.parametrize("tree_type", [None, "custom", "tagged", "yaml", "unknown"])
 def test_asdf_open_tree_type(tmp_path, tree_type):
     fn = tmp_path / "test.asdf"
     asdf.AsdfFile({"a": np.zeros(3)}).write_to(fn)
@@ -407,5 +407,7 @@ def test_asdf_open_tree_type(tmp_path, tree_type):
     with asdf.open(fn, tree_type=tree_type) as af:
         if tree_type == "tagged":
             assert isinstance(af["a"], asdf.tagged.TaggedDict)
+        elif tree_type == "yaml":
+            assert isinstance(af["a"], dict)
         else:
             assert isinstance(af["a"], asdf.tags.core.ndarray.NDArrayType)

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -57,7 +57,7 @@ def test_tagged_tree_to_custom_tree_force_raw_types_deprecation(tmp_path, force_
     fn = tmp_path / "test.asdf"
     asdf.AsdfFile({"a": np.zeros(3)}).write_to(fn)
 
-    with asdf.open(fn, as_tagged=True) as af:
+    with asdf.open(fn, tree_type="tagged") as af:
         with pytest.warns(AsdfDeprecationWarning, match="force_raw_types is deprecated"):
             asdf.yamlutil.tagged_tree_to_custom_tree(af.tree, af, force_raw_types)
 

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -50,3 +50,26 @@ def test_resolve_and_inline_deprecation():
     with pytest.warns(AsdfDeprecationWarning, match="resolve_and_inline is deprecated"):
         af = asdf.AsdfFile({"arr": np.arange(42)})
         af.resolve_and_inline()
+
+
+@pytest.mark.parametrize("force_raw_types", [True, False])
+def test_tagged_tree_to_custom_tree_force_raw_types_deprecation(tmp_path, force_raw_types):
+    fn = tmp_path / "test.asdf"
+    asdf.AsdfFile({"a": np.zeros(3)}).write_to(fn)
+
+    with asdf.open(fn, as_tagged=True) as af:
+        with pytest.warns(AsdfDeprecationWarning, match="force_raw_types is deprecated"):
+            asdf.yamlutil.tagged_tree_to_custom_tree(af.tree, af, force_raw_types)
+
+
+@pytest.mark.parametrize("force_raw_types", [True, False])
+def test_asdf_open_force_raw_types_deprecation(tmp_path, force_raw_types):
+    fn = tmp_path / "test.asdf"
+    asdf.AsdfFile({"a": np.zeros(3)}).write_to(fn)
+
+    with pytest.warns(AsdfDeprecationWarning, match="_force_raw_types is deprecated"):
+        with asdf.open(fn, _force_raw_types=force_raw_types) as af:
+            if force_raw_types:
+                assert isinstance(af["a"], asdf.tagged.TaggedDict)
+            else:
+                assert isinstance(af["a"], asdf.tags.core.ndarray.NDArrayType)

--- a/asdf/_tests/test_reference.py
+++ b/asdf/_tests/test_reference.py
@@ -190,9 +190,7 @@ def test_internal_reference(tmp_path):
     buff = io.BytesIO()
     ff.write_to(buff)
     buff.seek(0)
-    ff = asdf.AsdfFile()
-    content = asdf.AsdfFile()._open_impl(ff, buff, _get_yaml_content=True)
-    assert b"{$ref: ''}" in content
+    assert b"{$ref: ''}" in buff.read()
 
 
 def test_implicit_internal_reference(tmp_path):

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -378,9 +378,9 @@ def diff(filenames, minimal, iostream=sys.stdout, ignore=None):
     ignore_expressions = [] if ignore is None else [jmespath.compile(e) for e in ignore]
 
     try:
-        with asdf.open(filenames[0], as_tagged=True) as asdf0, asdf.open(
+        with asdf.open(filenames[0], tree_type="tagged") as asdf0, asdf.open(
             filenames[1],
-            as_tagged=True,
+            tree_type="tagged",
         ) as asdf1:
             ignore_ids = set()
             for expression in ignore_expressions:

--- a/asdf/commands/diff.py
+++ b/asdf/commands/diff.py
@@ -378,9 +378,9 @@ def diff(filenames, minimal, iostream=sys.stdout, ignore=None):
     ignore_expressions = [] if ignore is None else [jmespath.compile(e) for e in ignore]
 
     try:
-        with asdf.open(filenames[0], _force_raw_types=True) as asdf0, asdf.open(
+        with asdf.open(filenames[0], as_tagged=True) as asdf0, asdf.open(
             filenames[1],
-            _force_raw_types=True,
+            as_tagged=True,
         ) as asdf1:
             ignore_ids = set()
             for expression in ignore_expressions:

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -262,7 +262,7 @@ def edit(path):
                 # Blocks are not read during validation, so this will not raise
                 # an error even though we're only opening the YAML portion of
                 # the file.
-                with open_asdf(io.BytesIO(new_content), _force_raw_types=True):
+                with open_asdf(io.BytesIO(new_content), as_tagged=True):
                     pass
             except yaml.YAMLError as e:
                 print("Error: failed to parse updated YAML:")

--- a/asdf/commands/edit.py
+++ b/asdf/commands/edit.py
@@ -262,7 +262,7 @@ def edit(path):
                 # Blocks are not read during validation, so this will not raise
                 # an error even though we're only opening the YAML portion of
                 # the file.
-                with open_asdf(io.BytesIO(new_content), as_tagged=True):
+                with open_asdf(io.BytesIO(new_content), tree_type="tagged"):
                     pass
             except yaml.YAMLError as e:
                 print("Error: failed to parse updated YAML:")

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -7,7 +7,7 @@ import yaml
 
 from . import config, schema, tagged, treeutil, util
 from .constants import STSCI_SCHEMA_TAG_BASE, YAML_TAG_PREFIX
-from .exceptions import AsdfConversionWarning
+from .exceptions import AsdfConversionWarning, AsdfDeprecationWarning
 from .extension._serialization_context import BlockAccess
 from .tags.core import AsdfObject
 from .versioning import _yaml_base_loader
@@ -303,11 +303,20 @@ def custom_tree_to_tagged_tree(tree, ctx, _serialization_context=None):
     )
 
 
-def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False, _serialization_context=None):
+def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=util.NotSet, _serialization_context=None):
     """
     Convert a tree containing only basic data types, annotated with
     tags, to a tree containing custom data types.
     """
+    if force_raw_types is not util.NotSet:
+        warnings.warn(
+            "force_raw_types is deprecated. Once removed tagged_tree_to_custom_tree will "
+            "always behave as if force_raw_types was False, for uses where force_raw_types "
+            "was True calling of tagged_tree_to_custom_tree can be skipped",
+            AsdfDeprecationWarning,
+        )
+    else:
+        force_raw_types = False
     if _serialization_context is None:
         _serialization_context = ctx._create_serialization_context(BlockAccess.READ)
 


### PR DESCRIPTION
This PR introduces the `tree_type` argument to `asdf.open`.

```python
af = asdf.open('foo.asdf', tree_type='tagged')
assert isinstance(af.tree, asdf.tagged.TaggedDict)  # note, not an AsdfObject
assert isinstance(af.tree['asdf_library'], asdf.tagged.TaggedDict)
# etc...
```

Note that this can be useful in situations where the asdf file was produced with an extension that is no longer supported (such is the case with old roman files) and may be useful for situations where custom objects are unnecessary (such as [this use in crds](https://github.com/spacetelescope/crds/blob/ba57aaf4f09e4071b5cc90951b80bc5a4f0ffc11/crds/io/factory.py#L79)).

As this argument replaces the need for `_force_raw_types` the `_force_raw_types` argument is also deprecated. Additionally, the `force_raw_types` argument to `yamlutil.tagged_tree_to_cusom_tree` is deprecated and will be removed with no replacement (when set to `True` this makes `tagged_tree_to_custom_tree` effectively do nothing).

The deprecations cause warnings (and for some packages these will become errors) in downstream including stdatamodels, dkist, asdf-astropy, and crds (all of which use `_force_raw_types`). These should all be addressed (or have paths to being addressed if the effect is minor) before this PR is merged. Likely the solution for all these uses will be to add an asdf version check and using `tree_type` instead of `_force_raw_types`.

I propose that we:
- review and decide on the new API introduced in this PR
- when approved, delay merging until the usage of `_force_raw_types` is updated in: asdf-astropy, dkist, stdatamodels, crds
- once all known downstream usage is updated this PR can be merged