### PR TITLE
Record manifest providing package in history, use specific warning for `_check_extensions`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 
 - Deprecate ``asdf.util.filepath_to_url`` use ``pathlib.Path.to_uri`` [#1735]
 
+- Record package providing manifest for extensions used to write
+  a file and ``AsdfPackageVersionWarning`` when installed extension/manifest
+  package does not match that used to write the file [#1758]
+
 
 3.2.0 (2024-04-05)
 ------------------

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -374,6 +374,32 @@ class AsdfFile:
 
                     warnings.warn(msg, AsdfWarning)
 
+            # check version of manifest providing package (if one was recorded)
+            if "manifest_software" in extension:
+                package_name = extension["manifest_software"]["name"]
+                package_version = Version(extension["manifest_software"]["version"])
+                package_description = f"{package_name}=={package_version}"
+                installed_version = None
+                for mapping in get_config().resource_manager._resource_mappings:
+                    if mapping.package_name == package_name:
+                        installed_version = Version(mapping.package_version)
+                        break
+                msg = None
+                if installed_version is None:
+                    msg = (
+                        f"File {filename}was created with package {package_description}, "
+                        "which is currently not installed"
+                    )
+                elif installed_version < package_version:
+                    msg = (
+                        f"File {filename}was created with package {package_description}, "
+                        f"but older package({package_name}=={installed_version}) is installed."
+                    )
+                if msg:
+                    if strict:
+                        raise RuntimeError(msg)
+                    warnings.warn(msg, AsdfWarning)
+
     def _process_plugin_extensions(self):
         """
         Select installed extensions that are compatible with this

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -460,6 +460,15 @@ class AsdfFile:
                 ext_meta["extension_uri"] = extension.extension_uri
             if extension.compressors:
                 ext_meta["supported_compression"] = [comp.label.decode("ascii") for comp in extension.compressors]
+            manifest = getattr(extension._delegate, "_manifest", None)
+            if manifest is not None:
+                # check if this extension was built from a manifest is a different package
+                resource_mapping = get_config().resource_manager._mappings_by_uri.get(manifest["id"])
+                if resource_mapping.package_name != extension.package_name:
+                    ext_meta["manifest_software"] = Software(
+                        name=resource_mapping.package_name,
+                        version=resource_mapping.package_version,
+                    )
 
             for i, entry in enumerate(tree["history"]["extensions"]):
                 # Update metadata about this extension if it already exists

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -19,6 +19,7 @@ from .config import config_context, get_config
 from .exceptions import (
     AsdfConversionWarning,
     AsdfDeprecationWarning,
+    AsdfPackageVersionWarning,
     AsdfWarning,
     DelimiterNotFoundError,
     ValidationError,
@@ -356,7 +357,7 @@ class AsdfFile:
                 if strict:
                     raise RuntimeError(msg)
 
-                warnings.warn(msg, AsdfWarning)
+                warnings.warn(msg, AsdfPackageVersionWarning)
 
             elif extension.software:
                 # Local extensions may not have a real version.  If the package name changed,
@@ -372,7 +373,7 @@ class AsdfFile:
                     if strict:
                         raise RuntimeError(msg)
 
-                    warnings.warn(msg, AsdfWarning)
+                    warnings.warn(msg, AsdfPackageVersionWarning)
 
             # check version of manifest providing package (if one was recorded)
             if "manifest_software" in extension:
@@ -398,7 +399,7 @@ class AsdfFile:
                 if msg:
                     if strict:
                         raise RuntimeError(msg)
-                    warnings.warn(msg, AsdfWarning)
+                    warnings.warn(msg, AsdfPackageVersionWarning)
 
     def _process_plugin_extensions(self):
         """

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 
 import asdf
 from asdf import config_context, get_config, treeutil, versioning
-from asdf.exceptions import AsdfDeprecationWarning, AsdfWarning, ValidationError
+from asdf.exceptions import AsdfDeprecationWarning, AsdfPackageVersionWarning, ValidationError
 from asdf.extension import ExtensionProxy
 from asdf.resource import ResourceMappingProxy
 from asdf.testing.helpers import roundtrip_object, yaml_to_asdf
@@ -316,7 +316,7 @@ def test_extension_version_check(installed, extension, warns):
     }
 
     if warns:
-        with pytest.warns(AsdfWarning, match=r"File 'test.asdf' was created with"):
+        with pytest.warns(AsdfPackageVersionWarning, match=r"File 'test.asdf' was created with"):
             af._check_extensions(tree)
 
         with pytest.raises(RuntimeError, match=r"^File 'test.asdf' was created with"):
@@ -364,7 +364,7 @@ def test_check_extension_manifest_software(installed, extension, warns):
         }
 
         if warns:
-            with pytest.warns(AsdfWarning, match=r"File 'test.asdf' was created with"):
+            with pytest.warns(AsdfPackageVersionWarning, match=r"File 'test.asdf' was created with"):
                 af._check_extensions(tree)
 
             with pytest.raises(RuntimeError, match=r"^File 'test.asdf' was created with"):

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -285,6 +285,7 @@ def test_open_pathlib_path(tmp_path):
 @pytest.mark.parametrize(
     ("installed", "extension", "warns"),
     [
+        (None, "2.0.0", True),
         ("1.2.3", "2.0.0", True),
         ("1.2.3", "2.0.dev10842", True),
         ("2.0.0", "2.0.0", False),
@@ -299,7 +300,8 @@ def test_extension_version_check(installed, extension, warns):
     proxy = ExtensionProxy(FooExtension(), package_name="foo", package_version=installed)
 
     with config_context() as config:
-        config.add_extension(proxy)
+        if installed is not None:
+            config.add_extension(proxy)
         af = asdf.AsdfFile()
 
     af._fname = "test.asdf"
@@ -329,6 +331,7 @@ def test_extension_version_check(installed, extension, warns):
 @pytest.mark.parametrize(
     ("installed", "extension", "warns"),
     [
+        (None, "2.0.0", True),
         ("1.2.3", "2.0.0", True),
         ("1.2.3", "2.0.dev10842", True),
         ("2.0.0", "2.0.0", False),
@@ -346,7 +349,8 @@ def test_check_extension_manifest_software(installed, extension, warns):
 
     with config_context() as config:
         config.add_extension(proxy)
-        config.add_resource_mapping(mapping)
+        if installed is not None:
+            config.add_resource_mapping(mapping)
         af = asdf.AsdfFile()
 
         af._fname = "test.asdf"

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -48,3 +48,9 @@ class AsdfProvisionalAPIWarning(AsdfWarning, FutureWarning):
     are likely to be added in a future ASDF version. However, Use of
     provisional features is highly discouraged for production code.
     """
+
+
+class AsdfPackageVersionWarning(AsdfWarning):
+    """
+    A warning indicating a package version mismatch
+    """


### PR DESCRIPTION
# Description

This PR adds the package name and version for the package providing the manifest used to create an extension that was used to write the file. For example, writing out a file with this PR produces a `history`:
```yaml
history:
  extensions:
  - !core/extension_metadata-1.0.0
    extension_class: asdf.extension._manifest.ManifestExtension
    extension_uri: asdf://asdf-format.org/core/extensions/core-1.5.0
    manifest_software: !core/software-1.0.0 {name: asdf-standard, version: 1.0.4.dev153+gcafd84a}
    software: !core/software-1.0.0 {name: asdf, version: 3.0.2.dev81+g67e7a8e3.d20240205}
```
This will be beneficial for tracking what software was used for the many asdf extensions that use manifests from other packages (like `gwcs` and `asdf-wcs-schemas`, `roman_datamodels` and `rad`, etc...).

This new `manifest_software` is also checked during `AsdfFile._check_extension`.

Finally, the warning class used during `_check_extension` was changed from the generic `AsdfWarning` to a more specific `AsdfPackageVersionWarning` (which inherits from `AsdfWarning`).

Fixes #1740

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
