### PR TITLE
add float16 support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Fix ``numpy.ma.MaskedArray`` saving for numpy 2.x [#1769]
 
+- Add ``float16`` support [#1692]
+
+
 3.1.0 (2024-02-27)
 ------------------
 
@@ -51,6 +54,7 @@ The ASDF Standard is at v1.6.0
   if it contains a single line (and does not fail)  [#1748]
 
 - Deprecate ``AsdfFile.version_map`` [#1745]
+
 
 3.0.1 (2023-10-30)
 ------------------

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -16,6 +16,7 @@ _datatype_names = {
     "uint16": "u2",
     "uint32": "u4",
     "uint64": "u8",
+    "float16": "f2",
     "float32": "f4",
     "float64": "f8",
     "complex64": "c8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ dynamic = [
   'version',
 ]
 dependencies = [
-  #"asdf-standard>=1.0.1",
-  "asdf-standard @ git+https://github.com/braingram/asdf-standard.git@f16",
+  "asdf-standard>=1.1.0",
   "asdf-transform-schemas>=0.3",
   "asdf-unit-schemas>=0.1",
   "importlib-metadata>=4.11.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dynamic = [
   'version',
 ]
 dependencies = [
-  "asdf-standard>=1.0.1",
+  #"asdf-standard>=1.0.1",
+  "asdf-standard @ git+https://github.com/braingram/asdf-standard.git@f16",
   "asdf-transform-schemas>=0.3",
   "asdf-unit-schemas>=0.1",
   "importlib-metadata>=4.11.4",


### PR DESCRIPTION
# Description

This PR adds `float16` support to asdf. As this requires changes to the `ndarray` schema (part of the asdf standard) ~this PR currently has `asdf-standard` installed via git from the source branch for: https://github.com/asdf-format/asdf-standard/pull/411~ EDIT: a new version of `asdf-standard` was released

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
