### PR TITLE
allow non-null post tree pre block padding

### DIFF
--- a/changes/1918.bugfix.rst
+++ b/changes/1918.bugfix.rst
@@ -1,0 +1,1 @@
+Allow non-null bytes before the first byte.


### PR DESCRIPTION
## Description

On main if padding bytes are found between the end of the tree and the beginning of the first block they must be all null.
https://github.com/asdf-format/asdf/blob/ad470c0cac455d8297a484b2541254f06f2a139d/asdf/_block/reader.py#L172-L173
This doesn't agree with the [standard](https://www.asdf-format.org/projects/asdf-standard/en/1.1.1/file_layout.html#tree):
> This empty space may be filled with any content (as long as it doesn’t contain the block_magic_token described in [Blocks](https://www.asdf-format.org/projects/asdf-standard/en/1.1.1/file_layout.html#block)).

This PR updates the block parsing to allow non-null bytes as long as they don't match the block magic. Since the block header does not contain a checksum of the header bytes it's not possible to detect invalid padding (that includes the block magic). See https://github.com/asdf-format/asdf-standard/issues/460

Once this is merged and https://github.com/asdf-format/asdf-standard/pull/456 are merged https://github.com/asdf-format/asdf-standard/issues/441 can be closed.

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
