### PR TITLE
inspect asdf_standard resources to find supported versions

### DIFF
--- a/asdf/_core/_extensions.py
+++ b/asdf/_core/_extensions.py
@@ -1,4 +1,5 @@
 from asdf.extension import ManifestExtension
+from asdf.versioning import supported_versions
 
 from ._converters.complex import ComplexConverter
 from ._converters.constant import ConstantConverter
@@ -37,15 +38,7 @@ VALIDATORS = [
 ]
 
 
-MANIFEST_URIS = [
-    "asdf://asdf-format.org/core/manifests/core-1.0.0",
-    "asdf://asdf-format.org/core/manifests/core-1.1.0",
-    "asdf://asdf-format.org/core/manifests/core-1.2.0",
-    "asdf://asdf-format.org/core/manifests/core-1.3.0",
-    "asdf://asdf-format.org/core/manifests/core-1.4.0",
-    "asdf://asdf-format.org/core/manifests/core-1.5.0",
-    "asdf://asdf-format.org/core/manifests/core-1.6.0",
-]
+MANIFEST_URIS = [f"asdf://asdf-format.org/core/manifests/core-{version}" for version in supported_versions]
 
 
 EXTENSIONS = [

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -3,6 +3,7 @@ This module deals with things that change between different versions
 of the ASDF spec.
 """
 
+import importlib.resources
 from functools import total_ordering
 
 import yaml
@@ -143,15 +144,19 @@ class AsdfSpec(SimpleSpec):
         return super().__hash__()
 
 
-supported_versions = [
-    AsdfVersion("1.0.0"),
-    AsdfVersion("1.1.0"),
-    AsdfVersion("1.2.0"),
-    AsdfVersion("1.3.0"),
-    AsdfVersion("1.4.0"),
-    AsdfVersion("1.5.0"),
-    AsdfVersion("1.6.0"),
-]
+def _find_asdf_standard_version_map_versions():
+    # each version has a map
+    version_map_filenames = (
+        importlib.resources.files("asdf_standard") / "resources" / "schemas" / "stsci.edu" / "asdf"
+    ).glob("version_map-*.yaml")
+    versions = []
+    for version_map_filename in version_map_filenames:
+        _, version_string = version_map_filename.with_suffix("").name.split("-", 1)
+        versions.append(AsdfVersion(version_string))
+    return sorted(versions)
+
+
+supported_versions = _find_asdf_standard_version_map_versions()
 
 
 default_version = AsdfVersion("1.5.0")


### PR DESCRIPTION
Requires https://github.com/asdf-format/asdf-standard/pull/416 (this is currently included in the CI to verify the sequence of fixes described in that PR work). This temporary change can be removed when the linked PR is merged.

This PR changes how asdf determines supported ASDF standard versions (the standard not the `asdf-standard` python package). With this PR asdf will inspect the `asdf-standard` package and support all versions that have a `version-map` file. This should allow `asdf-standard` to add new standards without breaking asdf (more on that below).

Currently if a new standard were added that contains schema changes that shouldn't require asdf code changes one would need to:
- update asdf-standard with the new version (breaking asdf tests)
- release asdf-standard (and/or add conditional logic in asdf)
- update asdf to support the new version and increase the asdf-standard lower pin
- (hopefully remember to remove the now unneeded conditional logic)

With this PR the above new standard would require no changes in asdf. This will not be true for all ASDF standard versions as some may require changes to the converters/etc where some version of the above coordination might be required.

After this PR is merged https://github.com/asdf-format/asdf-standard/pull/415 can be brought out of draft.

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
