### PR TITLE
Fix copy/deepcopy for `AsdfFile`

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -491,14 +491,17 @@ class AsdfFile:
         self._external_asdf_by_uri.clear()
         self._blocks.close()
 
-    def copy(self) -> AsdfFile:
+    def __deepcopy__(self, memo):
         return self.__class__(
-            copy.deepcopy(self._tree),
+            copy.deepcopy(self._tree, memo),
             self._blocks._uri,
             self._user_extensions,
         )
 
-    __copy__ = __deepcopy__ = copy
+    def copy(self) -> AsdfFile:
+        return copy.deepcopy(self)
+
+    __copy__ = copy
 
     @property
     def uri(self) -> str | None:

--- a/asdf/_tests/test_lazy_nodes.py
+++ b/asdf/_tests/test_lazy_nodes.py
@@ -12,6 +12,7 @@ import asdf.lazy_nodes
 import asdf.tagged
 import asdf.tags.core
 import asdf.treeutil
+from asdf import AsdfFile
 from asdf.lazy_nodes import AsdfDictNode, AsdfListNode, AsdfOrderedDictNode, _resolve_af_ref, _to_lazy_node
 
 
@@ -418,7 +419,8 @@ def test_lazy_generator_converter(tmp_path, lazy_generator_class):
         assert isinstance(af["obj"].data, dict)
 
 
-def test_lazy_copy(tmp_path):
+@pytest.mark.parametrize("copy_op", [copy.copy, copy.deepcopy, AsdfFile.copy])
+def test_lazy_copy(tmp_path, copy_op):
     """
     Test that copying an AsdfFile instance with a lazy
     tree doesn't result in the copy retaining references
@@ -426,16 +428,21 @@ def test_lazy_copy(tmp_path):
     """
     fn = tmp_path / "test.asdf"
     obj = asdf.tags.core.IntegerType(1)
-    tree: dict[str, Any] = {"a": {"b": obj}}
+    tree: dict[str, Any] = {
+        "a": {"b": obj},
+        "array": {"inner": np.arange(3)},
+    }
     # make a recursive structure
     tree["a"]["c"] = tree["a"]
 
     asdf.AsdfFile(tree).write_to(fn)
 
     with asdf.open(fn, lazy_tree=True) as af:
-        af2 = af.copy()
+        af2 = copy_op(af)
 
     del af
     gc.collect(2)
+
     assert af2["a"]["b"] == obj
     assert af2["a"]["c"]["b"] is af2["a"]["b"]
+    np.array_equal(af2["array"]["inner"][:], np.arange(3))

--- a/asdf/lazy_nodes.py
+++ b/asdf/lazy_nodes.py
@@ -4,6 +4,7 @@ lazy conversion of tagged ASDF tree nodes to custom objects.
 """
 
 import collections
+import copy
 import inspect
 import warnings
 import weakref
@@ -146,7 +147,7 @@ class _AsdfNode:
         return self.data
 
     def __deepcopy__(self, memo):
-        return treeutil.walk_and_modify(self, lambda n: n)
+        return copy.deepcopy(treeutil.walk_and_modify(self, lambda n: n), memo)
 
     def _convert_and_cache(self, value, key):
         """

--- a/changes/2133.bugfix.1.rst
+++ b/changes/2133.bugfix.1.rst
@@ -1,0 +1,1 @@
+Fixed `asdf.AsdfFile.copy` failing for files created with ``lazy_tree=True``.

--- a/changes/2133.bugfix.rst
+++ b/changes/2133.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `copy.deepcopy` raising an exception when passed `asdf.AsdfFile`.


### PR DESCRIPTION
## Description
Closes #2103

- Fixed `copy.deepcopy` not working with `AsdfFile`
- Fixed `AsdfFile.copy` not working for files with ndarrays when `lazy_tree=True`

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
