### PR TITLE
support core-1.7.0

### DIFF
--- a/asdf/_core/_converters/integer.py
+++ b/asdf/_core/_converters/integer.py
@@ -7,6 +7,7 @@ class IntegerConverter(Converter):
     tags = [
         "tag:stsci.edu:asdf/core/integer-1.0.0",
         "tag:stsci.edu:asdf/core/integer-1.1.0",
+        "tag:stsci.edu:asdf/core/integer-1.2.0",
     ]
     types = ["asdf.tags.core.integer.IntegerType"]
 

--- a/asdf/_core/_converters/ndarray.py
+++ b/asdf/_core/_converters/ndarray.py
@@ -7,6 +7,7 @@ class NDArrayConverter(Converter):
     tags = [
         "tag:stsci.edu:asdf/core/ndarray-1.0.0",
         "tag:stsci.edu:asdf/core/ndarray-1.1.0",
+        "tag:stsci.edu:asdf/core/ndarray-1.2.0",
     ]
     types = [
         np.ndarray,  # we use the type here so the extension can find the sub-classes

--- a/asdf/_core/_extensions.py
+++ b/asdf/_core/_extensions.py
@@ -45,6 +45,7 @@ MANIFEST_URIS = [
     "asdf://asdf-format.org/core/manifests/core-1.4.0",
     "asdf://asdf-format.org/core/manifests/core-1.5.0",
     "asdf://asdf-format.org/core/manifests/core-1.6.0",
+    "asdf://asdf-format.org/core/manifests/core-1.7.0",
 ]
 
 

--- a/asdf/_core/_extensions.py
+++ b/asdf/_core/_extensions.py
@@ -1,4 +1,5 @@
 from asdf.extension import ManifestExtension
+from asdf.versioning import get_supported_core_schema_versions
 
 from ._converters.complex import ComplexConverter
 from ._converters.constant import ConstantConverter
@@ -38,16 +39,8 @@ VALIDATORS = [
 
 
 MANIFEST_URIS = [
-    "asdf://asdf-format.org/core/manifests/core-1.0.0",
-    "asdf://asdf-format.org/core/manifests/core-1.1.0",
-    "asdf://asdf-format.org/core/manifests/core-1.2.0",
-    "asdf://asdf-format.org/core/manifests/core-1.3.0",
-    "asdf://asdf-format.org/core/manifests/core-1.4.0",
-    "asdf://asdf-format.org/core/manifests/core-1.5.0",
-    "asdf://asdf-format.org/core/manifests/core-1.6.0",
-    "asdf://asdf-format.org/core/manifests/core-1.7.0",
+    f"asdf://asdf-format.org/core/manifests/core-{version}" for version in get_supported_core_schema_versions()
 ]
-
 
 EXTENSIONS = [
     ManifestExtension.from_uri(

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -102,7 +102,7 @@ def test_get_history_entries(tmp_path):
 def test_extension_metadata(tmp_path):
     file_path = tmp_path / "extension.asdf"
 
-    ff = asdf.AsdfFile()
+    ff = asdf.AsdfFile(version="1.6.0")
     ff.write_to(file_path)
 
     with asdf.open(file_path) as af:

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -737,7 +737,7 @@ custom: !<tag:nowhere.org:custom/tag_reference-1.0.0>
     """
 
     with tag_reference_extension():
-        buff = yaml_to_asdf(yaml)
+        buff = yaml_to_asdf(yaml, version="1.6.0")
         with asdf.open(buff) as ff:
             custom = ff.tree["custom"]
             assert custom.name == "Something"
@@ -798,7 +798,7 @@ custom: !<tag:nowhere.org:custom/foreign_tag_reference-1.0.0>
         cfg.add_resource_mapping({schema_uri: tag_schema})
         cfg.add_extension(ForeignTagReferenceExtension())
 
-        buff = yaml_to_asdf(yaml)
+        buff = yaml_to_asdf(yaml, version="1.6.0")
         with asdf.open(buff) as ff:
             a = ff.tree["custom"].a
             assert a.name == "Something"

--- a/asdf/_tests/test_types.py
+++ b/asdf/_tests/test_types.py
@@ -22,7 +22,7 @@ undefined_data:
         - !core/ndarray-1.1.0 [[7],[8],[9],[10]]
         - !core/complex-1.0.0 3.14j
 """
-    buff = yaml_to_asdf(yaml)
+    buff = yaml_to_asdf(yaml, version="1.6.0")
     with pytest.warns(Warning) as warning:
         afile = asdf.open(buff)
         missing = afile.tree["undefined_data"]

--- a/asdf/_tests/test_versioning.py
+++ b/asdf/_tests/test_versioning.py
@@ -2,7 +2,6 @@ from itertools import combinations
 
 from asdf.versioning import (
     AsdfVersion,
-    asdf_standard_development_version,
     default_version,
     supported_versions,
 )
@@ -10,10 +9,6 @@ from asdf.versioning import (
 
 def test_default_in_supported_versions():
     assert default_version in supported_versions
-
-
-def test_development_is_not_default():
-    assert default_version != asdf_standard_development_version
 
 
 def test_version_constructor():

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -8,6 +8,14 @@ from functools import total_ordering
 import yaml
 from semantic_version import SimpleSpec, Version
 
+try:
+    from asdf_standard._versioning import get_supported_core_schema_versions
+except ImportError:
+
+    def get_supported_core_schema_versions():
+        return ("1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0")
+
+
 _yaml_base_loader = yaml.CSafeLoader if getattr(yaml, "__with_libyaml__", None) else yaml.SafeLoader
 
 
@@ -83,23 +91,9 @@ class AsdfVersion(AsdfVersionMixin, Version):
         super().__init__(version)
 
 
-supported_versions = [
-    AsdfVersion("1.0.0"),
-    AsdfVersion("1.1.0"),
-    AsdfVersion("1.2.0"),
-    AsdfVersion("1.3.0"),
-    AsdfVersion("1.4.0"),
-    AsdfVersion("1.5.0"),
-    AsdfVersion("1.6.0"),
-    AsdfVersion("1.7.0"),
-]
+supported_versions = tuple(AsdfVersion(version) for version in get_supported_core_schema_versions())
 
-
-default_version = AsdfVersion("1.6.0")
-
-# This is the ASDF core schemas version that is currently in development
-# it is possible that breaking changes will be made to this version.
-asdf_standard_development_version = AsdfVersion("1.7.0")
+default_version = supported_versions[-1]
 
 
 # This is the ASDF core schemas version at which the format of the history

--- a/asdf/versioning.py
+++ b/asdf/versioning.py
@@ -91,6 +91,7 @@ supported_versions = [
     AsdfVersion("1.4.0"),
     AsdfVersion("1.5.0"),
     AsdfVersion("1.6.0"),
+    AsdfVersion("1.7.0"),
 ]
 
 

--- a/changes/1962.feature.rst
+++ b/changes/1962.feature.rst
@@ -1,0 +1,2 @@
+Add support for registering development versions of core extensions if the ASDF_DEV_CORE_SCHEMAS environment variable is set.
+Writing files with development extensions is discouraged as schema changes may make these files unreable in the future.

--- a/changes/1962.feature.rst
+++ b/changes/1962.feature.rst
@@ -1,2 +1,2 @@
-Add support for registering development versions of core extensions if the ASDF_DEV_CORE_SCHEMAS environment variable is set.
-Writing files with development extensions is discouraged as schema changes may make these files unreable in the future.
+Add support for registering unstable/development versions of core extensions if the ASDF_UNSTABLE_CORE_SCHEMAS environment variable is set.
+Writing files with unstable/development extensions is discouraged as schema changes may make these files unreable in the future.

--- a/docs/asdf/config.rst
+++ b/docs/asdf/config.rst
@@ -33,14 +33,14 @@ the currently active config:
 .. code-block:: pycon
 
     >>> import asdf
-    >>> asdf.get_config()
+    >>> asdf.get_config()  # doctest: +ELLIPSIS
     <AsdfConfig
       array_inline_threshold: None
       all_array_storage: None
       all_array_compression: input
       all_array_compression_kwargs: None
       default_array_save_base: True
-      default_version: 1.6.0
+      default_version: ...
       io_block_size: -1
       legacy_fill_schema_defaults: True
       validate_on_read: True
@@ -55,7 +55,7 @@ This allows for short-lived configuration changes that do not impact other code:
 .. code-block:: pycon
 
     >>> import asdf
-    >>> with asdf.config_context() as config:
+    >>> with asdf.config_context() as config:  # doctest: +ELLIPSIS
     ...     config.validate_on_read = False
     ...     asdf.get_config()
     ...
@@ -65,20 +65,20 @@ This allows for short-lived configuration changes that do not impact other code:
       all_array_compression: input
       all_array_compression_kwargs: None
       default_array_save_base: True
-      default_version: 1.6.0
+      default_version: ...
       io_block_size: -1
       legacy_fill_schema_defaults: True
       validate_on_read: False
       lazy_tree: False
     >
-    >>> asdf.get_config()
+    >>> asdf.get_config()  # doctest: +ELLIPSIS
     <AsdfConfig
       array_inline_threshold: None
       all_array_storage: None
       all_array_compression: input
       all_array_compression_kwargs: None
       default_array_save_base: True
-      default_version: 1.6.0
+      default_version: ...
       io_block_size: -1
       legacy_fill_schema_defaults: True
       validate_on_read: True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ dynamic = [
   'version',
 ]
 dependencies = [
-  # "asdf-standard>=1.1.0",
-  "asdf-standard @ git+https://github.com/braingram/asdf-standard.git@standard_1p7p0",
+  "asdf-standard>=1.1.0",
   "asdf-transform-schemas>=0.3",  # required for asdf-1.0.0 schema
   "importlib-metadata>=4.11.4 ; python_version<='3.11'",
   "jmespath>=0.6.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dynamic = [
   'version',
 ]
 dependencies = [
-  "asdf-standard>=1.1.0",
+  # "asdf-standard>=1.1.0",
+  "asdf-standard @ git+https://github.com/braingram/asdf-standard.git@standard_1p7p0",
   "asdf-transform-schemas>=0.3",  # required for asdf-1.0.0 schema
   "importlib-metadata>=4.11.4 ; python_version<='3.11'",
   "jmespath>=0.6.2",

--- a/tox.ini
+++ b/tox.ini
@@ -44,10 +44,12 @@ commands_pre =
     oldestdeps: pip install -r {env_tmp_dir}/requirements-min.txt
 
     pip freeze
+# print out the default core schemas version
+    python -c "import asdf; print(f'Core schemas default version: {asdf.get_config().default_version}')"
+commands =
 # coverage run must be used because the pytest-asdf plugin will interfere
 # with proper coverage measurement due to the order pytest loads its
 # entry points.
-commands =
     coverage: coverage run --source=asdf --rcfile={tox_root}/pyproject.toml -m \
     pytest \
     compatibility: integration_tests/compatibility/ \

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ env_list =
 [testenv]
 set_env =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    devdeps: ASDF_DEV_CORE_SCHEMAS = 1
+    devdeps: ASDF_UNSTABLE_CORE_SCHEMAS = 1
 deps =
     compatibility: virtualenv
     coverage: coverage
@@ -52,7 +52,7 @@ commands =
 # entry points.
     coverage: coverage run --source=asdf --rcfile={tox_root}/pyproject.toml -m \
     pytest \
-    devdeps: -W "ignore::asdf_standard.exceptions.DevCoreSchemasWarning"
+    devdeps: -W "ignore::asdf_standard.exceptions.UnstableCoreSchemasWarning"
     compatibility: integration_tests/compatibility/ \
     mocks3: integration_tests/mocks3/ \
     --remote-data \

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ commands =
 # entry points.
     coverage: coverage run --source=asdf --rcfile={tox_root}/pyproject.toml -m \
     pytest \
+    devdeps: -W "ignore::asdf_standard.exceptions.DevCoreSchemasWarning"
     compatibility: integration_tests/compatibility/ \
     mocks3: integration_tests/mocks3/ \
     --remote-data \

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ env_list =
 [testenv]
 set_env =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps: ASDF_DEV_CORE_SCHEMAS = 1
 deps =
     compatibility: virtualenv
     coverage: coverage


### PR DESCRIPTION
## Description

Support new "unstable" schemas (1.7.0) added in https://github.com/asdf-format/asdf-standard/pull/479 by:
- adding new integer-1.2.0 and ndarray-1.2.0 tags to converters
- use "get_supported_core_schema_versions" from asdf-standard to dynamically set the supported versions (in part based on the presence of the `ASDF_UNSTABLE_CORE_SCHEMAS` environment variable)
- set `ASDF_UNSTABLE_CORE_SCHEMAS` in devdeps to test unstable version of schemas
- update several tests that started breaking with the unstable schemas. Most expected tags only in 1.6.0 (such as ndarray-1.1.0). These were updated in a way that should be compatible with future updates by dynamically inspecting the currently used tag or by forcing a core schema version (where the test was not designed to test the schema/extension but instead test the asdf implementation behavior).

The plan is for this PR will stay draft until after the asdf 5.0.0 release and then start testing and eventually update to 1.7.0 as part of a 5.x.x release (I'm not at the moment convinced that a change in default core schema should require a major version bump).

Closes: https://github.com/asdf-format/asdf/issues/1963

Requires https://github.com/asdf-format/asdf-standard/pull/479 first to fix the devdeps (since the referenced Exception does not yet appear in asdf-standard main). [Here's a run](https://github.com/asdf-format/asdf/actions/runs/17580400614/job/49935782058) where the devdeps were run with the linked PR and passed.

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
