### PR TITLE
skip dkist benchmarks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -322,5 +322,5 @@ commands =
 # the AsdfManifestURIMismatchWarning filter can be removed when a new sunpy
 # is released which contains the fixed manifests:
 # https://github.com/sunpy/sunpy/pull/7432
-    pytest dkist \
+    pytest dkist --benchmark-skip \
         -W "ignore::asdf.exceptions.AsdfManifestURIMismatchWarning"


### PR DESCRIPTION
# Description

dkist added benchmarks to their test suite in https://github.com/DKISTDC/dkist/pull/382

which they disable for unit test runs using [--benchmark-skip](https://github.com/DKISTDC/dkist/pull/382/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R38)

This PR adds the same skip to our downstream dkist test (which is otherwise [failing](https://github.com/asdf-format/asdf/actions/runs/10942008003/job/30377992700?pr=1744) on the benchmarks).

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, added a [towncrier news fragment](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) <details><summary>`changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.feature.rst``: new feature
    - ``changes/<PR#>.bugfix.rst``: bug fix
    - ``changes/<PR#>.doc.rst``: documentation change
    - ``changes/<PR#>.removal.rst``: deprecation or removal of public API
    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  </details>
- [ ] for a public change, updated documentation
- [ ] for any new features, unit tests were added
