### PR TITLE
get tags for rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,11 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
+      - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' || true
+      - git fetch --all --tags || true
 
 conda:
   environment: docs/rtd_environment.yaml


### PR DESCRIPTION
Applies changes from https://github.com/spacetelescope/jwst/pull/8633

to allow removal of the stable branch (RTD will automatically generate one since we're semantically versioned).

I've already renamed the stable branch to "old_stable".
