### PR TITLE
info don't show value for bad __str__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,10 +42,6 @@ The ASDF Standard is at v1.6.0
   from working. If you want these warnings to produce errors you can
   now add your own warning filter [#1757]
 
-- For ``info`` and ``search`` show ``str`` representation of childless
-  (leaf) nodes if ``show_values`` is enabled  [#1687]
-
-- Deprecate ``asdf.util.is_primitive`` [#1687]
 
 - Only show ``str`` representation during ``info`` and ``search``
   if it contains a single line (and does not fail)  [#1748]
@@ -57,6 +53,10 @@ The ASDF Standard is at v1.6.0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Fix bug in ``asdftool diff`` for arrays within a list [#1672]
+- For ``info`` and ``search`` show ``str`` representation of childless
+  (leaf) nodes if ``show_values`` is enabled  [#1687]
+- Deprecate ``asdf.util.is_primitive`` [#1687]
+
 
 3.0.0 (2023-10-16)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,14 @@ The ASDF Standard is at v1.6.0
   from working. If you want these warnings to produce errors you can
   now add your own warning filter [#1757]
 
+- For ``info`` and ``search`` show ``str`` representation of childless
+  (leaf) nodes if ``show_values`` is enabled  [#1687]
+
+- Deprecate ``asdf.util.is_primitive`` [#1687]
+
+- Only show ``str`` representation during ``info`` and ``search``
+  if it contains a single line (and does not fail)  [#1748]
+
 3.0.1 (2023-10-30)
 ------------------
 
@@ -49,9 +57,6 @@ The ASDF Standard is at v1.6.0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Fix bug in ``asdftool diff`` for arrays within a list [#1672]
-- For ``info`` and ``search`` show ``str`` representation of childless
-  (leaf) nodes if ``show_values`` is enabled  [#1687]
-- Deprecate ``asdf.util.is_primitive`` [#1687]
 
 3.0.0 (2023-10-16)
 ------------------

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -257,7 +257,17 @@ class _TreeRenderer:
             return f"({rendered_type}): shape={info.node.shape}, dtype={info.node.dtype.name}"
 
         if not info.children and self._show_values:
-            return f"({rendered_type}): {info.node}"
+            try:
+                s = f"{info.node}"
+            except Exception:
+                # if __str__ fails, don't fail info, instead use an empty string
+                s = ""
+            # if __str__ returns multiple lines also use an empty string
+            if len(s.splitlines()) > 1:
+                s = ""
+            # if s is empty use the non-_show_values format below
+            if s:
+                return f"({rendered_type}): {s}"
 
         return f"({rendered_type})"
 

--- a/asdf/_tests/test_info.py
+++ b/asdf/_tests/test_info.py
@@ -691,7 +691,7 @@ def test_info_str(capsys):
     af["d"] = NiceStr()
     af.info()
     captured = capsys.readouterr()
-    assert f"(BadStr){os.linesep}" in captured.out
-    assert f"(NewlineStr){os.linesep}" in captured.out
-    assert f"(CarriageReturnStr){os.linesep}" in captured.out
-    assert f"(NiceStr): nice{os.linesep}" in captured.out
+    assert "(BadStr)\n" in captured.out
+    assert "(NewlineStr)\n" in captured.out
+    assert "(CarriageReturnStr)\n" in captured.out
+    assert "(NiceStr): nice\n" in captured.out

--- a/asdf/_tests/test_info.py
+++ b/asdf/_tests/test_info.py
@@ -665,3 +665,33 @@ def test_search():
 
     result = af.search(value="hello")
     assert result.node == "hello"
+
+
+def test_info_str(capsys):
+    class BadStr:
+        def __str__(self):
+            raise Exception()
+
+    class NewlineStr:
+        def __str__(self):
+            return "a\nb"
+
+    class CarriageReturnStr:
+        def __str__(self):
+            return "a\rb"
+
+    class NiceStr:
+        def __str__(self):
+            return "nice"
+
+    af = asdf.AsdfFile()
+    af["a"] = BadStr()
+    af["b"] = NewlineStr()
+    af["c"] = CarriageReturnStr()
+    af["d"] = NiceStr()
+    af.info()
+    captured = capsys.readouterr()
+    assert f"(BadStr){os.linesep}" in captured.out
+    assert f"(NewlineStr){os.linesep}" in captured.out
+    assert f"(CarriageReturnStr){os.linesep}" in captured.out
+    assert f"(NiceStr): nice{os.linesep}" in captured.out


### PR DESCRIPTION
# Description

if `__str__` fails during `asdf.info` or returns multiple lines then don't show the value.

This fixes the current roman_datamodels downstream job which is failing due to a wcs which contains no transforms which causes gwcs to fail a `__str__` call.

A PR is open to fix the `__str__` issue in gwcs: https://github.com/spacetelescope/gwcs/pull/489

However even with the above fix the `WCS.__str__` result is a multi-line string which breaks `info` formatting. To deal with this, this PR also checks the `__str__` output for multiple lines and in that case discards the `__str__ ` result.

To provide a few examples using a tree containing `gwcs.WCS(output_frame="icrs")`.

Without the gwcs PR and with asdf main, asdf.info returns:
```
File ~/projects/src/gwcs/gwcs/wcs.py:1347, in WCS.__str__(self)
   1344 for item in self._pipeline[: -1]:
   1345     #model = item[1]
   1346     model = item.transform
-> 1347     if model.name is not None:
   1348         col2.append(model.name)
   1349     else:

AttributeError: 'NoneType' object has no attribute 'name'
```

With the above gwcs PR with asdf 3.0.1 (the latest release), asdf.info returns:
```
└─w (WCS)
```

With the above gwcs PR and asdf main, asdf.info returns (note the break in formatting)
```
└─w (WCS):   From   Transform
-------- ---------
detector      None
    icrs      None
```

With (or without) the above gwcs PR and with this PR, asdf.info returns:
```
└─w (WCS)
```

Note that with this PR time formatting is still preserved (so the issue #1686) fixed by #1687 is still fixed:
```
└─t (Time): 2024-02-03 14:20:29.350503
```

Finally, this PR fixes the changelog error where #1687 is listed under the wrong version (see the [changelog for 3.0.x](https://github.com/asdf-format/asdf/blob/3.0.x/CHANGES.rst)).

The weldx downstream error is unrelated (and caused by a new pandas).

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
