### PR TITLE
fix bug where a dict with an id causes contained refs to fail to resolve

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@
   a file and ``AsdfPackageVersionWarning`` when installed extension/manifest
   package does not match that used to write the file [#1758]
 
+- Fix bug where a dictionary containing a key ``id`` caused
+  any contained references to fail to resolve [#1716]
+
 
 3.2.0 (2024-04-05)
 ------------------

--- a/asdf/_tests/_regtests/test_1715.py
+++ b/asdf/_tests/_regtests/test_1715.py
@@ -1,0 +1,28 @@
+import pytest
+
+import asdf
+
+
+def test_id_in_tree_breaks_ref(tmp_path):
+    """
+    a dict containing id will break contained References
+
+    https://github.com/asdf-format/asdf/issues/1715
+    """
+    external_fn = tmp_path / "external.asdf"
+
+    external_tree = {"thing": 42}
+
+    asdf.AsdfFile(external_tree).write_to(external_fn)
+
+    main_fn = tmp_path / "main.asdf"
+
+    af = asdf.AsdfFile({})
+    af["id"] = "bogus"
+    af["myref"] = {"$ref": "external.asdf#/thing"}
+    af.write_to(main_fn)
+
+    with pytest.warns(asdf.exceptions.AsdfDeprecationWarning, match="find_references"):
+        with asdf.open(main_fn) as af:
+            af.resolve_references()
+            assert af["myref"] == 42

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -111,11 +111,11 @@ def find_references(tree, ctx, _warning_msg=False):
     `Reference` objects.
     """
 
-    def do_find(tree, json_id):
+    def do_find(tree):
         if isinstance(tree, dict) and "$ref" in tree:
             if _warning_msg:
                 warnings.warn(_warning_msg, AsdfDeprecationWarning)
-            return Reference(tree["$ref"], json_id, asdffile=ctx)
+            return Reference(tree["$ref"], asdffile=ctx)
         return tree
 
     return treeutil.walk_and_modify(tree, do_find, ignore_implicit_conversion=ctx._ignore_implicit_conversion)


### PR DESCRIPTION
# Description

Remove use of `json_id` in `find_references` callback passed to `walk_and_modify`.

The `json_id` argument (which stores the most recently encountered 'id' value) is primarily (perhaps only) useful for schema parsing. However, `find_references` (called on the ASDF tree) uses the `json_id` value to construct the uri for the referred object. I see no reference to this behavior in:
https://datatracker.ietf.org/doc/html/rfc6901
https://datatracker.ietf.org/doc/html/draft-pbryan-zyp-json-ref-03
https://datatracker.ietf.org/doc/html/rfc3986
and this can lead to reference resolution failure (see #1715).

Fixes #1715 

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
