### PR TITLE
Deprecate `AsdfFile.version_map`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ The ASDF Standard is at v1.6.0
 - Only show ``str`` representation during ``info`` and ``search``
   if it contains a single line (and does not fail)  [#1748]
 
+- Deprecate ``AsdfFile.version_map`` [#1745]
+
 3.0.1 (2023-10-30)
 ------------------
 

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -258,7 +258,7 @@ class AsdfFile:
 
     @property
     def version_map(self):
-        return versioning.get_version_map(self.version_string)
+        return versioning._get_version_map(self.version_string)
 
     @property
     def extensions(self):

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -750,6 +750,10 @@ class AsdfFile:
             msg = f"Unparsable version in ASDF file: {parts[1]}"
             raise ValueError(msg) from err
 
+        if version != versioning._FILE_FORMAT_VERSION:
+            msg = f"Unsupported ASDF file format version {version}"
+            raise ValueError(msg)
+
         return version
 
     @classmethod
@@ -825,13 +829,15 @@ class AsdfFile:
                 msg = "Does not appear to be a ASDF file."
                 raise ValueError(msg) from e
             self._file_format_version = cls._parse_header_line(header_line)
-            self.version = self.file_format_version
 
             self._comments = cls._read_comment_section(fd)
 
             version = cls._find_asdf_version_in_comments(self._comments)
             if version is not None:
                 self.version = version
+            else:
+                # If no ASDF_STANDARD comment is found...
+                self.version = versioning.AsdfVersion("1.0.0")
 
             # Now that version is set for good, we can add any additional
             # extensions, which may have narrow ASDF Standard version

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -259,6 +259,10 @@ class AsdfFile:
 
     @property
     def version_map(self):
+        warnings.warn(
+            "AsdfFile.version_map is deprecated. Please use the extension_manager",
+            AsdfDeprecationWarning,
+        )
         return versioning._get_version_map(self.version_string)
 
     @property

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -925,7 +925,7 @@ class AsdfFile:
     def _write_tree(self, tree, fd, pad_blocks):
         fd.write(constants.ASDF_MAGIC)
         fd.write(b" ")
-        fd.write(self.version_map["FILE_FORMAT"].encode("ascii"))
+        fd.write(f"{self.file_format_version}".encode("ascii"))
         fd.write(b"\n")
 
         fd.write(b"#")

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -143,8 +143,8 @@ class AsdfFile:
         """
         self._fname = ""
 
-        # only 1 version of the file format exists
-        self._file_format_version = versioning.AsdfVersion("1.0.0")
+        # make a new AsdfVersion instance here so files don't share the same instance
+        self._file_format_version = versioning.AsdfVersion(versioning._FILE_FORMAT_VERSION)
 
         # Don't use the version setter here; it tries to access
         # the extensions, which haven't been assigned yet.

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -143,6 +143,9 @@ class AsdfFile:
         """
         self._fname = ""
 
+        # only 1 version of the file format exists
+        self.file_format_version = versioning.AsdfVersion("1.0.0")
+
         # Don't use the version setter here; it tries to access
         # the extensions, which haven't been assigned yet.
         if version is None:
@@ -166,8 +169,6 @@ class AsdfFile:
         # Set of (string, string) tuples representing tag version mismatches
         # that we've already warned about for this file.
         self._warned_tag_pairs = set()
-
-        self._file_format_version = None
 
         # Context of a call to treeutil.walk_and_modify, needed in the AsdfFile
         # in case walk_and_modify is re-entered by extension code (via
@@ -467,13 +468,6 @@ class AsdfFile:
                     break
             else:
                 tree["history"]["extensions"].append(ext_meta)
-
-    @property
-    def file_format_version(self):
-        if self._file_format_version is None:
-            return versioning.AsdfVersion(self.version_map["FILE_FORMAT"])
-
-        return self._file_format_version
 
     def close(self):
         """
@@ -822,8 +816,8 @@ class AsdfFile:
             except DelimiterNotFoundError as e:
                 msg = "Does not appear to be a ASDF file."
                 raise ValueError(msg) from e
-            self._file_format_version = cls._parse_header_line(header_line)
-            self.version = self._file_format_version
+            self.file_format_version = cls._parse_header_line(header_line)
+            self.version = self.file_format_version
 
             self._comments = cls._read_comment_section(fd)
 

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -144,7 +144,7 @@ class AsdfFile:
         self._fname = ""
 
         # only 1 version of the file format exists
-        self.file_format_version = versioning.AsdfVersion("1.0.0")
+        self._file_format_version = versioning.AsdfVersion("1.0.0")
 
         # Don't use the version setter here; it tries to access
         # the extensions, which haven't been assigned yet.
@@ -468,6 +468,10 @@ class AsdfFile:
                     break
             else:
                 tree["history"]["extensions"].append(ext_meta)
+
+    @property
+    def file_format_version(self):
+        return self._file_format_version
 
     def close(self):
         """
@@ -816,7 +820,7 @@ class AsdfFile:
             except DelimiterNotFoundError as e:
                 msg = "Does not appear to be a ASDF file."
                 raise ValueError(msg) from e
-            self.file_format_version = cls._parse_header_line(header_line)
+            self._file_format_version = cls._parse_header_line(header_line)
             self.version = self.file_format_version
 
             self._comments = cls._read_comment_section(fd)

--- a/asdf/_tests/_helpers.py
+++ b/asdf/_tests/_helpers.py
@@ -22,13 +22,9 @@ except ImportError:
 import numpy as np
 
 import asdf
-from asdf import versioning
 from asdf._asdf import AsdfFile, _get_asdf_library_info
 from asdf.exceptions import AsdfConversionWarning
 from asdf.tags.core import AsdfObject
-from asdf.versioning import (
-    AsdfVersion,
-)
 
 from .httpserver import RangeHTTPServer
 
@@ -42,7 +38,6 @@ __all__ = [
     "get_test_data_path",
     "assert_tree_match",
     "assert_roundtrip_tree",
-    "yaml_to_asdf",
     "get_file_sizes",
     "display_warnings",
 ]
@@ -278,57 +273,6 @@ def _assert_roundtrip_tree(
         assert_tree_match(tree, ff.tree, ff, funcname=tree_match_func)
         if asdf_check_func:
             asdf_check_func(ff)
-
-
-def yaml_to_asdf(yaml_content, yaml_headers=True, standard_version=None):
-    """
-    Given a string of YAML content, adds the extra pre-
-    and post-amble to make it an ASDF file.
-
-    Parameters
-    ----------
-    yaml_content : string
-
-    yaml_headers : bool, optional
-        When True (default) add the standard ASDF YAML headers.
-
-    Returns
-    -------
-    buff : io.BytesIO()
-        A file-like object containing the ASDF-like content.
-    """
-    if isinstance(yaml_content, str):
-        yaml_content = yaml_content.encode("utf-8")
-
-    buff = io.BytesIO()
-
-    if standard_version is None:
-        standard_version = versioning.default_version
-
-    standard_version = AsdfVersion(standard_version)
-
-    yaml_version = ".".join([str(v) for v in versioning._YAML_VERSION])
-    af = asdf.AsdfFile(version=standard_version)
-    tree_converter = af.extension_manager.get_converter_for_type(asdf.tags.core.AsdfObject)
-    tree_version = asdf.versioning.split_tag_version(tree_converter.tags[0])[1]
-
-    if yaml_headers:
-        buff.write(
-            f"""#ASDF {versioning._FILE_FORMAT_VERSION}
-#ASDF_STANDARD {standard_version}
-%YAML {yaml_version}
-%TAG ! tag:stsci.edu:asdf/
---- !core/asdf-{tree_version}
-""".encode(
-                "ascii",
-            ),
-        )
-    buff.write(yaml_content)
-    if yaml_headers:
-        buff.write(b"\n...\n")
-
-    buff.seek(0)
-    return buff
 
 
 def get_file_sizes(dirname):

--- a/asdf/_tests/_helpers.py
+++ b/asdf/_tests/_helpers.py
@@ -30,8 +30,8 @@ from asdf.exceptions import AsdfConversionWarning
 from asdf.tags.core import AsdfObject
 from asdf.versioning import (
     AsdfVersion,
+    _get_version_map,
     asdf_standard_development_version,
-    get_version_map,
     split_tag_version,
     supported_versions,
 )
@@ -313,7 +313,7 @@ def yaml_to_asdf(yaml_content, yaml_headers=True, standard_version=None):
 
     standard_version = AsdfVersion(standard_version)
 
-    vm = get_version_map(standard_version)
+    vm = _get_version_map(standard_version)
     file_format_version = vm["FILE_FORMAT"]
     yaml_version = vm["YAML_VERSION"]
     tree_version = vm["tags"]["tag:stsci.edu:asdf/core/asdf"]
@@ -442,7 +442,7 @@ def _assert_extension_type_correctness(extension, extension_type, resolver):
     for sibling in extension_type.versioned_siblings:
         tag_base, version = split_tag_version(sibling.yaml_tag)
         for asdf_standard_version in asdf_standard_versions:
-            vm = get_version_map(asdf_standard_version)
+            vm = _get_version_map(asdf_standard_version)
             if tag_base in vm["tags"] and AsdfVersion(vm["tags"][tag_base]) == version:
                 types_to_check.append(sibling)
                 break

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -122,7 +122,10 @@ def test_default_version():
     See https://github.com/asdf-format/asdf/issues/364
     """
     ff = asdf.AsdfFile()
-    assert ff.file_format_version == versioning.AsdfVersion("1.0.0")
+    assert ff.file_format_version == versioning._FILE_FORMAT_VERSION
+
+    # make sure these are different AsdfVersion instances
+    assert ff.file_format_version is not versioning._FILE_FORMAT_VERSION
 
 
 def test_update_exceptions(tmp_path):

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -121,11 +121,8 @@ def test_default_version():
     """
     See https://github.com/asdf-format/asdf/issues/364
     """
-
-    version_map = versioning._get_version_map(versioning.default_version)
-
     ff = asdf.AsdfFile()
-    assert ff.file_format_version == version_map["FILE_FORMAT"]
+    assert ff.file_format_version == versioning.AsdfVersion("1.0.0")
 
 
 def test_update_exceptions(tmp_path):

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -122,7 +122,7 @@ def test_default_version():
     See https://github.com/asdf-format/asdf/issues/364
     """
 
-    version_map = versioning.get_version_map(versioning.default_version)
+    version_map = versioning._get_version_map(versioning.default_version)
 
     ff = asdf.AsdfFile()
     assert ff.file_format_version == version_map["FILE_FORMAT"]

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -14,8 +14,9 @@ import asdf
 from asdf import config_context, get_config, treeutil, versioning
 from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning, ValidationError
 from asdf.extension import ExtensionProxy
+from asdf.testing.helpers import yaml_to_asdf
 
-from ._helpers import assert_no_warnings, assert_roundtrip_tree, assert_tree_match, yaml_to_asdf
+from ._helpers import assert_no_warnings, assert_roundtrip_tree, assert_tree_match
 
 RNG = np.random.default_rng(97)
 

--- a/asdf/_tests/test_array_blocks.py
+++ b/asdf/_tests/test_array_blocks.py
@@ -755,7 +755,7 @@ def test_invalid_block_index_offset(block_index_index):
         stream=buff,
         explicit_start=True,
         explicit_end=True,
-        version=(1, 1),
+        version=asdf.versioning._YAML_VERSION,
         allow_unicode=True,
         encoding="utf-8",
     )

--- a/asdf/_tests/test_array_blocks.py
+++ b/asdf/_tests/test_array_blocks.py
@@ -749,14 +749,13 @@ def test_invalid_block_index_offset(block_index_index):
     block_index_start = block_index_header_start + len(constants.INDEX_HEADER)
     block_index = yaml.load(bs[block_index_start:], yaml.SafeLoader)
     block_index[block_index_index] -= 4
-    yaml_version = tuple(int(x) for x in ff.version_map["YAML_VERSION"].split("."))
     buff.seek(block_index_start)
     yaml.dump(
         block_index,
         stream=buff,
         explicit_start=True,
         explicit_end=True,
-        version=yaml_version,
+        version=(1, 1),
         allow_unicode=True,
         encoding="utf-8",
     )

--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -5,9 +5,10 @@ import pytest
 from asdf import config_context
 from asdf._asdf import AsdfFile, open_asdf
 from asdf._entry_points import get_extensions
-from asdf._tests._helpers import assert_no_warnings, assert_tree_match, yaml_to_asdf
+from asdf._tests._helpers import assert_no_warnings, assert_tree_match
 from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
 from asdf.extension import ExtensionProxy
+from asdf.testing.helpers import yaml_to_asdf
 from asdf.versioning import AsdfVersion
 
 
@@ -215,7 +216,7 @@ def test_reading_extension_metadata():
 
         # Test missing history:
         content = """
-        foo: bar
+foo: bar
         """
         buff = yaml_to_asdf(content)
         with assert_no_warnings():
@@ -223,24 +224,24 @@ def test_reading_extension_metadata():
 
         # Test the old history format:
         content = """
-        history:
-          - !core/history_entry-1.0.0
-            description: Once upon a time, there was a carnivorous panda.
-          - !core/history_entry-1.0.0
-            description: This entry intentionally left blank.
-        foo: bar
+history:
+  - !core/history_entry-1.0.0
+    description: Once upon a time, there was a carnivorous panda.
+  - !core/history_entry-1.0.0
+    description: This entry intentionally left blank.
+foo: bar
         """
-        buff = yaml_to_asdf(content, standard_version="1.0.0")
+        buff = yaml_to_asdf(content, version="1.0.0")
         with assert_no_warnings():
             open_asdf(buff)
 
         # Test matching by URI:
         content = """
-        history:
-          extensions:
-            - !core/extension_metadata-1.0.0
-              extension_uri: asdf://somewhere.org/extensions/foo-1.0
-              extension_class: some.unrecognized.extension.class.Name
+history:
+  extensions:
+    - !core/extension_metadata-1.0.0
+      extension_uri: asdf://somewhere.org/extensions/foo-1.0
+      extension_class: some.unrecognized.extension.class.Name
         """
         buff = yaml_to_asdf(content)
         with assert_no_warnings():
@@ -248,10 +249,10 @@ def test_reading_extension_metadata():
 
         # Test matching by legacy class name:
         content = """
-        history:
-          extensions:
-            - !core/extension_metadata-1.0.0
-              extension_class: some.legacy.class.Name
+history:
+  extensions:
+    - !core/extension_metadata-1.0.0
+      extension_class: some.legacy.class.Name
         """
         buff = yaml_to_asdf(content)
         with assert_no_warnings():
@@ -260,11 +261,11 @@ def test_reading_extension_metadata():
         # Warn when the URI is missing, even if there's
         # a class name match:
         content = f"""
-        history:
-          extensions:
-            - !core/extension_metadata-1.0.0
-              extension_uri: some-missing-URI
-              extension_class: {extension_with_uri.class_name}
+history:
+  extensions:
+    - !core/extension_metadata-1.0.0
+      extension_uri: some-missing-URI
+      extension_class: {extension_with_uri.class_name}
         """
         buff = yaml_to_asdf(content)
         with pytest.warns(AsdfWarning, match=r"URI 'some-missing-URI'"):
@@ -272,10 +273,10 @@ def test_reading_extension_metadata():
 
         # Warn when the class name is missing:
         content = """
-        history:
-          extensions:
-            - !core/extension_metadata-1.0.0
-              extension_class: some.missing.class.Name
+history:
+  extensions:
+    - !core/extension_metadata-1.0.0
+      extension_class: some.missing.class.Name
         """
         buff = yaml_to_asdf(content)
         with pytest.warns(AsdfWarning, match=r"class 'some.missing.class.Name'"):
@@ -283,14 +284,14 @@ def test_reading_extension_metadata():
 
         # Warn when the package version is older:
         content = """
-        history:
-          extensions:
-            - !core/extension_metadata-1.0.0
-              extension_uri: asdf://somewhere.org/extensions/foo-1.0
-              extension_class: some.class.Name
-              software: !core/software-1.0.0
-                name: foo
-                version: 9.2.4
+history:
+  extensions:
+    - !core/extension_metadata-1.0.0
+      extension_uri: asdf://somewhere.org/extensions/foo-1.0
+      extension_class: some.class.Name
+      software: !core/software-1.0.0
+        name: foo
+        version: 9.2.4
         """
         buff = yaml_to_asdf(content)
         with pytest.warns(AsdfWarning, match=r"older package"):
@@ -298,14 +299,14 @@ def test_reading_extension_metadata():
 
         # Shouldn't warn when the package version is later:
         content = """
-        history:
-          extensions:
-            - !core/extension_metadata-1.0.0
-              extension_uri: asdf://somewhere.org/extensions/foo-1.0
-              extension_class: some.class.Name
-              software: !core/software-1.0.0
-                name: foo
-                version: 0.1.2
+history:
+  extensions:
+    - !core/extension_metadata-1.0.0
+      extension_uri: asdf://somewhere.org/extensions/foo-1.0
+      extension_class: some.class.Name
+      software: !core/software-1.0.0
+        name: foo
+        version: 0.1.2
         """
         buff = yaml_to_asdf(content)
         with assert_no_warnings():
@@ -314,14 +315,14 @@ def test_reading_extension_metadata():
         # Shouldn't receive a warning when the package
         # name changes, even if the version is later:
         content = """
-        history:
-          extensions:
-            - !core/extension_metadata-1.0.0
-              extension_uri: asdf://somewhere.org/extensions/foo-1.0
-              extension_class: some.class.Name
-              software: !core/software-1.0.0
-                name: bar
-                version: 9.4.5
+history:
+  extensions:
+    - !core/extension_metadata-1.0.0
+      extension_uri: asdf://somewhere.org/extensions/foo-1.0
+      extension_class: some.class.Name
+      software: !core/software-1.0.0
+        name: bar
+        version: 9.4.5
         """
         buff = yaml_to_asdf(content)
         with assert_no_warnings():

--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -6,7 +6,7 @@ from asdf import config_context
 from asdf._asdf import AsdfFile, open_asdf
 from asdf._entry_points import get_extensions
 from asdf._tests._helpers import assert_no_warnings, assert_tree_match, yaml_to_asdf
-from asdf.exceptions import AsdfWarning
+from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning
 from asdf.extension import ExtensionProxy
 from asdf.versioning import AsdfVersion
 
@@ -103,10 +103,12 @@ def test_asdf_file_version():
             af.version = AsdfVersion("2.5.4")
 
         af.version = "1.0.0"
-        assert af.version_map["tags"]["tag:stsci.edu:asdf/core/asdf"] == "1.0.0"
+        with pytest.warns(AsdfDeprecationWarning, match="AsdfFile.version_map is deprecated"):
+            assert af.version_map["tags"]["tag:stsci.edu:asdf/core/asdf"] == "1.0.0"
 
         af.version = "1.2.0"
-        assert af.version_map["tags"]["tag:stsci.edu:asdf/core/asdf"] == "1.1.0"
+        with pytest.warns(AsdfDeprecationWarning, match="AsdfFile.version_map is deprecated"):
+            assert af.version_map["tags"]["tag:stsci.edu:asdf/core/asdf"] == "1.1.0"
 
 
 def test_asdf_file_extensions():

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -117,3 +117,9 @@ def test_AsdfFile_init_validation_deprecation():
         pytest.raises(ValidationError),
     ):
         asdf.AsdfFile({"history": 42})
+
+
+def test_asdffile_version_map_deprecation():
+    af = asdf.AsdfFile()
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfFile.version_map is deprecated"):
+        af.version_map

--- a/asdf/_tests/test_file_format.py
+++ b/asdf/_tests/test_file_format.py
@@ -175,7 +175,7 @@ def test_invalid_version(tmp_path):
 foo : bar
 ..."""
     buff = io.BytesIO(content)
-    with pytest.raises(ValueError, match=r"ASDF Standard version .* is not supported by asdf==.*"), asdf.open(buff):
+    with pytest.raises(ValueError, match=r"Unsupported ASDF file format version*"), asdf.open(buff):
         pass
 
 

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -12,6 +12,7 @@ from asdf import config_context, constants, get_config, schema, tagged, util, ya
 from asdf._tests import _helpers as helpers
 from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning, ValidationError
 from asdf.extension import TagDefinition
+from asdf.testing.helpers import yaml_to_asdf
 
 
 @contextlib.contextmanager
@@ -93,7 +94,7 @@ not_tagged:
     """
     with asdf.config_context() as cfg:
         cfg.add_extension(ScalarExtension())
-        buff = helpers.yaml_to_asdf(yaml)
+        buff = yaml_to_asdf(yaml)
         with asdf.open(buff) as ff:
             assert isinstance(ff.tree["tagged"], Scalar)
             assert not isinstance(ff.tree["not_tagged"], Scalar)
@@ -450,7 +451,7 @@ default: 42
 custom: !<{tag_uri}>
   foo
     """
-    buff = helpers.yaml_to_asdf(yaml)
+    buff = yaml_to_asdf(yaml)
     # This should cause a warning but not an error because without explicitly
     # providing an extension, our custom type will not be recognized and will
     # simply be converted to a raw type.
@@ -477,12 +478,9 @@ custom: !<{tag_uri}>
       custom: !<{tag_uri}>
         foo
         """
-        buff = helpers.yaml_to_asdf(yaml)
-        with (
-            pytest.raises(ValidationError, match=r".* is not of type .*"),
-            asdf.open(
-                buff,
-            ),
+        buff = yaml_to_asdf(yaml)
+        with pytest.raises(ValidationError, match=r".* is not of type .*"), asdf.open(
+            buff,
         ):
             pass
 
@@ -632,7 +630,7 @@ custom: !<http://nowhere.org/tags/custom/default-1.0.0>
   j:
     l: 362
         """
-        buff = helpers.yaml_to_asdf(yaml)
+        buff = yaml_to_asdf(yaml)
         with asdf.open(buff) as ff:
             assert "a" in ff.tree["custom"]
             assert ff.tree["custom"]["a"] == 42
@@ -744,7 +742,7 @@ one_of: !<{tag_uri}>
         cfg.add_extension(OneOfExtension())
         cfg.add_resource_mapping({schema_uri: tag_schema})
 
-        buff = helpers.yaml_to_asdf(yaml)
+        buff = yaml_to_asdf(yaml)
         with asdf.open(buff) as ff:
             assert ff["one_of"].value == "foo"
 
@@ -759,7 +757,7 @@ custom: !<tag:nowhere.org:custom/tag_reference-1.0.0>
     """
 
     with tag_reference_extension():
-        buff = helpers.yaml_to_asdf(yaml)
+        buff = yaml_to_asdf(yaml)
         with asdf.open(buff) as ff:
             custom = ff.tree["custom"]
             assert custom.name == "Something"
@@ -820,7 +818,7 @@ custom: !<tag:nowhere.org:custom/foreign_tag_reference-1.0.0>
         cfg.add_resource_mapping({schema_uri: tag_schema})
         cfg.add_extension(ForeignTagReferenceExtension())
 
-        buff = helpers.yaml_to_asdf(yaml)
+        buff = yaml_to_asdf(yaml)
         with asdf.open(buff) as ff:
             a = ff.tree["custom"].a
             assert a.name == "Something"
@@ -891,14 +889,14 @@ def test_max_min_literals_write(num, ttype, tmp_path):
 def test_read_large_literal(value):
     yaml = f"integer: {value}"
 
-    buff = helpers.yaml_to_asdf(yaml)
+    buff = yaml_to_asdf(yaml)
 
     with pytest.warns(AsdfWarning, match=r"Invalid integer literal value"), asdf.open(buff) as af:
         assert af["integer"] == value
 
     yaml = f"{value}: foo"
 
-    buff = helpers.yaml_to_asdf(yaml)
+    buff = yaml_to_asdf(yaml)
 
     with pytest.warns(AsdfWarning, match=r"Invalid integer literal value"), asdf.open(buff) as af:
         assert af[value] == "foo"

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -479,8 +479,11 @@ custom: !<{tag_uri}>
         foo
         """
         buff = yaml_to_asdf(yaml)
-        with pytest.raises(ValidationError, match=r".* is not of type .*"), asdf.open(
-            buff,
+        with (
+            pytest.raises(ValidationError, match=r".* is not of type .*"),
+            asdf.open(
+                buff,
+            ),
         ):
             pass
 

--- a/asdf/_tests/test_types.py
+++ b/asdf/_tests/test_types.py
@@ -2,8 +2,7 @@ import pytest
 
 import asdf
 from asdf.exceptions import AsdfConversionWarning
-
-from . import _helpers as helpers
+from asdf.testing.helpers import yaml_to_asdf
 
 
 def test_undefined_tag():
@@ -23,7 +22,7 @@ undefined_data:
         - !core/ndarray-1.0.0 [[7],[8],[9],[10]]
         - !core/complex-1.0.0 3.14j
 """
-    buff = helpers.yaml_to_asdf(yaml)
+    buff = yaml_to_asdf(yaml)
     with pytest.warns(Warning) as warning:
         afile = asdf.open(buff)
         missing = afile.tree["undefined_data"]
@@ -46,5 +45,4 @@ undefined_data:
 
     # Make sure no warning occurs if explicitly ignored
     buff.seek(0)
-    with helpers.assert_no_warnings():
-        afile = asdf.open(buff, ignore_unrecognized_tag=True)
+    afile = asdf.open(buff, ignore_unrecognized_tag=True)

--- a/asdf/_tests/test_yaml.py
+++ b/asdf/_tests/test_yaml.py
@@ -199,7 +199,7 @@ def test_tags_removed_after_load(tmp_path):
 
 
 def test_explicit_tags():
-    yaml = """#ASDF 1.0.0
+    yaml = b"""#ASDF 1.0.0
 #ASDF_STANDARD 1.5.0
 %YAML 1.1
 --- !<tag:stsci.edu:asdf/core/asdf-1.1.0>
@@ -207,7 +207,7 @@ foo: !<tag:stsci.edu:asdf/core/ndarray-1.0.0> [1, 2, 3]
 ..."""
 
     # Check that fully qualified explicit tags work
-    buff = helpers.yaml_to_asdf(yaml, yaml_headers=False)
+    buff = io.BytesIO(yaml)
 
     with asdf.open(buff) as ff:
         assert all(ff.tree["foo"] == [1, 2, 3])

--- a/asdf/_tests/test_yaml.py
+++ b/asdf/_tests/test_yaml.py
@@ -199,7 +199,8 @@ def test_tags_removed_after_load(tmp_path):
 
 
 def test_explicit_tags():
-    yaml = f"""#ASDF {asdf.versioning.default_version}
+    yaml = """#ASDF 1.0.0
+#ASDF_STANDARD 1.5.0
 %YAML 1.1
 --- !<tag:stsci.edu:asdf/core/asdf-1.1.0>
 foo: !<tag:stsci.edu:asdf/core/ndarray-1.0.0> [1, 2, 3]

--- a/asdf/_tests/test_yaml.py
+++ b/asdf/_tests/test_yaml.py
@@ -9,6 +9,7 @@ import yaml
 import asdf
 from asdf import tagged, treeutil, yamlutil
 from asdf.exceptions import AsdfConversionWarning, AsdfWarning
+from asdf.testing.helpers import yaml_to_asdf
 
 from . import _helpers as helpers
 
@@ -321,15 +322,11 @@ def test_ndarray_subclass_conversion(tmp_path):
     ],
 )
 def test_invalid_omap(payload):
-    test_yaml = f"""#ASDF {asdf.versioning.default_version}
-%YAML 1.1
---- !<tag:stsci.edu:asdf/core/asdf-1.1.0>
-od: !!omap
-{payload}
-..."""
+    test_yaml = f"""od: !!omap
+{payload}"""
 
     # Check that fully qualified explicit tags work
-    buff = helpers.yaml_to_asdf(test_yaml, yaml_headers=False)
+    buff = yaml_to_asdf(test_yaml)
 
     with pytest.raises(yaml.constructor.ConstructorError):
         with asdf.open(buff) as ff:

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -33,7 +33,7 @@ def join_tag_version(name, version):
 _version_map = {}
 
 
-def get_version_map(version):
+def _get_version_map(version):
     version_map = _version_map.get(version)
 
     if version_map is None:

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -174,3 +174,10 @@ RESTRICTED_KEYS_MIN_VERSION = AsdfVersion("1.6.0")
 # This library never removed defaults for ASDF Standard versions
 # later than 1.5.0, so filling them isn't necessary.
 FILL_DEFAULTS_MAX_VERSION = AsdfVersion("1.5.0")
+
+# ASDF currently only defined a single file format version
+_FILE_FORMAT_VERSION = AsdfVersion("1.0.0")
+
+# ASDF currently only supports a single yaml version
+# use a tuple as that is what yaml expects
+_YAML_VERSION = (1, 1)

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -10,7 +10,7 @@ from .constants import STSCI_SCHEMA_TAG_BASE, YAML_TAG_PREFIX
 from .exceptions import AsdfConversionWarning
 from .extension._serialization_context import BlockAccess
 from .tags.core import AsdfObject
-from .versioning import _yaml_base_loader
+from .versioning import _YAML_VERSION, _yaml_base_loader
 
 __all__ = ["custom_tree_to_tagged_tree", "tagged_tree_to_custom_tree"]
 
@@ -396,9 +396,6 @@ def dump_tree(tree, fd, ctx, tree_finalizer=None, _serialization_context=None):
         tree_finalizer(tree)
     schema.validate(tree, ctx)
 
-    # only 1 yaml version is supported
-    yaml_version = (1, 1)
-
     # add yaml %TAG definitions from extensions
     if _serialization_context:
         for ext in _serialization_context._extensions_used:
@@ -412,7 +409,7 @@ def dump_tree(tree, fd, ctx, tree_finalizer=None, _serialization_context=None):
         Dumper=AsdfDumper,
         explicit_start=True,
         explicit_end=True,
-        version=yaml_version,
+        version=_YAML_VERSION,
         allow_unicode=True,
         encoding="utf-8",
         tags=tags,

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -396,7 +396,8 @@ def dump_tree(tree, fd, ctx, tree_finalizer=None, _serialization_context=None):
         tree_finalizer(tree)
     schema.validate(tree, ctx)
 
-    yaml_version = tuple(int(x) for x in ctx.version_map["YAML_VERSION"].split("."))
+    # only 1 yaml version is supported
+    yaml_version = (1, 1)
 
     # add yaml %TAG definitions from extensions
     if _serialization_context:

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -211,7 +211,6 @@ class AsdfSchemaExampleItem(pytest.Item):
 
     def runtest(self):
         from asdf import AsdfFile, _block, generic_io, util
-        from asdf.exceptions import AsdfDeprecationWarning
         from asdf.testing.helpers import yaml_to_asdf
 
         # Make sure that the examples in the schema files (and thus the

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -211,11 +211,12 @@ class AsdfSchemaExampleItem(pytest.Item):
 
     def runtest(self):
         from asdf import AsdfFile, _block, generic_io, util
-        from asdf._tests import _helpers as helpers
+        from asdf.exceptions import AsdfDeprecationWarning
+        from asdf.testing.helpers import yaml_to_asdf
 
         # Make sure that the examples in the schema files (and thus the
         # ASDF standard document) are valid.
-        buff = helpers.yaml_to_asdf("example: " + self.example.example.strip(), standard_version=self.example.version)
+        buff = yaml_to_asdf("example: " + self.example.example.strip(), version=self.example.version)
 
         ff = AsdfFile(
             uri=util.filepath_to_url(os.path.abspath(self.filename)),


### PR DESCRIPTION
# Description

This PR:
- deprecates `AsdfFile.version_map`
- removes asdf uses of `versioning.get_version_map` (which this PR also renames to `_get_version_map` as it is undocumented, not listed in `versioning.__all__` and unused by all known downstream packages)
- no longer relies on the [version maps in asdf-standard](https://github.com/asdf-format/asdf-standard/blob/main/resources/schemas/stsci.edu/asdf/version_map-1.6.0.yaml) to map asdf standard versions to file format and yaml versions

Note that at the moment ASDF only supports file format 1.0.0 and yaml 1.1. This PR adds those constants to `asdf.versioning`.

When this PR is merged a new issue can be opened to track the removal of `AsdfFile.version_map` in asdf 4.0. The PR that removes `version_map` can also remove `versioning._get_version_map`. Once that PR is merged, the version map files can be removed from asdf standard.

sunpy downstream is failing due to pytest 8
weldx is failing due to new pandas deprecations

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
