### PR TITLE
issue warning if manifest id does not match uri

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@
 - Fix bug where a dictionary containing a key ``id`` caused
   any contained references to fail to resolve [#1716]
 
+- Issue a ``AsdfManifestURIMismatchWarning`` during write if a used
+  extension was created from a manifest registered with a uri that
+  does not match the id in the manifest [#1785]
+
 
 3.2.0 (2024-04-05)
 ------------------

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -3,6 +3,8 @@ from asdf._jsonschema import ValidationError
 __all__ = [
     "AsdfConversionWarning",
     "AsdfDeprecationWarning",
+    "AsdfManifestURIMismatchWarning",
+    "AsdfPackageVersionWarning",
     "AsdfProvisionalAPIWarning",
     "AsdfWarning",
     "DelimiterNotFoundError",
@@ -53,4 +55,11 @@ class AsdfProvisionalAPIWarning(AsdfWarning, FutureWarning):
 class AsdfPackageVersionWarning(AsdfWarning):
     """
     A warning indicating a package version mismatch
+    """
+
+
+class AsdfManifestURIMismatchWarning(AsdfWarning):
+    """
+    A warning indicaing that an extension registered with a manifest
+    contains a id that does not match the uri of the manifest.
     """

--- a/tox.ini
+++ b/tox.ini
@@ -274,8 +274,7 @@ commands_pre =
     pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
-    pytest roman_datamodels/tests \
-        -W "ignore:asdf.extensions plugin from package gwcs==0.18.3:asdf.exceptions.AsdfWarning"
+    pytest roman_datamodels/tests
 
 [testenv:weldx]
 change_dir = {env_tmp_dir}
@@ -320,5 +319,8 @@ commands_pre =
     pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
+# the AsdfManifestURIMismatchWarning filter can be removed when a new sunpy
+# is released which contains the fixed manifests:
+# https://github.com/sunpy/sunpy/pull/7432
     pytest dkist \
-        -W "ignore:asdf.extensions plugin from package gwcs==0.18.3:asdf.exceptions.AsdfWarning"
+        -W "ignore::asdf.exceptions.AsdfManifestURIMismatchWarning"


### PR DESCRIPTION
# Description

https://github.com/asdf-format/asdf/pull/1758 assumed that the `uri` used for a manifest matches the `id` in the manifest. This should be the case (as defined in the [extension manifest schema](https://github.com/asdf-format/asdf-standard/blob/1458b25b3092231a7b023ac934ebb7bd31f77d3f/resources/schemas/asdf-format.org/core/extension_manifest-1.0.0.yaml#L23)). However this was not previously being checked. Both [dkist](https://github.com/asdf-format/asdf/actions/runs/9002886955/job/24732233076#step:10:1157) and [weldx](https://github.com/asdf-format/asdf/actions/runs/9002886955/job/24732232556#step:10:10740) downstream jobs show failures since both these packages use manifests with ids that do not match the uris. The dkist failure is due to use of sunpy manifests (which are [fixed in main but are unreleased](https://github.com/sunpy/sunpy/pull/7432)) and a PR is open for weldx to [update the ids to match](https://github.com/BAMWelDX/weldx/pull/910).

This PR detects the mismatch and instead of producing an exception issues a new warning `AsdfManifestURIMismatchWarning` with a message to file an issue with the package maintainers.

The weldx downstream job (which doesn't turn warnings into errors) shows the new warning:
https://github.com/asdf-format/asdf/actions/runs/9004808168/job/24738692670?pr=1785#step:10:714

A warning filter is added in this PR to the `tox.ini` to filter out the warning for the dkist downstream job since it's an issue with the sunpy manifests and will be fixed in the next major sunpy release.

# Checklist:

- [x] pre-commit checks ran successfully
- [x] tests ran successfully
- [x] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [x] for any new features, unit tests were added
