### PR TITLE
MNT: handle a deprecation warning from `attrs` v24.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Drop ``importlib_metadata`` as a dependency on Python 3.12 and newer [#1810]
 
+- Bumped minimal requirement on ``attrs`` from ``20.1.0`` to ``22.2.0`` [#1815]
+
 3.3.0 (2024-07-12)
 ------------------
 

--- a/asdf/_jsonschema/exceptions.py
+++ b/asdf/_jsonschema/exceptions.py
@@ -176,7 +176,7 @@ class SchemaError(_Error):
     _word_for_instance_in_error_message = "schema"
 
 
-@attr.s(hash=True)
+@attr.s(unsafe_hash=True)
 class RefResolutionError(Exception):
     """
     A ref could not be resolved.

--- a/asdf/_jsonschema/tests/_suite.py
+++ b/asdf/_jsonschema/tests/_suite.py
@@ -35,7 +35,7 @@ def _find_suite():
     return root
 
 
-@attr.s(hash=True)
+@attr.s(unsafe_hash=True)
 class Suite:
 
     _root = attr.ib(default=attr.Factory(_find_suite))
@@ -62,7 +62,7 @@ class Suite:
         )
 
 
-@attr.s(hash=True)
+@attr.s(unsafe_hash=True)
 class Version:
 
     _path = attr.ib()
@@ -139,7 +139,7 @@ class Version:
             )
 
 
-@attr.s(hash=True, repr=False)
+@attr.s(unsafe_hash=True, repr=False)
 class _Test:
 
     version = attr.ib()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "pyyaml>=5.4.1",
   "semantic_version>=2.8",
   # for vendorized jsonschema
-  "attrs>=20.1.0",
+  "attrs>=22.2.0",
   # end of vendorized jsonschema deps
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

`attrs` 24.1.0 (released yesterday) deprecated the `hash` argument in favor of `unsafe_hash`
For simplicity of implementation, I also bumped the minimal requirement to 22.2.0, which added the `unsafe_hash` argument.

xref https://github.com/python-attrs/attrs/pull/1323

For context, I noticed this because it breaks astropy's CI, so please let me know if this patch can be released promptly or not. We'll be able to adapt in any case.


# Checklist:

- [x] pre-commit checks ran successfully
- [x] tests ran successfully
- [x] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
