### PR TITLE
Simplify open

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1359,12 +1359,12 @@ def open_asdf(
     if lazy_tree is NotSet:
         lazy_tree = get_config().lazy_tree
 
-    # TODO pass in extensions?
     instance = AsdfFile(
         ignore_unrecognized_tag=ignore_unrecognized_tag,
         memmap=memmap,
         lazy_load=lazy_load,
         custom_schema=custom_schema,
+        extensions=extensions,
     )
 
     with _io.maybe_close(fd, mode, uri) as generic_file:
@@ -1381,10 +1381,6 @@ def open_asdf(
         instance._comments = comments
 
         instance.version = _io.find_asdf_version_in_comments(comments, versioning.AsdfVersion("1.0.0"))
-
-        # TODO pass in extensions above?
-        if extensions:
-            instance.extensions = extensions
 
         if tree is None:
             # TODO ugh

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1373,7 +1373,6 @@ def open_asdf(
         )
 
         instance._blocks = blocks
-
         instance._mode = generic_file.mode
         instance._fd = generic_file
         instance._fname = instance._fd._uri if instance._fd._uri else ""
@@ -1383,7 +1382,6 @@ def open_asdf(
         instance.version = _io.find_asdf_version_in_comments(comments, versioning.AsdfVersion("1.0.0"))
 
         if tree is None:
-            # TODO ugh
             # At this point the tree should be tagged, but we want it to be
             # tagged with the core/asdf version appropriate to this file's
             # ASDF Standard version.  We're using custom_tree_to_tagged_tree

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -13,7 +13,6 @@ from . import _compression as mcompression
 from . import _display as display
 from . import _io, constants, generic_io, lazy_nodes, reference, schema, treeutil, util, versioning, yamlutil
 from . import _node_info as node_info
-from . import _version as version
 from ._block.manager import Manager as BlockManager
 from ._helpers import validate_version
 from .config import config_context, get_config
@@ -28,21 +27,6 @@ from .extension import Extension, ExtensionProxy, _serialization_context, get_ca
 from .search import AsdfSearchResult
 from .tags.core import AsdfObject, ExtensionMetadata, HistoryEntry, Software
 from .util import NotSet
-
-
-def _get_asdf_library_info():
-    """
-    Get information about asdf to include in the asdf_library entry
-    in the Tree.
-    """
-    return Software(
-        {
-            "name": "asdf",
-            "version": version.version,
-            "homepage": "http://github.com/asdf-format/asdf",
-            "author": "The ASDF Developers",
-        },
-    )
 
 
 class AsdfFile:
@@ -794,7 +778,7 @@ class AsdfFile:
             try:
                 # prep a tree for a writing
                 tree = copy.copy(self._tree)
-                tree["asdf_library"] = _get_asdf_library_info()
+                tree["asdf_library"] = _io.get_asdf_library_info()
                 if "history" in self._tree:
                     tree["history"] = copy.deepcopy(self._tree["history"])
 
@@ -917,7 +901,7 @@ class AsdfFile:
 
             self._pre_write(fd)
             try:
-                self._tree["asdf_library"] = _get_asdf_library_info()
+                self._tree["asdf_library"] = _io.get_asdf_library_info()
 
                 # prepare block manager for writing
                 with self._blocks.write_context(self._fd, copy_options=False):

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -85,8 +85,6 @@ class AsdfFile:
             files follow custom conventions beyond those enforced by the
             standard.
         """
-        self._fname = ""
-
         # make a new AsdfVersion instance here so files don't share the same instance
         self._file_format_version = versioning.AsdfVersion(versioning._FILE_FORMAT_VERSION)
 
@@ -251,7 +249,7 @@ class AsdfFile:
                     installed = ext
                     break
 
-            filename = f"'{self._fname}' " if self._fname else ""
+            filename = f"'{self._fd._uri}'" if (self._fd is not None and self._fd._uri) else ""
             if extension.extension_uri is not None:
                 extension_description = f"URI '{extension.extension_uri}'"
             else:
@@ -1375,7 +1373,6 @@ def open_asdf(
         instance._blocks = blocks
         instance._mode = generic_file.mode
         instance._fd = generic_file
-        instance._fname = instance._fd._uri if instance._fd._uri else ""
         instance._file_format_version = file_format_version
         instance._comments = comments
 

--- a/asdf/_commands/edit.py
+++ b/asdf/_commands/edit.py
@@ -15,7 +15,7 @@ import tempfile
 
 import yaml
 
-from asdf import constants, generic_io, schema, util
+from asdf import _io, constants, generic_io, schema, util
 from asdf._asdf import AsdfFile
 from asdf._block import io as bio
 from asdf._block.exceptions import BlockIndexError
@@ -337,8 +337,8 @@ def parse_asdf_version(content):
     asdf.versioning.AsdfVersion
         ASDF Standard version
     """
-    comments = AsdfFile._read_comment_section(generic_io.get_file(io.BytesIO(content)))
-    return AsdfFile._find_asdf_version_in_comments(comments)
+    comments = _io.read_comment_section(generic_io.get_file(io.BytesIO(content)))
+    return _io.find_asdf_version_in_comments(comments)
 
 
 def parse_yaml_version(content):

--- a/asdf/_io.py
+++ b/asdf/_io.py
@@ -1,0 +1,66 @@
+"""
+Low-level input/output routines for AsdfFile instances
+"""
+
+from . import constants, versioning
+
+
+def parse_header_line(line):
+    """
+    Parses the header line in a ASDF file to obtain the ASDF version.
+    """
+    parts = line.split()
+    if len(parts) != 2 or parts[0] != constants.ASDF_MAGIC:
+        msg = "Does not appear to be a ASDF file."
+        raise ValueError(msg)
+
+    try:
+        version = versioning.AsdfVersion(parts[1].decode("ascii"))
+    except ValueError as err:
+        msg = f"Unparsable version in ASDF file: {parts[1]}"
+        raise ValueError(msg) from err
+
+    if version != versioning._FILE_FORMAT_VERSION:
+        msg = f"Unsupported ASDF file format version {version}"
+        raise ValueError(msg)
+
+    return version
+
+
+def read_comment_section(fd):
+    """
+    Reads the comment section, between the header line and the
+    Tree or first block.
+    """
+    content = fd.read_until(
+        b"(%YAML)|(" + constants.BLOCK_MAGIC + b")",
+        5,
+        "start of content",
+        include=False,
+        exception=False,
+    )
+
+    comments = []
+
+    lines = content.splitlines()
+    for line in lines:
+        if not line.startswith(b"#"):
+            msg = "Invalid content between header and tree"
+            raise ValueError(msg)
+        comments.append(line[1:].strip())
+
+    return comments
+
+
+def find_asdf_version_in_comments(comments):
+    for comment in comments:
+        parts = comment.split()
+        if len(parts) == 2 and parts[0] == constants.ASDF_STANDARD_COMMENT:
+            try:
+                version = versioning.AsdfVersion(parts[1].decode("ascii"))
+            except ValueError:
+                pass
+            else:
+                return version
+
+    return None

--- a/asdf/_io.py
+++ b/asdf/_io.py
@@ -2,7 +2,23 @@
 Low-level input/output routines for AsdfFile instances
 """
 
-from . import constants, versioning
+from . import _version, constants, versioning
+from .tags.core import Software
+
+
+def get_asdf_library_info():
+    """
+    Get information about asdf to include in the asdf_library entry
+    in the Tree.
+    """
+    return Software(
+        {
+            "name": "asdf",
+            "version": _version.version,
+            "homepage": "http://github.com/asdf-format/asdf",
+            "author": "The ASDF Developers",
+        },
+    )
 
 
 def parse_header_line(line):

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -302,8 +302,6 @@ def test_extension_version_check(installed, extension, warns):
             config.add_extension(proxy)
         af = asdf.AsdfFile()
 
-    af._fname = "test.asdf"
-
     tree = {
         "history": {
             "extensions": [
@@ -316,10 +314,10 @@ def test_extension_version_check(installed, extension, warns):
     }
 
     if warns:
-        with pytest.warns(AsdfPackageVersionWarning, match=r"File 'test.asdf' was created with"):
+        with pytest.warns(AsdfPackageVersionWarning, match=r"File was created with"):
             af._check_extensions(tree)
 
-        with pytest.raises(RuntimeError, match=r"^File 'test.asdf' was created with"):
+        with pytest.raises(RuntimeError, match=r"^File was created with"):
             af._check_extensions(tree, strict=True)
 
     else:
@@ -351,8 +349,6 @@ def test_check_extension_manifest_software(installed, extension, warns):
             config.add_resource_mapping(mapping)
         af = asdf.AsdfFile()
 
-        af._fname = "test.asdf"
-
         tree = {
             "history": {
                 "extensions": [
@@ -366,10 +362,10 @@ def test_check_extension_manifest_software(installed, extension, warns):
         }
 
         if warns:
-            with pytest.warns(AsdfPackageVersionWarning, match=r"File 'test.asdf' was created with"):
+            with pytest.warns(AsdfPackageVersionWarning, match=r"File was created with"):
                 af._check_extensions(tree)
 
-            with pytest.raises(RuntimeError, match=r"^File 'test.asdf' was created with"):
+            with pytest.raises(RuntimeError, match=r"^File was created with"):
                 af._check_extensions(tree, strict=True)
 
         else:

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -330,6 +330,7 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False, _serialization_
     Convert a tree containing only basic data types, annotated with
     tags, to a tree containing custom data types.
     """
+    # TODO deprecate force_raw_types
     if _serialization_context is None:
         _serialization_context = ctx._create_serialization_context(BlockAccess.READ)
 

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -330,7 +330,6 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False, _serialization_
     Convert a tree containing only basic data types, annotated with
     tags, to a tree containing custom data types.
     """
-    # TODO deprecate force_raw_types
     if _serialization_context is None:
         _serialization_context = ctx._create_serialization_context(BlockAccess.READ)
 

--- a/changes/1955.bugfix.rst
+++ b/changes/1955.bugfix.rst
@@ -1,0 +1,1 @@
+Fix pytest-asdf example testing to validate example without requiring round tripping.


### PR DESCRIPTION
## Description

Simply what happens when `asdf.open` is called. On main this involves:
- `asdf.open` an alias of [asdf._asdf.open_asdf](https://github.com/asdf-format/asdf/blob/6197b4c8505cdbaa1e4076566becc6af17877e89/asdf/_asdf.py#L1507)
- then calls [AsdfFile._open_impl](https://github.com/asdf-format/asdf/blob/6197b4c8505cdbaa1e4076566becc6af17877e89/asdf/_asdf.py#L909) a class method that expects an instance as an argument
- then calls [AsdfFile._open_asdf](https://github.com/asdf-format/asdf/blob/6197b4c8505cdbaa1e4076566becc6af17877e89/asdf/_asdf.py#L796) another class method that expects an instance

This PR simplifies the process to:
- `asdf.open` an alias of asdf._asdf.open_asdf
- calls `asdf._io.open_asdf` (which reads the comments, tree and blocks)
- returns a created instance (which still involves a bunch of private attribute assignment but that can be improved in a follow-up PR)

As part of the simplification the following private API changes are made:
- add `asdf._io` this may expand in future PR to encapsulate more of the "low-level" IO and is currently the new home of some code that was previously part of `AsdfFile` including [_parse_header_line](https://github.com/asdf-format/asdf/blob/6197b4c8505cdbaa1e4076566becc6af17877e89/asdf/_asdf.py#L735) [_read_comment_section](https://github.com/asdf-format/asdf/blob/6197b4c8505cdbaa1e4076566becc6af17877e89/asdf/_asdf.py#L757) etc
- removes `AsdfFile._fname` and instead uses `AsdfFile._fd._uri` (the value that was assigned in `asdf.open`)
- removes `AsdfFile._pre_write` and `AsdfFile._post_write`
- removes `_get_yaml_content` argument to `asdf.open` (unused)

~Requires: https://github.com/astropy/asdf-astropy/pull/290~ EDIT: merged

The pytest-asdf plugin had to be fixed as part of this work. This originally revealed some issues with the ndarray examples (where the external block example was only partially tested and the mask example fails to round-trip). See https://github.com/asdf-format/asdf-standard/pull/475 for more details. The approach taken in this PR is to update the plugin to:
- convert the example to a tagged tree
- validate the tagged tree using the schema

This avoids any need to roundtrip data or provide blocks (or external blocks) which ultimately improves decoupling between the example testing and the quirks of the python asdf library.

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
