### PR TITLE
Error for Convert subclasses with multiple tags if select_tag isn't implemented

### DIFF
--- a/asdf/_tests/test_extension.py
+++ b/asdf/_tests/test_extension.py
@@ -6,7 +6,7 @@ from packaging.specifiers import SpecifierSet
 
 import asdf
 from asdf import AsdfFile, config_context
-from asdf.exceptions import AsdfManifestURIMismatchWarning, AsdfSerializationError, AsdfWarning, ValidationError
+from asdf.exceptions import AsdfManifestURIMismatchWarning, AsdfSerializationError, ValidationError
 from asdf.extension import (
     Compressor,
     Converter,
@@ -892,10 +892,8 @@ def test_warning_or_error_for_default_select_tag(is_subclass, indirect):
         "asdf://somewhere.org/tags/foo-2.0.0",
     ]
     extension = FullExtension(converters=[FooConverter()], tags=tags)
-    ctx_type = pytest.warns if is_subclass else pytest.raises
-    exception_class = AsdfWarning if is_subclass else RuntimeError
     with config_context() as config:
-        with ctx_type(exception_class, match="Converter handles multiple tags"):
+        with pytest.raises(RuntimeError, match="Converter handles multiple tags"):
             config.add_extension(extension)
 
 

--- a/asdf/extension/_converter.py
+++ b/asdf/extension/_converter.py
@@ -4,9 +4,7 @@ types.  Will eventually replace the `asdf.types` module.
 """
 
 import abc
-import warnings
 
-from asdf.exceptions import AsdfWarning
 from asdf.util import get_class_name, uri_match
 
 
@@ -179,23 +177,8 @@ class ConverterProxy(Converter):
                 raise TypeError(msg)
 
         if len(relevant_tags) > 1 and not hasattr(delegate, "select_tag"):
-            # we cannot use isinstance here because Converter supports
-            # virtual subclasses
-            if Converter in delegate.__class__.__mro__:
-                # prior to asdf 3.0 Converter provided a default select_tag
-                # to provide backwards compatibility allow Converter subclasses
-                # to be registered with >1 tag but produce a warning
-                msg = (
-                    "Converter handles multiple tags for this extension, "
-                    "but does not implement a select_tag method. "
-                    "This previously worked because Converter subclasses inherited "
-                    "the now removed select_tag. This will be an error in a future "
-                    "version of asdf"
-                )
-                warnings.warn(msg, AsdfWarning)
-            else:
-                msg = "Converter handles multiple tags for this extension, but does not implement a select_tag method."
-                raise RuntimeError(msg)
+            msg = "Converter handles multiple tags for this extension, but does not implement a select_tag method."
+            raise RuntimeError(msg)
 
         self._tags = sorted(relevant_tags)
 

--- a/changes/1853.feature.rst
+++ b/changes/1853.feature.rst
@@ -1,0 +1,1 @@
+Raise RuntimeError if a Convert subclass supports multiple tags but doesn't implement select_tag.


### PR DESCRIPTION
# Description

Closes #1632

For a converter that supports multiple tags but does not implement select tag, raise a RuntimeError (instead of a warning). Previously a warning was produced only for `Converter` subclasses (virtual subclasses produced RuntimeErrors). Now both real and virtual subclasses produce errors.

# Checklist:

- [x] pre-commit checks ran successfully
- [x] tests ran successfully
- [x] for a public change, added a [towncrier news fragment](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) <details><summary>`changes/<PR#>.<changetype>.rst`</summary>

    - ``changes/<PR#>.feature.rst``: new feature
    - ``changes/<PR#>.bugfix.rst``: bug fix
    - ``changes/<PR#>.doc.rst``: documentation change
    - ``changes/<PR#>.removal.rst``: deprecation or removal of public API
    - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  </details>
- [ ] for a public change, updated documentation
- [ ] for any new features, unit tests were added
