### PR TITLE
Treeutil cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ The ASDF Standard is at v1.6.0
   is removed in an upcoming asdf release will be ``False`` and
   asdf will no longer by-default memory map arrays. [#1667]
 
+- Fix bug where a dictionary containing a key ``id`` caused
+  any contained references to fail to resolve [#1716]
+
 3.0.1 (2023-10-30)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@ The ASDF Standard is at v1.6.0
 - Fix bug where a dictionary containing a key ``id`` caused
   any contained references to fail to resolve [#1716]
 
+- Deprecate the following in ``asdf.treeutil``.
+  ``get_children``, ``is_container``, the ``json_id`` argument to
+  callbacks provided to ``walk_and_modify`` [#1719]
+
 3.0.1 (2023-10-30)
 ------------------
 

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -2,7 +2,7 @@ import re
 from collections import namedtuple
 
 from .schema import load_schema
-from .treeutil import get_children
+from .treeutil import _get_children
 
 
 def _filter_tree(info, filters):
@@ -290,7 +290,7 @@ class NodeSchemaInfo:
                     if parent is None:
                         info.schema = schema
 
-                    for child_identifier, child_node in get_children(t_node):
+                    for child_identifier, child_node in _get_children(t_node):
                         next_nodes.append((info, child_identifier, child_node))
 
             if len(next_nodes) == 0:

--- a/asdf/_tests/_regtests/test_1715.py
+++ b/asdf/_tests/_regtests/test_1715.py
@@ -1,0 +1,28 @@
+import pytest
+
+import asdf
+
+
+def test_id_in_tree_breaks_ref(tmp_path):
+    """
+    a dict containing id will break contained References
+
+    https://github.com/asdf-format/asdf/issues/1715
+    """
+    external_fn = tmp_path / "external.asdf"
+
+    external_tree = {"thing": 42}
+
+    asdf.AsdfFile(external_tree).write_to(external_fn)
+
+    main_fn = tmp_path / "main.asdf"
+
+    af = asdf.AsdfFile({})
+    af["id"] = "bogus"
+    af["myref"] = {"$ref": "external.asdf#/thing"}
+    af.write_to(main_fn)
+
+    with pytest.warns(asdf.exceptions.AsdfDeprecationWarning, match="find_references"):
+        with asdf.open(main_fn) as af:
+            af.resolve_references()
+            assert af["myref"] == 42

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -77,3 +77,11 @@ def test_get_children_deprecation():
 def test_is_container_deprecation():
     with pytest.warns(AsdfDeprecationWarning, match="is_container is deprecated"):
         asdf.treeutil.is_container({})
+
+
+def test_json_id_deprecation():
+    def callback(obj, json_id):
+        return obj
+
+    with pytest.warns(AsdfDeprecationWarning, match="the json_id callback argument is deprecated"):
+        asdf.treeutil.walk_and_modify({"a": 1}, callback)

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -67,3 +67,13 @@ def test_find_references_during_open_deprecation(tmp_path):
     with pytest.warns(AsdfDeprecationWarning, match="find_references during open"):
         with asdf.open(fn) as af:
             pass
+
+
+def test_get_children_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="get_children is deprecated"):
+        asdf.treeutil.get_children({})
+
+
+def test_is_container_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="is_container is deprecated"):
+        asdf.treeutil.is_container({})

--- a/asdf/_tests/test_treeutil.py
+++ b/asdf/_tests/test_treeutil.py
@@ -3,27 +3,27 @@ from asdf import treeutil
 
 def test_get_children():
     parent = ["foo", "bar"]
-    assert treeutil.get_children(parent) == [(0, "foo"), (1, "bar")]
+    assert treeutil._get_children(parent) == [(0, "foo"), (1, "bar")]
 
     parent = ("foo", "bar")
-    assert treeutil.get_children(parent) == [(0, "foo"), (1, "bar")]
+    assert treeutil._get_children(parent) == [(0, "foo"), (1, "bar")]
 
     parent = {"foo": "bar", "ding": "dong"}
-    assert sorted(treeutil.get_children(parent)) == sorted([("foo", "bar"), ("ding", "dong")])
+    assert sorted(treeutil._get_children(parent)) == sorted([("foo", "bar"), ("ding", "dong")])
 
     parent = "foo"
-    assert treeutil.get_children(parent) == []
+    assert treeutil._get_children(parent) == []
 
     parent = None
-    assert treeutil.get_children(parent) == []
+    assert treeutil._get_children(parent) == []
 
 
 def test_is_container():
     for value in [[], {}, ()]:
-        assert treeutil.is_container(value) is True
+        assert treeutil._is_container(value) is True
 
     for value in ["foo", 12, 13.9827]:
-        assert treeutil.is_container(value) is False
+        assert treeutil._is_container(value) is False
 
 
 def test_walk_and_modify_shared_references():

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -112,11 +112,11 @@ def find_references(tree, ctx, _warning_msg=False):
     `Reference` objects.
     """
 
-    def do_find(tree, json_id):
+    def do_find(tree):
         if isinstance(tree, dict) and "$ref" in tree:
             if _warning_msg:
                 warnings.warn(_warning_msg, AsdfDeprecationWarning)
-            return Reference(tree["$ref"], json_id, asdffile=ctx)
+            return Reference(tree["$ref"], asdffile=ctx)
         return tree
 
     return treeutil.walk_and_modify(tree, do_find, ignore_implicit_conversion=ctx._ignore_implicit_conversion)

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -488,7 +488,7 @@ def _load_schema_cached(url, resolver, resolve_references):
 
             return node
 
-        schema = treeutil.walk_and_modify(schema, resolve_refs)
+        schema = treeutil.walk_and_modify(schema, resolve_refs, _track_id=True)
 
     return schema
 

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -8,7 +8,7 @@ import typing
 
 from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES, format_faint, format_italic, render_tree
 from ._node_info import NodeSchemaInfo, collect_schema_info
-from .treeutil import get_children, is_container
+from .treeutil import _get_children, _is_container
 from .util import NotSet
 
 __all__ = ["AsdfSearchResult"]
@@ -184,7 +184,7 @@ class AsdfSearchResult:
                 return False
 
             if isinstance(value, typing.Pattern):
-                if is_container(node):
+                if _is_container(node):
                     # The string representation of a container object tends to
                     # include the child object values, but that's probably not
                     # what searchers want.
@@ -383,7 +383,7 @@ def _walk_tree_breadth_first(root_identifiers, root_node, callback):
             if (isinstance(node, (dict, list, tuple)) or NodeSchemaInfo.traversable(node)) and id(node) in seen:
                 continue
             tnode = node.__asdf_traverse__() if NodeSchemaInfo.traversable(node) else node
-            children = get_children(tnode)
+            children = _get_children(tnode)
             callback(identifiers, parent, node, [c for _, c in children])
             next_nodes.extend([([*identifiers, i], node, c) for i, c in children])
             seen.add(id(node))

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -220,7 +220,7 @@ class _RemoveNode:
 RemoveNode = _RemoveNode()
 
 
-def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=True, _context=None):
+def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=True, _context=None, _track_id=False):
     """Modify a tree by walking it with a callback function.  It also has
     the effect of doing a deep copy.
 
@@ -234,14 +234,16 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
         one or two arguments:
 
         - an instance from the tree
-        - a json id (optional)
+        - a json id (optional) DEPRECATED
 
         It may return a different instance in order to modify the
         tree.  If the singleton instance `~asdf.treeutil._RemoveNode`
         is returned, the node will be removed from the tree.
 
-        The json id is the context under which any relative URLs
-        should be resolved.  It may be `None` if no ids are in the file
+        The json id optional argument is deprecated. This function
+        will no longer track ids. The json id is the context under which
+        any relative URLs should be resolved.  It may be `None` if no
+        ids are in the file
 
         The tree is traversed depth-first, with order specified by the
         ``postorder`` argument.
@@ -266,7 +268,10 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
 
     """
     callback_arity = callback.__code__.co_argcount
-    if callback_arity < 1 or callback_arity > 2:
+    if callback_arity == 2:
+        if not _track_id:
+            warnings.warn("the json_id callback argument is deprecated", AsdfDeprecationWarning)
+    elif callback_arity != 1:
         msg = "Expected callback to accept one or two arguments"
         raise ValueError(msg)
 

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -7,7 +7,7 @@ import warnings
 from contextlib import contextmanager
 
 from . import tagged
-from .exceptions import AsdfWarning
+from .exceptions import AsdfDeprecationWarning, AsdfWarning
 
 __all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container", "PendingValue", "RemoveNode"]
 
@@ -420,7 +420,7 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
         # call to walk_and_modify.
 
 
-def get_children(node):
+def _get_children(node):
     """
     Retrieve the children (and their dict keys or list/tuple indices) of
     an ASDF tree node.
@@ -446,7 +446,15 @@ def get_children(node):
     return []
 
 
-def is_container(node):
+def get_children(node):
+    warnings.warn("asdf.treeutil.get_children is deprecated", AsdfDeprecationWarning)
+    return _get_children(node)
+
+
+get_children.__doc__ = _get_children.__doc__
+
+
+def _is_container(node):
     """
     Determine if an ASDF tree node is an instance of a "container" type
     (i.e., value may contain child nodes).
@@ -462,3 +470,11 @@ def is_container(node):
         True if node is a container, False otherwise
     """
     return isinstance(node, (dict, list, tuple))
+
+
+def is_container(node):
+    warnings.warn("asdf.treeutil.is_container is deprecated", AsdfDeprecationWarning)
+    return _is_container(node)
+
+
+is_container.__doc__ = _is_container.__doc__

--- a/docs/asdf/deprecations.rst
+++ b/docs/asdf/deprecations.rst
@@ -20,6 +20,13 @@ Automatic calling of ``AsdfFile.find_references`` during calls to
 ``AsdfFile.__init__`` and ``asdf.open``. Call ``AsdfFile.find_references`` to
 find references.
 
+``asdf.treeutil.get_children`` and ``asdf.treeutil.is_container`` are deprecated.
+These were never intended to be public.
+
+The support for callbacks with a ``json_id`` to ``asdf.treeutil.walk_and_modify``
+is deprecated. Please use a different library or your own code to track ids during
+tree modifications.
+
 Version 3.0
 ===========
 


### PR DESCRIPTION
# Description

Based off changes in: https://github.com/asdf-format/asdf/pull/1716

~Requires: https://github.com/spacetelescope/stdatamodels/pull/244~ Merged

This PR is work towards cleaning up `asdf.treeutil`. By:
- deprecating `get_children` and `is_container`
- deprecate the `json_id` argument for callbacks provided to `walk_and_modify` (more on this below)

The tracking needed for and the use of `json_id` opens up the possibilities for bugs when not parsing schemas (see #1715 and https://github.com/spacetelescope/stdatamodels/pull/244). Removing this feature would make further improvements to `treeutil` easier (like those that might be required for superdictionaries).

A separate PR will attempt to deprecate `ignore_implicit_conversion` which might include deprecating the AsdfFile argument [ignore_implicit_conversion](https://github.com/asdf-format/asdf/blob/45b166188b58f8516f07f3f4c3399c0a10e61377/asdf/_asdf.py#L75C9-L75C35). This will require further investigation and more extensive changes.

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
