### PR TITLE
update pyproject.toml to avoid setuptools warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: "asdf/(_extern||_jsonschema)/.*"
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
     - id: check-added-large-files
     - id: check-ast
@@ -29,7 +29,7 @@ repos:
     - id: text-unicode-replacement-char
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.1
   hooks:
     - id: codespell
       args: ["--write-changes"]
@@ -43,22 +43,22 @@ repos:
       exclude: "asdf/(extern||_jsonschema)/.*"
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.6.8'
+  rev: 'v0.11.6'
   hooks:
     - id: ruff
       args: ["--fix"]
 
 - repo: https://github.com/psf/black
-  rev: 24.8.0
+  rev: 25.1.0
   hooks:
     - id: black
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: '1.18.0'
+  rev: '1.19.1'
   hooks:
     - id: blacken-docs
 
 - repo: https://github.com/abravalheri/validate-pyproject
-  rev: "v0.20.2"
+  rev: "v0.24.1"
   hooks:
     - id: validate-pyproject

--- a/asdf/__init__.py
+++ b/asdf/__init__.py
@@ -5,15 +5,15 @@ Data Format (ASDF) files
 
 __all__ = [
     "AsdfFile",
-    "Stream",
-    "open",
-    "IntegerType",
     "ExternalArrayReference",
-    "info",
-    "__version__",
+    "IntegerType",
+    "Stream",
     "ValidationError",
-    "get_config",
+    "__version__",
     "config_context",
+    "get_config",
+    "info",
+    "open",
 ]
 
 

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -264,11 +264,8 @@ class AsdfFile:
         for extension in tree["history"]["extensions"]:
             installed = None
             for ext in self._user_extensions + self._plugin_extensions:
-                if (
-                    extension.extension_uri is not None
-                    and extension.extension_uri == ext.extension_uri
-                    or extension.extension_uri is None
-                    and extension.extension_class in ext.legacy_class_names
+                if (extension.extension_uri is not None and extension.extension_uri == ext.extension_uri) or (
+                    extension.extension_uri is None and extension.extension_class in ext.legacy_class_names
                 ):
                     installed = ext
                     break
@@ -442,10 +439,8 @@ class AsdfFile:
             for i, entry in enumerate(tree["history"]["extensions"]):
                 # Update metadata about this extension if it already exists
                 if (
-                    entry.extension_uri is not None
-                    and entry.extension_uri == extension.extension_uri
-                    or entry.extension_class in extension.legacy_class_names
-                ):
+                    entry.extension_uri is not None and entry.extension_uri == extension.extension_uri
+                ) or entry.extension_class in extension.legacy_class_names:
                     tree["history"]["extensions"][i] = ext_meta
                     break
             else:

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -13,8 +13,8 @@ import sys
 from ._node_info import create_tree
 
 __all__ = [
-    "DEFAULT_MAX_ROWS",
     "DEFAULT_MAX_COLS",
+    "DEFAULT_MAX_ROWS",
     "DEFAULT_SHOW_VALUES",
     "render_tree",
 ]
@@ -89,7 +89,7 @@ class _TreeRenderer:
     def _format_code(self, value, code):
         if not self._isatty:
             return f"{value}"
-        return f"\x1B[{code}m{value}\x1B[0m"
+        return f"\x1b[{code}m{value}\x1b[0m"
 
     def render(self, info):
         self._mark_visible(info)

--- a/asdf/commands/__init__.py
+++ b/asdf/commands/__init__.py
@@ -7,4 +7,4 @@ from .info import info
 from .tags import list_tags
 from .to_yaml import to_yaml
 
-__all__ = ["implode", "explode", "to_yaml", "defragment", "diff", "list_tags", "find_extensions", "info", "edit"]
+__all__ = ["defragment", "diff", "edit", "explode", "find_extensions", "implode", "info", "list_tags", "to_yaml"]

--- a/asdf/commands/exploded.py
+++ b/asdf/commands/exploded.py
@@ -9,7 +9,7 @@ from asdf import AsdfFile
 
 from .main import Command
 
-__all__ = ["implode", "explode"]
+__all__ = ["explode", "implode"]
 
 
 class Implode(Command):

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -15,7 +15,7 @@ from .exceptions import AsdfDeprecationWarning
 from .extension import ExtensionProxy
 from .resource import ResourceManager, ResourceMappingProxy
 
-__all__ = ["AsdfConfig", "get_config", "config_context"]
+__all__ = ["AsdfConfig", "config_context", "get_config"]
 
 
 DEFAULT_VALIDATE_ON_READ = True

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -25,7 +25,7 @@ from ._extern import atomicfile
 from .exceptions import AsdfDeprecationWarning, DelimiterNotFoundError
 from .util import _patched_urllib_parse
 
-__all__ = ["get_file", "get_uri", "resolve_uri", "relative_uri"]
+__all__ = ["get_file", "get_uri", "relative_uri", "resolve_uri"]
 
 
 _FILE_PERMISSIONS_DEFAULT_UMASK = 0o22

--- a/asdf/reference.py
+++ b/asdf/reference.py
@@ -13,7 +13,7 @@ import numpy as np
 from . import generic_io, treeutil, util
 from .util import _patched_urllib_parse
 
-__all__ = ["resolve_fragment", "Reference", "find_references", "resolve_references", "make_reference"]
+__all__ = ["Reference", "find_references", "make_reference", "resolve_fragment", "resolve_references"]
 
 
 def resolve_fragment(tree, pointer):

--- a/asdf/resource.py
+++ b/asdf/resource.py
@@ -11,10 +11,10 @@ from asdf_standard import DirectoryResourceMapping as _DirectoryResourceMapping
 from .util import get_class_name
 
 __all__ = [
-    "ResourceMappingProxy",
     "DirectoryResourceMapping",
-    "ResourceManager",
     "JsonschemaResourceMapping",
+    "ResourceManager",
+    "ResourceMappingProxy",
 ]
 
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -21,7 +21,7 @@ from .util import _patched_urllib_parse
 
 YAML_SCHEMA_METASCHEMA_ID = "http://stsci.edu/schemas/yaml-schema/draft-01"
 
-__all__ = ["validate", "fill_defaults", "remove_defaults", "check_schema", "load_schema"]
+__all__ = ["check_schema", "fill_defaults", "load_schema", "remove_defaults", "validate"]
 
 PYTHON_TYPE_TO_YAML_TAG = {
     None: "null",

--- a/asdf/tagged.py
+++ b/asdf/tagged.py
@@ -31,7 +31,7 @@ is not intended to be exposed to the end user.
 from collections import UserDict, UserList, UserString
 from copy import copy, deepcopy
 
-__all__ = ["tag_object", "get_tag", "Tagged", "TaggedDict", "TaggedList", "TaggedString"]
+__all__ = ["Tagged", "TaggedDict", "TaggedList", "TaggedString", "get_tag", "tag_object"]
 
 
 class Tagged:

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -9,14 +9,14 @@ from .stream import Stream
 __all__ = [
     "AsdfObject",
     "Constant",
-    "Software",
-    "HistoryEntry",
     "ExtensionMetadata",
-    "SubclassMetadata",
-    "NDArrayType",
-    "IntegerType",
     "ExternalArrayReference",
+    "HistoryEntry",
+    "IntegerType",
+    "NDArrayType",
+    "Software",
     "Stream",
+    "SubclassMetadata",
 ]
 
 

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 from . import lazy_nodes, tagged
 
-__all__ = ["walk", "iter_tree", "walk_and_modify", "get_children", "is_container", "PendingValue", "RemoveNode"]
+__all__ = ["PendingValue", "RemoveNode", "get_children", "is_container", "iter_tree", "walk", "walk_and_modify"]
 
 
 def walk(top, callback):

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -40,15 +40,15 @@ _patched_urllib_parse.uses_netloc.append("asdf")
 
 
 __all__ = [
-    "load_yaml",
+    "FileType",
+    "NotSet",
+    "calculate_padding",
     "get_array_base",
     "get_base_uri",
-    "calculate_padding",
-    "NotSet",
-    "uri_match",
     "get_class_name",
     "get_file_type",
-    "FileType",
+    "load_yaml",
+    "uri_match",
 ]
 
 

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -11,7 +11,7 @@ from semantic_version import SimpleSpec, Version
 _yaml_base_loader = yaml.CSafeLoader if getattr(yaml, "__with_libyaml__", None) else yaml.SafeLoader
 
 
-__all__ = ["AsdfVersion", "AsdfVersionMixin", "split_tag_version", "join_tag_version"]
+__all__ = ["AsdfVersion", "AsdfVersionMixin", "join_tag_version", "split_tag_version"]
 
 
 def split_tag_version(tag):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,18 +2,13 @@
 name = "asdf"
 description = "Python implementation of the ASDF Standard"
 readme = 'README.rst'
-license = { file = 'LICENSE' }
+license-files = ['LICENSE']
 authors = [{ name = 'The ASDF Developers', email = 'help@stsci.edu' }]
 requires-python = '>=3.9'
 classifiers = [
   'Development Status :: 5 - Production/Stable',
-  "License :: OSI Approved :: BSD License",
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
-  'Programming Language :: Python :: 3.9',
-  'Programming Language :: Python :: 3.10',
-  'Programming Language :: Python :: 3.11',
-  'Programming Language :: Python :: 3.12',
 ]
 dynamic = [
   'version',


### PR DESCRIPTION
## Description

Closes #1911

This required updating the pre-commit hooks as older versions of the pyproject.toml validator don't understand `license-files`. This also updated the ruff version and pulled in some new rules mainly sorting `__all__`. I can roll back this change if preferred.

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
