### PR TITLE
fix astrocut downstream tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -194,7 +194,7 @@ commands_pre =
     pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
-    pytest astrocut/astrocut/tests/test_ASDFCutout.py
+    pytest --pyargs astrocut
 
 [testenv:gwcs]
 change_dir = {env_tmp_dir}


### PR DESCRIPTION
## Description

astrocut moved their asdf tests in https://github.com/spacetelescope/astrocut/pull/149

This PR updates the astrocut downstream tests here to use `--pyargs` which looks to be the expected way to run these tests based on:
https://github.com/spacetelescope/astrocut/blob/9c5aebecd806705e3942bd9204dd8be705b38059/tox.ini#L65
also rather than calling just the asdf tests (which breaks every time they rename/reorg the test files) this PR also just runs all astrocut tests.

<!--
Please describe what this PR accomplishes.
If the changes are non-obvious, please explain how they work.
If this PR adds a new feature please include tests and documentation.
If this PR fixes an issue, please add closing keywords (eg 'fixes #XXX')
-->

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
