### PR TITLE
allow block index loading to use CSafeLoader

### DIFF
--- a/asdf/_block/io.py
+++ b/asdf/_block/io.py
@@ -13,6 +13,7 @@ import yaml
 
 from asdf import _compression as mcompression
 from asdf import constants, util
+from asdf.versioning import _yaml_base_loader as BaseLoader
 
 from .exceptions import BlockIndexError
 
@@ -479,7 +480,10 @@ def read_block_index(fd, offset=None):
         msg = "Failed to read block index header at offset {offset}"
         raise BlockIndexError(msg)
     try:
-        block_index = yaml.load(fd.read(-1), yaml.SafeLoader)
+        # the noqa is needed here since the linter doesn't know
+        # that BaseLoader here is either SafeLoader or CSafeLoader
+        # both of which do not violate S506.
+        block_index = yaml.load(fd.read(-1), BaseLoader)  # noqa: S506
     except yaml.error.YAMLError:
         raise BlockIndexError("Failed to parse block index as yaml")
     if (

--- a/changes/1920.feature.rst
+++ b/changes/1920.feature.rst
@@ -1,0 +1,1 @@
+Load block index with CSafeLoader if available.


### PR DESCRIPTION
On main the block index is always loaded with `SafeLoader`. For files with a very large number of blocks this can take a considerable length of time.

This PR replaces the `SafeLoader` use with the "base loader" from asdf.versioning:
https://github.com/asdf-format/asdf/blob/9149ab669e545dfb35102340e7b390ec444d5750/asdf/versioning.py#L11
which can be `CSafeLoader`.

For a file with 10000 blocks main takes ~0.5 second (more with profiling) to load the block index:

<img width="1125" alt="Screenshot 2025-04-24 at 1 41 23 PM" src="https://github.com/user-attachments/assets/8c024a2b-5537-44ba-b9d9-6a5a8cb98ef3" />

With this PR the time is about a factor of 10 less:
<img width="1124" alt="Screenshot 2025-04-24 at 1 39 08 PM" src="https://github.com/user-attachments/assets/3d0633e9-1834-4761-87a3-21a732b0164f" />

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
