### PR TITLE
drop doctestplus test dependency

### DIFF
--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -69,7 +69,7 @@ jobs:
           run: |
             python3 -m venv --system-site-packages tests
             source tests/bin/activate
-            pip3 install --upgrade pip setuptools pytest pytest-doctestplus pytest-remotedata
+            pip3 install --upgrade pip setuptools pytest pytest-remotedata
             pip3 install -e .[all,tests]
             pip3 list
             python3 -m pytest --remote-data

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -471,7 +471,7 @@ class _InheritDocstrings(type):
         ...     def wiggle(self):
         ...         pass
         >>> B.wiggle.__doc__
-        u'Wiggle the thingamajig'
+        'Wiggle the thingamajig'
     """
 
     def __init__(cls, name, bases, dct):

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore = ["conf.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ tests = [
   "lz4>=0.10",
   "psutil",
   "pytest>=7",
-  "pytest-doctestplus",
   "pytest-remotedata",
 ]
 [project.urls]
@@ -101,18 +100,15 @@ force-exclude = '''
 [tool.pytest.ini_options]
 testpaths = ['asdf', 'docs']
 minversion = 4.6
-norecursedirs = ['build', 'docs/_build', 'docs/sphinxext']
-doctest_plus = 'enabled'
 remote_data_strict = true
 filterwarnings = [
     'error',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
 ]
-# Configuration for pytest-doctestplus
-text_file_format = 'rst'
 addopts = [
+    '--doctest-modules',
+    '--doctest-glob=*.rst',
     '--color=yes',
-    '--doctest-rst',
     '-rsxfE',
     '-p no:legacypath',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,6 @@ deps =
     oldestdeps: minimum_dependencies
     parallel: pytest-xdist
     pytestdev: git+https://github.com/pytest-dev/pytest
-# released versions of doctestplus aren't compatible with pytest-dev
-    pytestdev: git+https://github.com/scientific-python/pytest-doctestplus
 extras = all,tests
 # astropy will complain if the home directory is missing
 pass_env = HOME


### PR DESCRIPTION
# Description

pytest-doctestplus is listed as a test dependency. However, none of the "plus" features are used and this PR drops it as a dependency and replaces it with the builtin doctest.

With this PR the 3.11 tests pick up 1756 tests
https://github.com/asdf-format/asdf/actions/runs/8143804626/job/22256481482?pr=1765#step:10:247

this is the same as the 3.11 tests for main:
https://github.com/asdf-format/asdf/actions/runs/8096624540/job/22125799613#step:10:248

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
