### PR TITLE
add abacusutils to downstream

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -73,3 +73,4 @@ jobs:
         - linux: weldx
         - linux: sunpy
         - linux: dkist
+        - linux: abacusutils

--- a/tox.ini
+++ b/tox.ini
@@ -338,6 +338,7 @@ commands_pre =
     pip install --no-build-isolation classy corrfunc
     pip install -e abacusutils[test]
     pip install -r {env_tmp_dir}/requirements.txt
+    bash -c "echo '' > pytest.ini"
     pip freeze
 commands =
     pytest abacusutils

--- a/tox.ini
+++ b/tox.ini
@@ -338,7 +338,12 @@ commands_pre =
     pip install --no-build-isolation classy corrfunc
     pip install -e abacusutils[test]
     pip install -r {env_tmp_dir}/requirements.txt
+# make an empty pytest.ini to prevent pytest from crawling up
+# one directory and finding the pytest configuration for the asdf
+# repo clone
     bash -c "echo '' > pytest.ini"
     pip freeze
 commands =
-    pytest abacusutils
+# only running a subset of tests since only a portion of abacusutils
+# relies on asdf
+    pytest abacusutils/tests/test_data.py

--- a/tox.ini
+++ b/tox.ini
@@ -324,3 +324,20 @@ commands =
 # https://github.com/sunpy/sunpy/pull/7432
     pytest dkist --benchmark-skip \
         -W "ignore::asdf.exceptions.AsdfManifestURIMismatchWarning"
+
+[testenv:abacusutils]
+change_dir = {env_tmp_dir}
+allowlist_externals =
+    git
+    bash
+extras =
+commands_pre =
+    bash -c "pip freeze -q | grep 'asdf @' > {env_tmp_dir}/requirements.txt"
+    git clone https://github.com/abacusorg/abacusutils.git
+    pip install -vU setuptools wheel scipy Cython 'numpy<2'  # for classy and corrfunc
+    pip install --no-build-isolation classy corrfunc
+    pip install -e abacusutils[test]
+    pip install -r {env_tmp_dir}/requirements.txt
+    pip freeze
+commands =
+    pytest abacusutils


### PR DESCRIPTION
This PR adds https://github.com/abacusorg/abacusutils to our downstream tests.

The tox environment was largely modeled on the test setup in the downstream repo:
https://github.com/abacusorg/abacusutils/blob/6e18f79fc31aea7973abbb144b78d049a2452eeb/.github/workflows/tests.yml#L84
as there are a few "difficult to install" dependencies.

The tests are currently passing but do show some warnings related to asdf:
```
   /home/runner/work/asdf/asdf/asdf/_asdf.py:189: AsdfWarning: copy_arrays is deprecated; use memmap instead. Note that memmap will default to False in asdf 4.0.
```
which are expected following the deprecation of `copy_arrays` https://github.com/asdf-format/asdf/pull/1797

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, added a [towncrier news fragment](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) <details><summary>`changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.feature.rst``: new feature
    - ``changes/<PR#>.bugfix.rst``: bug fix
    - ``changes/<PR#>.doc.rst``: documentation change
    - ``changes/<PR#>.removal.rst``: deprecation or removal of public API
    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  </details>
- [ ] for a public change, updated documentation
- [ ] for any new features, unit tests were added
