### PR TITLE
Deprecate `asdf.testing.helpers.format_tag` and `asdf.versioning.AsdfSpec`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 - Fix ``__asdf_traverse__`` for non-tagged objects [#1739]
 
+- Deprecate ``asdf.testing.helpers.format_tag`` [#1774]
+
+- Deprecate ``asdf.versioning.AsdfSpec`` [#1774]
+
+
 3.2.0 (2024-04-05)
 ------------------
 

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import asdf
+import asdf.testing.helpers
 from asdf.exceptions import AsdfDeprecationWarning, ValidationError
 
 
@@ -123,3 +124,8 @@ def test_asdffile_version_map_deprecation():
     af = asdf.AsdfFile()
     with pytest.warns(AsdfDeprecationWarning, match="AsdfFile.version_map is deprecated"):
         af.version_map
+
+
+def test_format_tag_deprecation():
+    with pytest.warns(AsdfDeprecationWarning, match="format_tag is deprecated"):
+        asdf.testing.helpers.format_tag("stsci.edu", "asdf", "1.0.0", "fits/fits")

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -837,7 +837,7 @@ def test_self_reference_resolution(test_data_path):
 
 def test_schema_resolved_via_entry_points():
     """Test that entry points mappings to core schema works"""
-    tag = format_tag("stsci.edu", "asdf", "1.0.0", "fits/fits")
+    tag = "tag:stsci.edu:asdf/fits/fits-1.0.0"
     extension_manager = asdf.extension.get_cached_extension_manager(get_config().extensions)
     schema_uris = extension_manager.get_tag_definition(tag).schema_uris
     assert len(schema_uris) > 0

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -10,7 +10,7 @@ import asdf
 from asdf import config_context, constants, get_config, schema, tagged, util, yamlutil
 from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning, ValidationError
 from asdf.extension import TagDefinition
-from asdf.testing.helpers import format_tag, yaml_to_asdf
+from asdf.testing.helpers import yaml_to_asdf
 
 
 @contextlib.contextmanager

--- a/asdf/_tests/test_versioning.py
+++ b/asdf/_tests/test_versioning.py
@@ -1,5 +1,8 @@
 from itertools import combinations
 
+import pytest
+
+from asdf.exceptions import AsdfDeprecationWarning
 from asdf.versioning import (
     AsdfSpec,
     AsdfVersion,
@@ -171,7 +174,8 @@ def test_version_and_tuple_inequality():
 
 
 def test_spec_version_match():
-    spec = AsdfSpec(">=1.1.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.1.0")
 
     assert spec.match(AsdfVersion("1.1.0"))
     assert spec.match(AsdfVersion("1.2.0"))
@@ -180,7 +184,8 @@ def test_spec_version_match():
 
 
 def test_spec_version_select():
-    spec = AsdfSpec(">=1.1.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.1.0")
 
     versions = [AsdfVersion(x) for x in ["1.0.0", "1.0.9", "1.1.0", "1.2.0"]]
     assert spec.select(versions) == "1.2.0"
@@ -189,7 +194,8 @@ def test_spec_version_select():
 
 
 def test_spec_version_filter():
-    spec = AsdfSpec(">=1.1.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.1.0")
 
     versions = [AsdfVersion(x) for x in ["1.0.0", "1.0.9", "1.1.0", "1.2.0"]]
     for x, y in zip(spec.filter(versions), ["1.1.0", "1.2.0"]):
@@ -197,7 +203,8 @@ def test_spec_version_filter():
 
 
 def test_spec_string_match():
-    spec = AsdfSpec(">=1.1.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.1.0")
 
     assert spec.match("1.1.0")
     assert spec.match("1.2.0")
@@ -206,7 +213,8 @@ def test_spec_string_match():
 
 
 def test_spec_string_select():
-    spec = AsdfSpec(">=1.1.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.1.0")
 
     versions = ["1.0.0", "1.0.9", "1.1.0", "1.2.0"]
     assert spec.select(versions) == "1.2.0"
@@ -215,7 +223,8 @@ def test_spec_string_select():
 
 
 def test_spec_string_filter():
-    spec = AsdfSpec(">=1.1.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.1.0")
 
     versions = ["1.0.0", "1.0.9", "1.1.0", "1.2.0"]
     for x, y in zip(spec.filter(versions), ["1.1.0", "1.2.0"]):
@@ -223,7 +232,8 @@ def test_spec_string_filter():
 
 
 def test_spec_tuple_match():
-    spec = AsdfSpec(">=1.1.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.1.0")
 
     assert spec.match((1, 1, 0))
     assert spec.match((1, 2, 0))
@@ -232,7 +242,8 @@ def test_spec_tuple_match():
 
 
 def test_spec_tuple_select():
-    spec = AsdfSpec(">=1.1.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.1.0")
 
     versions = [(1, 0, 0), (1, 0, 9), (1, 1, 0), (1, 2, 0)]
     assert spec.select(versions) == "1.2.0"
@@ -241,7 +252,8 @@ def test_spec_tuple_select():
 
 
 def test_spec_tuple_filter():
-    spec = AsdfSpec(">=1.1.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.1.0")
 
     versions = [(1, 0, 0), (1, 0, 9), (1, 1, 0), (1, 2, 0)]
     for x, y in zip(spec.filter(versions), ["1.1.0", "1.2.0"]):
@@ -250,7 +262,8 @@ def test_spec_tuple_filter():
 
 def test_spec_equal():
     """Make sure that equality means match"""
-    spec = AsdfSpec(">=1.2.0")
+    with pytest.warns(AsdfDeprecationWarning, match="AsdfSpec is deprecated"):
+        spec = AsdfSpec(">=1.2.0")
     version0 = AsdfVersion("1.1.0")
     version1 = AsdfVersion("1.3.0")
 

--- a/asdf/testing/helpers.py
+++ b/asdf/testing/helpers.py
@@ -2,9 +2,11 @@
 Helpers for writing unit tests of ASDF support.
 """
 
+import warnings
 from io import BytesIO
 
 import asdf
+from asdf.exceptions import AsdfDeprecationWarning
 from asdf.versioning import AsdfSpec
 
 
@@ -12,6 +14,8 @@ def format_tag(organization, standard, version, tag_name):
     """
     Format a YAML tag.
     """
+    warnings.warn("format_tag is deprecated", AsdfDeprecationWarning)
+
     tag = f"tag:{organization}:{standard}/{tag_name}"
 
     if version is None:

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -3,10 +3,13 @@ This module deals with things that change between different versions
 of the ASDF spec.
 """
 
+import warnings
 from functools import total_ordering
 
 import yaml
 from semantic_version import SimpleSpec, Version
+
+from .exceptions import AsdfDeprecationWarning
 
 _yaml_base_loader = yaml.CSafeLoader if getattr(yaml, "__with_libyaml__", None) else yaml.SafeLoader
 
@@ -112,7 +115,12 @@ class AsdfVersion(AsdfVersionMixin, Version):
 
 
 class AsdfSpec(SimpleSpec):
+    """
+    Deprecated.
+    """
+
     def __init__(self, *args, **kwargs):
+        warnings.warn("AsdfSpec is deprecated.", AsdfDeprecationWarning)
         super().__init__(*args, **kwargs)
 
     def match(self, version):


### PR DESCRIPTION
# Description

This PR deprecates `asdf.testing.helpers.format_tag` (and replaces it's one use with a string) and `asdf.versioning.AsdfSpec` (which is unused).

Fixes: #1773

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
