### PR TITLE
DEP: drop importlib_metadata as a dependency on Python 3.12 and newer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
   this inheritance may be dropped in a future asdf version. Please migrate to the new
   ``AsdfSerializationError``. [#1809]
 
+- Drop ``importlib_metadata`` as a dependency on Python 3.12 and newer [#1810]
+
 3.3.0 (2024-07-12)
 ------------------
 

--- a/asdf/_entry_points.py
+++ b/asdf/_entry_points.py
@@ -1,15 +1,20 @@
+import sys
 import warnings
+
+from .exceptions import AsdfWarning
+from .extension import ExtensionProxy
+from .resource import ResourceMappingProxy
 
 # The standard library importlib.metadata returns duplicate entrypoints
 # for all python versions up to and including 3.11
 # https://github.com/python/importlib_metadata/issues/410#issuecomment-1304258228
 # see PR https://github.com/asdf-format/asdf/pull/1260
 # see issue https://github.com/asdf-format/asdf/issues/1254
-from importlib_metadata import entry_points
+if sys.version_info >= (3, 12):
+    from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points
 
-from .exceptions import AsdfWarning
-from .extension import ExtensionProxy
-from .resource import ResourceMappingProxy
 
 RESOURCE_MAPPINGS_GROUP = "asdf.resource_mappings"
 EXTENSIONS_GROUP = "asdf.extensions"

--- a/asdf/_tests/test_entry_points.py
+++ b/asdf/_tests/test_entry_points.py
@@ -1,9 +1,5 @@
-# The standard library importlib.metadata returns duplicate entrypoints
-# for all python versions up to and including 3.11
-# https://github.com/python/importlib_metadata/issues/410#issuecomment-1304258228
-# see PR https://github.com/asdf-format/asdf/pull/1260
-# see issue https://github.com/asdf-format/asdf/issues/1254
-import importlib_metadata as metadata
+import sys
+
 import pytest
 
 from asdf import _entry_points
@@ -11,6 +7,16 @@ from asdf._version import version as asdf_package_version
 from asdf.exceptions import AsdfWarning
 from asdf.extension import ExtensionProxy
 from asdf.resource import ResourceMappingProxy
+
+# The standard library importlib.metadata returns duplicate entrypoints
+# for all python versions up to and including 3.11
+# https://github.com/python/importlib_metadata/issues/410#issuecomment-1304258228
+# see PR https://github.com/asdf-format/asdf/pull/1260
+# see issue https://github.com/asdf-format/asdf/issues/1254
+if sys.version_info >= (3, 12):
+    import importlib.metadata as metadata
+else:
+    import importlib_metadata as metadata
 
 
 @pytest.fixture()

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -4,6 +4,7 @@ import inspect
 import math
 import re
 import struct
+import sys
 import types
 import warnings
 from functools import lru_cache
@@ -12,16 +13,20 @@ from urllib.request import pathname2url
 
 import numpy as np
 import yaml
+from packaging.version import Version
+
+from . import constants, exceptions
 
 # The standard library importlib.metadata returns duplicate entrypoints
 # for all python versions up to and including 3.11
 # https://github.com/python/importlib_metadata/issues/410#issuecomment-1304258228
 # see PR https://github.com/asdf-format/asdf/pull/1260
 # see issue https://github.com/asdf-format/asdf/issues/1254
-from importlib_metadata import packages_distributions
-from packaging.version import Version
+if sys.version_info >= (3, 12):
+    from importlib.metadata import packages_distributions
+else:
+    from importlib_metadata import packages_distributions
 
-from . import constants, exceptions
 
 # We're importing our own copy of urllib.parse because
 # we need to patch it to support asdf:// URIs, but it'd

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,13 +6,18 @@ if sys.version_info < (3, 11):
 else:
     import tomllib
 
+from sphinx_asdf.conf import *  # noqa: F403
+
 # The standard library importlib.metadata returns duplicate entrypoints
 # for all python versions up to and including 3.11
 # https://github.com/python/importlib_metadata/issues/410#issuecomment-1304258228
 # see PR https://github.com/asdf-format/asdf/pull/1260
 # see issue https://github.com/asdf-format/asdf/issues/1254
-from importlib_metadata import distribution
-from sphinx_asdf.conf import *  # noqa: F403
+if sys.version_info >= (3, 12):
+    from importlib.metadata import distribution
+else:
+    from importlib_metadata import distribution
+
 
 # Get configuration information from `pyproject.toml`
 with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as configuration_file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = [
 dependencies = [
   "asdf-standard>=1.1.0",
   "asdf-transform-schemas>=0.3",  # required for asdf-1.0.0 schema
-  "importlib-metadata>=4.11.4",
+  "importlib-metadata>=4.11.4 ; python_version<='3.11'",
   "jmespath>=0.6.2",
   "numpy>=1.22",
   "packaging>=19",


### PR DESCRIPTION
This is a follow up to #1260: according to [the comment linked](https://github.com/python/importlib_metadata/issues/410#issuecomment-1304258228) in that PR's commit message, standard library `importlib.metadata` isn't problematic starting from Python 3.12


# Checklist:

- [x] pre-commit checks ran successfully
- [x] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
