### PR TITLE
remove s390 badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,6 @@ ASDF - Advanced Scientific Data Format
     :target: https://github.com/asdf-format/asdf/actions
     :alt: CI Status
 
-.. image:: https://github.com/asdf-format/asdf/workflows/s390x/badge.svg
-    :target: https://github.com/asdf-format/asdf/actions
-    :alt: s390x Status
-
 .. image:: https://github.com/asdf-format/asdf/workflows/Downstream/badge.svg
     :target: https://github.com/asdf-format/asdf/actions
     :alt: Downstream CI Status


### PR DESCRIPTION
I missed removal of the badge in https://github.com/asdf-format/asdf/pull/1818

This PR removes the badge for the now removed workflow.
