### PR TITLE
use yaml constructors for _IgnoreCustomTagsLoader

### DIFF
--- a/asdf/_tests/test_util.py
+++ b/asdf/_tests/test_util.py
@@ -128,3 +128,24 @@ def test_load_yaml_recursion(tmp_path, tagged):
     tree = util.load_yaml(fn, tagged=tagged)
     assert tree["d"]["d"] is tree["d"]
     assert tree["l"][0] is tree["l"]
+
+
+@pytest.mark.parametrize("tagged", [True, False])
+def test_load_yaml_recursion_with_tags(tagged):
+    contents = b"""#ASDF 1.0.0
+#ASDF_STANDARD 1.6.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+o: &id001 !transform/remap_axes-1.4.0
+  inputs: [x0, x1]
+  inverse: !transform/remap_axes-1.4.0
+    inputs: [x0, x1, x2]
+    inverse: *id001
+    mapping: [2, 1]
+    outputs: [x0, x1]
+  mapping: [0, 1, 0]
+  outputs: [x0, x1, x2]
+..."""
+    tree = util.load_yaml(io.BytesIO(contents), tagged=tagged)
+    assert tree["o"] is tree["o"]["inverse"]["inverse"]

--- a/asdf/_tests/test_util.py
+++ b/asdf/_tests/test_util.py
@@ -137,15 +137,12 @@ def test_load_yaml_recursion_with_tags(tagged):
 %YAML 1.1
 %TAG ! tag:stsci.edu:asdf/
 --- !core/asdf-1.1.0
-o: &id001 !transform/remap_axes-1.4.0
-  inputs: [x0, x1]
-  inverse: !transform/remap_axes-1.4.0
-    inputs: [x0, x1, x2]
+o: &id001 !some/tag-1.0.0
+  inverse: !some/tag-1.0.0
     inverse: *id001
-    mapping: [2, 1]
-    outputs: [x0, x1]
-  mapping: [0, 1, 0]
-  outputs: [x0, x1, x2]
+l: &id002 !some/tag-1.0.0
+  - *id002
 ..."""
     tree = util.load_yaml(io.BytesIO(contents), tagged=tagged)
     assert tree["o"] is tree["o"]["inverse"]["inverse"]
+    assert tree["l"] is tree["l"][0]

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -147,9 +147,9 @@ class _IgnoreCustomTagsLoader(_yaml_base_loader):
 
     def construct_undefined(self, node):
         if isinstance(node, yaml.MappingNode):
-            return self.construct_mapping(node)
+            return self.construct_yaml_map(node)
         elif isinstance(node, yaml.SequenceNode):
-            return self.construct_sequence(node)
+            return self.construct_yaml_seq(node)
         elif isinstance(node, yaml.ScalarNode):
             return self.construct_scalar(node)
         return super().construct_undefined(node)

--- a/changes/1907.bugfix.rst
+++ b/changes/1907.bugfix.rst
@@ -1,0 +1,1 @@
+Support recursive tagged nodes in load_yaml.


### PR DESCRIPTION
Closes #1821

## Description

The fix in #1825 was partial (only covering non-tagged nodes) since `construct_mapping` is not a generator but `construct_yaml_map` is).

This PR updates `_IgnoreCustomTagsLoader` to use `construct_yaml_map` and `construct_yaml_seq` (both generators) to handled tagged recursive structures.

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
