### PR TITLE
allow extra keywords in structured datatype validation

### DIFF
--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -812,6 +812,7 @@ obj: !<tag:nowhere.org:custom/datatype-1.0.0>
        data: [[1, 'a'], [2, 'b'], [3, 'c']]
        datatype:
          - name: a
+           description: a description
            datatype: int8
          - name: b
            datatype: ['ascii', 8]
@@ -829,6 +830,7 @@ obj: !<tag:nowhere.org:custom/datatype-1.0.0>
          - name: a
            datatype: int64
          - name: b
+           title: a title
            datatype: ['ascii', 8]
     """
     buff = helpers.yaml_to_asdf(content)

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -7,6 +7,8 @@ from numpy import ma
 from asdf import util
 from asdf._jsonschema import ValidationError
 
+_STRUCTURED_DATATYPE_KEYS = {"name", "datatype", "byteorder", "shape"}
+
 _datatype_names = {
     "int8": "i1",
     "int16": "i2",
@@ -532,6 +534,13 @@ def validate_datatype(validator, datatype, instance, schema):
     else:
         msg = "Not an array"
         raise ValidationError(msg)
+
+    # We are only concerned with some fields from the datatype
+    # object in the schema so if the schema datatype is structured
+    # copy the datatype and drop the irrelevant fields
+    # name datatype byteorder shape
+    if isinstance(datatype, list) and len(datatype) and isinstance(datatype[0], dict):
+        datatype = [{k: v for k, v in subitem.items() if k in _STRUCTURED_DATATYPE_KEYS} for subitem in datatype]
 
     if datatype == in_datatype:
         return

--- a/changes/1901.bugfix.rst
+++ b/changes/1901.bugfix.rst
@@ -1,0 +1,1 @@
+Allow extra keywords in structured datatype validation.


### PR DESCRIPTION
## Description

The ndarray schema doesn't prevent additional keywords in datatype definitions for structured datatypes.
https://github.com/asdf-format/asdf-standard/blob/c17c3ecabcad7b65e41e0fb79054988b37f45a38/resources/schemas/stsci.edu/asdf/core/ndarray-1.1.0.yaml#L214

For example, adding a description to a sub-datatype doesn't violate the schema:
```yaml
       datatype:
         - name: a
           description: a description
           datatype: int8
```
However it fails the custom datatype validation in asdf.

This PR updates the custom datatype validator to only compare a selection of datatype keys `{"name", "datatype", "byteorder", "shape"}`. This allows adding descriptions to sub-datatypes.

Fixes #1900

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
