### PR TITLE
Remove unused `asdf-unit-schemas` update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
       envs: |
         - linux: asdf-standard
         - linux: asdf-transform-schemas
-        - linux: asdf-unit-schemas
 
   test:
     needs: [core]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Add ``float16`` support [#1692]
 
+- Removed unused ``asdf-unit-schemas`` dependency [#1767]
+
 
 3.1.0 (2024-02-27)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ dynamic = [
 ]
 dependencies = [
   "asdf-standard>=1.1.0",
-  "asdf-transform-schemas>=0.3",
-  "asdf-unit-schemas>=0.1",
+  "asdf-transform-schemas>=0.3",  # required for asdf-1.0.0 schema
   "importlib-metadata>=4.11.4",
   "jmespath>=0.6.2",
   "numpy>=1.22",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,5 @@
-git+https://github.com/asdf-format/asdf-coordinates-schemas
 git+https://github.com/asdf-format/asdf-standard
 git+https://github.com/asdf-format/asdf-transform-schemas
-git+https://github.com/asdf-format/asdf-unit-schemas.git
-git+https://github.com/asdf-format/asdf-wcs-schemas
 git+https://github.com/yaml/pyyaml.git
 
 numpy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -115,21 +115,6 @@ commands_pre =
 commands =
     pytest asdf-transform-schemas
 
-[testenv:asdf-unit-schemas]
-change_dir = {env_tmp_dir}
-allowlist_externals =
-    git
-    bash
-extras =
-commands_pre =
-    bash -c "pip freeze -q | grep 'asdf @' > {env_tmp_dir}/requirements.txt"
-    git clone https://github.com/asdf-format/asdf-unit-schemas.git
-    pip install -e asdf-unit-schemas[test]
-    pip install -r {env_tmp_dir}/requirements.txt
-    pip freeze
-commands =
-    pytest asdf-unit-schemas
-
 [testenv:asdf-wcs-schemas]
 change_dir = {env_tmp_dir}
 allowlist_externals =


### PR DESCRIPTION
Removes the now-decommissioned [asdf-unit-schemas](https://github.com/asdf-format/asdf-unit-schemas) from the list of dependencies and updates the CI to:
- no longer test `asdf-unit-schemas`
- remove `asdf-wcs-schemas` and `asdf-coordinates-schemas` (which aren't dependencies) from `requirements-dev.txt`