### PR TITLE
deprecate ignore_version_mismatch

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -72,7 +72,7 @@ class AsdfFile:
         uri=None,
         extensions=None,
         version=None,
-        ignore_version_mismatch=True,
+        ignore_version_mismatch=NotSet,
         ignore_unrecognized_tag=False,
         ignore_implicit_conversion=NotSet,
         copy_arrays=NotSet,
@@ -102,6 +102,7 @@ class AsdfFile:
             configured default version.  See `asdf.config.AsdfConfig.default_version`.
 
         ignore_version_mismatch : bool, optional
+            Deprecated and unused. This setting does nothing since asdf 3.0.0
             When `True`, do not raise warnings for mismatched schema versions.
             Set to `True` by default.
 
@@ -162,7 +163,12 @@ class AsdfFile:
         else:
             self._custom_schema = None
 
-        self._ignore_version_mismatch = ignore_version_mismatch
+        if ignore_version_mismatch is not NotSet:
+            warnings.warn(
+                "ignore_version_mismatch is deprecated and has done " "nothing since asdf 3.0.0",
+                AsdfDeprecationWarning,
+            )
+
         self._ignore_unrecognized_tag = ignore_unrecognized_tag
         self._ignore_implicit_conversion = ignore_implicit_conversion
 
@@ -1619,7 +1625,7 @@ def open_asdf(
     mode=None,
     validate_checksums=False,
     extensions=None,
-    ignore_version_mismatch=True,
+    ignore_version_mismatch=NotSet,
     ignore_unrecognized_tag=False,
     _force_raw_types=False,
     copy_arrays=NotSet,
@@ -1657,6 +1663,7 @@ def open_asdf(
         May be an `asdf.extension.Extension` or a `list` of extensions.
 
     ignore_version_mismatch : bool, optional
+        Deprecated and unused. This setting does nothing since asdf 3.0.0
         When `True`, do not raise warnings for mismatched schema versions.
         Set to `True` by default.
 

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -165,7 +165,7 @@ class AsdfFile:
 
         if ignore_version_mismatch is not NotSet:
             warnings.warn(
-                "ignore_version_mismatch is deprecated and has done " "nothing since asdf 3.0.0",
+                "ignore_version_mismatch is deprecated and has done nothing since asdf 3.0.0",
                 AsdfDeprecationWarning,
             )
 

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -158,3 +158,9 @@ def test_copy_arrays_deprecation(copy_arrays, memmap, tmp_path):
     with pytest.warns(AsdfWarning, match="copy_arrays is deprecated; use memmap instead"):
         with asdf.open(fn, copy_arrays=copy_arrays, memmap=memmap) as af:
             pass
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_ignore_version_mismatch_deprecation(value):
+    with pytest.warns(AsdfDeprecationWarning, match="ignore_version_mismatch is deprecated"):
+        asdf.AsdfFile({}, ignore_version_mismatch=value)

--- a/changes/1819.removal.rst
+++ b/changes/1819.removal.rst
@@ -1,0 +1,2 @@
+Deprecate ``ignore_version_mismatch``. This option has done nothing since
+asdf 3.0.0 and will be removed in an upcoming asdf version

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -44,7 +44,8 @@ def pytest_addoption(parser):
     parser.addini(
         "asdf_schema_ignore_version_mismatch",
         "Set to true to disable warnings when missing explicit support for a tag",
-        type="bool",
+        type="string",
+        default="",
     )
     parser.addoption("--asdf-tests", action="store_true", help="Enable ASDF schema tests")
 
@@ -282,13 +283,11 @@ def pytest_collect_file(file_path, parent):
     validate_default = parent.config.getini("asdf_schema_validate_default")
     ignore_unrecognized_tag = parent.config.getini("asdf_schema_ignore_unrecognized_tag")
     ignore_version_mismatch = parent.config.getini("asdf_schema_ignore_version_mismatch")
-    if ignore_version_mismatch in (True, False):
+    if ignore_version_mismatch != "":
         from asdf.exceptions import AsdfDeprecationWarning
 
-        # pytest will return an empty list for getini on a bool with no default
-        # since we have a True or False here warn the user that this setting is deprecated
         warnings.warn(
-            "asdf_schema_ignore_version_mismatch is deprecated " "and has done nothing since asdf 3.0.0",
+            "asdf_schema_ignore_version_mismatch is deprecated and has done nothing since asdf 3.0.0",
             AsdfDeprecationWarning,
         )
 


### PR DESCRIPTION
This PR deprecates `ignore_version_mismatch`. Since asdf 3.0.0 it has done nothing (it was only used for the legacy extension API which was removed in asdf 3.0.0).

There are a few downstream uses in stdatamodels mostly in tests. However there is one jwst test that fails due to a non-specific warning filter:
https://github.com/spacetelescope/jwst/blob/89f126a035751674f29a9027e2deae11b3e63fca/jwst/assign_wcs/tests/test_schemas.py#L57

Requires https://github.com/spacetelescope/stdatamodels/pull/313
and likely https://github.com/spacetelescope/jwst/pull/8693 (or a release of stdatamodels with the above PR)
before merging. I'm opening it for review now in case there is discussion about the warning message (changes to the message would require updating the jwst PR).

Closes https://github.com/asdf-format/asdf/issues/1812

# Checklist:

- [x] pre-commit checks ran successfully
- [x] tests ran successfully
- [x] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
