### PR TITLE
remove jsonschema benchmark

### DIFF
--- a/benchmarks/schema.py
+++ b/benchmarks/schema.py
@@ -1,4 +1,3 @@
-import jsonschema
 import numpy
 
 import asdf
@@ -19,9 +18,6 @@ class SoftwareValidateSuite:
     def time_validate(self):
         self.af.validate()
 
-    def time_jsonschema_validate(self):
-        jsonschema.validators.Draft4Validator(self.schema).validate(self.obj)
-
 
 class NDArrayValidateSuite:
     def setup(self):
@@ -37,6 +33,3 @@ class NDArrayValidateSuite:
 
     def time_validate(self):
         self.af.validate()
-
-    def time_jsonschema_validate(self):
-        jsonschema.validators.Draft4Validator(self.schema).validate(self.obj)


### PR DESCRIPTION
As asdf no longer depends on jsonschema the benchmark that tests jsonschema will fail (as it's not installed).

This PR removes the jsonschema benchmark.

This should fix: https://github.com/spacetelescope/bench/issues/72

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
