### PR TITLE
change atomic file prefix

### DIFF
--- a/asdf/_extern/atomicfile.py
+++ b/asdf/_extern/atomicfile.py
@@ -132,7 +132,7 @@ def atomic_open(filename, mode='w'):
     """
     if mode in ('r', 'rb', 'r+', 'rb+', 'a', 'ab'):
         raise TypeError('Read or append modes don\'t work with atomic_open')
-    f = tempfile.NamedTemporaryFile(mode, prefix='.___atomic_write',
+    f = tempfile.NamedTemporaryFile(mode, prefix='.asdf_tmp',
                                     dir=os.path.dirname(filename),
                                     delete=False)
     return _AtomicWFile(f, f.name, filename)


### PR DESCRIPTION
Fixes #1850

# Description

The STScI central store network mount does odd things with `._` files.

```python
>>> f = open("._foo", "wb")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileNotFoundError: [Errno 2] No such file or directory: '._foo'
>>> f = open(".bam", "wb")
>>> f = open("._foo", "wb")
```

This causes issues for asdf which uses `.___atomic_write...` temporary files. This PR changes the files to `.asdf_tmp...` to work around the problematic mount.

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, added a [towncrier news fragment](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) <details><summary>`changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.feature.rst``: new feature
    - ``changes/<PR#>.bugfix.rst``: bug fix
    - ``changes/<PR#>.doc.rst``: documentation change
    - ``changes/<PR#>.removal.rst``: deprecation or removal of public API
    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  </details>
- [ ] for a public change, updated documentation
- [ ] for any new features, unit tests were added
