### PR TITLE
deprecate validation on AsdfFile.tree assignment, AsdfFile.__init__ and AsdfFile.resolve_references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ The ASDF Standard is at v1.6.0
 - Cleanup ``asdf.util`` including deprecating: ``human_list``
   ``resolve_name`` ``minversion`` and ``iter_subclasses`` [#1688]
 
+- Deprecate validation on ``AsdfFile.tree`` assignment. Please
+  use ``AsdfFile.validate`` to validate the tree [#1691]
+
+- Deprecate validation during ``AsdfFile.resolve_references``. Please
+  use ``AsdfFile.validate`` to validate the tree [#1691]
+
 - Deprecate ``asdf.asdf`` and ``AsdfFile.resolve_and_inline`` [#1690]
 
 - Deprecate automatic calling of ``AsdfFile.find_references`` during

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1239,10 +1239,18 @@ class AsdfFile:
         a ASDF file after this operation means it will have no
         external references, and will be completely self-contained.
         """
-        # Set to the property self.tree so the resulting "complete"
-        # tree will be validated.
+        if len(kwargs):
+            warnings.warn("Passing kwargs to resolve_references is deprecated and does nothing", AsdfDeprecationWarning)
         self._tree = reference.resolve_references(self._tree, self)
-        self.validate()
+        try:
+            self.validate()
+        except ValidationError:
+            warnings.warn(
+                "Validation during resolve_references is deprecated. "
+                "Please use AsdfFile.validate after resolve_references to validate the resolved tree",
+                AsdfDeprecationWarning,
+            )
+            raise
 
     def resolve_and_inline(self):
         """

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -203,7 +203,8 @@ class AsdfFile:
             self._tree = tree.tree
             self.find_references(_warning_msg=find_ref_warning_msg)
         else:
-            self.tree = tree
+            self._tree = AsdfObject(tree)
+            self.validate()
             self.find_references(_warning_msg=find_ref_warning_msg)
 
         self._comments = []
@@ -570,7 +571,13 @@ class AsdfFile:
     def tree(self, tree):
         asdf_object = AsdfObject(tree)
         # Only perform custom validation if the tree is not empty
-        self._validate(asdf_object, custom=bool(tree))
+        try:
+            self._validate(asdf_object, custom=bool(tree))
+        except ValidationError:
+            warnings.warn(
+                "Validation on tree assignment is deprecated. Please use AsdfFile.validate", AsdfDeprecationWarning
+            )
+            raise
         self._tree = asdf_object
 
     def keys(self):
@@ -1234,7 +1241,8 @@ class AsdfFile:
         """
         # Set to the property self.tree so the resulting "complete"
         # tree will be validated.
-        self.tree = reference.resolve_references(self._tree, self)
+        self._tree = reference.resolve_references(self._tree, self)
+        self.validate()
 
     def resolve_and_inline(self):
         """

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -204,7 +204,16 @@ class AsdfFile:
             self.find_references(_warning_msg=find_ref_warning_msg)
         else:
             self._tree = AsdfObject(tree)
-            self.validate()
+            try:
+                self.validate()
+            except ValidationError:
+                warnings.warn(
+                    "Validation during AsdfFile.__init__ is deprecated. "
+                    "Please use AsdfFile.validate to validate the tree",
+                    AsdfDeprecationWarning,
+                )
+                raise
+
             self.find_references(_warning_msg=find_ref_warning_msg)
 
         self._comments = []

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -92,3 +92,18 @@ def test_AsdfFile_tree_assignment_validation_deprecation():
         ValidationError
     ):
         af.tree = {"history": 42}
+
+
+def test_AsdfFile_resolve_references_validation_deprecation():
+    af = asdf.AsdfFile()
+    af._tree["history"] = 42
+    with pytest.warns(
+        AsdfDeprecationWarning, match="Validation during resolve_references is deprecated"
+    ), pytest.raises(ValidationError):
+        af.resolve_references()
+
+
+def test_AsdfFile_resolve_references_kwargs_deprecation():
+    af = asdf.AsdfFile()
+    with pytest.warns(AsdfDeprecationWarning, match="Passing kwargs to resolve_references is deprecated"):
+        af.resolve_references(foo=42)

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 import asdf
-from asdf.exceptions import AsdfDeprecationWarning
+from asdf.exceptions import AsdfDeprecationWarning, ValidationError
 
 
 def test_asdf_stream_deprecation():
@@ -84,3 +84,11 @@ def test_find_references_during_open_deprecation(tmp_path):
 def test_asdf_util_is_primitive_deprecation():
     with pytest.warns(AsdfDeprecationWarning, match="asdf.util.is_primitive is deprecated"):
         asdf.util.is_primitive(1)
+
+
+def test_AsdfFile_tree_assignment_validation_deprecation():
+    af = asdf.AsdfFile()
+    with pytest.warns(AsdfDeprecationWarning, match="Validation on tree assignment is deprecated"), pytest.raises(
+        ValidationError
+    ):
+        af.tree = {"history": 42}

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -107,3 +107,10 @@ def test_AsdfFile_resolve_references_kwargs_deprecation():
     af = asdf.AsdfFile()
     with pytest.warns(AsdfDeprecationWarning, match="Passing kwargs to resolve_references is deprecated"):
         af.resolve_references(foo=42)
+
+
+def test_AsdfFile_init_validation_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="Validation during AsdfFile.__init__ is deprecated"), pytest.raises(
+        ValidationError
+    ):
+        asdf.AsdfFile({"history": 42})

--- a/docs/asdf/deprecations.rst
+++ b/docs/asdf/deprecations.rst
@@ -20,6 +20,12 @@ Automatic calling of ``AsdfFile.find_references`` during calls to
 ``AsdfFile.__init__`` and ``asdf.open``. Call ``AsdfFile.find_references`` to
 find references.
 
+Automatic validation on assignment to the top-level ``AsdfFile.tree`` attribute is
+deprecated and will be disabled in a future version of asdf. Please call
+``AsdfFile.validate`` to validate the tree. As this is difficult to deprecate without
+triggering warnings for every tree assignment the warning will only be shown
+if the validation triggered by tree assignment fails.
+
 Version 3.0
 ===========
 

--- a/docs/asdf/deprecations.rst
+++ b/docs/asdf/deprecations.rst
@@ -26,6 +26,11 @@ deprecated and will be disabled in a future version of asdf. Please call
 triggering warnings for every tree assignment the warning will only be shown
 if the validation triggered by tree assignment fails.
 
+Similarly, validation during ``AsdfFile.resolve_references`` is deprecated (with the
+warning only appearing for a failed validation).
+
+Providing ``kwargs`` to ``AsdfFile.resolve_references`` does nothing and is deprecated.
+
 Version 3.0
 ===========
 

--- a/docs/asdf/deprecations.rst
+++ b/docs/asdf/deprecations.rst
@@ -20,14 +20,16 @@ Automatic calling of ``AsdfFile.find_references`` during calls to
 ``AsdfFile.__init__`` and ``asdf.open``. Call ``AsdfFile.find_references`` to
 find references.
 
-Automatic validation on assignment to the top-level ``AsdfFile.tree`` attribute is
-deprecated and will be disabled in a future version of asdf. Please call
-``AsdfFile.validate`` to validate the tree. As this is difficult to deprecate without
-triggering warnings for every tree assignment the warning will only be shown
-if the validation triggered by tree assignment fails.
+Several deprecations were added to ``AsdfFile`` methods that validate the
+tree. In a future version of asdf these methods will not perform any tree
+validation (please call ``AsdfFile.validate`` to validate the tree).
+As this behavior is difficult to deprecate (without triggering warnings
+for every call of the method) an ``AsdfDeprecationWarning`` will only
+be issued on a failed validation during the following methods:
 
-Similarly, validation during ``AsdfFile.resolve_references`` is deprecated (with the
-warning only appearing for a failed validation).
+* ``AsdfFile.tree`` assignment
+* ``AsdfFile.resolve_references``
+* ``AsdfFile.__init__`` (when the ``tree`` argument is provided)
 
 Providing ``kwargs`` to ``AsdfFile.resolve_references`` does nothing and is deprecated.
 

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -102,9 +102,8 @@ Schema validation
 Schema validation is used to determine whether an ASDF file is well formed. All
 ASDF files must conform to the schemas defined by the :ref:`ASDF Standard
 <asdf-standard:asdf-standard>`. Schema validation can be run using `AsdfFile.validate`
-and occurs when reading ASDF files (using `asdf.open`), writing them out
-(using `AsdfFile.write_to` or `AsdfFile.update`) and when constructing
-a new `AsdfFile` object from a tree/dictionary (as in ``AsdfFile(tree)``).
+and occurs when reading ASDF files (using `asdf.open`) and writing them out
+(using `AsdfFile.write_to` or `AsdfFile.update`).
 
 Schema validation also plays a role when using custom extensions (see
 :ref:`using_extensions` and :ref:`extending_extensions`). Extensions must provide schemas

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -101,15 +101,10 @@ Schema validation
 
 Schema validation is used to determine whether an ASDF file is well formed. All
 ASDF files must conform to the schemas defined by the :ref:`ASDF Standard
-<asdf-standard:asdf-standard>`. Schema validation occurs
-when reading ASDF files (using `asdf.open`), writing them out
-(using `AsdfFile.write_to` or `AsdfFile.update`), when assigning to the
-root of the ASDF tree (assigning to `AsdfFile.tree`) and when constructing
+<asdf-standard:asdf-standard>`. Schema validation can be run using `AsdfFile.validate`
+and occurs when reading ASDF files (using `asdf.open`), writing them out
+(using `AsdfFile.write_to` or `AsdfFile.update`) and when constructing
 a new `AsdfFile` object from a tree/dictionary (as in ``AsdfFile(tree)``).
-
-.. note::
-   Schema validation does not occur when a leaf/branch of the tree is
-   assigned but can be manually triggered by using `AsdfFile.validate`.
 
 Schema validation also plays a role when using custom extensions (see
 :ref:`using_extensions` and :ref:`extending_extensions`). Extensions must provide schemas


### PR DESCRIPTION
# Description

This PR deprecates automatic validation on assignment to `AsdfFile.tree`. This long-undocumented feature (documentation added in asdf 3.0 #1599) can be replaced by a call to `AsdfFile.validate` after tree assignment (which is already necessary for tree assignments that don't replace the entire tree).

The eventual disabling of the deprecated feature will allow downstream code that currently uses the non-public `_tree` attribute (to avoid the validation on assignment) to be updated to use the public `tree`. Here are a few examples:
- https://github.com/spacetelescope/stdatamodels/blob/4a06de96585dad1c8497e4fd01d4041ee2c210b4/src/stdatamodels/model_base.py#L623
- https://github.com/spacetelescope/stdatamodels/blob/4a06de96585dad1c8497e4fd01d4041ee2c210b4/src/stdatamodels/fits_support.py#L772

In addition to mentioning this change in the docs and changelog a deprecation warning is added which is triggered only on failed validation during `AsdfFile.tree` assignment. This was done to avoid raising a warning for every `AsdfFile.tree` assignment. As these warnings typically only show during test suite runs it will hopefully signal to any downstream developers that might be relying on the validation on `AsdfFile.tree` assignment. A survey of `AsdfFile.tree` assignment in all packages in our downstream testing suggests the deprecation and removal of this feature should only have the positive effect of removing many unnecessary validations (see below for an example).

In this example from [roman_datamodels.datamodels._core](https://github.com/spacetelescope/roman_datamodels/blob/14beded1b2734ca3613f42599439a34e2b2d5ac9/src/roman_datamodels/datamodels/_core.py#L211-L212):
```python
    def to_asdf(self, init, *args, **kwargs):
        with validate.nuke_validation():
            asdffile = self.open_asdf(**kwargs)
            asdffile.tree = {"roman": self._instance}
            asdffile.write_to(init, *args, **kwargs)
```
While writing out this model to an ASDF file, the model is validated (the `nuke_validation` setting is off by default) first on assignment to `asdffile.tree` (due to the feature deprecated in this PR) and validated a second time during the call to `asdffile.write_to`.

The roman_datamodels downstream failures are due to the new warning (being turned into an error). The failing tests are mostly from the same code used in the example above. The code could be updated (in this case) to avoid the duplicate validation and pass all tests with the changes in this PR:
```python
             asdffile["roman"] = self._instance
             asdffile.write_to(init, *args, **kwargs)
```
If this PR is approved a PR can be opened against roman_datamodels with the above change to allow those tests to pass both with and without this asdf PR. After the change is made in roman_datamodels and the downstream test passes here this PR can be merged.

A few tests in roman_datamodels also assume validation on `AsdfFile.__init__`. This branch has updates sufficient to allow all roman_datamodels tests to pass with the source branch for this PR: https://github.com/spacetelescope/roman_datamodels/compare/main...braingram:roman_datamodels:duplicate_validation

Fixes https://github.com/asdf-format/asdf/issues/315

# Checklist:

- [x] pre-commit checks ran successfully
- [x] tests ran successfully
- [x] for a public change, a changelog entry was added
- [x] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
