### PR TITLE
improve schema info collection combiner handling

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1378,6 +1378,10 @@ class AsdfFile:
         """
         Get a nested dictionary of the schema information for a given key, relative to the path.
 
+        This method will only return unambiguous info. If a property is subject to multiple
+        subschemas or contains ambiguous entries (multiple titles) no result will be returned
+        for that property.
+
         Parameters
         ----------
         key : str

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -46,7 +46,7 @@ def _get_subschema_for_property(schema, key):
 
     # next handle schema combiners
     if "not" in schema:
-        # since we're only concerned here with if the schema applies
+        # Since we're only concerned here with if the schema applies
         # it doesn't matter if the schema is nested in a not
         subschema = _get_subschema_for_property(schema["not"], key)
         if subschema is not None:
@@ -75,10 +75,8 @@ def _get_schema_key(schema, key):
     applicable = []
     if key in schema:
         applicable.append(schema[key])
-    if "not" in schema:
-        possible = _get_schema_key(schema["not"], key)
-        if possible is not None:
-            applicable.append(possible)
+    # Here we don't consider any subschema under "not" to avoid
+    # false positives for keys like "type" etc.
     for combiner in ("allOf", "oneOf", "anyOf"):
         for combined_schema in schema.get(combiner, []):
             possible = _get_schema_key(combined_schema, key)

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -1,7 +1,7 @@
 import re
 from collections import namedtuple
 
-from .exceptions import AsdfSchemaResolutionError
+from .exceptions import AsdfInfoResolutionError
 from .schema import load_schema
 from .treeutil import get_children
 
@@ -66,7 +66,7 @@ def _get_subschema_for_property(schema, key):
             f"schema info could not be determined for {key} since "
             f"{len(applicable)} possibly applicable schemas were found."
         )
-        raise AsdfSchemaResolutionError(msg)
+        raise AsdfInfoResolutionError(msg)
 
     return applicable[0]
 
@@ -92,7 +92,7 @@ def _get_schema_key(schema, key):
             f"schema info could not be determined for {key} since "
             f"{len(applicable)} possibly applicable schemas were found."
         )
-        raise AsdfSchemaResolutionError(msg)
+        raise AsdfInfoResolutionError(msg)
 
     return applicable[0]
 

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -46,11 +46,12 @@ def _get_subschema_for_property(schema, key):
 
     # next handle schema combiners
     if "not" in schema:
-        # Since we're only concerned here with if the schema applies
-        # it doesn't matter if the schema is nested in a not
         subschema = _get_subschema_for_property(schema["not"], key)
         if subschema is not None:
-            applicable.append(subschema)
+            # We can't resolve a valid subschema under a "not" since
+            # we'd have to know how to invert a schema
+            msg = f"schema info could not be determined for {key} since " f"it is nested under a 'not'."
+            raise AsdfInfoResolutionError(msg)
 
     for combiner in ("allOf", "oneOf", "anyOf"):
         for combined_schema in schema.get(combiner, []):

--- a/asdf/_tests/test_info.py
+++ b/asdf/_tests/test_info.py
@@ -168,8 +168,8 @@ properties:
     description: Some silly description
     type: integer
     archive_catalog:
-        datatype: int
-        destination: [ScienceCommon.silly]
+      datatype: int
+      destination: [ScienceCommon.silly]
   clown:
     title: clown name
     description: clown description
@@ -231,14 +231,14 @@ properties:
     title: Attribute1 Title
     type: string
     archive_catalog:
-        datatype: str
-        destination: [ScienceCommon.attribute1]
+      datatype: str
+      destination: [ScienceCommon.attribute1]
   attribute2:
     title: Attribute2 Title
     type: string
     archive_catalog:
-        datatype: str
-        destination: [ScienceCommon.attribute2]
+      datatype: str
+      destination: [ScienceCommon.attribute2]
 ...
 """
 
@@ -251,19 +251,29 @@ id: "asdf://somewhere.org/asdf/schemas/drink-1.0.0"
 type: object
 title: object with info support 3 title
 description: object description
+allOf:
+    - $ref: drink_ref-1.0.0
+...
+"""
+    drink_ref_schema = """
+%YAML 1.1
+---
+$schema: "asdf://stsci.edu/schemas/asdf/asdf-schema-1.1.0"
+id: "asdf://somewhere.org/asdf/schemas/drink_ref-1.0.0"
 properties:
   attributeOne:
     title: AttributeOne Title
     description: AttributeOne description
     type: string
     archive_catalog:
-        datatype: str
-        destination: [ScienceCommon.attributeOne]
+      datatype: str
+      destination: [ScienceCommon.attributeOne]
   attributeTwo:
-    title: AttributeTwo Title
-    description: AttributeTwo description
-    type: string
-    archive_catalog:
+    allOf:
+    - title: AttributeTwo Title
+      description: AttributeTwo description
+      type: string
+      archive_catalog:
         datatype: str
         destination: [ScienceCommon.attributeTwo]
 ...
@@ -278,6 +288,9 @@ properties:
     spath = tmp_path / "schemas" / "drink-1.0.0.yaml"
     with open(spath, "w") as fschema:
         fschema.write(drink_schema)
+    spath = tmp_path / "schemas" / "drink_ref-1.0.0.yaml"
+    with open(spath, "w") as fschema:
+        fschema.write(drink_ref_schema)
     os.mkdir(tmp_path / "manifests")
     mpath = str(tmp_path / "manifests" / "foo_manifest-1.0.yaml")
     with open(mpath, "w") as fmanifest:

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -86,7 +86,7 @@ class AsdfSerializationError(RepresenterError):
     """
 
 
-class AsdfSchemaResolutionError(ValueError):
+class AsdfInfoResolutionError(ValueError):
     """
     An attempt to lookup schema for an attribute failed.
     """

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -84,9 +84,3 @@ class AsdfSerializationError(RepresenterError):
     that the object does not have a supporting asdf Converter and needs to
     be manually converted to a supported type.
     """
-
-
-class AsdfInfoResolutionError(ValueError):
-    """
-    An attempt to lookup schema for an attribute failed.
-    """

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -84,3 +84,9 @@ class AsdfSerializationError(RepresenterError):
     that the object does not have a supporting asdf Converter and needs to
     be manually converted to a supported type.
     """
+
+
+class AsdfSchemaResolutionError(ValueError):
+    """
+    An attempt to lookup schema for an attribute failed.
+    """

--- a/changes/1875.bugfix.rst
+++ b/changes/1875.bugfix.rst
@@ -1,1 +1,1 @@
-Improve ``schema_info`` handling of schemas with combiners (allOf, anyOf, etc). Raise AsdfInfoResolutionError for ambiguous info.
+Improve ``schema_info`` handling of schemas with combiners (allOf, anyOf, etc).

--- a/changes/1875.bugfix.rst
+++ b/changes/1875.bugfix.rst
@@ -1,1 +1,1 @@
-Improve ``schema_info`` handling of schemas with combiners (allOf, anyOf, etc).
+Improve ``schema_info`` handling of schemas with combiners (allOf, anyOf, etc). Raise AsdfInfoResolutionError for ambiguous info.

--- a/changes/1875.bugfix.rst
+++ b/changes/1875.bugfix.rst
@@ -1,0 +1,1 @@
+Improve ``schema_info`` handling of schemas with combiners (allOf, anyOf, etc).


### PR DESCRIPTION
## Description

`schema_info` currently fails to find both subschemas and attributes of subschemas for schemas that use certain "combiners" (like `allOf`) and/or references.

This PR updates `schema_info` to support more schema configurations (including `$ref` and `allOf` usage).

~Requires https://github.com/spacetelescope/rad/pull/525 as the rad schemas contain invalid extra `$ref` items.~ EDIT: rad PR was merged see comment below about [compatibility](https://github.com/asdf-format/asdf/pull/1875#issuecomment-2546691245) (tldr; we'll want to set the asdf min in rad to >4.0.x when the changes in this PR are released)

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
