### PR TITLE
Docs updates

### DIFF
--- a/changes/1938.doc.rst
+++ b/changes/1938.doc.rst
@@ -1,0 +1,1 @@
+Expand extension documentation to cover tag vs ref, converter tag wildcards, versioning and user documentation to cover get/set_array_compression.

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -272,7 +272,7 @@ blocks by setting `asdf.config.AsdfConfig.all_array_compression`.
 for a specific block. Similarly `asdf.AsdfFile.get_array_compression` can
 be used to get the compression for a specific block.
 
-.. code::
+.. code:: python
 
    import asdf
    import numpy as np

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -240,8 +240,10 @@ Compression
 
 Individual blocks in an ASDF file may be compressed.
 
-You can easily `zlib <http://www.zlib.net/>`__ or `bzip2
-<http://www.bzip.org>`__ compress all blocks:
+`zlib <http://www.zlib.net/>`__ and `bzip2 <http://www.bzip.org>`__
+are included in every asdf install. Passing one of these 4 character
+codes as ``all_array_compression`` to `asdf.AsdfFile.write_to` will
+compress all blocks with the corresponding algorithm.:
 
 .. runcode::
 
@@ -262,6 +264,22 @@ You can easily `zlib <http://www.zlib.net/>`__ or `bzip2
 The `lz4 <https://en.wikipedia.org/wiki/LZ_4>`__ compression algorithm is also
 supported, but requires the optional
 `lz4 <https://python-lz4.readthedocs.io/>`__ package in order to work.
+
+Similarly, `asdf.config` can be used to configure compression of all
+blocks by setting `asdf.config.AsdfConfig.all_array_compression`.
+
+`asdf.AsdfFile.set_array_compression` can be used to set the compression
+for a specific block. Similarly `asdf.AsdfFile.get_array_compression` can
+be used to get the compression for a specific block.
+
+.. code::
+
+   import asdf
+   import numpy as np
+
+   af = asdf.AsdfFile({"arr": np.arange(42)})
+   af.set_array_compression(af["arr"], "lz4")
+   assert af.get_array_compression(af["arr"]) == "lz4"
 
 When reading a file with compressed blocks, the blocks will be automatically
 decompressed when accessed. If a file with compressed blocks is read and then

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -191,7 +191,7 @@ Tag wildcards to support multiple versions
 ==========================================
 
 As noted above `Converter.tags` can contain wildcard patterns
-("asdf://example.com/shapes/tags/rectangle-1.*" to match all 1.x.x versions
+(``asdf://example.com/shapes/tags/rectangle-1.*`` to match all ``1.x.x`` versions
 of the rectangle tag). When a wildcard is used the specific tag
 versions should be defined in the manifest (or extension) that uses
 the `Converter`. If a `Converter` with a tag wildcard is provided to an

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -186,6 +186,23 @@ the converter's list of tags and implement a `select_tag<Converter>` method:
             else:
                 return Rectangle(node["width"], node["height"])
 
+
+Tag wildcards to support multiple versions
+==========================================
+
+As noted above `Converter.tags` can contain wildcard patterns
+("asdf://example.com/shapes/tags/rectangle-1.*" to match all 1.x.x versions
+of the rectangle tag). When a wildcard is used the specific tag
+versions should be defined in the manifest (or extension) that uses
+the `Converter`. If a `Converter` with a tag wildcard is provided to an
+extension with a manifest that contains no tags that match the pattern
+the `Converter` will be ignored. No errors or warnings will be produced
+when this extension is registered with asdf (as this can be a useful pattern).
+However attempts to use the `Converter` can produce errors during
+reading and writing (if it's expected that the `Converter` is used).
+Developers are encouraged to write unit tests that check reading and
+writing with any custom `Converter` instances.
+
 .. _extending_converters_deferral:
 
 Deferring to another converter

--- a/docs/asdf/extending/extensions.rst
+++ b/docs/asdf/extending/extensions.rst
@@ -479,3 +479,28 @@ tag when writing the file.
 For more details on the behavior of schema and tag versioning from a user
 perspective, see :ref:`version_and_compat`, and also
 :ref:`custom_type_versions`.
+
+Versioning during development
+-----------------------------
+
+As described above every schema change can trigger tag, manifest and
+extension version changes. This is critically important as it allows
+asdf to open old files. However the above considerations largely apply
+only to released versions of schemas and manifests. During development
+of a package it is likely that several schemas will be changed and it
+is not necessary to increase the manifest version for each of these updates.
+Let's say we have a package ``libfoo`` that is currently released as version 1.2.3
+and has a manifest ``manifest/foo-1.0.0`` listing tags ``tag/bar-1.0.0``
+and ``tag/bam-1.0.0``. We make a change to ``schema/bar-1.0.0`` increasing
+it's version to ``schema/bar-1.1.0`` (which triggers a new manifest
+``manifest/foo-1.1.0``). However importantly we don't yet release these
+changes. If we make a second change, this time creating ``schema/bam-1.1.0``
+it's likely that no increase in manifest version is required (as no users
+of ``libfoo`` have yet had the opportunity to create files with
+``manifest/foo-1.1.0``). ``schema/bam-1.1.0`` can be added to
+``manifest/foo-1.1.0`` and it's not until the next version of ``libfoo`` is
+released do we need to have schema updates trigger manifest version increases.
+
+This is general guidance. If it is likely that users are creating files
+with a development version of ``libfoo`` then it may be worth increasing the
+manifest version for every schema change.


### PR DESCRIPTION
## Description

Add `get/set_array_compression` to section describing compression
Closes: #1855

Add comparison of tags vs refs in schemas (recommend `foo-1*` like tags)
Closes: #1791 

Expand documentation about versioning for extension developers
Closes: #1895

Add section about converter tag wildcards leading to ignored converters
Closes: #1631

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
