### PR TITLE
Datatype validator fix

### DIFF
--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -99,7 +99,11 @@ properties:
         datatype: int16
       - name: b
         datatype: ['ascii', 16]
-    exact_datatype: true""",
+    exact_datatype: true
+  e:
+    anyOf:
+      - type: "null"
+      - datatype: int16""",
                 "http://nowhere.org/schemas/custom/ndim-1.0.0": """%YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0"
@@ -801,6 +805,15 @@ obj: !<tag:nowhere.org:custom/datatype-1.0.0>
             buff,
         ),
     ):
+        pass
+
+    content = """
+obj: !<tag:nowhere.org:custom/datatype-1.0.0>
+    e: null
+    """
+    buff = helpers.yaml_to_asdf(content)
+
+    with asdf.open(buff):
         pass
 
 

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -526,18 +526,21 @@ def validate_datatype(validator, datatype, instance, schema):
             in_datatype, _ = numpy_dtype_to_asdf_datatype(array.dtype)
         else:
             msg = "Not an array"
-            raise ValidationError(msg)
+            yield ValidationError(msg)
+            return
     elif isinstance(instance, (np.ndarray, NDArrayType)):
         in_datatype, _ = numpy_dtype_to_asdf_datatype(instance.dtype)
     else:
         msg = "Not an array"
-        raise ValidationError(msg)
+        yield ValidationError(msg)
+        return
 
     if datatype == in_datatype:
         return
 
     if schema.get("exact_datatype", False):
         yield ValidationError(f"Expected datatype '{datatype}', got '{in_datatype}'")
+        return
 
     np_datatype = asdf_datatype_to_numpy_dtype(datatype)
     np_in_datatype = asdf_datatype_to_numpy_dtype(in_datatype)
@@ -545,16 +548,20 @@ def validate_datatype(validator, datatype, instance, schema):
     if not np_datatype.fields:
         if np_in_datatype.fields:
             yield ValidationError(f"Expected scalar datatype '{datatype}', got '{in_datatype}'")
+            return
 
         if not np.can_cast(np_in_datatype, np_datatype, "safe"):
             yield ValidationError(f"Can not safely cast from '{in_datatype}' to '{datatype}' ")
+            return
 
     else:
         if not np_in_datatype.fields:
             yield ValidationError(f"Expected structured datatype '{datatype}', got '{in_datatype}'")
+            return
 
         if len(np_in_datatype.fields) != len(np_datatype.fields):
             yield ValidationError(f"Mismatch in number of columns: Expected {len(datatype)}, got {len(in_datatype)}")
+            return
 
         for i in range(len(np_datatype.fields)):
             in_type = np_in_datatype[i]
@@ -565,3 +572,4 @@ def validate_datatype(validator, datatype, instance, schema):
                     f"Expected {numpy_dtype_to_asdf_datatype(out_type)[0]}, "
                     f"got {numpy_dtype_to_asdf_datatype(in_type)[0]}",
                 )
+                return


### PR DESCRIPTION
## Description

This PR replaces the use of `raise ValidationError` in `validate_datatype` with `yield ValidationError` to allow use of datatype validators in schema combiners (see #1903).

Fixes: #1903

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
