### PR TITLE
validate tagged objects using schema for tag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@
   extension was created from a manifest registered with a uri that
   does not match the id in the manifest [#1785]
 
+- When using a custom schema for validation, also validate using the
+  schema associated with the tag for a ``Tagged`` object [#1737]
+
 
 3.2.0 (2024-04-05)
 ------------------

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -20,7 +20,7 @@ def test_history():
     )
     assert len(ff.tree["history"]["entries"]) == 1
 
-    with pytest.raises(ValidationError, match=r".* is not valid under any of the given schemas"):
+    with pytest.raises(ValidationError, match=r"'name' is a required property"):
         ff.add_history_entry("That happened", {"author": "John Doe", "version": "2.0"})
     assert len(ff.tree["history"]["entries"]) == 1
 


### PR DESCRIPTION
Passing a `Tagged` object to a validator with a custom schema fails to validate the `Tagged` object using the schema associated with the tag.

This bug is impacting `roman_datamodels` (which uses this pattern for assignment validation). Without this PR the following will not raise a `ValidationError`:
```
import roman_datamodels.maker_utils

m = roman_datamodels.datamodels.ImageModel(roman_datamodels.maker_utils.mk_level2_image())
inst = m.meta.instrument
inst['name'] = 'a'
m.meta.instrument = inst
```
With this PR a `ValidationError` is raised (`'a' is not one of ['WFI']`).

This PR adds a test for that issue and fixes it by shuffling around a few items in the validator (so that tags trigger schema lookups even if a custom schema was provided to the validator).

This shuffling had the side effect of changing the validation error for one test (`test_history`) to what looks like a more helpful message.

This PR includes some changes from https://github.com/asdf-format/asdf/pull/1729 which should be merged first.

Running roman regtests as this will change how validation on assignment behaves: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/605/

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
