### PR TITLE
improve error when an object fails to serialize

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@
 
 - Fix issue where roundtripping a masked array with no masked values removes the mask [#1803]
 
+- Use a custom exception ``AsdfSerializationError`` to indicate when an object in the
+  tree fails to be serialized by asdf (and by yaml). This exception currently inherits
+  from ``yaml.representer.RepresenterError`` to provide backwards compatibility. However
+  this inheritance may be dropped in a future asdf version. Please migrate to the new
+  ``AsdfSerializationError``. [#1809]
+
 3.3.0 (2024-07-12)
 ------------------
 

--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -3,11 +3,10 @@ import sys
 
 import pytest
 from packaging.specifiers import SpecifierSet
-from yaml.representer import RepresenterError
 
 import asdf
 from asdf import AsdfFile, config_context
-from asdf.exceptions import AsdfManifestURIMismatchWarning, AsdfWarning, ValidationError
+from asdf.exceptions import AsdfManifestURIMismatchWarning, AsdfSerializationError, AsdfWarning, ValidationError
 from asdf.extension import (
     Compressor,
     Converter,
@@ -578,7 +577,7 @@ def test_converter_subclass_with_no_supported_tags():
     tree = {"obj": Foo()}
     with config_context() as cfg:
         cfg.add_extension(FooExtension())
-        with pytest.raises(RepresenterError, match=r"cannot represent an object"):
+        with pytest.raises(AsdfSerializationError, match=r"is not serializable by asdf"):
             roundtrip_object(tree)
 
 

--- a/asdf/_tests/test_yaml.py
+++ b/asdf/_tests/test_yaml.py
@@ -10,7 +10,7 @@ import yaml
 
 import asdf
 from asdf import tagged, treeutil, yamlutil
-from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfWarning
+from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfSerializationError, AsdfWarning
 from asdf.testing.helpers import yaml_to_asdf
 
 
@@ -104,7 +104,7 @@ def test_arbitrary_python_object():
 
     buff = io.BytesIO()
     ff = asdf.AsdfFile(tree)
-    with pytest.raises(yaml.YAMLError, match=r"\('cannot represent an object', .*\)"):
+    with pytest.raises(AsdfSerializationError, match=r".*is not serializable by asdf.*"):
         ff.write_to(buff)
 
 
@@ -350,7 +350,7 @@ def test_ndarray_subclass_conversion(tmp_path):
 
     with asdf.config.config_context() as cfg:
         cfg.convert_unknown_ndarray_subclasses = False
-        with pytest.raises(yaml.representer.RepresenterError, match=r".*cannot represent.*"):
+        with pytest.raises(AsdfSerializationError, match=r".*is not serializable by asdf.*"):
             af.write_to(fn)
 
 

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -1,3 +1,5 @@
+from yaml.representer import RepresenterError
+
 from asdf._jsonschema import ValidationError
 
 __all__ = [
@@ -72,4 +74,12 @@ class AsdfLazyReferenceError(ReferenceError):
     to an AsdfFile instance. This likely means the AsdfFile was garbage
     collected and you may need to update your code to keep the AsdfFile
     in memory (by keeping a reference).
+    """
+
+
+class AsdfSerializationError(RepresenterError):
+    """
+    An object failed serialization by asdf and by yaml. This likely indicates
+    that the object does not have a supporting asdf Converter and needs to
+    be manually converted to a supported type.
     """

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -9,6 +9,7 @@ __all__ = [
     "AsdfManifestURIMismatchWarning",
     "AsdfPackageVersionWarning",
     "AsdfProvisionalAPIWarning",
+    "AsdfSerializationError",
     "AsdfWarning",
     "DelimiterNotFoundError",
     "ValidationError",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,12 @@ man_pages = [("index", project.lower(), project + " Documentation", [author], 1)
 
 nitpicky = True
 
+# ignore a few pyyaml docs links since they don't appear to support intersphinx
+nitpick_ignore = [
+    ("py:class", "yaml.representer.RepresenterError"),
+    ("py:class", "yaml.error.YAMLError"),
+]
+
 # Add intersphinx mappings
 intersphinx_mapping["semantic_version"] = ("https://python-semanticversion.readthedocs.io/en/latest/", None)
 intersphinx_mapping["jsonschema"] = ("https://python-jsonschema.readthedocs.io/en/stable/", None)


### PR DESCRIPTION
# Description

asdf currently produces an unhelpful message for some objects that fail to serialize during `asdf.write_to`:
```python
import asdf, collections

class MyDict(collections.UserDict):
    pass

asdf.AsdfFile({"d": MyDict({"a": 1})}).write_to("foo.asdf")
```
Produces:
```
...
yaml.representer.RepresenterError: ('cannot represent an object', {'a': 1})
```

This PR adds a new exception `AsdfSerializationError` that includes the object type in the error message when yaml emits a `yaml.representer.RepresenterError` (for backwards compatibility the new exception inherits from `yaml.representer.RepresenterError`).

Running the above example with this PR produces:
```
asdf.exceptions.AsdfSerializationError: ("Object of type[<class '__main__.MyDict'>] is not serializable by asdf. Please convert the object to a supported type or implement a Converter for this type to allow the tree to be serialized.", {'a': 1})
```

Here is a related issue where the above message would have been helpful: https://github.com/spacetelescope/roman_datamodels/issues/361

# Checklist:

- [x] pre-commit checks ran successfully
- [ ] tests ran successfully
- [x] for a public change, a changelog entry was added
- [x] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
