### PR TITLE
Check for external pytest-asdf-plugin and don't register bundled plugin if the external one exists

### DIFF
--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -1,8 +1,6 @@
 import importlib
-import io
 import os
 import pathlib
-import warnings
 from dataclasses import dataclass
 
 import pytest
@@ -206,8 +204,8 @@ class AsdfSchemaExampleItem(pytest.Item):
         import asdf
         from asdf.testing.helpers import yaml_to_asdf
 
-        # warn inside test
-        warnings.warn("pytest_asdf is deprecated, install pytest_asdf_plugin instead", DeprecationWarning)
+        # warn inside test, we don't do this yet to allow time for downstream packages to adopt pytest-asdf-plugin
+        # warnings.warn("pytest_asdf is deprecated, install pytest_asdf_plugin instead", DeprecationWarning)
 
         # check the example is valid
         buff = yaml_to_asdf("example: " + self.example.example.strip(), version=self.example.version)

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -1,14 +1,20 @@
+import importlib
+import io
 import os
 import pathlib
+import warnings
 from dataclasses import dataclass
 
 import pytest
 import yaml
 
 # Avoid all imports of asdf at this level in order to avoid circular imports
+HAS_NEW_PLUGIN = importlib.util.find_spec("pytest_asdf_plugin") is not None
 
 
 def pytest_addoption(parser):
+    if HAS_NEW_PLUGIN:
+        return
     parser.addini("asdf_schema_root", "Root path indicating where schemas are stored")
     parser.addini("asdf_schema_skip_names", "Base names of files to skip in schema tests")
     parser.addini(
@@ -200,6 +206,9 @@ class AsdfSchemaExampleItem(pytest.Item):
         import asdf
         from asdf.testing.helpers import yaml_to_asdf
 
+        # warn inside test
+        warnings.warn("pytest_asdf is deprecated, install pytest_asdf_plugin instead", DeprecationWarning)
+
         # check the example is valid
         buff = yaml_to_asdf("example: " + self.example.example.strip(), version=self.example.version)
         tagged_tree = asdf.util.load_yaml(buff, tagged=True)
@@ -233,6 +242,8 @@ def _parse_test_list(content):
 
 
 def pytest_collect_file(file_path, parent):
+    if HAS_NEW_PLUGIN:
+        return None
     if not (parent.config.getini("asdf_schema_tests_enabled") or parent.config.getoption("asdf_tests")):
         return None
 


### PR DESCRIPTION
## Description

Start the deprecation process for the bundled pytest asdf plugin in favor of a separate package for the plugin.

See: https://github.com/asdf-format/pytest-asdf-plugin

The current plan is:
- merge this PR which adds a check for `pytest-asdf-plugin` to avoid registering both plugins
- make an asdf release
- make and release the separate package (tentatively `pytest-asdf-plugin` to avoid the name conflict) I have this after this check to allow it to be released with a real version check against a released asdf that has the plugin check added in this PR.
- the "external" plugin from the new package and the old "bundled" plugin from asdf should work along side each other. A user that installs asdf will continue to get the "bundled" plugin. If they install `pytest-asdf-plugin` they'll get the new plugin and the "bundled" one will be disabled.
- update downstream packages to use the new plugin
- deprecate the plugin (only warns if `pytest-asdf-plugin` is not installed)
- remove `pytest-asdf` in the following major version
- after some period remove the checks for the old "bundled" plugin from the new "external" plugin

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
