### PR TITLE
fix downstream astrocut tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -188,7 +188,7 @@ commands_pre =
     pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
-    pytest astrocut/astrocut/tests/test_asdf_cut.py
+    pytest astrocut/astrocut/tests/test_ASDFCutout.py
 
 [testenv:gwcs]
 change_dir = {env_tmp_dir}


### PR DESCRIPTION
## Description

https://github.com/spacetelescope/astrocut/pull/141 moved the asdf related tests in astrocut. This PR updates our downstream CI to use the new tests.

https://github.com/asdf-format/asdf/actions/runs/13766003671/job/38492519757
passing with this PR

(for reference failing on main due to no tests run https://github.com/asdf-format/asdf/actions/runs/13758873655/job/38470764784)

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
