### PR TITLE
fix __asdf_traverse__ for non-tagged object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+3.3.0 (unreleased)
+------------------
+
+- Fix ``__asdf_traverse__`` for non-tagged objects [#1739]
+
 3.2.0 (2024-04-05)
 ------------------
 

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -287,7 +287,9 @@ class NodeSchemaInfo:
                                 info.set_schema_from_node(node, extension_manager)
                             except KeyError:
                                 # if _tag is not a valid tag, no schema will be found
-                                # and a KeyError will be raised
+                                # and a KeyError will be raised. We don't raise the KeyError
+                                # (or another exception) here as the node (object) might
+                                # be using _tag for a non-ASDF purpose.
                                 pass
 
                     else:

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -282,7 +282,13 @@ class NodeSchemaInfo:
 
                     if cls.traversable(node):
                         t_node = node.__asdf_traverse__()
-                        info.set_schema_from_node(node, extension_manager)
+                        if hasattr(node, "_tag") and isinstance(node._tag, str):
+                            try:
+                                info.set_schema_from_node(node, extension_manager)
+                            except KeyError:
+                                # if _tag is not a valid tag, no schema will be found
+                                # and a KeyError will be raised
+                                pass
 
                     else:
                         t_node = node

--- a/asdf/_tests/_regtests/test_1738.py
+++ b/asdf/_tests/_regtests/test_1738.py
@@ -29,6 +29,8 @@ def test_info_on_non_tagged_asdf_traverse_object():
 
     # this should work even if _tag exists (and is not a tag)
     c._tag = {}
+    af.info()
     assert af.search(type_=int).paths == ["root['c'][0]", "root['c'][1]", "root['c'][2]"]
     c._tag = "a"
+    af.info()
     assert af.search(type_=int).paths == ["root['c'][0]", "root['c'][1]", "root['c'][2]"]

--- a/asdf/_tests/_regtests/test_1738.py
+++ b/asdf/_tests/_regtests/test_1738.py
@@ -1,0 +1,34 @@
+import asdf
+
+
+def test_info_on_non_tagged_asdf_traverse_object():
+    """
+    Calling info with a tree containing an object that implements
+    __asdf_traverse__ but does not have a _tag results in an
+    error
+
+    https://github.com/asdf-format/asdf/issues/1738
+    """
+
+    class MyContainer:
+        def __init__(self, data):
+            self.data = data
+
+        def __asdf_traverse__(self):
+            return self.data
+
+    c = MyContainer([1, 2, 3])
+    af = asdf.AsdfFile()
+    af["c"] = c
+
+    # info should not error out
+    af.info()
+
+    # and search should work with the container
+    assert af.search(type_=int).paths == ["root['c'][0]", "root['c'][1]", "root['c'][2]"]
+
+    # this should work even if _tag exists (and is not a tag)
+    c._tag = {}
+    assert af.search(type_=int).paths == ["root['c'][0]", "root['c'][1]", "root['c'][2]"]
+    c._tag = "a"
+    assert af.search(type_=int).paths == ["root['c'][0]", "root['c'][1]", "root['c'][2]"]


### PR DESCRIPTION
# Description

This PR adds a check for a `_tag` attribute before attempting to fetch schema for a node during `NodeSchemaInfo` tree traversal.

The current code assumes that any object implementing `__asdf_traverse__` also has a `_tag` attribute which contains a valid tag.

"duck typing" was used here (instead of checking for `isinstance(Tagged)` as `roman_datamodels` defines non-Tagged objects that contain valid `_tag` attributes.

Fixes #1738

The weldx failure is unrelated (caused by a new pandas version) the roman_datamodels failure is addressed in: https://github.com/asdf-format/asdf/pull/1748

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
