### PR TITLE
Add warning for upcoming change to `default_array_save_base`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,6 @@ jobs:
     with:
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
       test_extras: tests
-      test_command: pytest --pyargs asdf
+      test_command: pytest --pyargs asdf -c $GITHUB_WORKSPACE/pyproject.toml --rootdir=.
     secrets:
       pypi_token: ${{ secrets.PYPI_PASSWORD_ASDF_MAINTAINER }}

--- a/asdf/_tests/test_util.py
+++ b/asdf/_tests/test_util.py
@@ -153,6 +153,7 @@ l: &id002 !some/tag-1.0.0
     assert tree["l"] is tree["l"][0]
 
 
+# Need to enable ChangingDefaultWarning exceptions since they are off by default
 @pytest.mark.filterwarnings("error::asdf.exceptions.ChangingDefaultWarning")
 def test_changing_default():
     """Test that changing_default works as expected."""

--- a/asdf/_tests/test_util.py
+++ b/asdf/_tests/test_util.py
@@ -203,3 +203,17 @@ def test_changing_default():
     # Verify accessing the values once they've been manually set doesn't emit a warning
     assert cfg.value == 2
     assert cfg.other == "bar"
+
+    # Verify warning doesn't trigger even if value is deleted
+    del cfg.value
+    assert cfg.value == 1
+
+    class Subconfig(Config):
+        @Config.value.getter
+        def value(self) -> int:  # pyrefly: ignore [bad-override]
+            return self._value + 1
+
+    # Verify that overriding property getters works correctly
+    cfg = Subconfig()
+    cfg.value = 3
+    assert cfg.value == 4

--- a/asdf/_tests/test_util.py
+++ b/asdf/_tests/test_util.py
@@ -6,6 +6,8 @@ import pytest
 
 import asdf
 from asdf import generic_io, util
+from asdf.exceptions import ChangingDefaultWarning
+from asdf.util import changing_default
 
 
 def test_not_set():
@@ -149,3 +151,54 @@ l: &id002 !some/tag-1.0.0
     tree = util.load_yaml(io.BytesIO(contents), tagged=tagged)
     assert tree["o"] is tree["o"]["inverse"]["inverse"]
     assert tree["l"] is tree["l"][0]
+
+
+@pytest.mark.filterwarnings("error::asdf.exceptions.ChangingDefaultWarning")
+def test_changing_default():
+    """Test that changing_default works as expected."""
+
+    class CustomWarning(ChangingDefaultWarning): ...
+
+    class Config:
+        def __init__(self):
+            self._value = 1
+            self._other = None
+
+        @changing_default(2, CustomWarning)
+        @property
+        def value(self) -> int:
+            return self._value
+
+        @value.setter
+        def value(self, value: int) -> None:
+            self._value = value
+
+        @value.deleter
+        def value(self) -> None:
+            self._value = 1
+
+        @changing_default("foo")
+        @property
+        def other(self) -> str | None:
+            return self._other
+
+        @other.setter
+        def other(self, value: str) -> None:
+            self._other = value
+
+    cfg = Config()
+
+    # Verify accessing the value emits the custom warning
+    with pytest.warns(CustomWarning):
+        assert cfg.value == 1
+
+    # Verify accessing the value with no warning specified falls back to the default warning
+    with pytest.warns(ChangingDefaultWarning):
+        assert cfg.other is None
+
+    cfg.value = 2
+    cfg.other = "bar"
+
+    # Verify accessing the values once they've been manually set doesn't emit a warning
+    assert cfg.value == 2
+    assert cfg.other == "bar"

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -11,6 +11,8 @@ import threading
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
+from asdf.util import changing_default
+
 from . import _entry_points, util, versioning
 from ._helpers import validate_version
 from .extension import ExtensionProxy
@@ -405,12 +407,20 @@ class AsdfConfig:
             raise ValueError(msg)
         self._all_array_compression_kwargs = value
 
+    @changing_default(False)
     @property
     def default_array_save_base(self) -> bool:
         """
         Option to control if when saving arrays the base array should be
         saved (so views of the same array will refer to offsets/strides of the
         same block).
+
+        Warnings
+        --------
+        In a future release the default value will change from `True` to `False`.
+        Currently this field will emit a `asdf.exceptions.ChangingDefaultArraySaveBaseWarning`
+        if not explicitly set. To silence the warning, explicitly set ``default_array_save_base``
+        to either `True` or `False`.
         """
         return self._default_array_save_base
 

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -11,6 +11,8 @@ __all__ = [
     "AsdfProvisionalAPIWarning",
     "AsdfSerializationError",
     "AsdfWarning",
+    "ChangingDefaultArraySaveBaseWarning",
+    "ChangingDefaultWarning",
     "DelimiterNotFoundError",
     "ValidationError",
 ]
@@ -64,7 +66,7 @@ class AsdfPackageVersionWarning(AsdfWarning):
 
 class AsdfManifestURIMismatchWarning(AsdfWarning):
     """
-    A warning indicaing that an extension registered with a manifest
+    A warning indicating that an extension registered with a manifest
     contains a id that does not match the uri of the manifest.
     """
 
@@ -84,3 +86,10 @@ class AsdfSerializationError(RepresenterError):
     that the object does not have a supporting asdf Converter and needs to
     be manually converted to a supported type.
     """
+
+
+class ChangingDefaultWarning(AsdfWarning, DeprecationWarning):
+    """A warning indicating that a default argument or configuration option will change in a future release."""
+
+
+class ChangingDefaultArraySaveBaseWarning(ChangingDefaultWarning): ...

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -3,11 +3,15 @@ import importlib.util
 import math
 import re
 import struct
+import warnings
 from functools import lru_cache
-from typing import Final
+from typing import Final, Generic
 
 import numpy as np
 import yaml
+from typing_extensions import TypeVar
+
+from asdf.exceptions import ChangingDefaultWarning
 
 from . import constants
 
@@ -32,6 +36,7 @@ __all__ = [
     "FileType",
     "NotSet",
     "calculate_padding",
+    "changing_default",
     "get_array_base",
     "get_base_uri",
     "get_class_name",
@@ -348,3 +353,108 @@ class FileType(enum.Enum):
     ASDF = 1
     FITS = 2
     UNKNOWN = 3
+
+
+_T = TypeVar("_T")
+
+
+# Adapted from https://docs.python.org/3/howto/descriptor.html#properties
+class _ChangingDefault(Generic[_T]):
+    """See `changing_default`."""
+
+    def __init__(
+        self,
+        prop,
+        new_default: _T,
+        warning: type[ChangingDefaultWarning],
+    ):
+        self._prop = prop
+        self.__doc__ = self._prop.__doc__
+        self.new_default = new_default
+        self.warning = warning
+
+        self.is_set = False
+
+    def __set_name__(self, owner, name):
+        self.__name__ = name
+
+    def __get__(self, obj, objtype=None):
+        value = self._prop.__get__(obj, objtype)
+
+        if not self.is_set:
+            old_default = value
+            # Using the actual class here so if the name changes it doesn't get missed
+            cls = ChangingDefaultWarning.__name__
+            msg = (
+                f"In the future the default for {self.__name__} will be {self.new_default} "
+                f"instead of the current default of {old_default}. "
+                f"Explicitly pass {self.new_default} or {old_default} to silence this warning, "
+                f'or use warnings.simplefilter("ignore", {cls}) to silence all changing default warnings.'
+            )
+            warnings.warn(msg, self.warning, stacklevel=2)
+        return value
+
+    def __set__(self, obj, value):
+        self.is_set = True
+        return self._prop.__set__(obj, value)
+
+    def __delete__(self, obj):
+        self._prop.__delete__(obj)
+
+    def getter(self, fget):
+        self._prop = type(self._prop)(fget, self._prop.fset, self._prop.fdel, self.__doc__)
+        return self
+
+    def setter(self, fset):
+        self._prop = type(self._prop)(self._prop.fget, fset, self._prop.fdel, self.__doc__)
+        return self
+
+    def deleter(self, fdel):
+        self._prop = type(self._prop)(self._prop.fget, self._prop.fset, fdel, self.__doc__)
+        return self
+
+
+def changing_default(new_default: _T, warning: type[ChangingDefaultWarning] = ChangingDefaultWarning):
+    """Wrap a property to indicate that its default value will change in a future update.
+
+    Parameters
+    ----------
+    new_default:
+        New value that will become the default in the future.
+    warning:
+        Warning class to emit when the value isn't manually set.
+        Must be a subclass of `asdf.exceptions.ChangingDefaultWarning`.
+
+    Examples
+    --------
+    When planning to change the default value of a property simply add the ``@changing_default``
+    decorator after the ``@property`` decorator::
+
+        >>> class Config:
+        ...    def __init__(self):
+        ...        self._value = 1
+        ...
+        ...    @changing_default(2)
+        ...    @property  # Make sure to still include the property decorator
+        ...    def value(self) -> int:
+        ...        return self._value
+        ...
+        ...    @value.setter  # Setter is defined as usual
+        ...    def value(self, value: int) -> None:
+        ...        self._value = value
+        >>> cfg = Config()
+        >>> cfg.value # doctest: +SKIP
+        asdf.exceptions.ChangingDefaultWarning: In the future the default for value will
+            be 2 instead of the current default of 1. Explicitly pass 1 or 2 to silence
+            this warning, or use warnings.simplefilter("ignore", ChangingDefaultWarning)
+            to silence all changing default warnings.
+        1
+        >>> cfg.value = 3
+        >>> cfg.value
+        3
+    """
+
+    def inner(prop):
+        return _ChangingDefault(prop, new_default, warning)
+
+    return inner

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -36,7 +36,6 @@ __all__ = [
     "FileType",
     "NotSet",
     "calculate_padding",
-    "changing_default",
     "get_array_base",
     "get_base_uri",
     "get_class_name",

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -417,6 +417,9 @@ class _ChangingDefault(Generic[_T]):
 def changing_default(new_default: _T, warning: type[ChangingDefaultWarning] = ChangingDefaultWarning):
     """Wrap a property to indicate that its default value will change in a future update.
 
+    When the wrapped property is accessed, it will emit a warning if the property value hasn't been manually set.
+    If the value has been manually set, this decorator has no effect.
+
     Parameters
     ----------
     new_default:

--- a/changes/2117.general.rst
+++ b/changes/2117.general.rst
@@ -1,2 +1,2 @@
-`AsdfConfig.default_array_save_base`'s default value will change from `True` to `False` in a future release.
+The default value of ``default_array_save_base`` in `AsdfConfig` will change from `True` to `False` in a future release.
 The property now emits a warning when accessed unless its value is set manually.

--- a/changes/2117.general.rst
+++ b/changes/2117.general.rst
@@ -1,2 +1,2 @@
-The default value of ``default_array_save_base`` in `AsdfConfig` will change from `True` to `False` in a future release.
+The default value of ``default_array_save_base`` in `asdf.config.AsdfConfig` will change from `True` to `False` in a future release.
 The property now emits a warning when accessed unless its value is set manually.

--- a/changes/2117.general.rst
+++ b/changes/2117.general.rst
@@ -1,0 +1,2 @@
+`AsdfConfig.default_array_save_base`'s default value will change from `True` to `False` in a future release.
+The property now emits a warning when accessed unless its value is set manually.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ filterwarnings = [
   # This should really be the more specific asdf.exceptions.ChangingDefaultWarning
   # Unfortunately we can't register that warning without breaking devdeps
   # See: https://github.com/asdf-format/asdf/pull/2117#issuecomment-5333331813
-  "ignore:In the future the default for:DeprecationWarning",
+  "ignore:In the future the default for*:DeprecationWarning",
 ]
 addopts = [
   "--doctest-modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,10 @@ filterwarnings = [
   "error",  # also set in _tests/conftest to work with pyargs
   "ignore:numpy.ndarray size changed:RuntimeWarning",
   "ignore:Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.",
-  "ignore::asdf.exceptions.ChangingDefaultWarning",
+  # This should really be the more specific asdf.exceptions.ChangingDefaultWarning
+  # Unfortunately we can't register that warning without breaking devdeps
+  # See: https://github.com/asdf-format/asdf/pull/2117#issuecomment-5333331813
+  "ignore:In the future the default for:DeprecationWarning",
 ]
 addopts = [
   "--doctest-modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ filterwarnings = [
   "error",  # also set in _tests/conftest to work with pyargs
   "ignore:numpy.ndarray size changed:RuntimeWarning",
   "ignore:Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.",
+  "ignore::asdf.exceptions.ChangingDefaultWarning",
 ]
 addopts = [
   "--doctest-modules",


### PR DESCRIPTION
## Description
- Added deprecation warning to `AsdfConfig.default_array_save_base` which is triggered on access if value is not manually set.
- Added `asdf.util.changing_default` decorator for handing the warning logic for properties.
- Added `ChangingDefaultWarning` as a general superclass for all changing default warnings so that users can disable all such warnings if desired. Subclasses `AsdfWarning` and `DeprecationWarning` which means it and its subclasses are off by default for end-users.
- Added `ChangingDefaultArraySaveBaseWarning` as the specific warning class emitted by `default_array_save_base`.

This PR is a first step to eventually resolve #1994.

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
