### PR TITLE
only upload coverage for the asdf-format/asdf fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       shell: bash
       env:
         MATRIX_SESSION: ${{ matrix.session }}
-    - if: ${{ contains(matrix.session, 'coverage') }}
+    - if: ${{ contains(matrix.session, 'coverage') && github.repository == 'asdf-format/asdf' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
## Description
Make the coverage upload conditional since it always fails on forks:
https://github.com/braingram/asdf/actions/runs/34120074541/job/101735935799#step:6:362

## AI Disclosure
I asked github copilot to confirm the syntax and usage.

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
