### PR TITLE
restrict astrocut tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -205,7 +205,7 @@ commands_pre =
     pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
-    pytest astrocut
+    pytest astrocut/astrocut/tests/test_asdf_cut.py
 
 [testenv:gwcs]
 change_dir = {env_tmp_dir}


### PR DESCRIPTION
# Description

astrocut tests seem to be downloading files which is randomly failing.
See: https://github.com/asdf-format/asdf/actions/runs/7718257705/job/21039125750?pr=1745#step:10:463
and: https://github.com/asdf-format/asdf/actions/runs/7717678770/job/21037293335#step:10:559

As we're mainly interested in making sure the asdf portion of astrocut is not impacted by changes here this PR restricts the tests to those defined in [test_asdf_cut](https://github.com/spacetelescope/astrocut/blob/main/astrocut/tests/test_asdf_cut.py).

The change here is similar to restrictions placed on other downstream tests:
- [weldx](https://github.com/asdf-format/asdf/blob/7ae2d7eb198b4ef433eed6be8394a18ac22af619/tox.ini#L310)
- [sunpy](https://github.com/asdf-format/asdf/blob/7ae2d7eb198b4ef433eed6be8394a18ac22af619/tox.ini#L325)


# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
