### PR TITLE
warn when bundled pytest plugin runs

### DIFF
--- a/changes/1959.removal.rst
+++ b/changes/1959.removal.rst
@@ -1,0 +1,1 @@
+Deprecate the bundled pytest plugin, please install pytest-asdf-plugin to run schema tests.

--- a/pytest_asdf/plugin.py
+++ b/pytest_asdf/plugin.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import pathlib
+import warnings
 from dataclasses import dataclass
 
 import pytest
@@ -128,6 +129,9 @@ class AsdfSchemaItem(pytest.Item):
     def runtest(self):
         from asdf import schema
 
+        # warn inside test, we don't do this yet to allow time for downstream packages to adopt pytest-asdf-plugin
+        warnings.warn("pytest_asdf is deprecated, install pytest_asdf_plugin instead", DeprecationWarning)
+
         # Make sure that each schema itself is valid.
         schema_tree = schema.load_schema(
             self.schema_path,
@@ -205,7 +209,7 @@ class AsdfSchemaExampleItem(pytest.Item):
         from asdf.testing.helpers import yaml_to_asdf
 
         # warn inside test, we don't do this yet to allow time for downstream packages to adopt pytest-asdf-plugin
-        # warnings.warn("pytest_asdf is deprecated, install pytest_asdf_plugin instead", DeprecationWarning)
+        warnings.warn("pytest_asdf is deprecated, install pytest_asdf_plugin instead", DeprecationWarning)
 
         # check the example is valid
         buff = yaml_to_asdf("example: " + self.example.example.strip(), version=self.example.version)


### PR DESCRIPTION
## Description

With the release of https://pypi.org/project/pytest-asdf-plugin/ and updates to our downstream to use the new plugin we can start warning when the bundled plugin is used.

This PR issues a warning when the bundled plugin runs a test.

Requires:
- https://github.com/asdf-format/asdf-standard/pull/478
- https://github.com/asdf-format/asdf-wcs-schemas/pull/77
- https://github.com/asdf-format/asdf-transform-schemas/pull/127
- https://github.com/asdf-format/asdf-coordinates-schemas/pull/71
- https://github.com/astropy/asdf-astropy/pull/291
- https://github.com/spacetelescope/rad/pull/667 (rad has no devdeps testing with asdf so as long as these go in before the next asdf release we're fine to merge this asdf PR first)
- https://github.com/BAMWelDX/weldx/pull/997
- https://github.com/astropy/specutils/pull/1265

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
