### PR TITLE
switch convert_unknown_ndarray_subclasses to False

### DIFF
--- a/asdf/_tests/test_yaml.py
+++ b/asdf/_tests/test_yaml.py
@@ -9,7 +9,7 @@ import yaml
 
 import asdf
 from asdf import tagged, treeutil, yamlutil
-from asdf.exceptions import AsdfConversionWarning, AsdfSerializationError
+from asdf.exceptions import AsdfConversionWarning, AsdfDeprecationWarning, AsdfSerializationError
 from asdf.testing.helpers import yaml_to_asdf
 
 

--- a/asdf/_tests/test_yaml.py
+++ b/asdf/_tests/test_yaml.py
@@ -270,12 +270,13 @@ def test_ndarray_subclass_conversion(tmp_path):
     fn = tmp_path / "test.asdf"
     af = asdf.AsdfFile()
     af["a"] = MyNDArray([1, 2, 3])
-    with pytest.warns(AsdfConversionWarning, match=r"A ndarray subclass .*"):
+    with pytest.raises(AsdfSerializationError, match=r".*is not serializable by asdf.*"):
         af.write_to(fn)
 
     with asdf.config.config_context() as cfg:
-        cfg.convert_unknown_ndarray_subclasses = False
-        with pytest.raises(AsdfSerializationError, match=r".*is not serializable by asdf.*"):
+        with pytest.warns(AsdfDeprecationWarning, match=r"convert_unknown_ndarray_subclasses"):
+            cfg.convert_unknown_ndarray_subclasses = True
+        with pytest.warns(AsdfConversionWarning, match=r"A ndarray subclass .*"):
             af.write_to(fn)
 
 

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -6,10 +6,12 @@ options.
 import collections
 import copy
 import threading
+import warnings
 from contextlib import contextmanager
 
 from . import _entry_points, util, versioning
 from ._helpers import validate_version
+from .exceptions import AsdfDeprecationWarning
 from .extension import ExtensionProxy
 from .resource import ResourceManager, ResourceMappingProxy
 
@@ -25,7 +27,7 @@ DEFAULT_ALL_ARRAY_STORAGE = None
 DEFAULT_ALL_ARRAY_COMPRESSION = "input"
 DEFAULT_ALL_ARRAY_COMPRESSION_KWARGS = None
 DEFAULT_DEFAULT_ARRAY_SAVE_BASE = True
-DEFAULT_CONVERT_UNKNOWN_NDARRAY_SUBCLASSES = True
+DEFAULT_CONVERT_UNKNOWN_NDARRAY_SUBCLASSES = False
 DEFAULT_LAZY_TREE = False
 
 
@@ -458,6 +460,13 @@ class AsdfConfig:
 
     @convert_unknown_ndarray_subclasses.setter
     def convert_unknown_ndarray_subclasses(self, value):
+        if value:
+            msg = (
+                "Enabling convert_unknown_ndarray_subclasses is deprecated. "
+                "Please add a Converter or install an extension that supports "
+                "the ndarray subclass you'd like to converter"
+            )
+            warnings.warn(msg, AsdfDeprecationWarning)
         self._convert_unknown_ndarray_subclasses = value
 
     @property

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -464,7 +464,7 @@ class AsdfConfig:
             msg = (
                 "Enabling convert_unknown_ndarray_subclasses is deprecated. "
                 "Please add a Converter or install an extension that supports "
-                "the ndarray subclass you'd like to converter"
+                "the ndarray subclass you'd like to convert"
             )
             warnings.warn(msg, AsdfDeprecationWarning)
         self._convert_unknown_ndarray_subclasses = value

--- a/changes/1858.removal.rst
+++ b/changes/1858.removal.rst
@@ -1,0 +1,1 @@
+Switch default convert_unknown_ndarray_subclasses to False and issue deprecation warning if it is enabled.

--- a/docs/asdf/config.rst
+++ b/docs/asdf/config.rst
@@ -40,7 +40,7 @@ the currently active config:
       all_array_compression: input
       all_array_compression_kwargs: None
       default_array_save_base: True
-      convert_unknown_ndarray_subclasses: True
+      convert_unknown_ndarray_subclasses: False
       default_version: 1.5.0
       io_block_size: -1
       legacy_fill_schema_defaults: True
@@ -66,7 +66,7 @@ This allows for short-lived configuration changes that do not impact other code:
       all_array_compression: input
       all_array_compression_kwargs: None
       default_array_save_base: True
-      convert_unknown_ndarray_subclasses: True
+      convert_unknown_ndarray_subclasses: False
       default_version: 1.5.0
       io_block_size: -1
       legacy_fill_schema_defaults: True
@@ -80,7 +80,7 @@ This allows for short-lived configuration changes that do not impact other code:
       all_array_compression: input
       all_array_compression_kwargs: None
       default_array_save_base: True
-      convert_unknown_ndarray_subclasses: True
+      convert_unknown_ndarray_subclasses: False
       default_version: 1.5.0
       io_block_size: -1
       legacy_fill_schema_defaults: True
@@ -172,11 +172,11 @@ in asdf (for subclasses in existing asdf dependencies).
 
 With this setting enabled, asdf will continue to convert instances
 of subclasses of ndarray but will issue a warning when an instance is
-converted. In a future version of asdf this default will change
-to ``False``, a deprecation warning will be issued and finally
-the conversion of instances of subclasses will be removed.
+converted. This currently defaults to ``False`` and issues
+a deprecation warning if enabled. In a future version of asdf
+this setting will be removed.
 
-Defaults to ``True``.
+Defaults to ``False``.
 
 default_version
 ---------------


### PR DESCRIPTION
## Description

Switches the default value for [convert_unknown_ndarray_subclasses](https://asdf.readthedocs.io/en/latest/api/asdf.config.AsdfConfig.html#asdf.config.AsdfConfig.convert_unknown_ndarray_subclasses) to False and issues an `AsdfDeprecationWarning` if this setting is enabled. We can remove it in asdf 5.0.

## Tasks

- [x] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [x] run `pytest` on your machine
- [x] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [x] update relevant docstrings and / or `docs/` page
    - [x] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
