### PR TITLE
allow wildcard in asdf_schema_root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@
   resolve to public classes (even if the class is implemented
   in a private module). [#1654]
 
+- Allow use of a starting wildcard in the ``asdf_schema_root`` setting
+  for the asdf pytest plugin to allow schemas to be collected during
+  ``--pyargs`` test runs [#1756]
+
 
 3.2.0 (2024-04-05)
 ------------------

--- a/docs/asdf/extending/schemas.rst
+++ b/docs/asdf/extending/schemas.rst
@@ -276,6 +276,10 @@ package directory **when it is installed**. If this is different from the path
 in the source directory, then both paths can be used to facilitate in-place
 testing (see `asdf`'s own ``pyproject.toml`` for an example of this).
 
+The ``asdf_schema_root`` may also start with a "wildcard" (``*``) which will cause
+the plugin to match any path that contains the ``asdf_schema_root`` setting (without
+the wildcard).
+
 .. note::
 
    Older versions of `asdf` (prior to 2.4.0) required the plugin to be registered


### PR DESCRIPTION
# Description

This PR adds support for starting the `asdf_schema_root` path with a "wildcard" (`*`) to allow the pytest plugin to collect schema files when pytest is run with `--pyargs`.

The sunpy CI currently runs all of it's tests using [--pyargs](https://github.com/sunpy/sunpy/blob/8349d7f8698da737b884faa81b1773ddd1adaf1f/tox.ini#L29 ). Even though `asdf_schema_root` is defined in their [pytest.ini](https://github.com/sunpy/sunpy/blob/8349d7f8698da737b884faa81b1773ddd1adaf1f/pytest.ini#L22) no schema tests are run. This is due to the asdf pytest plugin expanding the `asdf_schema_root` based on the path of the configuration file (in the sunpy case this becomes `/home/runner/work/sunpy/sunpy/sunpy/io/special/asdf/resources/`) which then fails the `startswith` check for every schema file (which all start with something like `../../.tox/py310-oldestdeps/lib/python3.10/site-packages/sunpy/`). With this PR sunpy can update their `asdf_schema_root` to `*/sunpy/io/special/asdf/resources/` which will allow the asdf pytest plugin to collect the schemas for testing.

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
