### PR TITLE
deprecate ignore_implicit_conversion and implicit_conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@
   ``AsdfFile.set_array_save_base`` and
   ``SerializationContext.set_array_save_base`` [#1753]
 
+- Deprecate ``ignore_implicit_conversion`` and "implicit conversion" [#1724]
+
 
 3.2.0 (2024-04-05)
 ------------------

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -74,7 +74,7 @@ class AsdfFile:
         version=None,
         ignore_version_mismatch=True,
         ignore_unrecognized_tag=False,
-        ignore_implicit_conversion=False,
+        ignore_implicit_conversion=NotSet,
         copy_arrays=False,
         memmap=NotSet,
         lazy_load=True,
@@ -110,6 +110,7 @@ class AsdfFile:
             `False` by default.
 
         ignore_implicit_conversion : bool
+            DEPRECATED
             When `True`, do not raise warnings when types in the tree are
             implicitly converted into a serializable object. The motivating
             case for this is currently ``namedtuple``, which cannot be serialized

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -82,7 +82,6 @@ def test_find_references_during_open_deprecation(tmp_path):
             pass
 
 
-<<<<<<< HEAD
 def test_asdf_util_is_primitive_deprecation():
     with pytest.warns(AsdfDeprecationWarning, match="asdf.util.is_primitive is deprecated"):
         asdf.util.is_primitive(1)

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -82,6 +82,7 @@ def test_find_references_during_open_deprecation(tmp_path):
             pass
 
 
+<<<<<<< HEAD
 def test_asdf_util_is_primitive_deprecation():
     with pytest.warns(AsdfDeprecationWarning, match="asdf.util.is_primitive is deprecated"):
         asdf.util.is_primitive(1)
@@ -134,3 +135,15 @@ def test_format_tag_deprecation():
 def test_asdf_util_filepath_to_url_deprecation(tmp_path):
     with pytest.warns(AsdfDeprecationWarning, match="asdf.util.filepath_to_url is deprecated"):
         asdf.util.filepath_to_url(str(tmp_path))
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_AsdfFile_ignore_implicit_conversion_deprecation(value):
+    with pytest.warns(AsdfDeprecationWarning, match="ignore_implicit_conversion is deprecated"):
+        asdf.AsdfFile({"a": 1}, ignore_implicit_conversion=value)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_walk_and_modify_ignore_implicit_conversion_deprecation(value):
+    with pytest.warns(AsdfDeprecationWarning, match="ignore_implicit_conversion is deprecated"):
+        asdf.treeutil.walk_and_modify({}, lambda obj: obj, ignore_implicit_conversion=value)

--- a/asdf/_tests/test_yaml.py
+++ b/asdf/_tests/test_yaml.py
@@ -198,7 +198,11 @@ def test_implicit_conversion_warning():
 
     tree = {"val": nt(1, 2, np.ones(3))}
 
-    with pytest.warns(AsdfWarning, match=r"Failed to serialize instance"), asdf.AsdfFile(tree):
+    with (
+        pytest.warns(AsdfWarning, match=r"Failed to serialize instance"),
+        pytest.warns(AsdfDeprecationWarning, match=r"implicit conversion is deprecated"),
+        asdf.AsdfFile(tree),
+    ):
         pass
 
     with multi_warn(AsdfDeprecationWarning, ["ignore_implicit_conversion", "implicit conversion is deprecated"]):

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -7,7 +7,8 @@ import warnings
 from contextlib import contextmanager
 
 from . import tagged
-from .exceptions import AsdfWarning
+from .exceptions import AsdfDeprecationWarning, AsdfWarning
+from .util import NotSet
 
 __all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container", "PendingValue", "RemoveNode"]
 
@@ -220,7 +221,7 @@ class _RemoveNode:
 RemoveNode = _RemoveNode()
 
 
-def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=True, _context=None):
+def walk_and_modify(top, callback, ignore_implicit_conversion=NotSet, postorder=True, _context=None):
     """Modify a tree by walking it with a callback function.  It also has
     the effect of doing a deep copy.
 
@@ -253,6 +254,7 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
         parents first.  Defaults to `True`.
 
     ignore_implicit_conversion : bool
+        DEPRECATED
         Controls whether warnings should be issued when implicitly converting a
         given type instance in the tree into a serializable object. The primary
         case for this is currently ``namedtuple``.
@@ -265,6 +267,10 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
         The modified tree.
 
     """
+    if ignore_implicit_conversion is NotSet:
+        ignore_implicit_conversion = False
+    else:
+        warnings.warn("ignore_implicit_conversion is deprecated", AsdfDeprecationWarning)
     callback_arity = callback.__code__.co_argcount
     if callback_arity < 1 or callback_arity > 2:
         msg = "Expected callback to accept one or two arguments"
@@ -359,6 +365,7 @@ def walk_and_modify(top, callback, ignore_implicit_conversion=False, postorder=T
             if not ignore_implicit_conversion:
                 warnings.warn(f"Failed to serialize instance of {type(node)}, converting to list instead", AsdfWarning)
             result = contents
+            warnings.warn("implicit conversion is deprecated. Please instead use a Converter.", AsdfDeprecationWarning)
 
         return result
 

--- a/docs/asdf/deprecations.rst
+++ b/docs/asdf/deprecations.rst
@@ -6,6 +6,19 @@
 Deprecations
 ************
 
+Version 3.3
+===========
+
+``asdf.util.filepath_to_url`` is deprecated. Please use ``pathlib.Path.to_uri``.
+
+The ``ignore_implicit_conversion`` argument for ``AsdfFile`` and
+``treeutil.walk_and_modify`` is deprecated. "implicit conversion" is also
+deprecated. This referred to the behavior where certain types (namedtuple)
+were silently (or with a warning depending on the ``ignore_implicit_conversion``
+setting) converted to a list when added to an asdf tree. As these types
+(namedtuple) can be supported by a ``Converter`` this "implicit conversion"
+will be removed.
+
 Version 3.1
 ===========
 
@@ -32,8 +45,6 @@ be issued on a failed validation during the following methods:
 * ``AsdfFile.__init__`` (when the ``tree`` argument is provided)
 
 Providing ``kwargs`` to ``AsdfFile.resolve_references`` does nothing and is deprecated.
-
-``asdf.util.filepath_to_url`` is deprecated. Please use ``pathlib.Path.to_uri``.
 
 Version 3.0
 ===========


### PR DESCRIPTION
# Description

This is work towards fixing #1723

This PR deprecates "implicit conversion" and the flag controlling warning messages when this behavior occurs (`ignore_implicit_conversion`). See the above issue for more details. In brief, this prevents extensions from adding support for `namedtuple` classes.

The removal of this feature (after the deprecation period, which this PR will start) will mean that attempting to add a `namedtuple` to the asdf tree (without implementing a converter for the `namedtuple`) will result in an error. The effectively drops the "support" we currently have for `namedtuple` (which does not roundtrip, loses all `namedtuple` specifics and saves these instances as lists). User code that wishes to continue to support `namedtuple` instances will need to:
- convert them all to lists prior to saving
- implement a converter for their `namedtuple` classes to allow roundtripping

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
