### PR TITLE
fix yaml.constructor.ConstructorError import

### DIFF
--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -175,7 +175,7 @@ class AsdfLoader(_yaml_base_loader):
         yield omap
         if not isinstance(node, yaml.SequenceNode):
             msg = "while constructing an ordered map"
-            raise yaml.ConstructorError(
+            raise yaml.constructor.ConstructorError(
                 msg,
                 node.start_mark,
                 f"expected a sequence, but found {node.id}",
@@ -184,7 +184,7 @@ class AsdfLoader(_yaml_base_loader):
         for subnode in node.value:
             if not isinstance(subnode, yaml.MappingNode):
                 msg = "while constructing an ordered map"
-                raise yaml.ConstructorError(
+                raise yaml.constructor.ConstructorError(
                     msg,
                     node.start_mark,
                     f"expected a mapping of length 1, but found {subnode.id}",
@@ -192,10 +192,10 @@ class AsdfLoader(_yaml_base_loader):
                 )
             if len(subnode.value) != 1:
                 msg = "while constructing an ordered map"
-                raise yaml.ConstructorError(
+                raise yaml.constructor.ConstructorError(
                     msg,
                     node.start_mark,
-                    f"expected a single mapping item, but found {len(subnode.value): %d} items",
+                    f"expected a single mapping item, but found {len(subnode.value)} items",
                     subnode.start_mark,
                 )
             key_node, value_node = subnode.value[0]


### PR DESCRIPTION
# Description

This PR updates yamlutil to use `ConstructorError` from `yaml.constructor` instead of `yaml` (where it does not appear to be available in yaml 6.0 (and likely many earlier versions). This change is compatible with our minimum yaml version (5.4.1): https://github.com/yaml/pyyaml/blob/b79e34b37e676371a6a104970a8a944fb514b679/lib/yaml/constructor.py#L8

A parametrized test was added to cover the code that was updated (no test appears to have been covering these `raises`).

Fixes #1713

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
