### PR TITLE
deprecate find_references calls during AsdfFile.__init__ and open

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ The ASDF Standard is at v1.6.0
 
 - Deprecate ``asdf.asdf`` and ``AsdfFile.resolve_and_inline`` [#1690]
 
+- Deprecate automatic calling of ``AsdfFile.find_references`` during
+  ``AsdfFile.__init__`` and ``asdf.open`` [#1708]
+
 3.0.1 (2023-10-30)
 ------------------
 

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -50,3 +50,20 @@ def test_resolve_and_inline_deprecation():
     with pytest.warns(AsdfDeprecationWarning, match="resolve_and_inline is deprecated"):
         af = asdf.AsdfFile({"arr": np.arange(42)})
         af.resolve_and_inline()
+
+
+def test_find_references_during_init_deprecation():
+    tree = {"a": 1, "b": {"$ref": "#"}}
+    with pytest.warns(AsdfDeprecationWarning, match="find_references during AsdfFile.__init__"):
+        asdf.AsdfFile(tree)
+
+
+def test_find_references_during_open_deprecation(tmp_path):
+    fn = tmp_path / "test.asdf"
+    af = asdf.AsdfFile()
+    af["a"] = 1
+    af["b"] = {"$ref": "#"}
+    af.write_to(fn)
+    with pytest.warns(AsdfDeprecationWarning, match="find_references during open"):
+        with asdf.open(fn) as af:
+            pass

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -5,6 +5,7 @@ and `JSON Pointer standard <http://tools.ietf.org/html/rfc6901>`__.
 """
 
 
+import warnings
 import weakref
 from collections.abc import Sequence
 from contextlib import suppress
@@ -12,6 +13,7 @@ from contextlib import suppress
 import numpy as np
 
 from . import generic_io, treeutil, util
+from .exceptions import AsdfDeprecationWarning
 from .util import _patched_urllib_parse
 
 __all__ = ["resolve_fragment", "Reference", "find_references", "resolve_references", "make_reference"]
@@ -104,7 +106,7 @@ class Reference:
         return item in self._get_target()
 
 
-def find_references(tree, ctx):
+def find_references(tree, ctx, _warning_msg=False):
     """
     Find all of the JSON references in the tree, and convert them into
     `Reference` objects.
@@ -112,6 +114,8 @@ def find_references(tree, ctx):
 
     def do_find(tree, json_id):
         if isinstance(tree, dict) and "$ref" in tree:
+            if _warning_msg:
+                warnings.warn(_warning_msg, AsdfDeprecationWarning)
             return Reference(tree["$ref"], json_id, asdffile=ctx)
         return tree
 

--- a/docs/asdf/deprecations.rst
+++ b/docs/asdf/deprecations.rst
@@ -16,6 +16,10 @@ Version 3.1
 ``AsdfFile.resolve_references`` and provide ``all_array_storage='inline'`` to
 ``AdsfFile.write_to`` (or ``AsdfFile.update``).
 
+Automatic calling of ``AsdfFile.find_references`` during calls to
+``AsdfFile.__init__`` and ``asdf.open``. Call ``AsdfFile.find_references`` to
+find references.
+
 Version 3.0
 ===========
 


### PR DESCRIPTION
# Description

Deprecate the automatic calling of `AsdfFile.find_references` during `AsdfFile.__init__` and `asdf.open`. A warning will only appear if a reference is found. References appear to be unused in all known downstream packages so I don't expect we will see any of these warnings. `find_references` walks and modifies (so performs a deep copy of) the tree so the eventual removal of this automatic calling should speed up most calls to `AsdfFile.__init__` and `asdf.open`.

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
