### PR TITLE
fix deepcopy of lazy tree

### DIFF
--- a/asdf/lazy_nodes.py
+++ b/asdf/lazy_nodes.py
@@ -8,7 +8,7 @@ import inspect
 import warnings
 import weakref
 
-from . import tagged, yamlutil
+from . import tagged, treeutil, yamlutil
 from .exceptions import AsdfConversionWarning, AsdfLazyReferenceError
 from .extension._serialization_context import BlockAccess
 
@@ -136,6 +136,9 @@ class _AsdfNode:
         Return the tagged tree backing this node
         """
         return self.data
+
+    def __deepcopy__(self, memo):
+        return treeutil.walk_and_modify(self, lambda n: n)
 
     def _convert_and_cache(self, value, key):
         """

--- a/asdf/treeutil.py
+++ b/asdf/treeutil.py
@@ -2,6 +2,7 @@
 Utility functions for managing tree-like data structures.
 """
 
+import collections
 import types
 from contextlib import contextmanager
 
@@ -278,7 +279,9 @@ def walk_and_modify(top, callback, postorder=True, _context=None):
         return _handle_generator(result)
 
     def _handle_mapping(node, json_id):
-        if isinstance(node, lazy_nodes.AsdfDictNode):
+        if isinstance(node, lazy_nodes.AsdfOrderedDictNode):
+            result = collections.OrderedDict()
+        elif isinstance(node, lazy_nodes.AsdfDictNode):
             result = {}
         else:
             result = node.__class__()

--- a/changes/1922.bugfix.rst
+++ b/changes/1922.bugfix.rst
@@ -1,0 +1,1 @@
+Fix deepcopy of lazy tree.


### PR DESCRIPTION
## Description

This fixes a bug where a deepcopy of a lazy node retains references to the original lazy tree (instead of becoming non-lazy nodes). While adding tests for and fixing this issue I found that `walk_and_modify` converts `AsdfOrderedDictNode` instances into `dict`. That bug is also fixed in this PR and is required for this PR since `walk_and_modify` is used to handle the deepcopy.

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
