### PR TITLE
require pytest 8 to deal with warnings change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ tests = [
   "fsspec[http]>=2022.8.2",
   "lz4>=0.10",
   "psutil",
-  "pytest>=7",
+  "pytest>=8",
   "pytest-remotedata",
 ]
 [project.urls]


### PR DESCRIPTION
As reported in https://github.com/asdf-format/asdf/issues/1804 one of our tests fails when run with pytest < 8.

This PR pins pytest to > 8.

Fixes: https://github.com/asdf-format/asdf/issues/1804

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
