### PR TITLE
python 3.13 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
         - linux: py310-devdeps-parallel
         - linux: py311-devdeps-parallel
         - linux: py312-devdeps-parallel
+        - linux: py313-devdeps-parallel
         # separate pytest so a failure here doesn't cause the whole suite to fail
         - linux: py311-pytestdev-parallel
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 env_list =
     compatibility
     coverage
-    py{39,310,311,312}{,-compatibility,-coverage,-jsonschema}{,-devdeps}{,-parallel}{,-pytestdev}
+    py{39,310,311,312,313}{,-compatibility,-coverage,-jsonschema}{,-devdeps}{,-parallel}{,-pytestdev}
     asdf{-standard,-transform-schemas,-unit-schemas,-wcs-schemas,-coordinates-schemas,-astropy,-zarr,-compression}
     astrocut
     gwcs


### PR DESCRIPTION
Add python 3.13 testing. It looks like (with our devdeps) that python 3.13 is supported (at the moment, all tests pass with 3.13). This PR does not add "official" 3.13 support as it's still in beta.