### PR TITLE
update downstream jobs to run on python 3.12

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.10'
+      default_python: '3.12'
       envs: |
         - linux: asdf-wcs-schemas
         - linux: asdf-coordinates-schemas
@@ -42,7 +42,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.10'
+      default_python: '3.12'
       envs: |
         - linux: asdf-astropy
         - linux: specutils
@@ -53,7 +53,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.10'
+      default_python: '3.12'
       envs: |
         - linux: astrocut
         - linux: gwcs
@@ -68,7 +68,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.10'
+      default_python: '3.12'
       envs: |
         - linux: weldx
         - linux: sunpy


### PR DESCRIPTION
## Description

roman_datamodels (one of the packages we test in our downstream CI) now requires at least python 3.11. This PR updates the python versions used for our downstream testing to python 3.12 (from python 3.10).

The specutils failure is caused by gwcs and is fixed in https://github.com/spacetelescope/gwcs/pull/508 which is unreleased. I'm ok with this failing until a gwcs release is made.

The weldx failure is due to a pin for asdf < 4. We could consider disabling that job but I'm ok with it being a known failure.

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
