### PR TITLE
update changelog for 3.5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,37 @@
+3.5.0 (2024-10-02)
+==================
+
+Bugfix
+------
+
+- Allow ``asdf.util.load_yaml`` to handle recursive objects (`#1825
+  <https://github.com/asdf-format/asdf/pull/1825>`_)
+
+
+Doc
+---
+
+- added issue links to changelog entries (`#1827
+  <https://github.com/asdf-format/asdf/pull/1827>`_)
+- Change asdf standard changelog entries to notes to ease transition to
+  towncrier (`#1830 <https://github.com/asdf-format/asdf/pull/1830>`_)
+
+
+General
+-------
+
+- fix changelog checker to remove brackets (`#1828
+  <https://github.com/asdf-format/asdf/pull/1828>`_)
+
+
+Removal
+-------
+
+- Deprecate ``ignore_version_mismatch``. This option has done nothing since
+  asdf 3.0.0 and will be removed in an upcoming asdf version (`#1819
+  <https://github.com/asdf-format/asdf/pull/1819>`_)
+
+
 3.4.0 (2024-08-04)
 ==================
 

--- a/changes/1819.removal.rst
+++ b/changes/1819.removal.rst
@@ -1,2 +1,0 @@
-Deprecate ``ignore_version_mismatch``. This option has done nothing since
-asdf 3.0.0 and will be removed in an upcoming asdf version

--- a/changes/1825.bugfix.rst
+++ b/changes/1825.bugfix.rst
@@ -1,1 +1,0 @@
-Allow ``asdf.util.load_yaml`` to handle recursive objects

--- a/changes/1827.doc.rst
+++ b/changes/1827.doc.rst
@@ -1,1 +1,0 @@
-added issue links to changelog entries

--- a/changes/1828.general.rst
+++ b/changes/1828.general.rst
@@ -1,1 +1,0 @@
-fix changelog checker to remove brackets

--- a/changes/1830.doc.rst
+++ b/changes/1830.doc.rst
@@ -1,1 +1,0 @@
-Change asdf standard changelog entries to notes to ease transition to towncrier


### PR DESCRIPTION
# Description

Romancal regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/11151181622
JWST regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/11151191151
match those on main: https://github.com/spacetelescope/RegressionTests/actions/runs/11135377170

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, added a [towncrier news fragment](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) <details><summary>`changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.feature.rst``: new feature
    - ``changes/<PR#>.bugfix.rst``: bug fix
    - ``changes/<PR#>.doc.rst``: documentation change
    - ``changes/<PR#>.removal.rst``: deprecation or removal of public API
    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  </details>
- [ ] for a public change, updated documentation
- [ ] for any new features, unit tests were added
