### PR TITLE
Add warning when conversion fails with default `warn_on_failed_conversion`

### DIFF
--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -11,7 +11,7 @@ from numpy import ma
 from numpy.testing import assert_array_equal
 
 import asdf
-from asdf.exceptions import ValidationError
+from asdf.exceptions import AsdfFutureWarning, ValidationError
 from asdf.extension import Converter, Extension, TagDefinition
 from asdf.tags.core import ndarray
 from asdf.testing import helpers
@@ -954,8 +954,9 @@ arr: !{ndarray_tag}
 
     buff = helpers.yaml_to_asdf(content)
     with pytest.raises(ValueError, match=r"inline data doesn't match the given shape"):
-        with asdf.open(buff) as af:
-            af["arr"]
+        with pytest.warns(AsdfFutureWarning):
+            with asdf.open(buff) as af:
+                af["arr"]
 
 
 def test_broadcasted_array():

--- a/asdf/_tests/test_config.py
+++ b/asdf/_tests/test_config.py
@@ -6,8 +6,11 @@ import pytest
 import asdf
 from asdf import get_config
 from asdf._core._integration import get_json_schema_resource_mappings
+from asdf.config import config_context
+from asdf.exceptions import AsdfConversionWarning, AsdfFutureWarning
 from asdf.extension import ExtensionProxy
 from asdf.resource import ResourceMappingProxy
+from asdf.testing import helpers
 
 
 def test_config_context():
@@ -353,3 +356,68 @@ def test_invalid_set_default_array_save_base(value):
     with asdf.config_context() as config:
         with pytest.raises(ValueError, match="default_array_save_base must be a bool"):
             config.default_array_save_base = value
+
+
+class NeverConverter:
+    tags = ["asdf://example.com/tags/never-1.0.0"]
+    types = []
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return {}
+
+    def from_yaml_tree(self, node, tag, ctx):
+        msg = "This type always fails"
+        raise RuntimeError(msg)
+
+
+class NeverExtension:
+    tags = NeverConverter.tags
+    extension_uri = "asdf://example.com/extensions/never-1.0.0"
+    converters = [NeverConverter()]
+
+
+def test_warn_on_failed_conversion_default_warn():
+    """Test that when a node conversion fails a FutureWarning is emitted before the error
+    if warn_on_failed_conversion hasn't been manually set.
+
+    This test can be removed once the default for warn_on_failed_conversion changes.
+    """
+    with config_context() as cfg:
+        cfg.add_extension(NeverExtension())
+        buff = helpers.yaml_to_asdf(f"data: !<{NeverConverter.tags[0]}> {{}}")
+
+        with pytest.raises(RuntimeError), pytest.warns(AsdfFutureWarning):
+            with asdf.open(buff) as af:
+                af["data"]
+
+
+def test_warn_on_failed_conversion_false_no_warn():
+    """Test that when a node conversion fails no extra warning is emitted if
+    warn_on_failed_conversion has been set to False.
+
+    This test can be removed once the default for warn_on_failed_conversion changes.
+    """
+    with config_context() as cfg:
+        cfg.add_extension(NeverExtension())
+        buff = helpers.yaml_to_asdf(f"data: !<{NeverConverter.tags[0]}> {{}}")
+
+        cfg.warn_on_failed_conversion = False
+        with pytest.raises(RuntimeError):
+            with asdf.open(buff) as af:
+                af["data"]
+
+
+def test_warn_on_failed_conversion_true_no_warn():
+    """Test that when a node conversion fails no extra warning is emitted if
+    warn_on_failed_conversion has been set to True.
+
+    This test can be removed once the default for warn_on_failed_conversion changes.
+    """
+    with config_context() as cfg:
+        cfg.add_extension(NeverExtension())
+        buff = helpers.yaml_to_asdf(f"data: !<{NeverConverter.tags[0]}> {{}}")
+
+        cfg.warn_on_failed_conversion = True
+        with pytest.warns(AsdfConversionWarning):
+            with asdf.open(buff) as af:
+                af["data"]

--- a/asdf/_tests/test_config.py
+++ b/asdf/_tests/test_config.py
@@ -361,6 +361,7 @@ def test_invalid_set_default_array_save_base(value):
 class NeverConverter:
     tags = ["asdf://example.com/tags/never-1.0.0"]
     types = []
+    lazy = True
 
     def to_yaml_tree(self, obj, tag, ctx):
         return {}
@@ -376,13 +377,15 @@ class NeverExtension:
     converters = [NeverConverter()]
 
 
-def test_warn_on_failed_conversion_default_warn():
+@pytest.mark.parametrize("lazy", [True, False])
+def test_warn_on_failed_conversion_default_warn(lazy: bool):
     """Test that when a node conversion fails a FutureWarning is emitted before the error
     if warn_on_failed_conversion hasn't been manually set.
 
     This test can be removed once the default for warn_on_failed_conversion changes.
     """
     with config_context() as cfg:
+        cfg.lazy_tree = lazy
         cfg.add_extension(NeverExtension())
         buff = helpers.yaml_to_asdf(f"data: !<{NeverConverter.tags[0]}> {{}}")
 
@@ -391,13 +394,15 @@ def test_warn_on_failed_conversion_default_warn():
                 af["data"]
 
 
-def test_warn_on_failed_conversion_false_no_warn():
+@pytest.mark.parametrize("lazy", [True, False])
+def test_warn_on_failed_conversion_false_no_warn(lazy: bool):
     """Test that when a node conversion fails no extra warning is emitted if
     warn_on_failed_conversion has been set to False.
 
     This test can be removed once the default for warn_on_failed_conversion changes.
     """
     with config_context() as cfg:
+        cfg.lazy_tree = lazy
         cfg.add_extension(NeverExtension())
         buff = helpers.yaml_to_asdf(f"data: !<{NeverConverter.tags[0]}> {{}}")
 
@@ -407,13 +412,15 @@ def test_warn_on_failed_conversion_false_no_warn():
                 af["data"]
 
 
-def test_warn_on_failed_conversion_true_no_warn():
+@pytest.mark.parametrize("lazy", [True, False])
+def test_warn_on_failed_conversion_true_no_warn(lazy: bool):
     """Test that when a node conversion fails no extra warning is emitted if
     warn_on_failed_conversion has been set to True.
 
     This test can be removed once the default for warn_on_failed_conversion changes.
     """
     with config_context() as cfg:
+        cfg.lazy_tree = lazy
         cfg.add_extension(NeverExtension())
         buff = helpers.yaml_to_asdf(f"data: !<{NeverConverter.tags[0]}> {{}}")
 

--- a/asdf/_tests/test_lazy_nodes.py
+++ b/asdf/_tests/test_lazy_nodes.py
@@ -8,6 +8,10 @@ import numpy as np
 import pytest
 
 import asdf
+import asdf.lazy_nodes
+import asdf.tagged
+import asdf.tags.core
+import asdf.treeutil
 from asdf.lazy_nodes import AsdfDictNode, AsdfListNode, AsdfOrderedDictNode, _resolve_af_ref, _to_lazy_node
 
 

--- a/asdf/_tests/test_util.py
+++ b/asdf/_tests/test_util.py
@@ -5,7 +5,9 @@ import numpy as np
 import pytest
 
 import asdf
+import asdf.tagged
 from asdf import generic_io, util
+from asdf.util import is_set, tracked_property
 
 
 def test_not_set():
@@ -149,3 +151,59 @@ l: &id002 !some/tag-1.0.0
     tree = util.load_yaml(io.BytesIO(contents), tagged=tagged)
     assert tree["o"] is tree["o"]["inverse"]["inverse"]
     assert tree["l"] is tree["l"][0]
+
+
+class Tracked:
+    bar = None
+
+    def __init__(self):
+        self._value = 1
+        self.baz = None
+
+    @tracked_property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value
+
+
+def test_is_set_attr_error():
+    """Test that trying to access a non-existent property via `is_set` raises an `AttributeError`."""
+    x = Tracked()
+    with pytest.raises(AttributeError):
+        is_set(x).foo
+
+
+def test_is_set_type_error():
+    """Test that trying to access a property via `is_set` that isn't a `tracked_property` raises a `TypeError`."""
+    x = Tracked()
+    with pytest.raises(TypeError):
+        # Check class attribute
+        is_set(x).bar
+
+    with pytest.raises(TypeError):
+        # Check instance attribute
+        is_set(x).baz
+
+
+def test_tracked_property_slots_error():
+    """Test that using `tracked_property` on a class with `__slots__` (and no `__dict__`) raises a `TypeError`."""
+
+    class WithSlots:
+        __slots__ = ("_value",)
+
+        def __init__(self):
+            self._value = "foo"
+
+        @tracked_property
+        def value(self):
+            return self._value
+
+        @value.setter
+        def value(self, value):
+            self._value = value
+
+    with pytest.raises(TypeError):
+        WithSlots().value = "bar"

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -11,6 +11,8 @@ import threading
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
+from asdf.util import tracked_property
+
 from . import _entry_points, util, versioning
 from ._helpers import validate_version
 from .extension import ExtensionProxy
@@ -464,7 +466,7 @@ class AsdfConfig:
     def lazy_tree(self, value: bool) -> None:
         self._lazy_tree = value
 
-    @property
+    @tracked_property
     def warn_on_failed_conversion(self) -> bool:
         """
         Get configuration that controls if errors during
@@ -476,6 +478,13 @@ class AsdfConfig:
         Returns
         -------
         bool
+
+        Warnings
+        --------
+        In a future release the default value will change from `False` to `True`.
+        Currently, if a conversion fails and this field hasn't been set then ASDF will
+        emit an `asdf.exceptions.AsdfFutureWarning` *before* raising an exception.
+        Manually set the field to either `True` or `False` to silence this warning.
         """
         return self._warn_on_failed_conversion
 

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -5,6 +5,7 @@ from asdf._jsonschema import ValidationError
 __all__ = [
     "AsdfConversionWarning",
     "AsdfDeprecationWarning",
+    "AsdfFutureWarning",
     "AsdfLazyReferenceError",
     "AsdfManifestURIMismatchWarning",
     "AsdfPackageVersionWarning",

--- a/asdf/exceptions.py
+++ b/asdf/exceptions.py
@@ -84,3 +84,7 @@ class AsdfSerializationError(RepresenterError):
     that the object does not have a supporting asdf Converter and needs to
     be manually converted to a supported type.
     """
+
+
+class AsdfFutureWarning(AsdfWarning, FutureWarning):
+    """Warning about a future change in ASDF behavior."""

--- a/asdf/lazy_nodes.py
+++ b/asdf/lazy_nodes.py
@@ -8,6 +8,9 @@ import inspect
 import warnings
 import weakref
 
+from asdf.exceptions import AsdfFutureWarning
+from asdf.util import is_set
+
 from . import tagged, treeutil, yamlutil
 from .config import get_config
 from .exceptions import AsdfConversionWarning, AsdfLazyReferenceError
@@ -221,6 +224,16 @@ class _AsdfNode:
                             warnings.warn(f"A node failed to convert with: {err}", AsdfConversionWarning)
                             obj = _to_lazy_node(value, self._af_ref)
                         else:
+                            if not is_set(get_config()).warn_on_failed_conversion:
+                                # Only emit a warning if warn_on_failed_conversion hasn't been manually set
+                                warnings.warn(
+                                    (
+                                        "In the future failed node conversion will by default generate a warning "
+                                        "instead of an error. Set AsdfConfig.warn_on_failed_conversion to True to "
+                                        "opt-in to the new behavior, or to False to silence this warning."
+                                    ),
+                                    AsdfFutureWarning,
+                                )
                             raise
                     sctx.assign_object(obj)
                     sctx.assign_blocks()

--- a/asdf/lazy_nodes.py
+++ b/asdf/lazy_nodes.py
@@ -226,6 +226,7 @@ class _AsdfNode:
                         else:
                             if not is_set(get_config()).warn_on_failed_conversion:
                                 # Only emit a warning if warn_on_failed_conversion hasn't been manually set
+                                # This branch can be removed once the default for warn_on_failed_conversion is changed
                                 warnings.warn(
                                     (
                                         "In the future failed node conversion will by default generate a warning "

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import enum
 import importlib.util
 import math
 import re
 import struct
+from dataclasses import dataclass
 from functools import lru_cache
-from typing import Final
+from typing import Any, Final, Generic, final
 
 import numpy as np
 import yaml
+from typing_extensions import TypeVar
 
 from . import constants
 
@@ -348,3 +352,69 @@ class FileType(enum.Enum):
     ASDF = 1
     FITS = 2
     UNKNOWN = 3
+
+
+_T = TypeVar("_T")
+
+
+@final
+class is_set(Generic[_T]):
+    __slots__ = ("_inner",)
+
+    def __init__(self, inner: _T):
+        self._inner = inner
+
+    def __dir__(self):
+        return dir(self._inner)
+
+    def __getattr__(self, name: str) -> bool:
+        cache = self._inner.__dict__
+
+        try:
+            attr = cache[name]
+        except KeyError:
+            # This will raise an AttributeError if the attribute doesn't exist on the inner type
+            prop = getattr(self._inner.__class__, name)
+            if isinstance(prop, tracked_property):
+                attr = _get_attr(self._inner, name)
+            else:
+                attr = None
+
+        if not isinstance(attr, _IsSetAttr):
+            msg = f"{name} is not a tracked_property"
+            raise TypeError(msg)
+
+        return attr.is_set
+
+
+class tracked_property(property):
+    def __set_name__(self, owner: type[Any], name: str) -> None:
+        self.__name__ = name
+
+    def __set__(self, instance: object, value: Any) -> None:
+        _get_attr(instance, self.__name__).is_set = True
+        return super().__set__(instance, value)
+
+
+@dataclass(slots=True)
+class _IsSetAttr:
+    """Class that stores attribute metadata for is_set/tracked_property."""
+
+    is_set: bool = False
+
+
+def _get_attr(obj: object, attr: str) -> _IsSetAttr:
+    """Helper that gets or creates the `_IsSetAttr` corresponding to an attribute."""
+    # This function uses the same semantics as functools.cached_property
+    # where `_IsSetAttr` is stored in the instance __dict__ under the corresponding property name.
+    # This works because the property is only part of the class-level __dict__
+    # so the key should be empty in the instance __dict__.
+    try:
+        cache = obj.__dict__
+    except AttributeError:
+        msg = f"No '__dict__' attribute on {type(obj).__name__} instanceto store tracked_property metadata"
+        raise TypeError(msg) from None
+    if attr not in cache:
+        cache[attr] = _IsSetAttr()
+
+    return cache[attr]

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -40,9 +40,13 @@ __all__ = [
     "get_base_uri",
     "get_class_name",
     "get_file_type",
+    "is_set",
     "load_yaml",
+    "tracked_property",
     "uri_match",
 ]
+
+_T = TypeVar("_T")
 
 
 def load_yaml(init, tagged=False):
@@ -354,11 +358,13 @@ class FileType(enum.Enum):
     UNKNOWN = 3
 
 
-_T = TypeVar("_T")
-
-
 @final
 class is_set(Generic[_T]):
+    """Can be passed an object with `tracked_property` attributes to check if a property has been set.
+
+    See `tracked_property` for usage examples.
+    """
+
     __slots__ = ("_inner",)
 
     def __init__(self, inner: _T):
@@ -388,6 +394,34 @@ class is_set(Generic[_T]):
 
 
 class tracked_property(property):
+    """Extension to `property` that allows tracking whether a property's value has been
+    manually set after being initialized (even if set to its original value).
+
+    The decorated attribute behaves like a normal property when accessed from its parent object.
+    Passing the parent object to `is_set` returns a wrapper that reports whether each tracked
+    attribute has been manually set.
+
+    Examples
+    --------
+        >>> class Config:
+        ...     def __init__(self):
+        ...         self._value = 1
+        ...
+        ...     @tracked_property
+        ...     def value(self):
+        ...         return self._value
+        ...
+        ...     @value.setter
+        ...     def value(self, value):
+        ...         self._value = value
+        >>> cfg = Config()
+        >>> is_set(cfg).value
+        False
+        >>> cfg.value = 2
+        >>> is_set(cfg).value
+        True
+    """
+
     def __set_name__(self, owner: type[Any], name: str) -> None:
         self.__name__ = name
 
@@ -398,7 +432,7 @@ class tracked_property(property):
 
 @dataclass(slots=True)
 class _IsSetAttr:
-    """Class that stores attribute metadata for is_set/tracked_property."""
+    """Class that stores attribute metadata for `is_set`/`tracked_property`."""
 
     is_set: bool = False
 
@@ -412,7 +446,7 @@ def _get_attr(obj: object, attr: str) -> _IsSetAttr:
     try:
         cache = obj.__dict__
     except AttributeError:
-        msg = f"No '__dict__' attribute on {type(obj).__name__} instanceto store tracked_property metadata"
+        msg = f"No '__dict__' attribute on {type(obj).__name__} instance to store tracked_property metadata"
         raise TypeError(msg) from None
     if attr not in cache:
         cache[attr] = _IsSetAttr()

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING
 import numpy as np
 import yaml
 
+from asdf.exceptions import AsdfFutureWarning
+from asdf.util import is_set
+
 from . import schema, tagged, treeutil, util
 from .config import get_config
 from .constants import STSCI_SCHEMA_TAG_BASE, YAML_TAG_PREFIX
@@ -351,6 +354,16 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False, _serialization_
                     warnings.warn(f"A node failed to convert with: {err}", AsdfConversionWarning)
                     obj = node
                 else:
+                    if not is_set(get_config()).warn_on_failed_conversion:
+                        # Only emit a warning if warn_on_failed_conversion hasn't been manually set
+                        warnings.warn(
+                            (
+                                "In the future failed node conversion will by default generate a warning "
+                                "instead of an error. Set AsdfConfig.warn_on_failed_conversion to True to opt-in "
+                                "to the new behavior, or to False to silence this warning."
+                            ),
+                            AsdfFutureWarning,
+                        )
                     raise
             _serialization_context.assign_object(obj)
             _serialization_context.assign_blocks()

--- a/changes/2123.general.rst
+++ b/changes/2123.general.rst
@@ -1,0 +1,4 @@
+In a future release the default value for `asdf.config.AsdfConfig.warn_on_failed_conversion` will change from `False` to `True`.
+Currently if ASDF raises an exception due to a conversion error it will now *also* emit a warning regarding the change in behavior.
+To silence the warning you can either set ``warn_on_failed_conversion`` to `True` to opt into the new behavior
+or to `False` to retain the old behavior.


### PR DESCRIPTION
## Description
- Added `asdf.util.tracked_property` which allows checking if a property has been manually set or not.
- Applied `tracked_property` to `AsdfConfig.warn_on_failed_conversion`
- Added `asdf.exceptions.AsdfFutureWarning`
- Updated file loading logic so that if node conversion fails and `warn_on_failed_conversion` hasn't been manually set then `AsdfFutureWarning` is emitted before an exception is raised. 

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
