### PR TITLE
Add warning when validation error occurs with default `validate_on_read`

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -14,14 +14,13 @@ from packaging.version import Version
 from typing_extensions import Reader, Writer, deprecated
 
 from asdf.exceptions import AsdfFutureWarning, ValidationError
-from asdf.util import is_set
 
 from . import _compression as mcompression
 from . import _display as display
 from . import _io, constants, generic_io, lazy_nodes, reference, schema, treeutil, util, versioning, yamlutil
 from . import _node_info as node_info
 from ._block.manager import Manager as BlockManager
-from ._helpers import validate_version
+from ._helpers import is_set, validate_version
 from .config import config_context, get_config
 from .exceptions import (
     AsdfManifestURIMismatchWarning,

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1539,7 +1539,7 @@ def open_asdf(
             try:
                 instance._validate(tree, reading=True)
             except ValidationError:
-                if not is_set(get_config()).validate_on_read:
+                if not is_set(get_config(), "validate_on_read"):
                     warnings.warn(
                         (
                             "In the future validation on read will be off by default. "

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -13,6 +13,9 @@ from typing import TYPE_CHECKING, overload
 from packaging.version import Version
 from typing_extensions import Reader, Writer, deprecated
 
+from asdf.exceptions import AsdfFutureWarning, ValidationError
+from asdf.util import is_set
+
 from . import _compression as mcompression
 from . import _display as display
 from . import _io, constants, generic_io, lazy_nodes, reference, schema, treeutil, util, versioning, yamlutil
@@ -1534,7 +1537,19 @@ def open_asdf(
 
         # validate
         if get_config().validate_on_read:
-            instance._validate(tree, reading=True)
+            try:
+                instance._validate(tree, reading=True)
+            except ValidationError:
+                if not is_set(get_config()).validate_on_read:
+                    warnings.warn(
+                        (
+                            "In the future validation on read will be off by default. "
+                            "Set AsdfConfig.validate_on_read to False to opt-in to the new behavior, "
+                            "or to True to silence this warning."
+                        ),
+                        AsdfFutureWarning,
+                    )
+                raise
 
         # lazy tree?
         if lazy_tree and not _force_raw_types:

--- a/asdf/_commands/validate.py
+++ b/asdf/_commands/validate.py
@@ -3,6 +3,7 @@ Commands for validating ASDF files
 """
 
 import asdf
+from asdf.config import config_context
 
 from .main import Command
 
@@ -44,15 +45,19 @@ class Validate(Command):
 
 def validate(filename, custom_schema, skip_block_validation):
     # if we are skipping checksums we can lazy load, otherwise don't
-    with asdf.open(
-        filename,
-        custom_schema=custom_schema,
-        validate_checksums=not skip_block_validation,
-        lazy_load=skip_block_validation,
-    ) as af:  # noqa: F841
-        msg = f"{filename} is valid"
-        if custom_schema:
-            msg += f", conforms to {custom_schema}"
-        if not skip_block_validation:
-            msg += ", and block checksums match contents"
-        print(msg)
+    with config_context() as cfg:
+        # Manually set validate_on_read since in the future it will be off by default
+        cfg.validate_on_read = True
+
+        with asdf.open(
+            filename,
+            custom_schema=custom_schema,
+            validate_checksums=not skip_block_validation,
+            lazy_load=skip_block_validation,
+        ) as _af:
+            msg = f"{filename} is valid"
+            if custom_schema:
+                msg += f", conforms to {custom_schema}"
+            if not skip_block_validation:
+                msg += ", and block checksums match contents"
+            print(msg)

--- a/asdf/_tests/core/_converters/test_complex.py
+++ b/asdf/_tests/core/_converters/test_complex.py
@@ -15,6 +15,7 @@ a: !core/complex-1.0.0
     return helpers.yaml_to_asdf(yaml)
 
 
+@helpers.config(validate_on_read=True)
 @pytest.mark.parametrize(
     "invalid",
     [

--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -11,6 +11,7 @@ from numpy import ma
 from numpy.testing import assert_array_equal
 
 import asdf
+import asdf.constants
 from asdf.exceptions import AsdfFutureWarning, ValidationError
 from asdf.extension import Converter, Extension, TagDefinition
 from asdf.tags.core import ndarray
@@ -646,6 +647,7 @@ arr: !{ndarray_tag}
         pass
 
 
+@helpers.config(validate_on_read=True)
 def test_invalid_mask_datatype(ndarray_tag):
     content = f"""
 arr: !{ndarray_tag}
@@ -665,6 +667,7 @@ arr: !{ndarray_tag}
         pass
 
 
+@helpers.config(validate_on_read=True)
 @with_custom_extension()
 def test_ndim_validation(ndarray_tag):
     content = f"""
@@ -739,6 +742,7 @@ obj: !<tag:nowhere.org:custom/ndim-1.0.0>
         pass
 
 
+@helpers.config(validate_on_read=True)
 @with_custom_extension()
 def test_datatype_validation(ndarray_tag):
     content = f"""
@@ -825,6 +829,7 @@ obj: !<tag:nowhere.org:custom/datatype-1.0.0>
         pass
 
 
+@helpers.config(validate_on_read=True)
 @with_custom_extension()
 def test_structured_datatype_validation(ndarray_tag):
     content = f"""

--- a/asdf/_tests/test_config.py
+++ b/asdf/_tests/test_config.py
@@ -428,3 +428,40 @@ def test_warn_on_failed_conversion_true_no_warn(lazy: bool):
         with pytest.warns(AsdfConversionWarning):
             with asdf.open(buff) as af:
                 af["data"]
+
+
+def test_validate_on_read_default_warn():
+    """Test that when a ValidationError occurs while loading a file a FutureWarning is
+    emitted before the error if validate_on_read hasn't been manually set.
+
+    This test can be removed once the default for validate_on_read changes.
+    """
+    buff = helpers.yaml_to_asdf(r"invalid: !core/software-1.0.0 {version: 3}")
+    with pytest.raises(asdf.ValidationError), pytest.warns(AsdfFutureWarning):
+        with asdf.open(buff) as _af:
+            pass
+
+
+@helpers.config(validate_on_read=True)
+@pytest.mark.filterwarnings("error:AsdfFutureWarning")
+def test_validate_on_read_true_no_warn():
+    """Test that when a ValidationError occurs while loading a file no extra warning is
+    emitted if validate_on_read has been manually set to True.
+
+    This test can be removed once the default for validate_on_read changes.
+    """
+    buff = helpers.yaml_to_asdf(r"invalid: !core/software-1.0.0 {version: 3}")
+    with pytest.raises(asdf.ValidationError):
+        with asdf.open(buff) as _af:
+            pass
+
+
+@helpers.config(validate_on_read=False)
+@pytest.mark.filterwarnings("error:AsdfFutureWarning")
+def test_validate_on_read_false_no_warn():
+    """Test that when validate_on_read is set to False loading an invalid file produces
+    no errors and no warnings.
+    """
+    buff = helpers.yaml_to_asdf(r"invalid: !core/software-1.0.0 {version: 3}")
+    with asdf.open(buff) as _af:
+        pass

--- a/asdf/_tests/test_custom_schema.py
+++ b/asdf/_tests/test_custom_schema.py
@@ -3,7 +3,9 @@ from contextlib import nullcontext
 import pytest
 
 import asdf
+import asdf.tags.core
 from asdf.exceptions import ValidationError
+from asdf.testing import helpers
 
 # test cases with:
 # - custom schema path
@@ -59,6 +61,7 @@ def schema_name(request, test_data_path, as_pathlib):
     return as_pathlib(test_data_path / request.param)
 
 
+@helpers.config(validate_on_read=True)
 @pytest.mark.parametrize(
     "schema_name, tree, expected_error",
     TEST_CASES,
@@ -72,6 +75,7 @@ def test_custom_validation_write_to(tmp_path, schema_name, tree, expected_error)
         asdf.AsdfFile(tree, custom_schema=schema_name).write_to(asdf_file)
 
 
+@helpers.config(validate_on_read=True)
 @pytest.mark.parametrize(
     "schema_name, tree, expected_error",
     TEST_CASES,
@@ -113,6 +117,7 @@ def test_custom_validation_dumps(schema_name, tree, expected_error):
         asdf.dumps(tree, custom_schema=schema_name)
 
 
+@helpers.config(validate_on_read=True)
 @pytest.mark.parametrize(
     "schema_name, tree, expected_error",
     TEST_CASES,
@@ -142,6 +147,7 @@ def test_custom_validation_dump(tmp_path, schema_name, tree, expected_error):
         asdf.dump(tree, asdf_file, custom_schema=schema_name)
 
 
+@helpers.config(validate_on_read=True)
 @pytest.mark.parametrize(
     "schema_name, tree, expected_error",
     TEST_CASES,

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -7,9 +7,11 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import asdf
+import asdf.tags.core
 from asdf import config_context, constants, get_config, schema, tagged, util, yamlutil
 from asdf.exceptions import AsdfConversionWarning, AsdfWarning, ValidationError
-from asdf.extension import TagDefinition
+from asdf.extension import TagDefinition, get_cached_extension_manager
+from asdf.testing import helpers
 from asdf.testing.helpers import yaml_to_asdf
 
 
@@ -22,7 +24,7 @@ def tag_reference_extension():
 
     tag_uri = "tag:nowhere.org:custom/tag_reference-1.0.0"
     schema_uri = "http://nowhere.org/schemas/custom/tag_reference-1.0.0"
-    tag_def = asdf.extension.TagDefinition(tag_uri, schema_uris=schema_uri)
+    tag_def = TagDefinition(tag_uri, schema_uris=schema_uri)
 
     class TagReferenceConverter:
         tags = [tag_uri]
@@ -388,6 +390,7 @@ def test_property_order():
             last_index = index
 
 
+@helpers.config(validate_on_read=True)
 def test_invalid_nested():
     tag_uri = "http://nowhere.org/tags/custom/custom-1.0.0"
     schema_uri = "http://nowhere.org/schemas/custom/custom-1.0.0"
@@ -751,7 +754,7 @@ def test_foreign_tag_reference_validation():
 
     tag_uri = "tag:nowhere.org:custom/foreign_tag_reference-1.0.0"
     schema_uri = "http://nowhere.org/schemas/custom/foreign_tag_reference-1.0.0"
-    tag_def = asdf.extension.TagDefinition(tag_uri, schema_uris=schema_uri)
+    tag_def = TagDefinition(tag_uri, schema_uris=schema_uri)
 
     class ForeignTagReferenceConverter:
         tags = [tag_uri]
@@ -817,7 +820,7 @@ def test_self_reference_resolution(test_data_path):
 def test_schema_resolved_via_entry_points():
     """Test that entry points mappings to core schema works"""
     tag = "tag:stsci.edu:asdf/fits/fits-1.0.0"
-    extension_manager = asdf.extension.get_cached_extension_manager(get_config().extensions)
+    extension_manager = get_cached_extension_manager(get_config().extensions)
     schema_uris = extension_manager.get_tag_definition(tag).schema_uris
     assert len(schema_uris) > 0
     s = schema.load_schema(schema_uris[0])
@@ -1091,6 +1094,7 @@ tag: asdf://somewhere.org/tags/bar-*
             schema.validate(tagged.TaggedDict(tag="asdf://somewhere.org/tags/foo-1.0"), schema=schema_tree)
 
 
+@helpers.config(validate_on_read=True)
 def test_fail_under_combiner():
     """
     Test that a failed validation under a schema combiner that allows failures

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -422,7 +422,7 @@ class AsdfConfig(_IsSet):
             raise ValueError(msg)
         self._default_array_save_base = value
 
-    @tracked_property
+    @property
     def validate_on_read(self) -> bool:
         """
         Get configuration that controls schema validation of

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -423,7 +423,7 @@ class AsdfConfig:
             raise ValueError(msg)
         self._default_array_save_base = value
 
-    @property
+    @tracked_property
     def validate_on_read(self) -> bool:
         """
         Get configuration that controls schema validation of

--- a/asdf/config.py
+++ b/asdf/config.py
@@ -432,6 +432,14 @@ class AsdfConfig:
         Returns
         -------
         bool
+
+        Warnings
+        --------
+        In a future release the default value will change from `True` to `False`.
+        Currently, if a validation error occurs while loading a file and this field hasn't
+        been manually set then ASDF will emit an `asdf.exceptions.AsdfFutureWarning`
+        *before* raising an exception.
+        Manually set the field to either `True` or `False` to silence this warning.
         """
         return self._validate_on_read
 

--- a/asdf/testing/helpers.py
+++ b/asdf/testing/helpers.py
@@ -2,9 +2,23 @@
 Helpers for writing unit tests of ASDF support.
 """
 
+from contextlib import contextmanager
 from io import BytesIO
 
 import asdf
+
+
+@contextmanager
+def config(**kwargs):
+    """Temporarily set config values via keyword argument.
+
+    Can be used as a context manager or as a function decorator.
+    """
+
+    with asdf.config_context() as cfg:
+        for key, val in kwargs.items():
+            setattr(cfg, key, val)
+        yield cfg
 
 
 def roundtrip_object(obj, version=None):

--- a/asdf/testing/helpers.py
+++ b/asdf/testing/helpers.py
@@ -7,6 +7,8 @@ from io import BytesIO
 
 import asdf
 
+__all__ = ["config", "roundtrip_object", "yaml_to_asdf"]
+
 
 @contextmanager
 def config(**kwargs):

--- a/changes/2126.general.rst
+++ b/changes/2126.general.rst
@@ -1,0 +1,5 @@
+In a future release the default value for `asdf.config.AsdfConfig.validate_on_read` will change from `True` to `False`.
+Currently if a validation error occurs while reading a file ASDF will now *also* emit a warning regarding the change in behavior.
+To silence the warning you can either set ``validate_on_read`` to `False` to opt into the new behavior
+or to `True` to retain the old behavior.
+This change has no effect on manual calls to `asdf.AsdfFile.validate`.

--- a/docs/asdf/config.rst
+++ b/docs/asdf/config.rst
@@ -198,6 +198,13 @@ improve performance.
 
 Defaults to True.
 
+.. warning::
+  In a future release the default value will change from `True` to `False`.
+  Currently, if a validation error occurs while loading a file and this field hasn't
+  been manually set then ASDF will emit an `asdf.exceptions.AsdfFutureWarning`
+  *before* raising an exception.
+  Manually set the field to either `True` or `False` to silence this warning.
+
 lazy_tree
 ---------
 


### PR DESCRIPTION
## Description
Depends on #2125
Part of #2128 

- Updated file loading logic so that if a validation error occurs and `validate_on_read` hasn't been manually set then `AsdfFutureWarning` is emitted before an exception is raised.

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
