### PR TITLE
deprecate refresh_extension_manager

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1369,7 +1369,7 @@ class AsdfFile:
 
         return []
 
-    def schema_info(self, key="description", path=None, preserve_list=True, refresh_extension_manager=False):
+    def schema_info(self, key="description", path=None, preserve_list=True, refresh_extension_manager=NotSet):
         """
         Get a nested dictionary of the schema information for a given key, relative to the path.
 
@@ -1393,6 +1393,8 @@ class AsdfFile:
             key.  This is useful if you want to make sure that the schema
             data for a given key is up to date.
         """
+        if refresh_extension_manager is not NotSet:
+            warnings.warn("refresh_extension_manager is deprecated", DeprecationWarning)
 
         if isinstance(path, AsdfSearchResult):
             return path.schema_info(
@@ -1415,7 +1417,7 @@ class AsdfFile:
         max_rows=display.DEFAULT_MAX_ROWS,
         max_cols=display.DEFAULT_MAX_COLS,
         show_values=display.DEFAULT_SHOW_VALUES,
-        refresh_extension_manager=False,
+        refresh_extension_manager=NotSet,
     ):
         """
         Print a rendering of this file's tree to stdout.
@@ -1440,6 +1442,8 @@ class AsdfFile:
             Set to False to disable display of primitive values in
             the rendered tree.
         """
+        if refresh_extension_manager is not NotSet:
+            warnings.warn("refresh_extension_manager is deprecated", DeprecationWarning)
 
         lines = display.render_tree(
             self.tree,

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -11,6 +11,7 @@ return what it thinks is suitable for display.
 import sys
 
 from ._node_info import create_tree
+from .util import NotSet
 
 __all__ = [
     "DEFAULT_MAX_COLS",
@@ -32,7 +33,7 @@ def render_tree(
     show_values=DEFAULT_SHOW_VALUES,
     filters=None,
     identifier="root",
-    refresh_extension_manager=False,
+    refresh_extension_manager=NotSet,
     extension_manager=None,
 ):
     """

--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 from .schema import load_schema
 from .treeutil import get_children, is_container
+from .util import NotSet
 
 
 def _filter_tree(info, filters):
@@ -138,7 +139,7 @@ def _get_schema_key(schema, key):
     return None
 
 
-def create_tree(key, node, identifier="root", filters=None, refresh_extension_manager=False, extension_manager=None):
+def create_tree(key, node, identifier="root", filters=None, refresh_extension_manager=NotSet, extension_manager=None):
     """
     Create a `NodeSchemaInfo` tree which can be filtered from a base node.
 
@@ -153,6 +154,7 @@ def create_tree(key, node, identifier="root", filters=None, refresh_extension_ma
     preserve_list : bool
         If True, then lists are preserved. Otherwise, they are turned into dicts.
     refresh_extension_manager : bool
+        DEPRECATED
         If `True`, refresh the extension manager before looking up the
         key.  This is useful if you want to make sure that the schema
         data for a given key is up to date.
@@ -180,7 +182,7 @@ def collect_schema_info(
     identifier="root",
     filters=None,
     preserve_list=True,
-    refresh_extension_manager=False,
+    refresh_extension_manager=NotSet,
     extension_manager=None,
 ):
     """
@@ -200,6 +202,7 @@ def collect_schema_info(
     preserve_list : bool
         If True, then lists are preserved. Otherwise, they are turned into dicts.
     refresh_extension_manager : bool
+        DEPRECATED
         If `True`, refresh the extension manager before looking up the
         key.  This is useful if you want to make sure that the schema
         data for a given key is up to date.
@@ -229,6 +232,9 @@ def collect_schema_info(
 def _get_extension_manager(refresh_extension_manager):
     from ._asdf import AsdfFile, get_config
     from .extension import ExtensionManager
+
+    if refresh_extension_manager is NotSet:
+        refresh_extension_manager = False
 
     af = AsdfFile()
     if refresh_extension_manager:
@@ -359,7 +365,7 @@ class NodeSchemaInfo:
 
     @classmethod
     def from_root_node(
-        cls, key, root_identifier, root_node, schema=None, refresh_extension_manager=False, extension_manager=None
+        cls, key, root_identifier, root_node, schema=None, refresh_extension_manager=NotSet, extension_manager=None
     ):
         """
         Build a NodeSchemaInfo tree from the given ASDF root node.

--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -10,3 +10,15 @@ def test_resolver_deprecation():
 
     with pytest.warns(DeprecationWarning, match="resolver is deprecated"):
         asdf.schema.load_schema("http://stsci.edu/schemas/asdf/asdf-schema-1.0.0", resolver=resolver)
+
+
+@pytest.mark.parametrize("value", (True, False))
+def test_deprecate_refresh_extension_manager(value):
+    af = asdf.AsdfFile({"foo": 1})
+    with pytest.warns(DeprecationWarning, match="refresh_extension_manager is deprecated"):
+        af.schema_info(refresh_extension_manager=value)
+    with pytest.warns(DeprecationWarning, match="refresh_extension_manager is deprecated"):
+        af.info(refresh_extension_manager=value)
+    sr = af.search("foo")
+    with pytest.warns(DeprecationWarning, match="refresh_extension_manager is deprecated"):
+        sr.schema_info(refresh_extension_manager=value)

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -6,6 +6,7 @@ import builtins
 import inspect
 import re
 import typing
+import warnings
 
 from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES, render_tree
 from ._node_info import collect_schema_info
@@ -326,7 +327,7 @@ class AsdfSearchResult:
 
         return "\n".join(lines)
 
-    def schema_info(self, key="description", preserve_list=True, refresh_extension_manager=False):
+    def schema_info(self, key="description", preserve_list=True, refresh_extension_manager=NotSet):
         """
         Get a nested dictionary of the schema information for a given key, relative to this search result.
 
@@ -338,10 +339,13 @@ class AsdfSearchResult:
         preserve_list : bool
             If True, then lists are preserved. Otherwise, they are turned into dicts.
         refresh_extension_manager : bool
+            DEPRECATED
             If `True`, refresh the extension manager before looking up the
             key.  This is useful if you want to make sure that the schema
             data for a given key is up to date.
         """
+        if refresh_extension_manager is not NotSet:
+            warnings.warn("refresh_extension_manager is deprecated", DeprecationWarning)
 
         return collect_schema_info(
             key,

--- a/changes/1935.removal.rst
+++ b/changes/1935.removal.rst
@@ -1,0 +1,1 @@
+Deprecate ``refresh_extension_manager`` argument to ``info``, ``schema_info`` and ``SearchResult.schema_info``.


### PR DESCRIPTION
Deprecate `refresh_extension_manager` argument to `info`, `schema_info` and `SearchResult.schema_info`.

This is unused but does appear in the automatically generated docs.

Closes #1881

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
