### PR TITLE
deprecate url_mapping argument to get_validator

### DIFF
--- a/asdf/_tests/test_deprecated.py
+++ b/asdf/_tests/test_deprecated.py
@@ -48,3 +48,8 @@ properties:
     with pytest.warns(DeprecationWarning, match=f"Use of the {schema_property} validator with non-ndarray tag"):
         with pytest.raises(asdf.exceptions.ValidationError):
             af.validate()
+
+
+def test_url_mapping_deprecation():
+    with pytest.warns(DeprecationWarning, match="url_mapping is deprecated"):
+        asdf.schema.get_validator(url_mapping=lambda s: s)

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -518,6 +518,7 @@ def get_validator(
         of the built-in ones and ones provided by extension types).
 
     url_mapping : callable, optional
+        DEPRECATED
         A callable that takes one string argument and returns a string
         to convert remote URLs into local ones.
 
@@ -532,6 +533,9 @@ def get_validator(
     -------
     validator : jsonschema.Validator
     """
+    if url_mapping is not None:
+        warnings.warn("url_mapping is deprecated, arbitrary mapping of uris is no longer supported", DeprecationWarning)
+
     if ctx is None:
         from ._asdf import AsdfFile
 

--- a/changes/1936.removal.rst
+++ b/changes/1936.removal.rst
@@ -1,0 +1,1 @@
+Deprecate ``url_mapping`` argument to ``get_validator``. Arbitrary mapping of urls is no longer supported.


### PR DESCRIPTION
Deprecate `url_mapping` argument to `get_validator`. Arbitrary mapping of uris/urls is no longer supported.

Closes: #1864

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
