### PR TITLE
add pre-commit workflow to replace pre-commit-ci

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,26 @@
+<!--
+Thank you for opening an issue for asdf!
+
+Your feedback is crucial to maintaining this open source project.
+
+If this is a feature request or discussion question please add to
+or create a new discussion:
+
+https://github.com/asdf-format/asdf/discussions
+-->
+
+# Description of the problem
+
+<!-- If an Exception, Warning or some other error occurred please include
+the error message and full traceback -->
+
+# Example of the problem
+
+<!-- Please include an example that reproduces the problem or describe why
+an example isn't provided. -->
+
+# System information
+
+asdf version:
+python version:
+operating system:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+<!---
+Thanks for contributing to asdf!
+
+Your PR should trigger the CI (after approval for first-time contributors)
+which will:
+
+- check your code for 'style' using pre-commit
+- run your PR against the asdf unit tests for various OSes, python versions, and dependency versions
+- perform a test build of your PR
+
+It is highly recommended that you run some of these tests locally by:
+
+- [installing pre-commit](https://pre-commit.com/#quick-start)
+- [running pytest](https://docs.pytest.org/en/7.1.x/getting-started.html)
+
+This will increase the chances your PR will pass the required CI tests.
+-->
+
+# Description
+
+<!--
+Please describe what this PR accomplishes.
+If the changes are non-obvious, please explain how they work.
+If this PR adds a new feature please include tests and documentation.
+If this PR fixes an issue, please add closing keywords (eg 'fixes #XXX')
+-->
+
+# Checklist:
+
+- [ ] pre-commit checks ran successfully
+- [ ] tests ran successfully
+- [ ] for a public change, a changelog entry was added
+- [ ] for a public change, documentation was updated
+- [ ] for any new features, unit tests were added

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0
   core:
+    needs: [pre-commit]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       submodules: false
@@ -49,6 +56,7 @@ jobs:
         - linux: jsonschema
 
   asdf-schemas:
+    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       submodules: false


### PR DESCRIPTION
Since pre-commit-ci will no longer be auto-fixing PRs this PR also adds:
- a workflow that runs pre-commit (the branch protections will be updated when this PR is merged to make this a required job)
- a pull request template describing running pre-commit, pytest, etc

I also added an issue template to this PR since it seems like a good thing to provide.

Fixes https://github.com/asdf-format/asdf/issues/1679