### PR TITLE
[CI] test using `setup-uv` to build and cache environment

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,13 +18,16 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-entry-needed') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: pip install .
-      - run: pip install towncrier
+      - uses: astral-sh/setup-uv@f3bcaebff5eace81a1c062af9f9011aae482ca9d # v3.1.7
+        with:
+          version: "0.4.22"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+      - run: uv python install 3
+      - run: uv pip install .
+      - run: uv pip install towncrier
       - run: towncrier check
       - run: towncrier build --draft | grep -P '#${{ github.event.number }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@f3bcaebff5eace81a1c062af9f9011aae482ca9d # v3.1.7
+      with:
+        version: "0.4.22"
+        enable-cache: true
+        cache-dependency-glob: "pyproject.toml"
+    - run: uv python install 3
     - uses: pre-commit/action@v3.0.1
   core:
     needs: [pre-commit]


### PR DESCRIPTION
<!---
Thanks for contributing to asdf!

Your PR should trigger the CI (after approval for first-time contributors)
which will:

- check your code for 'style' using pre-commit
- run your PR against the asdf unit tests for various OSes, python versions, and dependency versions
- perform a test build of your PR

It is highly recommended that you run some of these tests locally by:

- [installing pre-commit](https://pre-commit.com/#quick-start)
- [running pytest](https://docs.pytest.org/en/7.1.x/getting-started.html)

This will increase the chances your PR will pass the required CI tests.
-->

# Description

<!--
Please describe what this PR accomplishes.
If the changes are non-obvious, please explain how they work.
If this PR adds a new feature please include tests and documentation.
If this PR fixes an issue, please add closing keywords (eg 'fixes #XXX')
-->

replace `setup-python` with `setup-uv` + `uv python install`; I imagine there probably won't be much difference in speed or caching but it's worth an explore

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, added a [towncrier news fragment](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) <details><summary>`changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.feature.rst``: new feature
    - ``changes/<PR#>.bugfix.rst``: bug fix
    - ``changes/<PR#>.doc.rst``: documentation change
    - ``changes/<PR#>.removal.rst``: deprecation or removal of public API
    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  </details>
- [ ] for a public change, updated documentation
- [ ] for any new features, unit tests were added
