### PR TITLE
fix changelog typo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,12 +7,6 @@ The ASDF Standard is at v1.6.0
 - Cleanup ``asdf.util`` including deprecating: ``human_list``
   ``resolve_name`` ``minversion`` and ``iter_subclasses`` [#1688]
 
-3.0.1 (2023-10-30)
-------------------
-
-The ASDF Standard is at v1.6.0
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 - Deprecate ``asdf.asdf`` and ``AsdfFile.resolve_and_inline`` [#1690]
 
 3.0.1 (2023-10-30)


### PR DESCRIPTION
Fix a typo in the changelog listing #1690 (which has not been released) under 3.0.1 (which has been released).