### PR TITLE
Fix docs and modify CI job run requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         - linux: asdf-unit-schemas
 
   test:
-    needs: [core, asdf-schemas]
+    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       submodules: false
@@ -84,7 +84,7 @@ jobs:
         - windows: py39-parallel
 
   dev:
-    needs: [core, asdf-schemas]
+    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       submodules: false
@@ -99,7 +99,7 @@ jobs:
         - linux: py311-pytestdev-parallel
 
   oldest:
-    needs: [core, asdf-schemas]
+    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       submodules: false
@@ -109,7 +109,7 @@ jobs:
         - linux: py39-oldestdeps-parallel
 
   compatibility:
-    needs: [core, asdf-schemas]
+    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       submodules: false
@@ -119,7 +119,7 @@ jobs:
         - linux: compatibility
 
   package:
-    needs: [core, asdf-schemas]
+    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
       python-version: "3.11"

--- a/docs/asdf/extending/schemas.rst
+++ b/docs/asdf/extending/schemas.rst
@@ -49,7 +49,7 @@ numeric value and corresponding unit:
       required: [value, unit]
     ...
 
-This is similar to the quantity schema, found :ref:`here <asdf-standard:unit-schema>`, of the ASDF Standard, but
+This is similar to the quantity schema, found :ref:`here <asdf-standard:stsci.edu/asdf/unit/quantity-1.1.0>`, of the ASDF Standard, but
 has been updated to reflect current recommendations regarding schemas.
 Let's walk through this schema line by line.
 
@@ -303,4 +303,4 @@ See also:
 
 - `Understanding JSON Schema <https://json-schema.org/understanding-json-schema/>`_
 
-- :ref:`Unit Schemas <asdf-standard:unit-schema>`
+- :ref:`Unit Schemas <asdf-standard:stsci.edu/asdf/unit/quantity-1.1.0>`


### PR DESCRIPTION
# Description

Fix a few docs links (due to changes in the asdf-standard docs) and modify the CI jobs to not prevent jobs from running if the `asdf-schemas` job fails (as it does now).

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
