### PR TITLE
fix dkist downstream test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -313,17 +313,13 @@ allowlist_externals =
     bash
 extras =
 commands_pre =
-    bash -c "pip freeze -q | grep 'asdf @' > {env_tmp_dir}/requirements.txt"
-    git clone https://github.com/DKISTDC/dkist.git
-    pip install -e dkist[tests]
-    pip install -r {env_tmp_dir}/requirements.txt
+    git clone https://github.com/DKISTDC/dkist.git .
+    bash -c "pip freeze -q | grep 'asdf @' > {env_tmp_dir}/asdf_requirement.txt"
+    pip install -e ".[tests]"
+    pip install -r {env_tmp_dir}/asdf_requirement.txt
     pip freeze
 commands =
-# the AsdfManifestURIMismatchWarning filter can be removed when a new sunpy
-# is released which contains the fixed manifests:
-# https://github.com/sunpy/sunpy/pull/7432
-    pytest dkist --benchmark-skip \
-        -W "ignore::asdf.exceptions.AsdfManifestURIMismatchWarning"
+    pytest --benchmark-skip
 
 [testenv:abacusutils]
 change_dir = {env_tmp_dir}


### PR DESCRIPTION
The dkist downstream job is failing:
https://github.com/asdf-format/asdf/actions/runs/12910632436/job/36001118249#step:10:493

This is due to the current test configuration being incompatible with the ignores in the dkist pytest.ini configuration file (the tests are run in `./dkist` but the configuration assumes the tests are run in `./`).

This PR updates the dkist downstream CI to be compatible with the dkist pytest configuration.

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
