### PR TITLE
pyproject.toml: version_file requires setuptools_scm>=8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ pytest11 = {asdf_schema_tester = 'pytest_asdf.plugin'}
 build-backend = 'setuptools.build_meta'
 requires = [
   "setuptools>=60",
-  "setuptools_scm[toml]>=3.4",
+  "setuptools_scm[toml]>=8",
   "wheel",
 ]
 


### PR DESCRIPTION
## Description

When the switch was made from `write_to` to `version_file`, the version requirement on setuptools_scm was not increased. `version_file` is only available as of v8, https://github.com/pypa/setuptools-scm/blob/v8.0.4/CHANGELOG.md?plain=1#L62.

## Tasks

Most tasks below are not applicable.

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests
