### PR TITLE
test py312 non-devdeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       default_python: '3.10'
       envs: |
         - linux: coverage
+          name: Python 3.12 coverage
+          python-version: 3.12
+        - linux: coverage
           name: Python 3.11 coverage
           python-version: 3.11
         - linux: coverage
@@ -92,7 +95,6 @@ jobs:
         - linux: py310-devdeps-parallel
         - linux: py311-devdeps-parallel
         - linux: py312-devdeps-parallel
-          python-version: '3.12-dev'
 
   oldest:
     needs: [core, asdf-schemas]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ filterwarnings = [
 ]
 # Configuration for pytest-doctestplus
 text_file_format = 'rst'
-addopts = '--color=yes --doctest-rst -rsx'
+addopts = '--color=yes --doctest-rst -rsxfE'
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
Add a non-devdeps python 3.12 run to the CI (and update devdeps 3.12 to use released 3.12).

This PR also adds a minor change to the pytest defaults to include failed and errored tests in the summary output.

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
