### PR TITLE
require pytest 7+ update for pytest 8.1.dev

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ The ASDF Standard is at v1.6.0
   of an ASDF file (with the option ``tagged`` to load the contents
   as a tree of ``asdf.tagged.Tagged`` instances to preserve tags) [#1700]
 
+- Require pytest 7+ and update asdf pytest plugin to be compatible
+  with the current development version of pytest (8.1) [#1731]
+
 3.0.1 (2023-10-30)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ tests = [
   "fsspec[http]>=2022.8.2",
   "lz4>=0.10",
   "psutil",
-  "pytest>=6",
+  "pytest>=7",
   "pytest-doctestplus",
   "pytest-remotedata",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,9 @@ deps =
     numpydev: cython
     oldestdeps: minimum_dependencies
     parallel: pytest-xdist
-    pytestdev: pytest>=0.0.dev0
+    pytestdev: git+https://github.com/pytest-dev/pytest
+# released versions of doctestplus aren't compatible with pytest-dev
+    pytestdev: git+https://github.com/scientific-python/pytest-doctestplus
 extras = all,tests
 # astropy will complain if the home directory is missing
 pass_env = HOME


### PR DESCRIPTION
This PR increases the minimum required pytest to 7+, updates the asdf pytest plugin for changes in pytest 8.1 (the current development version) and updates the `pytestdev` tox factor to test against the github/development version (instead of any pre-release).

Fixes https://github.com/asdf-format/asdf/issues/1730

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
